### PR TITLE
Docs: CONTRIBUTING and PRODUCT reflect the target repository registry

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,8 +2,10 @@
 
 Changes to the eliza.army site, contributor skill, leaderboard pipeline, and
 deployment automation are developed in this repository. Product contributions
-that the leaderboard tracks still belong in
-[`elizaOS/eliza`](https://github.com/elizaOS/eliza).
+that the leaderboard tracks belong in the target repository registry
+(`src/lib/repositories.mjs`) — currently
+[`elizaOS/eliza`](https://github.com/elizaOS/eliza) and
+[`lalalune/arklib`](https://github.com/lalalune/arklib).
 
 Open an issue before non-trivial work. Branch from the latest `develop`, keep
 the change scoped, and open a pull request back to `develop`. Before requesting

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -15,8 +15,10 @@ a reviewable record for maintainers.
 ## Product Purpose
 
 eliza.army connects contributors to a $10,000 monthly USDC pool for accepted
-elizaOS work. It provides one agent workflow, an unclaimed work queue, and a
-public record of tested contributions and their model provenance.
+work on the program's target repository registry, starting with the elizaOS
+framework and lalalune/arklib. It provides one agent workflow, an unclaimed
+work queue, and a public record of tested contributions and their model
+provenance.
 
 ## Brand Personality
 


### PR DESCRIPTION
Follow-up to #6: CONTRIBUTING.md still said tracked contributions "belong in elizaOS/eliza" and PRODUCT.md's purpose line was single-repo. Both now point at the target repository registry (elizaOS/eliza and lalalune/arklib).

🤖 Generated with [Claude Code](https://claude.com/claude-code)