### PR TITLE
Multi-repo target repository registry (elizaOS/eliza + lalalune/arklib)

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-repository.yml
+++ b/.github/ISSUE_TEMPLATE/add-repository.yml
@@ -1,0 +1,62 @@
+name: Add repository
+description: Request onboarding of your repository into the eliza.army target registry.
+title: "Add repository: <owner>/<name>"
+labels: ["add-repository"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        The program evaluates scope, license, contributing guide, CI, and
+        maintainer responsiveness. If accepted, the repository is added to the
+        target registry (`src/lib/repositories.mjs`), hosted and mirrored on
+        [Eliza Hub](https://github.com/elizaOS/hub), and registered with Merge
+        Steward policy before contributors start. Contributor scoring caps
+        stay global across every registry repository, so adding a repository
+        never adds scoring capacity.
+  - type: input
+    id: repository
+    attributes:
+      label: Repository
+      description: GitHub `owner/name` of the repository you want the army contributing to.
+      placeholder: owner/name
+    validations:
+      required: true
+  - type: input
+    id: integration-branch
+    attributes:
+      label: Integration branch
+      description: The branch pull requests must target (for example `main` or `develop`).
+    validations:
+      required: true
+  - type: input
+    id: verification
+    attributes:
+      label: Setup and verification commands
+      description: The exact commands a contributor runs to set up and verify a change (for example `bun install && bun run verify`, or `lake build`).
+    validations:
+      required: true
+  - type: textarea
+    id: work
+    attributes:
+      label: What work do you need
+      description: The kinds of issues and pull requests contributors should pick up, and how contributor-ready work will be labeled.
+    validations:
+      required: true
+  - type: input
+    id: maintainers
+    attributes:
+      label: Maintainer contact
+      description: GitHub handle(s) of the maintainers who will label contributor-ready issues and review contributor pull requests.
+    validations:
+      required: true
+  - type: checkboxes
+    id: acknowledgements
+    attributes:
+      label: Acknowledgements
+      options:
+        - label: The repository has a public license and a contributing guide.
+          required: true
+        - label: Maintainers will label contributor-ready issues and review contributor pull requests.
+          required: true
+        - label: I understand contributor scoring caps are global across the registry, so this repository adds no scoring capacity.
+          required: true

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ public/skill.md
 public/mission.md
 public/codex.md
 public/skill-manifest.json
+public/data/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,10 @@ contribution-compute entrypoint for elizaOS.
 ## Purpose
 
 This package publishes the installable `contribute-to-eliza` skill, a live work
-queue, and a transparent contribution leaderboard scoped to `elizaOS/eliza`.
+queue, and a transparent contribution leaderboard scoped to the target
+repository registry in `src/lib/repositories.mjs` — currently `elizaOS/eliza`
+(primary) and `lalalune/arklib`. The registry is the single source of truth
+for target repositories; never hardcode a target repository elsewhere.
 It is a private application, not a library. Cloudflare Pages serves the static
 build; GitHub Actions refreshes the public data and deploys only after package
 checks pass.
@@ -43,13 +46,14 @@ the generator's test option, never environment variables.
 ```text
 assets/               repository-owned elizaOS brand assets
 skills/               canonical contributor skill and supporting references
-  src/                  React UI, data contracts, scoring helpers
-  public/               Pages headers/redirects plus generated site assets
-  scripts/              skill packaging, live GitHub ingestion, evidence capture
-  tests/                unit and real-browser coverage
-  PRODUCT.md            users, purpose, principles, accessibility
-  DESIGN.md             visual system and interaction rules
-  wrangler.toml         Cloudflare Pages Direct Upload contract
+skill-tests/          bun tests for the bundled skill scripts
+src/                  React UI, data contracts, scoring helpers
+public/               Pages headers/redirects plus generated site assets
+scripts/              skill packaging, live GitHub ingestion, evidence capture
+tests/                unit and real-browser coverage
+PRODUCT.md            users, purpose, principles, accessibility
+DESIGN.md             visual system and interaction rules
+wrangler.toml         Cloudflare Pages Direct Upload contract
 ```
 
 Generated files under `public/brand/`, `public/downloads/`, and the raw hosted
@@ -95,9 +99,12 @@ one complete transaction.
 - Keep rules versioned, public, and deterministic.
 - Deduplicate by immutable GitHub IDs.
 - Exclude bots, self-review, post-merge review, and repeated low-value comments.
-- Cap review/comment awards by actor and artifact.
+- Cap review/comment awards by actor and artifact. Per-contributor caps are
+  global across every registry repository; a second repository never adds
+  scoring capacity.
 - Model disclosure is reported provenance, not proof, and never adds points.
-- Every public snapshot records its repository, window, rule version,
+- Every public snapshot records its repository registry with per-item
+  repository attribution, the primary repository, window, rule version,
   generation time, source cutoff, and any staleness.
 
 ## Work-candidate selection contract

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,10 @@ contribution-compute entrypoint for elizaOS.
 ## Purpose
 
 This package publishes the installable `contribute-to-eliza` skill, a live work
-queue, and a transparent contribution leaderboard scoped to `elizaOS/eliza`.
+queue, and a transparent contribution leaderboard scoped to the target
+repository registry in `src/lib/repositories.mjs` — currently `elizaOS/eliza`
+(primary) and `lalalune/arklib`. The registry is the single source of truth
+for target repositories; never hardcode a target repository elsewhere.
 It is a private application, not a library. Cloudflare Pages serves the static
 build; GitHub Actions refreshes the public data and deploys only after package
 checks pass.
@@ -43,13 +46,14 @@ the generator's test option, never environment variables.
 ```text
 assets/               repository-owned elizaOS brand assets
 skills/               canonical contributor skill and supporting references
-  src/                  React UI, data contracts, scoring helpers
-  public/               Pages headers/redirects plus generated site assets
-  scripts/              skill packaging, live GitHub ingestion, evidence capture
-  tests/                unit and real-browser coverage
-  PRODUCT.md            users, purpose, principles, accessibility
-  DESIGN.md             visual system and interaction rules
-  wrangler.toml         Cloudflare Pages Direct Upload contract
+skill-tests/          bun tests for the bundled skill scripts
+src/                  React UI, data contracts, scoring helpers
+public/               Pages headers/redirects plus generated site assets
+scripts/              skill packaging, live GitHub ingestion, evidence capture
+tests/                unit and real-browser coverage
+PRODUCT.md            users, purpose, principles, accessibility
+DESIGN.md             visual system and interaction rules
+wrangler.toml         Cloudflare Pages Direct Upload contract
 ```
 
 Generated files under `public/brand/`, `public/downloads/`, and the raw hosted
@@ -95,9 +99,12 @@ one complete transaction.
 - Keep rules versioned, public, and deterministic.
 - Deduplicate by immutable GitHub IDs.
 - Exclude bots, self-review, post-merge review, and repeated low-value comments.
-- Cap review/comment awards by actor and artifact.
+- Cap review/comment awards by actor and artifact. Per-contributor caps are
+  global across every registry repository; a second repository never adds
+  scoring capacity.
 - Model disclosure is reported provenance, not proof, and never adds points.
-- Every public snapshot records its repository, window, rule version,
+- Every public snapshot records its repository registry with per-item
+  repository attribution, the primary repository, window, rule version,
   generation time, source cutoff, and any staleness.
 
 ## Work-candidate selection contract

--- a/README.md
+++ b/README.md
@@ -1,7 +1,16 @@
 # eliza.army
 
-Accepted work on [`elizaOS/eliza`](https://github.com/elizaOS/eliza) can earn
-from a $10,000 monthly contributor pool paid in USDC.
+Accepted work on the program's target repository registry — currently
+[`elizaOS/eliza`](https://github.com/elizaOS/eliza) (primary) and
+[`lalalune/arklib`](https://github.com/lalalune/arklib) — can earn from a
+$10,000 monthly contributor pool paid in USDC. The program's repositories are
+hosted and mirrored on [Eliza Hub](https://github.com/elizaOS/hub), the
+Eliza-branded Forgejo distribution; this site is the public contribution front
+door for the repositories it hosts. Teams that want the army contributing to
+their repository can request onboarding by
+[opening an issue](https://github.com/elizaOS/army/issues/new?template=add-repository.yml)
+on `elizaOS/army`. The issue form states what an onboarding request must
+include and what happens after acceptance.
 
 If selected for a payout, publish a public Solana or Ethereum address through
 the [elizaOS profile editor](https://eliza.app/profile/edit). The editor
@@ -14,7 +23,8 @@ The package contains:
 
 - a minimal React + Vite site for installing and running the canonical
   `contribute-to-eliza` skill;
-- a GitHub ingestion/scoring pipeline scoped to this repository;
+- a GitHub ingestion/scoring pipeline spanning the target repository registry
+  in `src/lib/repositories.mjs`;
 - a transparent contribution ledger and latest GitHub work snapshot;
 - Cloudflare Pages Direct Upload configuration;
 - unit, browser, accessibility, download-integrity, and production smoke tests.
@@ -56,8 +66,12 @@ bundle.
 ## Data and scoring
 
 The production deploy generates `public/data/leaderboard.json` from the GitHub
-API immediately before building. Base merged-PR outcomes are complete across
-the rolling 30-day window. The more expensive verification data—resolved
+API immediately before building. The same complete collection pipeline runs
+for every repository in the target registry (`src/lib/repositories.mjs`);
+records merge by immutable GitHub node ID, and every score event and work item
+records its repository. The snapshot publishes the registry (`repositories`)
+alongside the backward-compatible primary `repository` field. Base merged-PR
+outcomes are complete across the rolling 30-day window. The more expensive verification data—resolved
 issues, substantive non-self reviews, material test changes, and concrete
 evidence—is complete across the trailing seven days. Every snapshot publishes
 both windows and their record counts; the generator rejects missing or
@@ -71,7 +85,9 @@ state reason alone does not qualify.
 Per-contributor caps keep the ledger from becoming a volume contest: the
 newest five merged pull requests, five resolved issues, five material-test
 bonuses, 30 evidence points, and ten substantive reviews can score in their
-respective windows. Input order cannot change which outcomes win a cap.
+respective windows. Caps are global across every registry repository — adding
+or working a second repository never adds scoring capacity — and input order
+cannot change which outcomes win a cap.
 
 Evidence points come only from immutable GitHub attachments in stable rows in
 the canonical PR body that the generator can fetch and structurally verify.

--- a/scripts/check-pr-evidence.mjs
+++ b/scripts/check-pr-evidence.mjs
@@ -9,6 +9,7 @@
 import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
+import { TARGET_REPOSITORIES } from "../src/lib/repositories.mjs";
 
 export const REQUIRED_EVIDENCE_ROWS = [
   { id: "before-screenshots", label: "Before screenshots" },
@@ -161,12 +162,17 @@ const USER_ATTACHMENT_PATH_RE = new RegExp(
   `^/user-attachments/assets/${UUID_PATH}$`,
   "i",
 );
+const REGISTRY_REPO_PATH_PATTERN = `(?:${TARGET_REPOSITORIES.map((repository) =>
+  repository.id.replaceAll(".", "\\."),
+).join("|")})`;
 const LEGACY_REPO_ASSET_PATH_RE = new RegExp(
-  `^/elizaOS/eliza/assets/[0-9]+/${UUID_PATH}$`,
+  `^/${REGISTRY_REPO_PATH_PATTERN}/assets/[0-9]+/${UUID_PATH}$`,
   "i",
 );
-const PR_EVIDENCE_RELEASE_PATH_RE =
-  /^\/elizaOS\/eliza\/releases\/download\/pr-evidence(?:-[1-9][0-9]*)?\/([^/]+)$/i;
+const PR_EVIDENCE_RELEASE_PATH_RE = new RegExp(
+  `^/${REGISTRY_REPO_PATH_PATTERN}/releases/download/pr-evidence(?:-[1-9][0-9]*)?/([^/]+)$`,
+  "i",
+);
 const LEGACY_USER_IMAGE_PATH_RE = /^\/[0-9]+\/[^/].+$/;
 
 function extensionFromPath(pathname) {

--- a/scripts/evidence-contract.mjs
+++ b/scripts/evidence-contract.mjs
@@ -6,6 +6,10 @@
 
 import { createHash } from "node:crypto";
 import { isIP } from "node:net";
+import {
+  PRIMARY_REPOSITORY,
+  TARGET_REPOSITORIES,
+} from "../src/lib/repositories.mjs";
 
 export const PRODUCTION_ORIGIN = "https://eliza.army";
 export const PRODUCTION_HOSTNAME = "eliza.army";
@@ -118,11 +122,28 @@ export function assertLiveLedgerReady(
       : contents,
     "leaderboard",
   );
-  if (snapshot.schemaVersion !== "1") {
-    throw new TypeError("leaderboard.schemaVersion must be 1");
+  if (snapshot.schemaVersion !== "2") {
+    throw new TypeError("leaderboard.schemaVersion must be 2");
   }
-  if (snapshot.repository !== "elizaOS/eliza") {
-    throw new TypeError("leaderboard.repository must be elizaOS/eliza");
+  if (snapshot.repository !== PRIMARY_REPOSITORY.id) {
+    throw new TypeError(
+      `leaderboard.repository must be ${PRIMARY_REPOSITORY.id}`,
+    );
+  }
+  if (
+    !Array.isArray(snapshot.repositories) ||
+    snapshot.repositories.length !== TARGET_REPOSITORIES.length ||
+    TARGET_REPOSITORIES.some(
+      (repository, index) =>
+        asObject(
+          snapshot.repositories[index],
+          `leaderboard.repositories[${index}]`,
+        ).id !== repository.id,
+    )
+  ) {
+    throw new TypeError(
+      "leaderboard.repositories must match the target repository registry",
+    );
   }
   if (snapshot.stale !== false) {
     throw new TypeError("leaderboard.stale must be false");

--- a/scripts/evidence-contract.test.mjs
+++ b/scripts/evidence-contract.test.mjs
@@ -22,8 +22,9 @@ const now = Date.parse("2026-07-30T20:00:00.000Z");
 
 function liveLedger(overrides = {}) {
   return {
-    schemaVersion: "1",
+    schemaVersion: "2",
     repository: "elizaOS/eliza",
+    repositories: [{ id: "elizaOS/eliza" }, { id: "lalalune/arklib" }],
     generatedAt: "2026-07-30T19:58:00.000Z",
     stale: false,
     source: {
@@ -99,6 +100,17 @@ describe("live ledger readiness", () => {
     expect(() =>
       assertLiveLedgerReady(liveLedger({ ledger: [] }), { now }),
     ).toThrow("leaderboard.ledger must be a non-empty array");
+    expect(() =>
+      assertLiveLedgerReady(liveLedger({ schemaVersion: "1" }), { now }),
+    ).toThrow("leaderboard.schemaVersion must be 2");
+    expect(() =>
+      assertLiveLedgerReady(
+        liveLedger({ repositories: [{ id: "elizaOS/eliza" }] }),
+        { now },
+      ),
+    ).toThrow(
+      "leaderboard.repositories must match the target repository registry",
+    );
     expect(() =>
       assertLiveLedgerReady(
         liveLedger({

--- a/scripts/generate-leaderboard.test.ts
+++ b/scripts/generate-leaderboard.test.ts
@@ -12,6 +12,10 @@ import type {
   PullRequestRecord,
 } from "../src/lib/leaderboard";
 import {
+  PRIMARY_REPOSITORY,
+  TARGET_REPOSITORIES,
+} from "../src/lib/repositories.mjs";
+import {
   assertOpenPullRequestReferencesCurrent,
   assertOpenWorkReferencesCurrent,
   collectSearchReferences,
@@ -566,9 +570,12 @@ describe("post-evidence open-PR revalidation", () => {
 
     liveHead = "b".repeat(40);
     await expect(
-      assertOpenPullRequestReferencesCurrent(client, "REPOSITORY_ELIZA", [
-        pullRequest,
-      ]),
+      assertOpenPullRequestReferencesCurrent(
+        client,
+        PRIMARY_REPOSITORY,
+        "REPOSITORY_ELIZA",
+        [pullRequest],
+      ),
     ).rejects.toThrow(
       "Open pull-request set changed during evidence verification",
     );
@@ -632,7 +639,13 @@ describe("post-evidence open-PR revalidation", () => {
 
     liveUpdatedAt = "2026-07-30T10:01:00.000Z";
     await expect(
-      assertOpenWorkReferencesCurrent(client, "REPOSITORY_ELIZA", [issue], []),
+      assertOpenWorkReferencesCurrent(
+        client,
+        PRIMARY_REPOSITORY,
+        "REPOSITORY_ELIZA",
+        [issue],
+        [],
+      ),
     ).rejects.toThrow("Open issue set changed during evidence verification");
   });
 });
@@ -1273,9 +1286,13 @@ describe("current-head review selection", () => {
     const client: GraphqlExecutor = {
       execute: async (document, variables) => {
         requestCount += 1;
+        const owner =
+          typeof variables?.owner === "string" ? variables.owner : null;
+        const repositoryNodeId =
+          owner === "lalalune" ? "REPOSITORY_ARKLIB" : "REPOSITORY_ELIZA";
         if (document.includes("query LeaderboardPreflight")) {
           return {
-            repository: { id: "REPOSITORY_ELIZA", updatedAt },
+            repository: { id: repositoryNodeId, updatedAt },
           };
         }
         if (document.includes("query LeaderboardSearchReferences")) {
@@ -1290,15 +1307,23 @@ describe("current-head review selection", () => {
         if (document.includes("query LeaderboardOpenIssueReferences")) {
           return {
             repository: {
-              id: "REPOSITORY_ELIZA",
+              id: repositoryNodeId,
               issues: emptyConnection(),
             },
           };
         }
         if (document.includes("query LeaderboardOpenPullRequestReferences")) {
+          if (owner === "lalalune") {
+            return {
+              repository: {
+                id: repositoryNodeId,
+                pullRequests: emptyConnection(),
+              },
+            };
+          }
           return {
             repository: {
-              id: "REPOSITORY_ELIZA",
+              id: repositoryNodeId,
               pullRequests: {
                 totalCount: 2,
                 pageInfo: { hasNextPage: false, endCursor: null },
@@ -1371,6 +1396,13 @@ describe("current-head review selection", () => {
     };
 
     const snapshot = await generateLeaderboardFromGitHub(client, { now });
+    expect(snapshot.source.repositories).toEqual([
+      { id: "elizaOS/eliza", repositoryId: "REPOSITORY_ELIZA" },
+      { id: "lalalune/arklib", repositoryId: "REPOSITORY_ARKLIB" },
+    ]);
+    expect(snapshot.repositories).toEqual(
+      TARGET_REPOSITORIES.map((repository) => ({ ...repository })),
+    );
     const staleItem = snapshot.workQueue.pullRequests.find(
       (item) => item.id === "PR_STALE",
     );
@@ -1429,6 +1461,7 @@ describe("rolling-window slicing", () => {
 
     const references = await collectSearchReferences(
       client,
+      PRIMARY_REPOSITORY,
       new Date("2026-07-30T00:00:00.000Z"),
       new Date("2026-07-30T00:02:00.000Z"),
       "closed",
@@ -1439,6 +1472,7 @@ describe("rolling-window slicing", () => {
 
     expect(references.map(({ id }) => id)).toEqual(["ISSUE_BOUNDARY"]);
     expect(queries).toHaveLength(3);
+    expect(queries[0]).toContain(`repo:${PRIMARY_REPOSITORY.id} `);
     expect(queries[1]).toContain(
       "closed:2026-07-30T00:00:00.000Z..2026-07-30T00:00:59.000Z",
     );
@@ -1470,6 +1504,7 @@ describe("rolling-window slicing", () => {
     await expect(
       collectSearchReferences(
         client,
+        PRIMARY_REPOSITORY,
         new Date("2026-07-30T00:00:00.000Z"),
         new Date("2026-07-30T00:01:00.000Z"),
         "closed",

--- a/scripts/generate-leaderboard.ts
+++ b/scripts/generate-leaderboard.ts
@@ -19,7 +19,6 @@ import {
   type GitHubTextSource,
   type IssueRecord,
   isBotActor,
-  LEADERBOARD_REPOSITORY,
   type LeaderboardSnapshot,
   type LeaderboardSourceMetadata,
   type MergedPullRequestOutcome,
@@ -32,6 +31,10 @@ import {
   VERIFICATION_WINDOW_DAYS,
   type VerifiedEvidenceArtifact,
 } from "../src/lib/leaderboard";
+import {
+  TARGET_REPOSITORIES,
+  type TargetRepository,
+} from "../src/lib/repositories.mjs";
 import {
   planReferencedArtifacts,
   verifyReferencedArtifacts,
@@ -308,8 +311,8 @@ const ISSUE_FRAGMENT = `
 `;
 
 const PREFLIGHT_QUERY = `
-  query LeaderboardPreflight {
-    repository(owner: "elizaOS", name: "eliza") { id updatedAt }
+  query LeaderboardPreflight($owner: String!, $name: String!) {
+    repository(owner: $owner, name: $name) { id updatedAt }
     rateLimit { cost limit remaining resetAt }
   }
 `;
@@ -377,8 +380,13 @@ const ISSUE_DETAILS_QUERY = `
 `;
 
 const OPEN_PULL_REQUEST_REFERENCES_QUERY = `
-  query LeaderboardOpenPullRequestReferences($after: String, $pageSize: Int!) {
-    repository(owner: "elizaOS", name: "eliza") {
+  query LeaderboardOpenPullRequestReferences(
+    $owner: String!
+    $name: String!
+    $after: String
+    $pageSize: Int!
+  ) {
+    repository(owner: $owner, name: $name) {
       id
       pullRequests(
         states: OPEN
@@ -396,8 +404,13 @@ const OPEN_PULL_REQUEST_REFERENCES_QUERY = `
 `;
 
 const OPEN_ISSUE_REFERENCES_QUERY = `
-  query LeaderboardOpenIssueReferences($after: String, $pageSize: Int!) {
-    repository(owner: "elizaOS", name: "eliza") {
+  query LeaderboardOpenIssueReferences(
+    $owner: String!
+    $name: String!
+    $after: String
+    $pageSize: Int!
+  ) {
+    repository(owner: $owner, name: $name) {
       id
       issues(
         states: OPEN
@@ -1297,18 +1310,25 @@ function chunks<T>(values: T[], size: number): T[][] {
 
 async function preflightRepository(
   client: GraphqlExecutor,
+  targetRepository: TargetRepository,
+  options: { requireStartingBudget: boolean },
 ): Promise<{ id: string; updatedAt: string }> {
-  const data = await client.execute(PREFLIGHT_QUERY);
+  const data = await client.execute(PREFLIGHT_QUERY, {
+    owner: targetRepository.owner,
+    name: targetRepository.name,
+  });
   const repository = child(data, "repository", "data");
-  const rateLimit = client.getRateLimit();
-  const requiredRemaining = Math.min(
-    MINIMUM_STARTING_RATE_LIMIT,
-    rateLimit.limit - MINIMUM_RATE_LIMIT_RESERVE,
-  );
-  if (rateLimit.remaining < requiredRemaining) {
-    throw new Error(
-      `GitHub GraphQL has only ${rateLimit.remaining} points remaining; at least ${requiredRemaining} are required to start a complete snapshot`,
+  if (options.requireStartingBudget) {
+    const rateLimit = client.getRateLimit();
+    const requiredRemaining = Math.min(
+      MINIMUM_STARTING_RATE_LIMIT,
+      rateLimit.limit - MINIMUM_RATE_LIMIT_RESERVE,
     );
+    if (rateLimit.remaining < requiredRemaining) {
+      throw new Error(
+        `GitHub GraphQL has only ${rateLimit.remaining} points remaining; at least ${requiredRemaining} are required to start a complete snapshot`,
+      );
+    }
   }
   return {
     id: asString(repository.id, "data.repository.id"),
@@ -1318,6 +1338,7 @@ async function preflightRepository(
 
 export async function collectSearchReferences(
   client: GraphqlExecutor,
+  repository: TargetRepository,
   from: Date,
   to: Date,
   qualifier: "closed" | "merged",
@@ -1325,7 +1346,7 @@ export async function collectSearchReferences(
   expectedKind: NodeReference["kind"],
   stats: { searchSliceCount: number },
 ): Promise<NodeReference[]> {
-  const searchQuery = `repo:${LEADERBOARD_REPOSITORY} ${kindQualifier} ${qualifier}:${searchRange(from, to)}`;
+  const searchQuery = `repo:${repository.id} ${kindQualifier} ${qualifier}:${searchRange(from, to)}`;
   stats.searchSliceCount += 1;
   const firstData = await client.execute(SEARCH_REFERENCES_QUERY, {
     searchQuery,
@@ -1344,6 +1365,7 @@ export async function collectSearchReferences(
     const split = midpoint(from, to);
     const left = await collectSearchReferences(
       client,
+      repository,
       from,
       split,
       qualifier,
@@ -1353,6 +1375,7 @@ export async function collectSearchReferences(
     );
     const right = await collectSearchReferences(
       client,
+      repository,
       split,
       to,
       qualifier,
@@ -1398,6 +1421,7 @@ export async function collectSearchReferences(
 
 async function countSearchResults(
   client: GraphqlExecutor,
+  repository: TargetRepository,
   from: Date,
   to: Date,
   qualifier: "closed" | "merged",
@@ -1405,7 +1429,7 @@ async function countSearchResults(
   expectedKind: NodeReference["kind"],
   stats: { searchSliceCount: number },
 ): Promise<number> {
-  const searchQuery = `repo:${LEADERBOARD_REPOSITORY} ${kindQualifier} ${qualifier}:${searchRange(from, to)}`;
+  const searchQuery = `repo:${repository.id} ${kindQualifier} ${qualifier}:${searchRange(from, to)}`;
   stats.searchSliceCount += 1;
   const data = await client.execute(SEARCH_REFERENCES_QUERY, {
     searchQuery,
@@ -1419,6 +1443,7 @@ async function countSearchResults(
 
 async function collectOpenReferences(
   client: GraphqlExecutor,
+  targetRepository: TargetRepository,
   document: string,
   field: "issues" | "pullRequests",
   kind: NodeReference["kind"],
@@ -1429,6 +1454,8 @@ async function collectOpenReferences(
   let repositoryId: string | null = null;
   do {
     const data = await client.execute(document, {
+      owner: targetRepository.owner,
+      name: targetRepository.name,
       after,
       pageSize: GRAPHQL_PAGE_SIZE,
     });
@@ -1974,12 +2001,14 @@ export function sameReferenceSet(
 
 async function collectStableOpenIssues(
   client: GraphqlExecutor,
+  targetRepository: TargetRepository,
   repositoryId: string,
   onProgress: (progress: GenerationProgress) => void,
 ): Promise<IssueRecord[]> {
   for (let attempt = 1; attempt <= MAX_TRANSIENT_ATTEMPTS; attempt += 1) {
     const before = await collectOpenReferences(
       client,
+      targetRepository,
       OPEN_ISSUE_REFERENCES_QUERY,
       "issues",
       "Issue",
@@ -1998,6 +2027,7 @@ async function collectStableOpenIssues(
       );
       const after = await collectOpenReferences(
         client,
+        targetRepository,
         OPEN_ISSUE_REFERENCES_QUERY,
         "issues",
         "Issue",
@@ -2023,12 +2053,14 @@ async function collectStableOpenIssues(
 
 async function collectStableOpenPullRequests(
   client: GraphqlExecutor,
+  targetRepository: TargetRepository,
   repositoryId: string,
   onProgress: (progress: GenerationProgress) => void,
 ): Promise<PullRequestRecord[]> {
   for (let attempt = 1; attempt <= MAX_TRANSIENT_ATTEMPTS; attempt += 1) {
     const before = await collectOpenReferences(
       client,
+      targetRepository,
       OPEN_PULL_REQUEST_REFERENCES_QUERY,
       "pullRequests",
       "PullRequest",
@@ -2047,6 +2079,7 @@ async function collectStableOpenPullRequests(
       );
       const after = await collectOpenReferences(
         client,
+        targetRepository,
         OPEN_PULL_REQUEST_REFERENCES_QUERY,
         "pullRequests",
         "PullRequest",
@@ -2072,11 +2105,13 @@ async function collectStableOpenPullRequests(
 
 export async function assertOpenPullRequestReferencesCurrent(
   client: GraphqlExecutor,
+  targetRepository: TargetRepository,
   repositoryId: string,
   pullRequests: PullRequestRecord[],
 ): Promise<void> {
   const current = await collectOpenReferences(
     client,
+    targetRepository,
     OPEN_PULL_REQUEST_REFERENCES_QUERY,
     "pullRequests",
     "PullRequest",
@@ -2099,11 +2134,13 @@ export async function assertOpenPullRequestReferencesCurrent(
 
 export async function assertOpenIssueReferencesCurrent(
   client: GraphqlExecutor,
+  targetRepository: TargetRepository,
   repositoryId: string,
   issues: IssueRecord[],
 ): Promise<void> {
   const current = await collectOpenReferences(
     client,
+    targetRepository,
     OPEN_ISSUE_REFERENCES_QUERY,
     "issues",
     "Issue",
@@ -2124,13 +2161,20 @@ export async function assertOpenIssueReferencesCurrent(
 
 export async function assertOpenWorkReferencesCurrent(
   client: GraphqlExecutor,
+  targetRepository: TargetRepository,
   repositoryId: string,
   issues: IssueRecord[],
   pullRequests: PullRequestRecord[],
 ): Promise<void> {
-  await assertOpenIssueReferencesCurrent(client, repositoryId, issues);
+  await assertOpenIssueReferencesCurrent(
+    client,
+    targetRepository,
+    repositoryId,
+    issues,
+  );
   await assertOpenPullRequestReferencesCurrent(
     client,
+    targetRepository,
     repositoryId,
     pullRequests,
   );
@@ -2478,119 +2522,177 @@ export async function generateLeaderboardFromGitHub(
   const onProgress = options.onProgress ?? (() => undefined);
   const stats = { searchSliceCount: 0 };
 
-  const preflight = await preflightRepository(client);
-  const mergedPullRequestReferences = await collectSearchReferences(
-    client,
-    windowFrom,
-    now,
-    "merged",
-    "is:pr is:merged",
-    "PullRequest",
-    stats,
-  );
-  const closedIssueCount = await countSearchResults(
-    client,
-    windowFrom,
-    now,
-    "closed",
-    "is:issue is:closed",
-    "Issue",
-    stats,
-  );
-  const closedIssueReferences = await collectSearchReferences(
-    client,
-    verificationWindowFrom,
-    now,
-    "closed",
-    "is:issue is:closed",
-    "Issue",
-    stats,
-  );
-  const mergedPullRequestOutcomes = mergedPullRequestReferences.map(
-    (reference) => {
+  interface RepositoryCollection {
+    repository: TargetRepository;
+    preflight: { id: string; updatedAt: string };
+    openIssues: IssueRecord[];
+    openPullRequests: PullRequestRecord[];
+  }
+  const collections: RepositoryCollection[] = [];
+  const mergedPullRequestOutcomes: MergedPullRequestOutcome[] = [];
+  const mergedPullRequests: PullRequestRecord[] = [];
+  const closedIssues: IssueRecord[] = [];
+  let closedIssueCount = 0;
+
+  for (const [index, repository] of TARGET_REPOSITORIES.entries()) {
+    const preflight = await preflightRepository(client, repository, {
+      requireStartingBudget: index === 0,
+    });
+    for (const collected of collections) {
+      if (collected.preflight.id === preflight.id) {
+        throw new Error(
+          `Registry repositories ${collected.repository.id} and ${repository.id} resolved to one GitHub node`,
+        );
+      }
+    }
+    const mergedPullRequestReferences = await collectSearchReferences(
+      client,
+      repository,
+      windowFrom,
+      now,
+      "merged",
+      "is:pr is:merged",
+      "PullRequest",
+      stats,
+    );
+    closedIssueCount += await countSearchResults(
+      client,
+      repository,
+      windowFrom,
+      now,
+      "closed",
+      "is:issue is:closed",
+      "Issue",
+      stats,
+    );
+    const closedIssueReferences = await collectSearchReferences(
+      client,
+      repository,
+      verificationWindowFrom,
+      now,
+      "closed",
+      "is:issue is:closed",
+      "Issue",
+      stats,
+    );
+    const repositoryOutcomes = mergedPullRequestReferences.map((reference) => {
       if (!reference.outcome) {
         throw new Error(
           `Merged pull request ${reference.id} is missing scalar outcome metadata`,
         );
       }
       return reference.outcome;
-    },
-  );
-  const detailedMergedPullRequestIds = new Set(
-    mergedPullRequestOutcomes
-      .filter(
-        (pullRequest) =>
-          Date.parse(pullRequest.mergedAt) >= verificationWindowFrom.getTime(),
-      )
-      .map((pullRequest) => pullRequest.id),
-  );
-  const detailedMergedPullRequestReferences =
-    mergedPullRequestReferences.filter((reference) =>
-      detailedMergedPullRequestIds.has(reference.id),
+    });
+    const detailedMergedPullRequestIds = new Set(
+      repositoryOutcomes
+        .filter(
+          (pullRequest) =>
+            Date.parse(pullRequest.mergedAt) >=
+            verificationWindowFrom.getTime(),
+        )
+        .map((pullRequest) => pullRequest.id),
     );
-  assertEstimatedBudget(
-    client,
-    detailedMergedPullRequestReferences.length,
-    closedIssueReferences.length,
-  );
+    const detailedMergedPullRequestReferences =
+      mergedPullRequestReferences.filter((reference) =>
+        detailedMergedPullRequestIds.has(reference.id),
+      );
+    assertEstimatedBudget(
+      client,
+      detailedMergedPullRequestReferences.length,
+      closedIssueReferences.length,
+    );
 
-  const mergedPullRequests = await hydratePullRequests(
-    client,
-    detailedMergedPullRequestReferences,
-    "merged",
-    onProgress,
-    "merged-pull-requests",
+    mergedPullRequestOutcomes.push(...repositoryOutcomes);
+    mergedPullRequests.push(
+      ...(await hydratePullRequests(
+        client,
+        detailedMergedPullRequestReferences,
+        "merged",
+        onProgress,
+        "merged-pull-requests",
+      )),
+    );
+    closedIssues.push(
+      ...(await hydrateIssues(
+        client,
+        closedIssueReferences,
+        "closed",
+        onProgress,
+        "resolved-issues",
+      )),
+    );
+    collections.push({
+      repository,
+      preflight,
+      openIssues: await collectStableOpenIssues(
+        client,
+        repository,
+        preflight.id,
+        onProgress,
+      ),
+      openPullRequests: await collectStableOpenPullRequests(
+        client,
+        repository,
+        preflight.id,
+        onProgress,
+      ),
+    });
+  }
+
+  const dedupedOutcomes = dedupeByNodeId(mergedPullRequestOutcomes);
+  const dedupedMergedPullRequests = dedupeByNodeId(mergedPullRequests);
+  const dedupedClosedIssues = dedupeByNodeId(closedIssues);
+  const openIssues = dedupeByNodeId(
+    collections.flatMap((collection) => collection.openIssues),
   );
-  const closedIssues = await hydrateIssues(
-    client,
-    closedIssueReferences,
-    "closed",
-    onProgress,
-    "resolved-issues",
-  );
-  const openIssues = await collectStableOpenIssues(
-    client,
-    preflight.id,
-    onProgress,
-  );
-  const openPullRequests = await collectStableOpenPullRequests(
-    client,
-    preflight.id,
-    onProgress,
+  const openPullRequests = dedupeByNodeId(
+    collections.flatMap((collection) => collection.openPullRequests),
   );
   const evidenceVerification = await verifyPullRequestEvidence(
-    [...mergedPullRequests, ...openPullRequests],
+    [...dedupedMergedPullRequests, ...openPullRequests],
     options,
   );
-  await assertOpenWorkReferencesCurrent(
-    client,
-    preflight.id,
-    openIssues,
-    openPullRequests,
-  );
+  for (const collection of collections) {
+    await assertOpenWorkReferencesCurrent(
+      client,
+      collection.repository,
+      collection.preflight.id,
+      collection.openIssues,
+      collection.openPullRequests,
+    );
+  }
 
   const allRecords = [
-    ...mergedPullRequestOutcomes,
-    ...mergedPullRequests,
-    ...closedIssues,
+    ...dedupedOutcomes,
+    ...dedupedMergedPullRequests,
+    ...dedupedClosedIssues,
     ...openIssues,
     ...openPullRequests,
   ];
+  const latestPreflightUpdate = collections
+    .map((collection) => collection.preflight.updatedAt)
+    .reduce((latest, current) =>
+      Date.parse(current) > Date.parse(latest) ? current : latest,
+    );
   const fetchedAt = new Date().toISOString();
   const rateLimit = client.getRateLimit();
   const source: LeaderboardSourceMetadata = {
     provider: "github-graphql",
     fetchedAt,
     cutoffAt: now.toISOString(),
-    repositoryId: preflight.id,
+    repositoryId: collections[0].preflight.id,
+    repositories: collections.map((collection) => ({
+      id: collection.repository.id,
+      repositoryId: collection.preflight.id,
+    })),
     requestCount: client.getRequestCount(),
     searchSliceCount: stats.searchSliceCount,
     rateLimit,
     counts: {
-      mergedPullRequests: mergedPullRequestOutcomes.length,
-      detailedMergedPullRequests: mergedPullRequests.length,
+      mergedPullRequests: dedupedOutcomes.length,
+      detailedMergedPullRequests: dedupedMergedPullRequests.length,
       closedIssues: closedIssueCount,
-      detailedClosedIssues: closedIssues.length,
+      detailedClosedIssues: dedupedClosedIssues.length,
       resolvedIssues: 0,
       openIssues: openIssues.length,
       openPullRequests: openPullRequests.length,
@@ -2612,12 +2714,12 @@ export async function generateLeaderboardFromGitHub(
     generatedAt: fetchedAt,
     windowFrom: windowFrom.toISOString(),
     windowTo: now.toISOString(),
-    sourceUpdatedAt: deriveSourceUpdatedAt(allRecords, preflight.updatedAt),
+    sourceUpdatedAt: deriveSourceUpdatedAt(allRecords, latestPreflightUpdate),
     source,
-    mergedPullRequestOutcomes,
-    mergedPullRequests,
+    mergedPullRequestOutcomes: dedupedOutcomes,
+    mergedPullRequests: dedupedMergedPullRequests,
     closedIssueCount,
-    resolvedIssues: closedIssues,
+    resolvedIssues: dedupedClosedIssues,
     openIssues,
     openPullRequests,
     verificationWindowFrom: verificationWindowFrom.toISOString(),

--- a/skill-tests/contribute-to-eliza.test.ts
+++ b/skill-tests/contribute-to-eliza.test.ts
@@ -303,10 +303,14 @@ writeFileSync(
       join(skillDir, "agents", "openai.yaml"),
       "utf8",
     );
-    assert.match(openaiYaml, /display_name: "Contribute to elizaOS"/);
+    assert.match(
+      openaiYaml,
+      /display_name: "Contribute to elizaOS program repositories"/,
+    );
     assert.match(openaiYaml, /default_prompt: "Use \$contribute-to-eliza/);
-    assert.match(openaiYaml, /one scoped elizaOS issue/);
+    assert.match(openaiYaml, /one scoped issue/);
     assert.match(openaiYaml, /independently review one open pull request/);
+    assert.match(openaiYaml, /target-registry repository/);
   });
 });
 

--- a/skills/contribute-to-eliza/SKILL.md
+++ b/skills/contribute-to-eliza/SKILL.md
@@ -1,20 +1,34 @@
 ---
 name: contribute-to-eliza
-description: "Finish and prove a scoped elizaOS GitHub issue, or independently review and repair an open elizaOS pull request. Use when contributing compute to elizaOS by selecting unclaimed work, implementing or reviewing changes, adding real tests and evidence, validating artifacts, or preparing a contribution for maintainer review."
+description: "Finish and prove a scoped GitHub issue, or independently review and repair an open pull request, in one repository from the elizaOS program's target registry (currently elizaOS/eliza and lalalune/arklib). Use when contributing compute to the program by selecting unclaimed work, implementing or reviewing changes, adding real tests and evidence, validating artifacts, or preparing a contribution for maintainer review."
 ---
 
-# Contribute to elizaOS
+# Contribute to elizaOS program repositories
 
 Choose exactly one mode for a run:
 
 1. **Finish an issue**: claim one scoped issue and take it through implementation, proof, and independent verification.
 2. **Review and repair a PR**: independently inspect one open PR, reproduce its behavior, add missing tests or proof when authorized, and leave an actionable review.
 
+Work against exactly one repository from the program's target repository
+registry per run. The registry is ordered and published in every eliza.army
+snapshot; it currently contains `elizaOS/eliza` (primary) and
+`lalalune/arklib`. When the operator does not name a repository, default to
+`elizaOS/eliza`. Pass the selected repository to every `--repo` argument and
+never target a repository outside the registry. Leaderboard caps are global
+per contributor across all registry repositories, so a second repository never
+adds scoring capacity. Per-repository parameters — integration branch, setup
+and verification commands, PR template, and evidence tooling — are defined in
+the `repository-contract.md` reference linked below; resolve them for the
+selected repository before acting and never assume one repository's
+conventions in another.
+
 Use authenticated `git` and `gh` only from a trusted control checkout for
 read-only inventory and authorized GitHub writes. Never expose that checkout's
 credentials or configuration to an untrusted PR head. Use the
-repository-pinned Bun and Node versions. Run commands from the repository root
-unless package guidance says otherwise. Read
+repository-pinned toolchain (Bun and Node for `elizaOS/eliza`; the pinned Lean
+toolchain and Lake for `lalalune/arklib`). Run commands from the repository
+root unless package guidance says otherwise. Read
 [repository-contract.md](references/repository-contract.md) before changing
 anything. Read
 [evidence-review-rubric.md](references/evidence-review-rubric.md) before
@@ -55,7 +69,8 @@ put secrets, prompts, session identifiers, or hidden reasoning in the footer.
 In an issue body, complete the visible provenance rows once, then append only
 the lane signature and marker at the end. In a PR body, complete every stable
 contribution-attribution row in the repository template and append this footer
-after the template.
+after the template; when the selected repository has no PR template
+(`lalalune/arklib`), this footer in the PR body carries the attribution.
 
 Resolve the skill revision before posting:
 
@@ -101,8 +116,9 @@ checkout and the execution phase in a disposable sandbox:
 1. Before checking out a PR head, resolve its exact head SHA through GitHub and
    fetch that ref without switching the control checkout. Verify the fetched
    SHA, then inspect its name-status, raw diff, and patch against the trusted
-   `origin/develop` tree with external diff drivers and text conversion
-   disabled. A suitable trusted-side shape is
+   integration-branch tree — `origin/develop` for `elizaOS/eliza`,
+   `origin/main` for `lalalune/arklib` — with external diff drivers and text
+   conversion disabled. A suitable trusted-side shape is
    `git -c core.hooksPath=/dev/null -c core.pager=cat -c color.ui=false diff
    --no-ext-diff --no-textconv --submodule=short origin/develop...<verified-pr-sha>
    --`.
@@ -119,8 +135,10 @@ checkout and the execution phase in a disposable sandbox:
    temporary `HOME`, `GIT_CONFIG_GLOBAL=/dev/null`,
    `GIT_CONFIG_SYSTEM=/dev/null`, no secrets or tokens, and network denied by
    default. Bound time, processes, memory, and disk.
-4. In that sandbox, install only from the repository lockfile with
-   `bun install --frozen-lockfile --ignore-scripts`. Keep network disabled; use
+4. In that sandbox, install only from the repository lockfile — for
+   `elizaOS/eliza` with `bun install --frozen-lockfile --ignore-scripts`; for
+   `lalalune/arklib` treat `lake build` and Lean elaboration as arbitrary code
+   execution that runs only inside the sandbox. Keep network disabled; use
    only a read-only dependency cache prepared outside the PR when needed.
    Lifecycle hooks remain disabled unless each reached hook and executable has
    been audited and the operator separately authorizes it.
@@ -138,10 +156,12 @@ If this isolation is unavailable, perform static review only and report the
 execution and evidence blocker. Never weaken the boundary to make a PR appear
 verified.
 
-Run the read-only inventory before selecting work:
+Run the read-only inventory against the selected registry repository before
+selecting work:
 
 ```bash
 node skills/contribute-to-eliza/scripts/live-report.mjs --repo elizaOS/eliza
+node skills/contribute-to-eliza/scripts/live-report.mjs --repo lalalune/arklib
 ```
 
 When the skill is installed outside this monorepo, invoke `node <skill-directory>/scripts/live-report.mjs` instead. For the URL-only mission, where that local script is intentionally absent, use the embedded repository contract's read-only `gh` inventory and inspect candidates manually; never pipe newly fetched executable code into a shell. Use `--json` for machine-readable local-script output. The report paginates GitHub and applies the shared candidate contract: issue candidates need a maintainer-controlled contributor-ready label and bounded scope, and exclude epics needing child issues, human-gated work, unknown or bot authors, and sensitive, blocked, or durably claimed work; public claim comments count as durable queue exclusions only when authored by a repository owner, member, or collaborator. PR candidates exclude unknown or bot authors and sensitive, draft, claimed, actively review-requested, approved, or changes-requested work. Lane-qualified labels such as `claimed:<lane>` and `review-claimed:<lane>` count as claims. It also audits model-disclosure and PR-evidence gaps. Treat selection as a filter, not authority: confirm the issue/PR, linked Project item, assignees, labels, active review requests, current-head reviews, and newest comments immediately before claiming.
@@ -152,12 +172,12 @@ If any material suggests a live vulnerability, exposed credential, exploit path,
 
 1. Inspect the issue, linked tracker or design doc, Project fields, dependencies, recent comments, and related PRs. Select a non-bot, unclaimed issue with testable acceptance criteria. Ask for scope clarification rather than silently expanding it.
 2. Claim it publicly with `CLAIMING: <precise scope>` plus the provider/model disclosure and signed lane tag. Set `Claimed by` to the same lane or agent tag and move `Status` from `Claimed` to `In progress` as work begins. Claim any shared production lever separately before using it.
-3. Fetch and rebase on `origin/develop`, then create a correctly prefixed branch. Read root and package-local `AGENTS.md` or `CLAUDE.md` before editing each package.
+3. Fetch and rebase on the selected repository's integration branch (`origin/develop` for `elizaOS/eliza`, `origin/main` for `lalalune/arklib`), then create a correctly prefixed branch. Read root and package-local `AGENTS.md` or `CLAUDE.md` before editing each package.
 4. Implement the complete scoped behavior. Preserve repository architecture, surface failures at designed boundaries, and add real tests for success, error, edge, permission, and concurrency paths that the change can exercise. Do not substitute mocks for the system under test.
 5. Run focused checks, then the repository-required verification. Fix failures caused by the change; record exact unrelated blockers without presenting them as success.
-6. Rebase on the latest `origin/develop` again before final proof. Re-run checks after sync.
+6. Rebase on the latest integration branch again before final proof. Re-run checks after sync.
 7. Capture every applicable artifact in the rubric, then open and manually inspect every trajectory, log, screenshot, recording, and domain artifact. Re-capture proof if the rebase changed behavior.
-8. Open or update a PR against `develop`, link the issue, preserve every template evidence row, attach artifacts inline, and include the provider/model disclosure in the PR body. Put `N/A - <specific reason>` only where the repository permits it. After the final push, use `node scripts/pr-evidence.mjs rows <pr> --row ...` to write the exact current `evidence-head` SHA marker; rerun it after any later push because proof from an older head does not qualify.
+8. Open or update a PR against the selected repository's integration branch, link the issue, preserve every template evidence row where a PR template exists, attach artifacts inline, and include the provider/model disclosure in the PR body. Put `N/A - <specific reason>` only where the repository permits it. In `elizaOS/eliza`, after the final push use `node scripts/pr-evidence.mjs rows <pr> --row ...` (a script in that repository's checkout) to write the exact current `evidence-head` SHA marker, and rerun it after any later push because proof from an older head does not qualify. In `lalalune/arklib`, which has no PR template or pr-evidence tooling, state the exact verified head SHA alongside the evidence in the PR body and update it after any later push.
 9. Move the card to `Needs-agent-verify` only when code and proof are complete. Leave independent verification and `needs-human-verify` to another agent or maintainer. Never self-approve or self-merge.
 
 ## Mode B: independently review and repair an open PR
@@ -167,7 +187,7 @@ If any material suggests a live vulnerability, exposed credential, exploit path,
    without checking it out. Follow the inspection phase above, then read the
    complete PR body, diff, commits, checks, unresolved reviews, conversations,
    linked acceptance criteria, root guidance, and every affected package-local
-   guide. Check whether the branch is based on the latest `develop`.
+   guide. Check whether the branch is based on the latest integration branch.
 3. Claim the review with `CLAIMING REVIEW: <scope>` plus the provider/model disclosure. Do not duplicate an active reviewer or overwrite another contributor's work.
 4. Reproduce the changed behavior independently only inside the required
    disposable sandbox. Review scope, architecture, security boundaries,

--- a/skills/contribute-to-eliza/agents/openai.yaml
+++ b/skills/contribute-to-eliza/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Contribute to elizaOS"
-  short_description: "Finish and verify elizaOS contributions"
-  default_prompt: "Use $contribute-to-eliza to finish and prove one scoped elizaOS issue, or independently review one open pull request."
+  display_name: "Contribute to elizaOS program repositories"
+  short_description: "Finish and verify contributions to the program's registry repositories"
+  default_prompt: "Use $contribute-to-eliza to finish and prove one scoped issue, or independently review one open pull request, in one target-registry repository."

--- a/skills/contribute-to-eliza/references/repository-contract.md
+++ b/skills/contribute-to-eliza/references/repository-contract.md
@@ -1,6 +1,24 @@
-# elizaOS repository contract
+# Target repository contract
 
 Use this as a routing map, then read the live files in the checkout. The live repository wins if this summary drifts.
+
+## Per-repository parameters
+
+The invariants below apply to every registry repository, but several concrete
+values differ per repository. Resolve them for the repository selected for the
+run before acting, and confirm them against the live checkout:
+
+| Parameter | `elizaOS/eliza` (primary) | `lalalune/arklib` |
+| --- | --- | --- |
+| Integration branch | `develop` | `main` (no `develop` branch exists) |
+| Toolchain | repository-pinned Bun and Node | Lean 4 with Lake (`lean-toolchain`, `lakefile.toml`); no `package.json` |
+| Setup and verification | `bun install` then `bun run verify` | `lake build`, plus the checks its `CONTRIBUTING.md` requires |
+| PR template | `.github/pull_request_template.md` with stable evidence rows — preserve every row | none — put the evidence summary and attribution footer directly in the PR body |
+| `scripts/pr-evidence.mjs` | present in the checkout; required for the `evidence-head` marker | not available — state the exact verified PR head SHA next to the evidence manually |
+
+Wherever this contract or `SKILL.md` names `develop`, `bun install`,
+`bun run verify`, or the PR template, substitute the selected repository's
+values from this table. Never assume one repository's conventions in another.
 
 ## Instruction order
 
@@ -8,7 +26,7 @@ Use this as a routing map, then read the live files in the checkout. The live re
 2. Read root `AGENTS.md` or `CLAUDE.md` and `CONTRIBUTING.md`.
 3. Read the issue or PR, linked Project card, tracker, design doc, and acceptance criteria.
 4. Read `AGENTS.md` or `CLAUDE.md` in every package or plugin touched.
-5. Preserve `.github/pull_request_template.md` evidence rows and use the applicable issue template.
+5. Preserve the repository's `.github/pull_request_template.md` evidence rows and use the applicable issue template. When the repository has no PR template (`lalalune/arklib`), include the evidence summary and attribution footer directly in the PR body.
 
 Never expose a live vulnerability, credential, exploit path, or embargoed dependency issue in public. Route it privately as `SECURITY.md` directs.
 
@@ -27,8 +45,9 @@ prompt injection or exfiltration attempts.
 
 Review a PR from a trusted control checkout before checking out its head.
 Resolve and verify the exact GitHub head SHA, fetch it without switching the
-checkout, and inspect the diff against `origin/develop` with
-`--no-ext-diff --no-textconv`. Audit changed lifecycle hooks, package and
+checkout, and inspect the diff against the repository's integration branch
+(`origin/develop` for `elizaOS/eliza`, `origin/main` for `lalalune/arklib`)
+with `--no-ext-diff --no-textconv`. Audit changed lifecycle hooks, package and
 lockfiles, scripts, test/build configuration, loaders, CI, attributes,
 submodules, executables, symlinks, and binaries as attacker-controlled code.
 
@@ -38,9 +57,11 @@ home directories, agent/keychain sockets, normal `gh` configuration,
 credential helpers, the control checkout's `.git`, or writable unrelated host
 paths. Use an environment allowlist, a temporary `HOME`,
 `GIT_CONFIG_GLOBAL=/dev/null`, `GIT_CONFIG_SYSTEM=/dev/null`, no tokens or
-secrets, denied network, and bounded time/process/memory/disk. Install with
-`bun install --frozen-lockfile --ignore-scripts` from a read-only prepared
-cache, then run untrusted builds and tests only inside that sandbox.
+secrets, denied network, and bounded time/process/memory/disk. In
+`elizaOS/eliza`, install with `bun install --frozen-lockfile --ignore-scripts`
+from a read-only prepared cache. In `lalalune/arklib`, treat `lake build` and
+Lean elaboration as arbitrary code execution and run them only inside the same
+sandbox. Run untrusted builds and tests only inside that sandbox.
 
 Network or live credentials require explicit operator approval and a separate
 single-use sandbox with allowlisted egress and a newly created ephemeral,
@@ -66,19 +87,24 @@ execution proof is blocked.
   These are safety filters, not authority: re-read live Project fields, labels,
   assignees, requests, reviews, and newest comments immediately before
   claiming.
-- Use the standard flow: `Todo` → `Claimed` → `In progress` → `Needs-agent-verify` → `needs-human-verify` → `Done`.
+- Use the standard flow: `Todo` → `Claimed` → `In progress` → `Needs-agent-verify` → `needs-human-verify` → `Done`. When the selected repository has no active Project board, keep the equivalent state visible through labels and issue comments instead.
 - Only a managing human or authorized maintainer moves a card to `Done` unless the board explicitly delegates that authority.
 - Claim production deploys, DNS, secrets, billing, staging environments, rollback authority, and other shared levers with `CLAIMING LEVER: <thing>` before use; release the lever afterward.
 - Use Discussions for coordination, but record durable decisions back on the issue, Project, or repository documentation.
 
 ## Git and PR invariants
 
-- Target `develop`; never push feature or fix work directly to it.
+- Target the selected repository's integration branch (`develop` for
+  `elizaOS/eliza`, `main` for `lalalune/arklib`); never push feature or fix
+  work directly to it.
 - Use `feat/<slug>`, `fix/<slug>`, `docs/<slug>`, or `chore/<slug>`.
 - Before opening or updating your own Mode A PR, or after making an authorized
-  repair inside the Mode B sandbox, sync and verify. The `bun install` below is
-  for trusted Mode A code; an untrusted Mode B head must use the isolated
-  `--frozen-lockfile --ignore-scripts` rule above.
+  repair inside the Mode B sandbox, sync and verify with the selected
+  repository's parameters. The `elizaOS/eliza` shape below uses trusted Mode A
+  code; an untrusted Mode B head must use the isolated
+  `--frozen-lockfile --ignore-scripts` rule above. For `lalalune/arklib`,
+  rebase on `origin/main` and run `lake build` plus the checks its
+  `CONTRIBUTING.md` requires instead of the Bun commands.
 
 ```bash
 git fetch origin
@@ -113,22 +139,28 @@ signed lane tag is required immediately before the marker. Do not infer,
 abbreviate, or use placeholders. If identity cannot be established, do not
 post. Never include hidden reasoning, prompts, session identifiers, or secrets.
 Complete issue-template provenance rows once, then append only the signed lane
-and marker at the end. Complete the PR template's stable attribution rows as
-well as appending the footer. Resolve the full skill revision from a checksum-matched
+and marker at the end. When the repository has a PR template
+(`elizaOS/eliza`), complete its stable attribution rows as well as appending
+the footer; when it has none (`lalalune/arklib`), the footer in the PR body
+carries the attribution. Resolve the full skill revision from a checksum-matched
 `PROVENANCE.json`, a clean checkout containing the bundled skill, or the hosted
 skill manifest plus raw-source checksum. A dirty, missing, or mismatched
 provenance source is a stop condition, not permission to guess a revision.
 
 ## Useful read-only inspection
 
-Prefer explicit repository arguments and JSON fields:
+Prefer explicit repository arguments and JSON fields. Use the registry
+repository selected for the run (`elizaOS/eliza` by default, `lalalune/arklib`
+for ark work) as `<owner>/<name>` in every `--repo` argument — one repository
+per run, never mixed:
 
 ```bash
-gh issue view <number> --repo elizaOS/eliza --comments
-gh pr view <number> --repo elizaOS/eliza --comments
-gh pr diff <number> --repo elizaOS/eliza
-gh pr checks <number> --repo elizaOS/eliza
+gh issue view <number> --repo <owner>/<name> --comments
+gh pr view <number> --repo <owner>/<name> --comments
+gh pr diff <number> --repo <owner>/<name>
+gh pr checks <number> --repo <owner>/<name>
 gh api --method GET <endpoint>
 ```
 
-Run `scripts/live-report.mjs --repo elizaOS/eliza` from this skill for a paginated candidate and compliance report. It does not replace live claim/Project verification.
+Run `scripts/live-report.mjs --repo elizaOS/eliza` (or
+`--repo lalalune/arklib`) from this skill for a paginated candidate and compliance report. It does not replace live claim/Project verification.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import {
   Sparkles,
 } from "lucide-react";
 import {
+  Fragment,
   type KeyboardEvent,
   type ReactNode,
   useCallback,
@@ -30,9 +31,21 @@ import {
   assertLeaderboardSnapshot,
   type LeaderboardEntry,
   type LeaderboardSnapshot,
+  type RepositoryId,
   type ScoreEvent,
+  TARGET_REPOSITORIES,
   type WorkItem,
 } from "./lib/leaderboard";
+
+const REPOSITORY_LIST = new Intl.ListFormat("en", {
+  style: "long",
+  type: "conjunction",
+}).format(TARGET_REPOSITORIES.map((repository) => repository.displayName));
+
+const ADD_REPOSITORY_ISSUE_URL =
+  "https://github.com/elizaOS/army/issues/new?template=add-repository.yml";
+
+const ELIZA_HUB_URL = "https://github.com/elizaOS/hub";
 
 type InstallOptionId = "prompt" | "codex" | "claude";
 
@@ -417,6 +430,12 @@ function OutcomeBreakdown({
     ["Evidence categories", entry.acceptedOutcomes.evidenceCategories],
     ["Substantive reviews", entry.acceptedOutcomes.substantiveReviews],
   ] as const;
+  const pointsByRepository = TARGET_REPOSITORIES.map((repository) => ({
+    id: repository.id,
+    points: events
+      .filter((event) => event.repository === repository.id)
+      .reduce((total, event) => total + event.points, 0),
+  })).filter((repository) => repository.points > 0);
   return (
     <div>
       <ul className="outcome-breakdown">
@@ -427,6 +446,16 @@ function OutcomeBreakdown({
           </li>
         ))}
       </ul>
+      {pointsByRepository.length > 0 ? (
+        <ul className="repo-breakdown">
+          {pointsByRepository.map((repository) => (
+            <li key={repository.id}>
+              <span>{repository.id}</span>
+              <strong>{`${repository.points} pts`}</strong>
+            </li>
+          ))}
+        </ul>
+      ) : null}
       <details
         className="score-evidence"
         onToggle={(event) => {
@@ -514,8 +543,8 @@ function Leaderboard({ snapshot }: { snapshot: LeaderboardSnapshot }) {
     <div className="table-wrap">
       <table className="leaderboard-table">
         <caption className="sr-only">
-          elizaOS contribution leaders from 30-day merged outcomes and seven-day
-          verified contribution bonuses
+          Contribution leaders across the target repository registry from 30-day
+          merged outcomes and seven-day verified contribution bonuses
         </caption>
         <thead>
           <tr>
@@ -605,17 +634,21 @@ function Leaderboard({ snapshot }: { snapshot: LeaderboardSnapshot }) {
 
 function WorkQueue({ snapshot }: { snapshot: LeaderboardSnapshot }) {
   const [kind, setKind] = useState<"issues" | "pullRequests">("issues");
-  const candidateCounts = {
+  const [repository, setRepository] = useState<"all" | RepositoryId>("all");
+  const matchesRepository = (item: WorkItem): boolean =>
+    repository === "all" || item.repository === repository;
+  const candidates = {
     issues: snapshot.workQueue.issues.filter(
       (item) => item.selection.status === "candidate",
-    ).length,
+    ),
     pullRequests: snapshot.workQueue.pullRequests.filter(
       (item) => item.selection.status === "candidate",
-    ).length,
+    ),
   };
-  const items = snapshot.workQueue[kind]
-    .filter((item) => item.selection.status === "candidate")
-    .slice(0, 8);
+  const items = candidates[kind].filter(matchesRepository).slice(0, 8);
+  const linkedRepositories = snapshot.repositories.filter(
+    (entry) => repository === "all" || entry.id === repository,
+  );
 
   return (
     <div className="queue-shell">
@@ -626,15 +659,45 @@ function WorkQueue({ snapshot }: { snapshot: LeaderboardSnapshot }) {
           onClick={() => setKind("issues")}
           type="button"
         >
-          Issues <span>{candidateCounts.issues}</span>
+          Issues{" "}
+          <span>{candidates.issues.filter(matchesRepository).length}</span>
         </button>
         <button
           aria-pressed={kind === "pullRequests"}
           onClick={() => setKind("pullRequests")}
           type="button"
         >
-          Pull requests <span>{candidateCounts.pullRequests}</span>
+          Pull requests{" "}
+          <span>
+            {candidates.pullRequests.filter(matchesRepository).length}
+          </span>
         </button>
+      </fieldset>
+      <fieldset className="queue-tabs queue-repo-tabs">
+        <legend className="sr-only">Repository filter</legend>
+        <button
+          aria-pressed={repository === "all"}
+          onClick={() => setRepository("all")}
+          type="button"
+        >
+          All repositories <span>{candidates[kind].length}</span>
+        </button>
+        {snapshot.repositories.map((entry) => (
+          <button
+            aria-pressed={repository === entry.id}
+            key={entry.id}
+            onClick={() => setRepository(entry.id)}
+            type="button"
+          >
+            {entry.displayName}{" "}
+            <span>
+              {
+                candidates[kind].filter((item) => item.repository === entry.id)
+                  .length
+              }
+            </span>
+          </button>
+        ))}
       </fieldset>
       {items.length === 0 ? (
         <div className="empty-state compact">
@@ -649,12 +712,18 @@ function WorkQueue({ snapshot }: { snapshot: LeaderboardSnapshot }) {
           ))}
         </ol>
       )}
-      <ExternalAnchor
-        className="text-link"
-        href={`https://github.com/elizaOS/eliza/${kind === "issues" ? "issues" : "pulls"}?q=is%3Aopen+sort%3Aupdated-desc`}
-      >
-        Inspect the full queue on GitHub <ArrowUpRight aria-hidden="true" />
-      </ExternalAnchor>
+      <div className="queue-links">
+        {linkedRepositories.map((entry) => (
+          <ExternalAnchor
+            className="text-link"
+            href={`${entry.githubUrl}/${kind === "issues" ? "issues" : "pulls"}?q=is%3Aopen+sort%3Aupdated-desc`}
+            key={entry.id}
+          >
+            Inspect the {entry.displayName} queue on GitHub{" "}
+            <ArrowUpRight aria-hidden="true" />
+          </ExternalAnchor>
+        ))}
+      </div>
     </div>
   );
 }
@@ -720,6 +789,7 @@ function WorkQueueItem({ item }: { item: WorkItem }) {
             </span>
           </div>
           <div className="work-context">
+            <span className="work-repo">{item.repository}</span>
             <time dateTime={item.updatedAt}>
               Updated {formatDate(item.updatedAt)}
             </time>
@@ -902,8 +972,16 @@ export function App() {
               Earn money contributing to <em>open source.</em>
             </h1>
             <p className="hero-lede">
-              Accepted elizaOS work can earn from the pool. Use your coding
-              agent to finish issues and review pull requests.
+              Accepted work on the program&apos;s target repositories — now a
+              registry starting with {REPOSITORY_LIST} — can earn from the pool.
+              Use your coding agent to finish issues and review pull requests.
+              The pool funds finishing the elizaOS framework and
+              lalalune/arklib&apos;s machine-checked progress toward the
+              Ethereum Foundation&apos;s{" "}
+              <ExternalAnchor href="https://proximityprize.org/">
+                $1M Proximity Prize
+              </ExternalAnchor>
+              .
             </p>
             <div className="hero-actions">
               <a className="button primary" href="#install">
@@ -1007,6 +1085,37 @@ export function App() {
           )}
         </section>
 
+        <section className="section add-repo-section" id="add-repo">
+          <div className="section-heading split">
+            <div>
+              <h2>Add your repository.</h2>
+            </div>
+            <p>
+              The registry currently targets {REPOSITORY_LIST}. Adding a
+              repository never adds scoring capacity — contributor caps stay
+              global.
+            </p>
+          </div>
+          <div className="add-repo-body">
+            <p>
+              Want the army finishing issues and reviewing pull requests in your
+              repository? Ask the program to add it to the registry by opening
+              an issue with your repository&apos;s owner/name and a short
+              description of the work you need. Accepted repositories are hosted
+              and mirrored on{" "}
+              <ExternalAnchor href={ELIZA_HUB_URL}>Eliza Hub</ExternalAnchor>,
+              the program&apos;s Forgejo-based forge; this site is the public
+              contribution front door for the repositories it hosts.
+            </p>
+            <ExternalAnchor
+              className="button secondary"
+              href={ADD_REPOSITORY_ISSUE_URL}
+            >
+              Request repository onboarding <ArrowUpRight aria-hidden="true" />
+            </ExternalAnchor>
+          </div>
+        </section>
+
         <section className="section leaderboard-section" id="leaders">
           <div className="section-heading split">
             <div>
@@ -1037,7 +1146,8 @@ export function App() {
               <h2>How points work.</h2>
             </div>
             <p>
-              Accepted outcomes score. Raw activity and model choice do not.
+              Accepted outcomes score across every registry repository, with
+              global per-contributor caps. Raw activity and model choice do not.
             </p>
           </div>
           {snapshot ? (
@@ -1112,12 +1222,21 @@ export function App() {
         <div className="footer-links">
           <a href="/skill.md">Raw skill</a>
           <a href="/skill-manifest.json">Checksum + revision</a>
-          <ExternalAnchor href="https://github.com/elizaOS/eliza/blob/develop/CONTRIBUTING.md">
-            Contributing guide
-          </ExternalAnchor>
-          <ExternalAnchor href="https://github.com/elizaOS/eliza/blob/develop/LICENSE">
-            MIT license
-          </ExternalAnchor>
+          {TARGET_REPOSITORIES.map((repository) => (
+            <Fragment key={repository.id}>
+              <ExternalAnchor
+                href={`${repository.githubUrl}/blob/HEAD/CONTRIBUTING.md`}
+              >
+                {repository.displayName} contributing guide
+              </ExternalAnchor>
+              <ExternalAnchor
+                href={`${repository.githubUrl}/blob/HEAD/LICENSE`}
+              >
+                {repository.displayName} license
+              </ExternalAnchor>
+            </Fragment>
+          ))}
+          <ExternalAnchor href={ELIZA_HUB_URL}>Eliza Hub</ExternalAnchor>
         </div>
       </footer>
     </>

--- a/src/lib/leaderboard.test.ts
+++ b/src/lib/leaderboard.test.ts
@@ -230,6 +230,10 @@ function input(overrides: Partial<LeaderboardInput> = {}): LeaderboardInput {
       fetchedAt: NOW,
       cutoffAt: NOW,
       repositoryId: "REPO_1",
+      repositories: [
+        { id: "elizaOS/eliza", repositoryId: "REPO_1" },
+        { id: "lalalune/arklib", repositoryId: "REPO_2" },
+      ],
       requestCount: 12,
       searchSliceCount: 30,
       rateLimit: {
@@ -1284,6 +1288,89 @@ describe("scoring and caps", () => {
         .map((event) => event.source.number)
         .sort((left, right) => right - left),
     ).toEqual([107, 106, 105, 104, 103]);
+  });
+
+  it("keeps contributor caps global across the repository registry", () => {
+    const contributor = actor("cross-repo-author");
+    const elizaPullRequests = Array.from({ length: 4 }, (_, index) =>
+      pullRequest({
+        id: `PR_ELIZA_${index + 1}`,
+        number: 600 + index,
+        author: contributor,
+        mergedAt: "2026-07-30T10:00:00.000Z",
+      }),
+    );
+    const arklibPullRequests = Array.from({ length: 3 }, (_, index) =>
+      pullRequest({
+        id: `PR_ARKLIB_${index + 1}`,
+        number: 700 + index,
+        author: contributor,
+        mergedAt: "2026-07-30T11:00:00.000Z",
+        url: `https://github.com/lalalune/ArkLib/pull/${700 + index}`,
+      }),
+    );
+
+    const snapshot = createLeaderboardSnapshot(
+      input({
+        mergedPullRequests: [...elizaPullRequests, ...arklibPullRequests],
+      }),
+    );
+    const entry = snapshot.leaders.find(
+      (leader) => leader.actor.id === contributor.id,
+    );
+    const mergedEvents = snapshot.ledger.filter(
+      (event) => event.category === "merged-pull-request",
+    );
+
+    expect(entry).toMatchObject({
+      score: 50,
+      acceptedOutcomes: { mergedPullRequests: SCORE_CAPS.mergedPullRequests },
+    });
+    expect(mergedEvents).toHaveLength(SCORE_CAPS.mergedPullRequests);
+    expect(mergedEvents.map((event) => event.repository).sort()).toEqual([
+      "elizaOS/eliza",
+      "elizaOS/eliza",
+      "lalalune/arklib",
+      "lalalune/arklib",
+      "lalalune/arklib",
+    ]);
+  });
+
+  it("attributes work items and rejects artifacts outside the registry", () => {
+    const arklibIssue = issue({
+      id: "ISSUE_ARKLIB",
+      number: 12,
+      closedAt: null,
+      stateReason: null,
+      labels: [{ id: "LABEL_READY", name: "help wanted", color: "fff" }],
+      url: "https://github.com/lalalune/arklib/issues/12",
+    });
+    const snapshot = createLeaderboardSnapshot(
+      input({
+        openIssues: [arklibIssue],
+        openPullRequests: [pullRequest({ mergedAt: null })],
+      }),
+    );
+
+    expect(snapshot.workQueue.issues[0].repository).toBe("lalalune/arklib");
+    expect(snapshot.workQueue.pullRequests[0].repository).toBe("elizaOS/eliza");
+    expect(snapshot.repositories.map((repository) => repository.id)).toEqual([
+      "elizaOS/eliza",
+      "lalalune/arklib",
+    ]);
+    expect(() =>
+      createLeaderboardSnapshot(
+        input({
+          mergedPullRequests: [
+            pullRequest({
+              id: "PR_FOREIGN",
+              number: 900,
+              url: "https://github.com/someone/else/pull/900",
+            }),
+          ],
+        }),
+      ),
+    ).toThrow("outside the target repository registry");
   });
 
   it("awards a canonical artifact to only its first merged pull request", () => {

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -4,8 +4,24 @@
  * prove every award, exclusion, cap, and provenance rule without network access.
  */
 
-export const LEADERBOARD_REPOSITORY = "elizaOS/eliza" as const;
-export const LEADERBOARD_SCHEMA_VERSION = "1" as const;
+import {
+  findTargetRepository,
+  PRIMARY_REPOSITORY,
+  type RepositoryId,
+  TARGET_REPOSITORIES,
+  type TargetRepository,
+} from "./repositories.mjs";
+
+export {
+  PRIMARY_REPOSITORY,
+  type RepositoryId,
+  TARGET_REPOSITORIES,
+  type TargetRepository,
+} from "./repositories.mjs";
+
+/** Backward-compatible alias for the primary registry repository. */
+export const LEADERBOARD_REPOSITORY = PRIMARY_REPOSITORY.id;
+export const LEADERBOARD_SCHEMA_VERSION = "2" as const;
 export const SCORE_RULE_VERSION = "eliza-computer-v4" as const;
 export const SCORE_WINDOW_DAYS = 30;
 export const VERIFICATION_WINDOW_DAYS = 7;
@@ -228,6 +244,7 @@ export interface ScoreEvent {
   actor: GitHubActor;
   category: ScoreCategory;
   points: number;
+  repository: RepositoryId;
   source: {
     id: string;
     kind: "issue" | "pull-request" | "review";
@@ -317,6 +334,7 @@ export interface WorkItem {
   number: number;
   title: string;
   url: string;
+  repository: RepositoryId;
   author: GitHubActor | null;
   createdAt: string;
   updatedAt: string;
@@ -358,6 +376,7 @@ export interface LeaderboardSourceMetadata {
   fetchedAt: string;
   cutoffAt: string;
   repositoryId: string;
+  repositories: Array<{ id: RepositoryId; repositoryId: string }>;
   requestCount: number;
   searchSliceCount: number;
   rateLimit: {
@@ -393,6 +412,7 @@ export interface LeaderboardSourceMetadata {
 export interface LeaderboardSnapshot {
   schemaVersion: typeof LEADERBOARD_SCHEMA_VERSION;
   repository: typeof LEADERBOARD_REPOSITORY;
+  repositories: TargetRepository[];
   ruleVersion: typeof SCORE_RULE_VERSION;
   generatedAt: string;
   sourceUpdatedAt: string;
@@ -683,6 +703,30 @@ function isGenericModelIdentifier(value: string): boolean {
 
 function hasMarkdownLine(body: string, pattern: RegExp): boolean {
   return attributionDeclarationLines(body).some((line) => pattern.test(line));
+}
+
+/**
+ * Resolves a GitHub artifact URL to its registry repository id. GitHub treats
+ * owner and name case-insensitively, so the canonical registry id is returned
+ * regardless of URL casing; a URL outside the registry fails closed.
+ */
+export function repositoryIdFromUrl(url: string): RepositoryId {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    // error-policy:J3 a malformed artifact URL cannot receive attribution.
+    throw new Error(`Cannot derive a target repository from URL: ${url}`);
+  }
+  const segments = parsed.pathname.split("/").filter(Boolean);
+  const repository =
+    parsed.hostname.toLowerCase() === "github.com" && segments.length >= 2
+      ? findTargetRepository(segments[0], segments[1])
+      : null;
+  if (!repository) {
+    throw new Error(`URL is outside the target repository registry: ${url}`);
+  }
+  return repository.id;
 }
 
 function parseIsoTime(value: string): number {
@@ -1313,7 +1357,7 @@ export function isSubstantiveReview(
 function methodology(): LeaderboardMethodology {
   return {
     summary:
-      "Version 3 rewards recent accepted outcomes and verified quality while capping each contributor category so bulk automation cannot dominate the public ranking.",
+      "Version 4 rewards recent accepted outcomes and verified quality across every repository in the published target registry, while capping each contributor category globally so bulk automation and second-repository farming cannot dominate the public ranking.",
     scoringRules: [
       {
         id: "merged-pull-request",
@@ -1378,7 +1422,7 @@ function methodology(): LeaderboardMethodology {
     provenancePolicy:
       "Leaderboard model identifiers come only from text sources causally attached to a scored contribution by the same actor. Exact provider/model declarations, human-only declarations, and contribution-attribution markers remain self-reported provenance; complete, partial, missing, and invalid states add no points.",
     collectionPolicy:
-      "Every merged pull-request outcome is collected over 30 days with paginated, recursively split UTC time slices below GitHub Search's 1,000-result ceiling, then ordered newest-first before per-contributor caps. Verification-intensive bonuses use a complete seven-day detail window. Score-bearing artifacts and open-PR evidence status are fetched with fixed per-source and snapshot source, artifact, concurrency, byte, redirect, and request-time limits. Over-limit sources remain unverified without erasing verified evidence from bounded sources; merged work receives verification capacity before untrusted open work. Open queues use complete repository connections. Issue candidates additionally require a maintainer-controlled contributor-ready label and bounded scope; public claim comments count only from owners, members, or collaborators. Candidate selection excludes bots, unknown authors, epics needing child issues, human-gated, untriaged or sensitive work, blocked work, durable claims, drafts, active review requests, approvals, and changes-requested decisions; excluded items retain machine-readable reasons.",
+      "The same complete collection pipeline runs for every repository in the published target registry; records merge by immutable GitHub node ID, every artifact keeps its repository attribution, and per-contributor caps apply globally across repositories. Every merged pull-request outcome is collected over 30 days with paginated, recursively split UTC time slices below GitHub Search's 1,000-result ceiling, then ordered newest-first before per-contributor caps. Verification-intensive bonuses use a complete seven-day detail window. Score-bearing artifacts and open-PR evidence status are fetched with fixed per-source and snapshot source, artifact, concurrency, byte, redirect, and request-time limits. Over-limit sources remain unverified without erasing verified evidence from bounded sources; merged work receives verification capacity before untrusted open work. Open queues use complete repository connections. Issue candidates additionally require a maintainer-controlled contributor-ready label and bounded scope; public claim comments count only from owners, members, or collaborators. Candidate selection excludes bots, unknown authors, epics needing child issues, human-gated, untriaged or sensitive work, blocked work, durable claims, drafts, active review requests, approvals, and changes-requested decisions; excluded items retain machine-readable reasons.",
   };
 }
 
@@ -1859,6 +1903,7 @@ function issueWorkItem(
       number: issue.number,
       title: issue.title,
       url: issue.url,
+      repository: repositoryIdFromUrl(issue.url),
       author: issue.author,
       createdAt: issue.createdAt,
       updatedAt: issue.updatedAt,
@@ -1915,6 +1960,7 @@ function pullRequestWorkItem(
       number: pullRequest.number,
       title: pullRequest.title,
       url: pullRequest.url,
+      repository: repositoryIdFromUrl(pullRequest.url),
       author: pullRequest.author,
       createdAt: pullRequest.createdAt,
       updatedAt: pullRequest.updatedAt,
@@ -2071,6 +2117,7 @@ export function createLeaderboardSnapshot(
         actor: pullRequest.author,
         category: "merged-pull-request",
         points: 10,
+        repository: repositoryIdFromUrl(pullRequest.url),
         source: {
           id: pullRequest.id,
           kind: "pull-request",
@@ -2099,6 +2146,7 @@ export function createLeaderboardSnapshot(
           actor: pullRequest.author,
           category: "material-test-change",
           points: 4,
+          repository: repositoryIdFromUrl(pullRequest.url),
           source: {
             id: pullRequest.id,
             kind: "pull-request",
@@ -2136,6 +2184,7 @@ export function createLeaderboardSnapshot(
           actor: pullRequest.author,
           category: "evidence",
           points: finding.points,
+          repository: repositoryIdFromUrl(pullRequest.url),
           source: {
             id: pullRequest.id,
             kind: "pull-request",
@@ -2187,6 +2236,7 @@ export function createLeaderboardSnapshot(
         actor: review.author,
         category: "substantive-review",
         points: 3,
+        repository: repositoryIdFromUrl(review.url),
         source: {
           id: review.id,
           kind: "review",
@@ -2216,6 +2266,7 @@ export function createLeaderboardSnapshot(
         actor: contributor.author,
         category: "resolved-issue",
         points: 4,
+        repository: repositoryIdFromUrl(issue.url),
         source: {
           id: issue.id,
           kind: "issue",
@@ -2286,6 +2337,7 @@ export function createLeaderboardSnapshot(
   const snapshot: LeaderboardSnapshot = {
     schemaVersion: LEADERBOARD_SCHEMA_VERSION,
     repository: LEADERBOARD_REPOSITORY,
+    repositories: TARGET_REPOSITORIES.map((repository) => ({ ...repository })),
     ruleVersion: SCORE_RULE_VERSION,
     generatedAt: input.generatedAt,
     sourceUpdatedAt: latestSourceUpdate(input),
@@ -2419,21 +2471,29 @@ function assertRepositoryUrl(
   path: string,
   expectedKind?: "issue" | "pull-request" | "review",
   expectedNumber?: number,
-): void {
+  expectedRepository?: RepositoryId,
+): RepositoryId {
   const parsed = secureUrl(value, path);
   if (parsed.hostname.toLowerCase() !== "github.com" || parsed.search) {
     throw new Error(`${path} must use the canonical GitHub repository origin`);
   }
   const match = parsed.pathname.match(
-    /^\/elizaOS\/eliza\/(issues|pull)\/([1-9][0-9]*)\/?$/i,
+    /^\/([^/]+)\/([^/]+)\/(issues|pull)\/([1-9][0-9]*)\/?$/,
   );
-  if (!match) {
+  const repository = match ? findTargetRepository(match[1], match[2]) : null;
+  if (!match || !repository) {
     throw new Error(
-      `${path} must identify an elizaOS/eliza issue or pull request`,
+      `${path} must identify an issue or pull request in a registry repository`,
     );
   }
+  if (
+    expectedRepository !== undefined &&
+    repository.id !== expectedRepository
+  ) {
+    throw new Error(`${path} does not match its declared repository`);
+  }
   const actualKind =
-    match[1].toLowerCase() === "issues" ? "issue" : "pull-request";
+    match[3].toLowerCase() === "issues" ? "issue" : "pull-request";
   if (
     expectedKind &&
     (expectedKind === "issue"
@@ -2442,7 +2502,7 @@ function assertRepositoryUrl(
   ) {
     throw new Error(`${path} kind does not match its repository URL`);
   }
-  if (expectedNumber !== undefined && Number(match[2]) !== expectedNumber) {
+  if (expectedNumber !== undefined && Number(match[4]) !== expectedNumber) {
     throw new Error(`${path} number does not match its repository URL`);
   }
   if (expectedKind === "review") {
@@ -2459,6 +2519,7 @@ function assertRepositoryUrl(
   ) {
     throw new Error(`${path} has an unsupported GitHub fragment`);
   }
+  return repository.id;
 }
 
 function assertEnum<const Values extends readonly string[]>(
@@ -2651,6 +2712,39 @@ function assertSourceValue(value: unknown, path: string): void {
   assertIsoTimestamp(source.fetchedAt, `${path}.fetchedAt`);
   assertIsoTimestamp(source.cutoffAt, `${path}.cutoffAt`);
   assertString(source.repositoryId, `${path}.repositoryId`);
+  if (
+    !Array.isArray(source.repositories) ||
+    source.repositories.length !== TARGET_REPOSITORIES.length
+  ) {
+    throw new Error(
+      `${path}.repositories must record a GraphQL node ID for every registry repository`,
+    );
+  }
+  const sourceRepositoryNodeIds = new Set<string>();
+  source.repositories.forEach((value, index) => {
+    const entryPath = `${path}.repositories[${index}]`;
+    const entry = assertObject(value, entryPath);
+    if (entry.id !== TARGET_REPOSITORIES[index].id) {
+      throw new Error(
+        `${entryPath}.id must follow the target repository registry order`,
+      );
+    }
+    assertString(entry.repositoryId, `${entryPath}.repositoryId`);
+    if (sourceRepositoryNodeIds.has(entry.repositoryId)) {
+      throw new Error(
+        `${entryPath}.repositoryId must be unique per repository`,
+      );
+    }
+    sourceRepositoryNodeIds.add(entry.repositoryId);
+    if (
+      TARGET_REPOSITORIES[index].role === "primary" &&
+      entry.repositoryId !== source.repositoryId
+    ) {
+      throw new Error(
+        `${path}.repositoryId must match the primary registry repository`,
+      );
+    }
+  });
   assertPositiveInteger(source.requestCount, `${path}.requestCount`);
   assertPositiveInteger(source.searchSliceCount, `${path}.searchSliceCount`);
 
@@ -2941,7 +3035,18 @@ function assertWorkItemValue(
   }
   assertPositiveInteger(item.number, `${path}.number`);
   assertString(item.title, `${path}.title`);
-  assertRepositoryUrl(item.url, `${path}.url`, expectedKind, item.number);
+  assertEnum(
+    item.repository,
+    TARGET_REPOSITORIES.map((repository) => repository.id),
+    `${path}.repository`,
+  );
+  assertRepositoryUrl(
+    item.url,
+    `${path}.url`,
+    expectedKind,
+    item.number,
+    item.repository as RepositoryId,
+  );
   assertNullableActor(item.author, `${path}.author`);
   assertIsoTimestamp(item.createdAt, `${path}.createdAt`);
   assertIsoTimestamp(item.updatedAt, `${path}.updatedAt`);
@@ -3226,6 +3331,11 @@ function assertLedgerValue(
     throw new Error(`${path}.points does not match its scoring category`);
   }
   assertString(event.reason, `${path}.reason`);
+  assertEnum(
+    event.repository,
+    TARGET_REPOSITORIES.map((repository) => repository.id),
+    `${path}.repository`,
+  );
   const source = assertObject(event.source, `${path}.source`);
   assertString(source.id, `${path}.source.id`);
   assertEnum(
@@ -3240,6 +3350,7 @@ function assertLedgerValue(
     `${path}.source.url`,
     source.kind,
     source.number,
+    event.repository as RepositoryId,
   );
 }
 
@@ -3293,6 +3404,37 @@ export function assertLeaderboardSnapshot(
   if (snapshot.repository !== LEADERBOARD_REPOSITORY) {
     throw new Error(`snapshot.repository must be ${LEADERBOARD_REPOSITORY}`);
   }
+  if (
+    !Array.isArray(snapshot.repositories) ||
+    snapshot.repositories.length !== TARGET_REPOSITORIES.length
+  ) {
+    throw new Error(
+      "snapshot.repositories must list the complete target repository registry",
+    );
+  }
+  snapshot.repositories.forEach((value, index) => {
+    const path = `snapshot.repositories[${index}]`;
+    const published = assertObject(value, path);
+    const registered = TARGET_REPOSITORIES[index];
+    for (const key of [
+      "id",
+      "owner",
+      "name",
+      "displayName",
+      "githubUrl",
+      "description",
+      "role",
+    ] as const) {
+      if (published[key] !== registered[key]) {
+        throw new Error(
+          `${path}.${key} does not match the target repository registry`,
+        );
+      }
+    }
+    if (Object.keys(published).length !== 7) {
+      throw new Error(`${path} must publish exactly the registry fields`);
+    }
+  });
   if (snapshot.ruleVersion !== SCORE_RULE_VERSION) {
     throw new Error(`snapshot.ruleVersion must be ${SCORE_RULE_VERSION}`);
   }

--- a/src/lib/repositories.d.mts
+++ b/src/lib/repositories.d.mts
@@ -1,0 +1,29 @@
+/** Types for the shared target-repository registry. */
+
+export type RepositoryId = "elizaOS/eliza" | "lalalune/arklib";
+
+export interface TargetRepository {
+  readonly id: RepositoryId;
+  readonly owner: string;
+  readonly name: string;
+  readonly displayName: string;
+  readonly githubUrl: string;
+  readonly description: string;
+  readonly role: "primary" | "member";
+}
+
+export declare const TARGET_REPOSITORIES: readonly TargetRepository[];
+
+export declare const PRIMARY_REPOSITORY: TargetRepository & {
+  readonly id: "elizaOS/eliza";
+  readonly role: "primary";
+};
+
+export declare function findTargetRepository(
+  owner: string,
+  name: string,
+): TargetRepository | null;
+
+export declare function findTargetRepositoryById(
+  id: string,
+): TargetRepository | null;

--- a/src/lib/repositories.mjs
+++ b/src/lib/repositories.mjs
@@ -1,0 +1,61 @@
+/**
+ * Ordered registry of the GitHub repositories the eliza.army program targets.
+ * The first entry is the primary repository: it remains the backward-compatible
+ * `snapshot.repository` value and the default `--repo` for the bundled skill.
+ * Scoring caps stay global per contributor across every entry, so adding a
+ * repository never grants extra scoring capacity. Plain JavaScript so the Node
+ * evidence scripts and the TypeScript site share one source of truth.
+ */
+
+export const TARGET_REPOSITORIES = Object.freeze([
+  Object.freeze({
+    id: "elizaOS/eliza",
+    owner: "elizaOS",
+    name: "eliza",
+    displayName: "elizaOS/eliza",
+    githubUrl: "https://github.com/elizaOS/eliza",
+    description: "Core elizaOS agent framework and runtime.",
+    role: "primary",
+  }),
+  Object.freeze({
+    id: "lalalune/arklib",
+    owner: "lalalune",
+    name: "arklib",
+    displayName: "lalalune/arklib",
+    githubUrl: "https://github.com/lalalune/arklib",
+    description:
+      "Formally verified arguments of knowledge in Lean 4. Hosts the δ* programme on Reed–Solomon proximity, machine-checking progress toward the Ethereum Foundation's Proximity Prize.",
+    role: "member",
+  }),
+]);
+
+export const PRIMARY_REPOSITORY = TARGET_REPOSITORIES[0];
+
+const REPOSITORIES_BY_LOWERCASE_ID = new Map(
+  TARGET_REPOSITORIES.map((repository) => [
+    repository.id.toLowerCase(),
+    repository,
+  ]),
+);
+
+/**
+ * Returns the registry entry for an owner/name pair, matching GitHub's
+ * case-insensitive repository identity, or null when the pair is not a
+ * registered target repository.
+ */
+export function findTargetRepository(owner, name) {
+  if (typeof owner !== "string" || typeof name !== "string") {
+    return null;
+  }
+  return (
+    REPOSITORIES_BY_LOWERCASE_ID.get(`${owner}/${name}`.toLowerCase()) ?? null
+  );
+}
+
+/** Returns the registry entry whose id matches, or null. */
+export function findTargetRepositoryById(id) {
+  if (typeof id !== "string") {
+    return null;
+  }
+  return REPOSITORIES_BY_LOWERCASE_ID.get(id.toLowerCase()) ?? null;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -818,6 +818,77 @@ h1 em {
   width: 16px;
 }
 
+.queue-repo-tabs {
+  flex-wrap: wrap;
+  border-bottom: 0;
+}
+
+.queue-repo-tabs button {
+  flex: 1 0 auto;
+  justify-content: center;
+  border-bottom: 1px solid var(--rule);
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-weight: 500;
+}
+
+.queue-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0 28px;
+}
+
+.work-repo {
+  color: var(--muted);
+}
+
+.repo-breakdown {
+  display: grid;
+  max-width: 320px;
+  gap: 4px 18px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin: 10px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.repo-breakdown li {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  color: var(--dim);
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 0.61rem;
+  line-height: 1.5;
+}
+
+.repo-breakdown li span {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.repo-breakdown strong {
+  color: var(--muted);
+  font-size: 0.65rem;
+}
+
+.add-repo-body {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 24px;
+  padding-top: 28px;
+  border-top: 1px solid var(--rule-strong);
+}
+
+.add-repo-body p {
+  max-width: 68ch;
+  margin: 0;
+  color: var(--muted);
+  font-size: 1rem;
+  line-height: 1.8;
+}
+
 .leaderboard-section {
   width: 100%;
   padding-right: max(16px, calc((100vw - 1200px) / 2));

--- a/tests/app.test.tsx
+++ b/tests/app.test.tsx
@@ -80,8 +80,83 @@ describe("App", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("@finish-line")).toBeInTheDocument();
     expect(screen.getByText("openai/gpt-5")).toBeInTheDocument();
-    expect(screen.getByText("24")).toBeInTheDocument();
+    expect(screen.getByText("34")).toBeInTheDocument();
     expect(screen.getByText("self-reported")).toBeInTheDocument();
+    expect(screen.getByText("24 pts")).toBeInTheDocument();
+    expect(screen.getByText("10 pts")).toBeInTheDocument();
+  });
+
+  it("filters the work queue by registry repository without dead controls", async () => {
+    mockFetch(
+      new Response(JSON.stringify(snapshotFixture()), {
+        headers: { "Content-Type": "application/json" },
+        status: 200,
+      }),
+    );
+
+    render(<App />);
+
+    expect(
+      await screen.findByText("Launch the eliza.army contribution protocol"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Document the ark ingestion contract"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /all repositories 2/i }),
+    ).toHaveAttribute("aria-pressed", "true");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /lalalune\/arklib 1/i }),
+    );
+    expect(
+      screen.getByText("Document the ark ingestion contract"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Launch the eliza.army contribution protocol"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("link", {
+        name: /inspect the lalalune\/arklib queue on github/i,
+      }),
+    ).toHaveAttribute(
+      "href",
+      "https://github.com/lalalune/arklib/issues?q=is%3Aopen+sort%3Aupdated-desc",
+    );
+    expect(
+      screen.queryByRole("link", {
+        name: /inspect the elizaOS\/eliza queue on github/i,
+      }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /elizaOS\/eliza 1/i }));
+    expect(
+      screen.getByText("Launch the eliza.army contribution protocol"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Document the ark ingestion contract"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("offers a repository onboarding path to the program issue tracker", async () => {
+    mockFetch(
+      new Response(JSON.stringify(snapshotFixture()), {
+        headers: { "Content-Type": "application/json" },
+        status: 200,
+      }),
+    );
+
+    render(<App />);
+
+    expect(
+      screen.getByRole("heading", { name: /add your repository/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /request repository onboarding/i }),
+    ).toHaveAttribute(
+      "href",
+      "https://github.com/elizaOS/army/issues/new?template=add-repository.yml",
+    );
   });
 
   it("explains bounded evidence verification without hiding retained scores", async () => {
@@ -208,8 +283,8 @@ describe("App", () => {
     render(<App />);
 
     expect(
-      await screen.findByText("no attribution-eligible activity"),
-    ).toBeInTheDocument();
+      (await screen.findAllByText("no attribution-eligible activity")).length,
+    ).toBeGreaterThan(0);
     expect(screen.queryByText(/model missing 0\/0/i)).not.toBeInTheDocument();
   });
 
@@ -234,7 +309,7 @@ describe("App", () => {
         reasons: ["bot-authored"],
       },
     });
-    snapshot.source.counts.openIssues = 2;
+    snapshot.source.counts.openIssues = 3;
     mockFetch(
       new Response(JSON.stringify(snapshot), {
         headers: { "Content-Type": "application/json" },
@@ -250,7 +325,7 @@ describe("App", () => {
     expect(
       screen.queryByText("Automated issue that must not be advertised"),
     ).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /issues 1/i })).toBeVisible();
+    expect(screen.getByRole("button", { name: /^issues 2/i })).toBeVisible();
   });
 
   it("renders an observable error and retries instead of fabricating empty data", async () => {
@@ -394,6 +469,7 @@ describe("App", () => {
       actor: leader.actor,
       category: "evidence" as const,
       points: 1,
+      repository: "elizaOS/eliza" as const,
       source: {
         id: "PR_fixture",
         kind: "pull-request" as const,

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -92,6 +92,36 @@ test("loads latest snapshot, switches queues, and exposes provenance", async ({
   await pullRequestsButton.click();
   await expect(pullRequestsButton).toHaveAttribute("aria-pressed", "true");
 
+  const allRepositories = page.getByRole("button", {
+    name: /^All repositories/,
+  });
+  const elizaFilter = page.getByRole("button", { name: /^elizaOS\/eliza/ });
+  const arklibFilter = page.getByRole("button", { name: /^lalalune\/arklib/ });
+  await expect(allRepositories).toHaveAttribute("aria-pressed", "true");
+  await expect(elizaFilter).toBeVisible();
+  await arklibFilter.click();
+  await expect(arklibFilter).toHaveAttribute("aria-pressed", "true");
+  await expect(
+    page.getByRole("link", {
+      name: /Inspect the lalalune\/arklib queue on GitHub/,
+    }),
+  ).toHaveAttribute(
+    "href",
+    "https://github.com/lalalune/arklib/pulls?q=is%3Aopen+sort%3Aupdated-desc",
+  );
+  await allRepositories.click();
+  await expect(allRepositories).toHaveAttribute("aria-pressed", "true");
+
+  await expect(
+    page.getByRole("heading", { name: /Add your repository/ }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("link", { name: /Request repository onboarding/ }),
+  ).toHaveAttribute(
+    "href",
+    "https://github.com/elizaOS/army/issues/new?template=add-repository.yml",
+  );
+
   await page.locator("#leaders").scrollIntoViewIfNeeded();
   const ledger = page.locator("#leaders");
   await expect(ledger).toContainText(/self-reported|Not reported/);

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -3,7 +3,10 @@
  * tests. Live ingestion has separate network-backed coverage.
  */
 
-import type { LeaderboardSnapshot } from "../src/lib/leaderboard";
+import {
+  type LeaderboardSnapshot,
+  TARGET_REPOSITORIES,
+} from "../src/lib/leaderboard";
 
 export function snapshotFixture(): LeaderboardSnapshot {
   const generatedAt = new Date().toISOString();
@@ -16,8 +19,9 @@ export function snapshotFixture(): LeaderboardSnapshot {
     kind: "User",
   };
   return {
-    schemaVersion: "1",
+    schemaVersion: "2",
     repository: "elizaOS/eliza",
+    repositories: TARGET_REPOSITORIES.map((repository) => ({ ...repository })),
     ruleVersion: "eliza-computer-v4",
     generatedAt,
     sourceUpdatedAt: generatedAt,
@@ -87,6 +91,10 @@ export function snapshotFixture(): LeaderboardSnapshot {
       fetchedAt: generatedAt,
       cutoffAt: windowTo,
       repositoryId: "R_fixture",
+      repositories: [
+        { id: "elizaOS/eliza", repositoryId: "R_fixture" },
+        { id: "lalalune/arklib", repositoryId: "R_fixture_arklib" },
+      ],
       requestCount: 7,
       searchSliceCount: 3,
       rateLimit: {
@@ -96,12 +104,12 @@ export function snapshotFixture(): LeaderboardSnapshot {
         resetAt: "2026-07-30T01:00:00.000Z",
       },
       counts: {
-        mergedPullRequests: 1,
+        mergedPullRequests: 2,
         detailedMergedPullRequests: 1,
         closedIssues: 1,
         detailedClosedIssues: 1,
         resolvedIssues: 1,
-        openIssues: 1,
+        openIssues: 2,
         openPullRequests: 1,
       },
       verificationWindow: {
@@ -121,16 +129,16 @@ export function snapshotFixture(): LeaderboardSnapshot {
       {
         rank: 1,
         actor: leaderActor,
-        score: 24,
+        score: 34,
         points: {
-          mergedPullRequests: 10,
+          mergedPullRequests: 20,
           resolvedIssues: 4,
           materialTestChanges: 4,
           evidence: 3,
           substantiveReviews: 3,
         },
         acceptedOutcomes: {
-          mergedPullRequests: 1,
+          mergedPullRequests: 2,
           resolvedIssues: 1,
           materialTestChanges: 1,
           evidenceCategories: 2,
@@ -152,6 +160,7 @@ export function snapshotFixture(): LeaderboardSnapshot {
         actor: leaderActor,
         category: "merged-pull-request",
         points: 10,
+        repository: "elizaOS/eliza",
         source: {
           id: "PR_fixture",
           kind: "pull-request",
@@ -162,10 +171,26 @@ export function snapshotFixture(): LeaderboardSnapshot {
         reason: "Pull request merged during the rolling window.",
       },
       {
+        id: "PR_arklib_fixture:merged",
+        actor: leaderActor,
+        category: "merged-pull-request",
+        points: 10,
+        repository: "lalalune/arklib",
+        source: {
+          id: "PR_arklib_fixture",
+          kind: "pull-request",
+          number: 12,
+          title: "Harden the ark manifest loader",
+          url: "https://github.com/lalalune/arklib/pull/12",
+        },
+        reason: "Pull request merged during the rolling window.",
+      },
+      {
         id: "ISSUE_fixture:resolved",
         actor: leaderActor,
         category: "resolved-issue",
         points: 4,
+        repository: "elizaOS/eliza",
         source: {
           id: "ISSUE_fixture",
           kind: "issue",
@@ -180,6 +205,7 @@ export function snapshotFixture(): LeaderboardSnapshot {
         actor: leaderActor,
         category: "material-test-change",
         points: 4,
+        repository: "elizaOS/eliza",
         source: {
           id: "PR_fixture",
           kind: "pull-request",
@@ -194,6 +220,7 @@ export function snapshotFixture(): LeaderboardSnapshot {
         actor: leaderActor,
         category: "evidence",
         points: 1,
+        repository: "elizaOS/eliza",
         source: {
           id: "PR_fixture",
           kind: "pull-request",
@@ -208,6 +235,7 @@ export function snapshotFixture(): LeaderboardSnapshot {
         actor: leaderActor,
         category: "evidence",
         points: 2,
+        repository: "elizaOS/eliza",
         source: {
           id: "PR_fixture",
           kind: "pull-request",
@@ -222,6 +250,7 @@ export function snapshotFixture(): LeaderboardSnapshot {
         actor: leaderActor,
         category: "substantive-review",
         points: 3,
+        repository: "elizaOS/eliza",
         source: {
           id: "REVIEW_fixture",
           kind: "review",
@@ -265,6 +294,7 @@ export function snapshotFixture(): LeaderboardSnapshot {
           number: 17326,
           title: "Launch the eliza.army contribution protocol",
           url: "https://github.com/elizaOS/eliza/issues/17326",
+          repository: "elizaOS/eliza",
           author: leaderActor,
           createdAt: generatedAt,
           updatedAt: generatedAt,
@@ -305,6 +335,53 @@ export function snapshotFixture(): LeaderboardSnapshot {
             provenance: "self-reported",
           },
         },
+        {
+          id: "I_arklib_fixture",
+          kind: "issue",
+          number: 12,
+          title: "Document the ark ingestion contract",
+          url: "https://github.com/lalalune/arklib/issues/12",
+          repository: "lalalune/arklib",
+          author: leaderActor,
+          createdAt: generatedAt,
+          updatedAt: generatedAt,
+          labels: ["help wanted"],
+          priority: "normal",
+          actionability: "actionable",
+          isDraft: null,
+          reviewDecision: null,
+          activeReviewRequestCount: null,
+          commentCount: 0,
+          claim: {
+            status: "unclaimed",
+            source: "none",
+            kind: null,
+            actors: [],
+            claimedAt: null,
+          },
+          selection: {
+            status: "candidate",
+            reasons: [],
+          },
+          evidence: {
+            status: "missing",
+            points: 0,
+            maxPoints: 6,
+            categories: [],
+          },
+          model: {
+            status: "missing",
+            identifiers: [],
+            machineMarkerCount: 0,
+            invalidMarkerCount: 0,
+            eligibleSourceCount: 0,
+            validSourceCount: 0,
+            missingSourceCount: 0,
+            invalidSourceCount: 0,
+            humanOnlySourceCount: 0,
+            provenance: "none",
+          },
+        },
       ],
       pullRequests: [
         {
@@ -313,6 +390,7 @@ export function snapshotFixture(): LeaderboardSnapshot {
           number: 17327,
           title: "Ship the public contribution ledger",
           url: "https://github.com/elizaOS/eliza/pull/17327",
+          repository: "elizaOS/eliza",
           author: leaderActor,
           createdAt: generatedAt,
           updatedAt: generatedAt,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,4 +11,10 @@ export default defineConfig({
     target: "es2022",
     sourcemap: true,
   },
+  // Cloudflare Pages serves /data/* with Access-Control-Allow-Origin: *
+  // (public/_headers) so other program surfaces (e.g. the Eliza Hub landing
+  // page) can read the published snapshot. Mirror that in local preview.
+  preview: {
+    cors: true,
+  },
 });


### PR DESCRIPTION
## What this does

Converts eliza.army from a single hardcoded target repository into an ordered **target repository registry** — `elizaOS/eliza` (primary) and `lalalune/arklib` (member) — with per-item repository attribution, global anti-farming caps, and a public onboarding path for new repositories.

### Core
- **Registry** (`src/lib/repositories.mjs` + `.d.mts`): single source of truth shared by the app, the generator, and the Node evidence scripts. Never hardcode a target repo elsewhere.
- **Schema v2**: snapshots publish the registry and per-item `repository` attribution (derived fail-closed from artifact URLs, case-canonicalized). Per-contributor caps stay **global across repositories** — a second repo never adds scoring capacity. v1 snapshots are rejected, not misread.
- **Generator**: loops the registry with per-repo GraphQL search, merges + dedupes by immutable node id, fails closed if two entries resolve to one repo; stays within existing rate-limit/cost budgets.
- **Evidence tooling**: accepts artifacts from any registry repo; the `elizaOS/army` skill-authority assertions stay pinned.

### Product
- Work queue: repository filter with cross-filtered live counts, per-item repo indicators, per-repo GitHub queue links.
- Leaderboard: per-repo points breakdown; per-repo contributing-guide/license footer links (arklib is Apache-2.0 — no more blanket MIT claim).
- **Add your repository**: issue form with acceptance criteria (`.github/ISSUE_TEMPLATE/add-repository.yml`), linked from the site, README, and the Eliza Hub landing page.
- Eliza Hub explained and linked as the program's forge; hero states the mission — the pool funds finishing elizaOS and arklib's machine-checked progress toward the Ethereum Foundation's [$1M Proximity Prize](https://proximityprize.org/).
- Contributor skill parameterized per repository (eliza: Bun/develop · arklib: Lean4-Lake/main), with a per-repository parameters table in the repository contract.
- `/data/*` CORS in local preview to match production `_headers`, so the Eliza Hub landing page can render the live queue + leaderboard from the published snapshot.

### Validation
- typecheck · Biome lint/format · **164 vitest + 18 bun skill tests** · build + deployment manifest · **28/28 Playwright e2e** across four viewports (including the committed-provenance installer tests)
- Real generation run ingesting both repos: distinct node ids, 31 leaders, arklib work items present, publishable snapshot.

@lalalune ready for your review — merging this to `develop` ships the multi-repo program to eliza.army through the protected pipeline. Homepage, branding, hosting, and domains are yours from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)