### PR TITLE
Operator payout planner (dry-run) and project proposal form

### DIFF
--- a/.github/ISSUE_TEMPLATE/start-a-project.yml
+++ b/.github/ISSUE_TEMPLATE/start-a-project.yml
@@ -1,0 +1,107 @@
+name: Start a project
+description: Propose an agent-built project, or offer to fund one.
+title: "Start a project: <project name>"
+labels: ["start-a-project"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form to propose a project for the program to build with coding
+        agents, or to offer to fund one. Opening an issue starts an evaluation
+        and nothing else: it is not an agreement, not a commitment of money, an
+        amount, or a date, and not acceptance into the target registry
+        (`src/lib/repositories.mjs`). The program answers on the issue.
+
+        The program evaluates whether the work is public and open source,
+        bounded enough for coding agents to finish, verifiable by commands that
+        run in CI, and backed by named maintainers who will review agent pull
+        requests. Funding decisions are discretionary and made separately from
+        this issue; funding a project never buys leaderboard points, ranking, or
+        a payout.
+
+        No money moves through this issue. Never post payment credentials,
+        account details, private keys, or seed phrases here.
+
+        If the repository already exists and you only want contributors working
+        it, use the
+        [Add repository](https://github.com/elizaOS/army/issues/new?template=add-repository.yml)
+        form instead.
+  - type: input
+    id: project
+    attributes:
+      label: Project
+      description: The project name and one sentence describing what it does.
+      placeholder: name — one-sentence description
+    validations:
+      required: true
+  - type: dropdown
+    id: intent
+    attributes:
+      label: What you are asking for
+      options:
+        - Proposing a project for the program to build
+        - Offering to fund work on a project
+        - Both — proposing a project and offering to fund it
+    validations:
+      required: true
+  - type: textarea
+    id: outcome
+    attributes:
+      label: What exists when it is done
+      description: The concrete result, who uses it, and how anyone can tell it works.
+    validations:
+      required: true
+  - type: input
+    id: repository
+    attributes:
+      label: Repository
+      description: GitHub `owner/name` of the existing repository, or `none` if the code does not exist yet.
+      placeholder: owner/name
+    validations:
+      required: true
+  - type: input
+    id: license
+    attributes:
+      label: License
+      description: The public open-source license the project uses or will use (for example `MIT` or `Apache-2.0`).
+    validations:
+      required: true
+  - type: textarea
+    id: verification
+    attributes:
+      label: How a change is verified
+      description: The exact commands that set up and verify a change (for example `bun install && bun run verify`, or `lake build`), and whether they run in CI today.
+    validations:
+      required: true
+  - type: textarea
+    id: first-work
+    attributes:
+      label: First units of work
+      description: Three to five bounded pieces of work an agent could pick up first, and what makes each one accepted.
+    validations:
+      required: true
+  - type: input
+    id: maintainers
+    attributes:
+      label: Maintainer contact
+      description: GitHub handle(s) of the maintainers who will label contributor-ready issues and review agent pull requests.
+    validations:
+      required: true
+  - type: textarea
+    id: funding
+    attributes:
+      label: Funding you are offering
+      description: Only if you are offering to fund this work — what you want funded and the scale you have in mind. Leave blank when you are proposing a project without funding it. Never include payment credentials or account details.
+  - type: checkboxes
+    id: acknowledgements
+    attributes:
+      label: Acknowledgements
+      options:
+        - label: The project is or will be public and open source under the license above.
+          required: true
+        - label: Maintainers will label contributor-ready issues and review agent pull requests.
+          required: true
+        - label: I understand this issue starts an evaluation and commits no funding, amount, date, or registry placement.
+          required: true
+        - label: I understand contributor scoring caps are global across the registry, so a new repository adds no scoring capacity, and funding a project never buys leaderboard points or payouts.
+          required: true

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 playwright-report/
 test-results/
 evidence/
+plans/
 public/brand/
 public/downloads/
 public/skill.md

--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ door for the repositories it hosts. Teams that want the army contributing to
 their repository can request onboarding by
 [opening an issue](https://github.com/elizaOS/army/issues/new?template=add-repository.yml)
 on `elizaOS/army`. The issue form states what an onboarding request must
-include and what happens after acceptance.
+include and what happens after acceptance. Teams without a repository yet, or
+teams offering to fund one, can
+[propose or sponsor a project](https://github.com/elizaOS/army/issues/new?template=start-a-project.yml)
+with the project intake form; opening either issue starts an evaluation and
+commits no funding, amount, or date.
 
 If selected for a payout, publish a public Solana or Ethereum address through
 the [elizaOS profile editor](https://eliza.app/profile/edit). The editor
@@ -108,6 +112,58 @@ Pull-request authors never count as their own review claimant.
 
 The public methodology, window, caps, exclusions, rule version, and refresh
 timestamp ship inside every snapshot and are rendered on the site.
+
+## Operator payout planning
+
+`scripts/plan-payouts.ts` is an operator planning tool. It reads the published
+snapshot and prints a deterministic plan of how a pool would divide across the
+contributors the ledger scores. It moves no money, credits no balance, calls no
+payment or account service, and does not determine payouts. Leaderboard points
+still do not determine payouts, and no distribution rule has been approved: the
+model is an input the operator chooses, and every input is recorded in the plan
+so any plan can be recomputed and audited.
+
+`--pool` and `--model` are both required. The planner assumes neither a pool
+size nor a distribution model, because a default model would be an unapproved
+answer to how money splits.
+
+```bash
+bun run payouts:plan --pool 10000 --model proportional-by-points-v1
+bun run payouts:plan --pool 10000 --model equal-share-v1 --currency USDC
+bun run payouts:plan --pool 10000 --model equal-share-v1 --minimum-points 10 \
+  --out ~/eliza-army-plans/draft.json
+```
+
+The readable summary is written to stderr and the plan document to stdout.
+`--out` additionally writes the document atomically. A plan lists every scoring
+contributor's GitHub identity beside an amount, and this repository is public,
+so `--out` refuses any path inside `public/` and any path Git can track: write
+plans outside the working tree, or into the Git-ignored `plans/` directory.
+
+Only non-bot GitHub user accounts can hold a share. The published snapshot
+contract permits `Bot`, `Mannequin`, `Organization`, and `Unknown` actors, so
+the planner re-checks every leader instead of trusting the generator's bot
+exclusion: a bot or non-user leader fails the whole plan and points at the
+ledger that has to be regenerated.
+
+Money exists only as integer minor units of the selected currency (USD cents or
+USDC micro-units); no amount becomes a floating-point number. Each share is
+`floor(pool * weight / totalWeight)`. The leftover minor units — always fewer
+than the number of eligible contributors — are awarded one each by descending
+exact remainder, then by the plan's canonical order: weight, then lowercased
+login, login, and immutable actor ID. Published rank is deliberately not an
+ordering input, because equal scores receive different ranks purely by login.
+Allocations therefore sum to the pool exactly, and no contributor receives more
+than one minor unit above their exact share.
+
+Every allocation carries the contributor's GitHub identity and an explicitly
+unresolved `payee` record. No GitHub-identity-to-Eliza-Cloud-account mapping
+exists in this repository, so each plan reports that linkage as missing and
+lists it among the execution blockers instead of assuming an account.
+
+The planner never guesses. A missing, empty, malformed, contract-violating, or
+older-than-eight-hour snapshot fails loudly, as do an empty eligible set and a
+zero pool; it never emits an empty or zero plan.
 
 ## Deployment
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "predev": "bun run prepare:site",
     "prebuild": "bun run prepare:site",
     "leaderboard:generate": "bun scripts/generate-leaderboard.ts",
+    "payouts:plan": "bun scripts/plan-payouts.ts",
     "typecheck": "tsc -b",
     "test": "vitest run && bun test skill-tests/contribute-to-eliza.test.ts",
     "test:e2e": "playwright test",

--- a/scripts/plan-payouts.test.ts
+++ b/scripts/plan-payouts.test.ts
@@ -1,0 +1,893 @@
+/**
+ * Proves the operator payout planner splits a pool exactly, orders and rounds
+ * deterministically, never overpays a contributor, and refuses stale, invalid,
+ * or empty inputs instead of emitting a plan nobody can audit.
+ */
+
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import type {
+  GitHubActorKind,
+  LeaderboardEntry,
+  LeaderboardSnapshot,
+  ScoreEvent,
+} from "../src/lib/leaderboard";
+import { snapshotFixture } from "../tests/fixtures";
+import {
+  ACCOUNT_LINKAGE_STATUS,
+  allocateByWeight,
+  assertOperatorOutputPath,
+  createPayoutPlan,
+  type DistributionModelId,
+  ELIGIBLE_ACTOR_REQUIREMENT,
+  formatMinorUnits,
+  formatPayoutPlanSummary,
+  MAX_SNAPSHOT_AGE_HOURS,
+  OPERATOR_PLAN_DIRECTORY,
+  type PayoutCurrencyCode,
+  type PayoutPlan,
+  PUBLISHED_SITE_DIRECTORY,
+  parseDecimalToMinorUnits,
+  parsePayoutPlanArguments,
+  REPOSITORY_ROOT,
+  runPayoutPlanner,
+  type SnapshotSource,
+  writePlanAtomically,
+} from "./plan-payouts";
+
+const SNAPSHOT_DIGEST = `sha256:${"a".repeat(64)}`;
+const HOUR_MS = 60 * 60 * 1000;
+
+interface ContributorSpec {
+  login: string;
+  kind?: GitHubActorKind;
+  mergedPullRequests?: number;
+  substantiveReviews?: number;
+}
+
+function compareFixtureEntries(
+  left: LeaderboardEntry,
+  right: LeaderboardEntry,
+): number {
+  if (left.score !== right.score) {
+    return right.score - left.score;
+  }
+  const leftLower = left.actor.login.toLowerCase();
+  const rightLower = right.actor.login.toLowerCase();
+  if (leftLower !== rightLower) {
+    return leftLower < rightLower ? -1 : 1;
+  }
+  if (left.actor.login !== right.actor.login) {
+    return left.actor.login < right.actor.login ? -1 : 1;
+  }
+  return left.actor.id < right.actor.id ? -1 : 1;
+}
+
+/**
+ * Builds a contract-valid snapshot whose leaders and ledger reconcile exactly,
+ * so the planner is exercised against the same shape the site publishes.
+ */
+function planningSnapshot(
+  specs: readonly ContributorSpec[],
+): LeaderboardSnapshot {
+  const snapshot = snapshotFixture();
+  const ledger: ScoreEvent[] = [];
+  const entries: LeaderboardEntry[] = [];
+  let pullRequestNumber = 20_000;
+
+  specs.forEach((spec, index) => {
+    const mergedPullRequests = spec.mergedPullRequests ?? 0;
+    const substantiveReviews = spec.substantiveReviews ?? 0;
+    const actor = {
+      id: `U_plan_${index}`,
+      login: spec.login,
+      avatarUrl: `https://avatars.githubusercontent.com/u/${900 + index}?v=4`,
+      url: `https://github.com/${spec.login}`,
+      kind: spec.kind ?? ("User" as GitHubActorKind),
+    };
+    for (let merged = 0; merged < mergedPullRequests; merged += 1) {
+      pullRequestNumber += 1;
+      const sourceId = `PR_plan_${index}_${merged}`;
+      ledger.push({
+        id: `${sourceId}:merged`,
+        actor,
+        category: "merged-pull-request",
+        points: 10,
+        repository: "elizaOS/eliza",
+        source: {
+          id: sourceId,
+          kind: "pull-request",
+          number: pullRequestNumber,
+          title: `Merged work ${merged} by ${spec.login}`,
+          url: `https://github.com/elizaOS/eliza/pull/${pullRequestNumber}`,
+        },
+        reason: "Pull request merged during the rolling window.",
+      });
+    }
+    for (let review = 0; review < substantiveReviews; review += 1) {
+      pullRequestNumber += 1;
+      ledger.push({
+        id: `PR_review_${index}_${review}:reviewer:${actor.id}`,
+        actor,
+        category: "substantive-review",
+        points: 3,
+        repository: "elizaOS/eliza",
+        source: {
+          id: `REVIEW_plan_${index}_${review}`,
+          kind: "review",
+          number: pullRequestNumber,
+          title: `Reviewed work ${review} by ${spec.login}`,
+          url: `https://github.com/elizaOS/eliza/pull/${pullRequestNumber}#pullrequestreview-${pullRequestNumber}`,
+        },
+        reason: "Substantive review completed before merge.",
+      });
+    }
+    entries.push({
+      rank: 1,
+      actor,
+      score: mergedPullRequests * 10 + substantiveReviews * 3,
+      points: {
+        mergedPullRequests: mergedPullRequests * 10,
+        resolvedIssues: 0,
+        materialTestChanges: 0,
+        evidence: 0,
+        substantiveReviews: substantiveReviews * 3,
+      },
+      acceptedOutcomes: {
+        mergedPullRequests,
+        resolvedIssues: 0,
+        materialTestChanges: 0,
+        evidenceCategories: 0,
+        substantiveReviews,
+      },
+      rawActivity: {
+        comments: 0,
+        reviews: substantiveReviews,
+        commits: mergedPullRequests,
+        additions: 0,
+        deletions: 0,
+      },
+      reportedModels: [],
+    });
+  });
+
+  snapshot.leaders = entries
+    .sort(compareFixtureEntries)
+    .map((entry, index) => ({ ...entry, rank: index + 1 }));
+  snapshot.ledger = ledger;
+  snapshot.attributions = [];
+  snapshot.invalidAttributionMarkers = [];
+  snapshot.attributionCoverage = {
+    status: "missing",
+    eligibleSourceCount: 0,
+    validSourceCount: 0,
+    missingSourceCount: 0,
+    invalidSourceCount: 0,
+    humanOnlySourceCount: 0,
+  };
+  const mergedEventCount = ledger.filter(
+    (event) => event.category === "merged-pull-request",
+  ).length;
+  const reviewedPullRequestCount = ledger.filter(
+    (event) => event.category === "substantive-review",
+  ).length;
+  snapshot.source.counts.mergedPullRequests = Math.max(
+    mergedEventCount,
+    reviewedPullRequestCount,
+  );
+  snapshot.source.counts.detailedMergedPullRequests = reviewedPullRequestCount;
+  return snapshot;
+}
+
+function planTime(snapshot: LeaderboardSnapshot, offsetMs = 60_000): number {
+  return Date.parse(snapshot.generatedAt) + offsetMs;
+}
+
+function plan(
+  snapshot: LeaderboardSnapshot,
+  rule: Partial<Parameters<typeof createPayoutPlan>[0]["rule"]> = {},
+  now = planTime(snapshot),
+): PayoutPlan {
+  return createPayoutPlan({
+    snapshot,
+    source: { path: "public/data/leaderboard.json", digest: SNAPSHOT_DIGEST },
+    rule: {
+      model: "proportional-by-points-v1",
+      pool: "1000",
+      currency: "USD",
+      minimumPoints: 0,
+      ...rule,
+    },
+    now,
+  });
+}
+
+function totalAllocated(payoutPlan: PayoutPlan): bigint {
+  return payoutPlan.allocations.reduce(
+    (total, allocation) =>
+      total + BigInt(allocation.allocation.amountMinorUnits),
+    0n,
+  );
+}
+
+function candidatesFor(specs: readonly ContributorSpec[]) {
+  return planningSnapshot(specs).leaders.map((entry) => ({
+    entry,
+    weight: BigInt(entry.score),
+  }));
+}
+
+describe("decimal money parsing", () => {
+  it("parses decimal amounts into exact minor units", () => {
+    expect(parseDecimalToMinorUnits("10000", 2)).toBe(1_000_000n);
+    expect(parseDecimalToMinorUnits("10000.00", 2)).toBe(1_000_000n);
+    expect(parseDecimalToMinorUnits("0.07", 2)).toBe(7n);
+    expect(parseDecimalToMinorUnits("10.005", 6)).toBe(10_005_000n);
+  });
+
+  it("rejects amounts a currency cannot express exactly", () => {
+    expect(() => parseDecimalToMinorUnits("10.005", 2)).toThrow(
+      /more than the 2 decimal places/,
+    );
+    expect(() => parseDecimalToMinorUnits("-5", 2)).toThrow(/plain positive/);
+    expect(() => parseDecimalToMinorUnits("1e3", 2)).toThrow(/plain positive/);
+    expect(() => parseDecimalToMinorUnits("1,000", 2)).toThrow(
+      /plain positive/,
+    );
+  });
+
+  it("renders minor units back without floating point", () => {
+    expect(formatMinorUnits(1_000_000n, 2)).toBe("10000.00");
+    expect(formatMinorUnits(7n, 2)).toBe("0.07");
+    expect(formatMinorUnits(0n, 6)).toBe("0.000000");
+  });
+});
+
+describe("weighted allocation", () => {
+  it("splits a pool in proportion to weights", () => {
+    const allocations = allocateByWeight(
+      100_000n,
+      candidatesFor([
+        { login: "ada", mergedPullRequests: 5 },
+        { login: "bo", mergedPullRequests: 3 },
+        { login: "cy", mergedPullRequests: 2 },
+      ]),
+    );
+    expect(
+      allocations.map((allocation) => [
+        allocation.candidate.entry.actor.login,
+        allocation.amountMinorUnits,
+      ]),
+    ).toEqual([
+      ["ada", 50_000n],
+      ["bo", 30_000n],
+      ["cy", 20_000n],
+    ]);
+  });
+
+  it("settles the remainder by largest remainder, then canonical order", () => {
+    const allocations = allocateByWeight(
+      100n,
+      candidatesFor([
+        { login: "ada", mergedPullRequests: 1 },
+        { login: "bo", mergedPullRequests: 1 },
+        { login: "cy", mergedPullRequests: 4 },
+      ]),
+    );
+    expect(
+      allocations.map((allocation) => [
+        allocation.candidate.entry.actor.login,
+        allocation.amountMinorUnits,
+        allocation.remainderUnitAwarded,
+      ]),
+    ).toEqual([
+      ["cy", 67n, true],
+      ["ada", 17n, true],
+      ["bo", 16n, false],
+    ]);
+    expect(
+      allocations.reduce(
+        (total, allocation) => total + allocation.amountMinorUnits,
+        0n,
+      ),
+    ).toBe(100n);
+  });
+
+  it("sums to the pool exactly for indivisible splits", () => {
+    for (const pool of [1n, 2n, 7n, 100n, 999_983n, 1_000_000n]) {
+      const allocations = allocateByWeight(
+        pool,
+        candidatesFor([
+          { login: "ada", mergedPullRequests: 5, substantiveReviews: 1 },
+          { login: "bo", mergedPullRequests: 3 },
+          { login: "cy", mergedPullRequests: 2, substantiveReviews: 7 },
+          { login: "dee", substantiveReviews: 1 },
+        ]),
+      );
+      expect(
+        allocations.reduce(
+          (total, allocation) => total + allocation.amountMinorUnits,
+          0n,
+        ),
+      ).toBe(pool);
+    }
+  });
+
+  it("never awards a contributor more than one minor unit above their exact share", () => {
+    const candidates = candidatesFor([
+      { login: "ada", mergedPullRequests: 5, substantiveReviews: 3 },
+      { login: "bo", mergedPullRequests: 1 },
+      { login: "cy", mergedPullRequests: 2, substantiveReviews: 10 },
+      { login: "dee", substantiveReviews: 1 },
+      { login: "eve", mergedPullRequests: 4 },
+    ]);
+    const totalWeight = candidates.reduce(
+      (total, candidate) => total + candidate.weight,
+      0n,
+    );
+    for (const pool of [3n, 97n, 1_000n, 1_000_000n, 999_999_937n]) {
+      for (const allocation of allocateByWeight(pool, candidates)) {
+        const exact = pool * allocation.candidate.weight;
+        expect(
+          allocation.amountMinorUnits * totalWeight <= exact + totalWeight,
+        ).toBe(true);
+        expect(allocation.amountMinorUnits >= allocation.floorMinorUnits).toBe(
+          true,
+        );
+      }
+    }
+  });
+
+  it("refuses a pool or candidate set it cannot split", () => {
+    const candidates = candidatesFor([{ login: "ada", mergedPullRequests: 1 }]);
+    expect(() => allocateByWeight(0n, candidates)).toThrow(/greater than zero/);
+    expect(() => allocateByWeight(-1n, candidates)).toThrow(
+      /greater than zero/,
+    );
+    expect(() => allocateByWeight(100n, [])).toThrow(
+      /at least one eligible contributor/,
+    );
+    expect(() =>
+      allocateByWeight(100n, [{ entry: candidates[0].entry, weight: 0n }]),
+    ).toThrow(/no distribution weight/);
+  });
+});
+
+describe("payout plan", () => {
+  it("allocates proportionally and records every input", () => {
+    const snapshot = planningSnapshot([
+      { login: "ada", mergedPullRequests: 5 },
+      { login: "bo", mergedPullRequests: 3 },
+      { login: "cy", mergedPullRequests: 2 },
+    ]);
+    const payoutPlan = plan(snapshot, { pool: "10000" });
+
+    expect(payoutPlan.status).toBe("dry-run");
+    expect(payoutPlan.movesMoney).toBe(false);
+    expect(payoutPlan.determinesPayouts).toBe(false);
+    expect(payoutPlan.rule.model).toBe("proportional-by-points-v1");
+    expect(payoutPlan.rule.status).toBe("unapproved-planning-parameter");
+    expect(payoutPlan.rule.inputs).toMatchObject({
+      pool: "10000.00",
+      poolMinorUnits: "1000000",
+      currency: "USD",
+      minorUnitScale: 2,
+      minimumPoints: 0,
+    });
+    expect(payoutPlan.rule.rounding.mode).toBe("floor-then-largest-remainder");
+    expect(payoutPlan.snapshot.digest).toBe(SNAPSHOT_DIGEST);
+    expect(payoutPlan.snapshot.ruleVersion).toBe("eliza-computer-v4");
+    expect(payoutPlan.snapshot.ledgerPointTotal).toBe(100);
+    expect(
+      payoutPlan.allocations.map((allocation) => [
+        allocation.contributor.githubLogin,
+        allocation.allocation.amount,
+      ]),
+    ).toEqual([
+      ["ada", "5000.00"],
+      ["bo", "3000.00"],
+      ["cy", "2000.00"],
+    ]);
+    expect(payoutPlan.totals.allocated).toBe("10000.00");
+    expect(payoutPlan.totals.unallocatedMinorUnits).toBe("0");
+    expect(totalAllocated(payoutPlan)).toBe(1_000_000n);
+  });
+
+  it("keeps per-repository ledger provenance for each allocation", () => {
+    const snapshot = planningSnapshot([
+      { login: "ada", mergedPullRequests: 2, substantiveReviews: 4 },
+    ]);
+    const [allocation] = plan(snapshot).allocations;
+    expect(allocation.points).toMatchObject({
+      total: 32,
+      mergedPullRequests: 20,
+      substantiveReviews: 12,
+    });
+    expect(allocation.ledger.eventCount).toBe(6);
+    expect(allocation.ledger.byRepository).toEqual([
+      { repository: "elizaOS/eliza", points: 32, events: 6 },
+    ]);
+  });
+
+  it("leaves every Eliza Cloud account linkage explicitly unresolved", () => {
+    const snapshot = planningSnapshot([
+      { login: "ada", mergedPullRequests: 2 },
+      { login: "bo", mergedPullRequests: 1 },
+    ]);
+    const payoutPlan = plan(snapshot);
+    expect(payoutPlan.accountLinkage).toMatchObject({
+      provider: "eliza-cloud",
+      status: ACCOUNT_LINKAGE_STATUS,
+      mappingSource: "none",
+      linkedAccounts: 0,
+      unlinkedAccounts: 2,
+    });
+    expect(payoutPlan.executionBlockers).toContain(
+      "eliza-cloud-account-linkage-unresolved",
+    );
+    for (const allocation of payoutPlan.allocations) {
+      expect(allocation.payee).toEqual({
+        provider: "eliza-cloud",
+        accountId: null,
+        linkageStatus: "unresolved",
+        linkedAt: null,
+      });
+      expect(allocation.contributor.githubActorId).toMatch(/^U_plan_/);
+      expect(allocation.contributor.githubLogin.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("distributes the remainder so allocations sum to the pool exactly", () => {
+    const snapshot = planningSnapshot([
+      { login: "ada", mergedPullRequests: 1 },
+      { login: "bo", mergedPullRequests: 1 },
+      { login: "cy", mergedPullRequests: 1 },
+    ]);
+    const payoutPlan = plan(snapshot, { pool: "1.00" });
+    expect(
+      payoutPlan.allocations.map((allocation) => [
+        allocation.contributor.githubLogin,
+        allocation.allocation.amount,
+        allocation.allocation.remainderUnitAwarded,
+      ]),
+    ).toEqual([
+      ["ada", "0.34", true],
+      ["bo", "0.33", false],
+      ["cy", "0.33", false],
+    ]);
+    expect(payoutPlan.totals.remainderUnitsDistributed).toBe(1);
+    expect(totalAllocated(payoutPlan)).toBe(100n);
+  });
+
+  it("reports contributors a small pool rounds down to nothing", () => {
+    const snapshot = planningSnapshot([
+      { login: "ada", mergedPullRequests: 1 },
+      { login: "bo", mergedPullRequests: 1 },
+      { login: "cy", mergedPullRequests: 4 },
+    ]);
+    const payoutPlan = plan(snapshot, { pool: "0.02" });
+    expect(
+      payoutPlan.allocations.map(
+        (allocation) => allocation.allocation.amountMinorUnits,
+      ),
+    ).toEqual(["2", "0", "0"]);
+    expect(payoutPlan.totals.zeroAllocationContributors).toBe(2);
+    expect(totalAllocated(payoutPlan)).toBe(2n);
+    expect(formatPayoutPlanSummary(payoutPlan)).toContain(
+      "2 eligible contributor(s) allocate zero cents",
+    );
+  });
+
+  it("orders allocations canonically rather than by published rank", () => {
+    const snapshot = planningSnapshot([
+      { login: "zeta", mergedPullRequests: 5 },
+      { login: "ada", mergedPullRequests: 1 },
+    ]);
+    const proportional = plan(snapshot);
+    expect(
+      proportional.allocations.map(
+        (allocation) => allocation.contributor.githubLogin,
+      ),
+    ).toEqual(["zeta", "ada"]);
+
+    const equal = plan(snapshot, { model: "equal-share-v1", pool: "10" });
+    expect(
+      equal.allocations.map((allocation) => [
+        allocation.contributor.githubLogin,
+        allocation.contributor.snapshotRank,
+        allocation.allocation.amount,
+      ]),
+    ).toEqual([
+      ["ada", 2, "5.00"],
+      ["zeta", 1, "5.00"],
+    ]);
+  });
+
+  it("produces byte-identical plans regardless of ledger input order", () => {
+    const snapshot = planningSnapshot([
+      { login: "ada", mergedPullRequests: 5, substantiveReviews: 2 },
+      { login: "bo", mergedPullRequests: 3 },
+      { login: "cy", mergedPullRequests: 2, substantiveReviews: 9 },
+    ]);
+    const shuffled = structuredClone(snapshot);
+    shuffled.ledger = [...shuffled.ledger].reverse();
+
+    const first = plan(snapshot, { pool: "10000" });
+    const second = plan(shuffled, { pool: "10000" });
+    expect(second.planId).toBe(first.planId);
+    expect(JSON.stringify(second)).toBe(JSON.stringify(first));
+    expect(first.planId).toMatch(/^sha256:[0-9a-f]{64}$/);
+  });
+
+  it("changes the plan identity when a recorded input changes", () => {
+    const snapshot = planningSnapshot([
+      { login: "ada", mergedPullRequests: 5 },
+      { login: "bo", mergedPullRequests: 1 },
+    ]);
+    const base = plan(snapshot, { pool: "10000" });
+    expect(plan(snapshot, { pool: "9000" }).planId).not.toBe(base.planId);
+    expect(
+      plan(snapshot, { pool: "10000", model: "equal-share-v1" }).planId,
+    ).not.toBe(base.planId);
+  });
+
+  it("applies the eligibility minimum recorded in the plan", () => {
+    const snapshot = planningSnapshot([
+      { login: "ada", mergedPullRequests: 5 },
+      { login: "bo", substantiveReviews: 1 },
+    ]);
+    const payoutPlan = plan(snapshot, { minimumPoints: 10 });
+    expect(payoutPlan.eligibility).toMatchObject({
+      actorRequirement: ELIGIBLE_ACTOR_REQUIREMENT,
+      minimumPoints: 10,
+      snapshotLeaders: 2,
+      eligibleContributors: 1,
+      excludedContributors: 1,
+    });
+    expect(payoutPlan.allocations).toHaveLength(1);
+    expect(payoutPlan.allocations[0].contributor.githubLogin).toBe("ada");
+    expect(totalAllocated(payoutPlan)).toBe(100_000n);
+  });
+
+  it("plans in the minor units of the selected currency", () => {
+    const snapshot = planningSnapshot([
+      { login: "ada", mergedPullRequests: 2 },
+      { login: "bo", mergedPullRequests: 1 },
+    ]);
+    const payoutPlan = plan(snapshot, { currency: "USDC", pool: "10000" });
+    expect(payoutPlan.rule.inputs.poolMinorUnits).toBe("10000000000");
+    expect(payoutPlan.allocations[0].allocation.amount).toBe("6666.666667");
+    expect(totalAllocated(payoutPlan)).toBe(10_000_000_000n);
+  });
+});
+
+describe("refusals", () => {
+  it("refuses a stale snapshot", () => {
+    const snapshot = planningSnapshot([
+      { login: "ada", mergedPullRequests: 1 },
+    ]);
+    expect(() =>
+      plan(
+        snapshot,
+        {},
+        planTime(snapshot, (MAX_SNAPSHOT_AGE_HOURS + 1) * HOUR_MS),
+      ),
+    ).toThrow(/stale snapshot/);
+    expect(() =>
+      plan(snapshot, {}, planTime(snapshot, MAX_SNAPSHOT_AGE_HOURS * HOUR_MS)),
+    ).not.toThrow();
+  });
+
+  it("refuses a wrong-schema or malformed snapshot", () => {
+    const snapshot = planningSnapshot([
+      { login: "ada", mergedPullRequests: 1 },
+    ]);
+    const wrongSchema = structuredClone(snapshot);
+    (wrongSchema as { schemaVersion: string }).schemaVersion = "1";
+    expect(() => plan(wrongSchema)).toThrow(/published leaderboard contract/);
+
+    const brokenLedger = structuredClone(snapshot);
+    brokenLedger.leaders[0].score = 99;
+    expect(() => plan(brokenLedger)).toThrow(/published leaderboard contract/);
+
+    expect(() =>
+      createPayoutPlan({
+        snapshot: { leaders: [] },
+        source: { path: "x.json", digest: SNAPSHOT_DIGEST },
+        rule: {
+          model: "proportional-by-points-v1",
+          pool: "100",
+          currency: "USD",
+          minimumPoints: 0,
+        },
+        now: Date.now(),
+      }),
+    ).toThrow(/published leaderboard contract/);
+  });
+
+  it("refuses an empty eligible set instead of emitting a zero plan", () => {
+    const snapshot = planningSnapshot([
+      { login: "ada", mergedPullRequests: 1 },
+      { login: "bo", substantiveReviews: 1 },
+    ]);
+    expect(() => plan(snapshot, { minimumPoints: 500 })).toThrow(
+      /refusing to emit an empty plan/,
+    );
+  });
+
+  it("refuses a snapshot whose leaders include a bot", () => {
+    const snapshot = planningSnapshot([
+      { login: "dependabot[bot]", kind: "Bot", mergedPullRequests: 4 },
+      { login: "ada", mergedPullRequests: 1 },
+    ]);
+    expect(() => plan(snapshot, { pool: "10000" })).toThrow(
+      /include the bot dependabot\[bot\] \(actor kind Bot, rank 1, 40 points\)/,
+    );
+
+    const disguised = planningSnapshot([
+      { login: "release-bot", kind: "User", mergedPullRequests: 4 },
+      { login: "ada", mergedPullRequests: 1 },
+    ]);
+    expect(() => plan(disguised, { pool: "10000" })).toThrow(
+      /include the bot release-bot/,
+    );
+  });
+
+  it("refuses a snapshot whose leaders include a non-user actor", () => {
+    for (const kind of ["Organization", "Mannequin", "Unknown"] as const) {
+      const snapshot = planningSnapshot([
+        { login: "ada", mergedPullRequests: 5 },
+        { login: "acme-labs", kind, mergedPullRequests: 1 },
+      ]);
+      expect(() => plan(snapshot, { pool: "10000" })).toThrow(
+        new RegExp(
+          `acme-labs with GitHub actor kind ${kind} \\(rank 2, 10 points\\): only a User account can hold a pool share`,
+        ),
+      );
+    }
+  });
+
+  it("refuses a zero pool, an unknown model, and an unknown currency", () => {
+    const snapshot = planningSnapshot([
+      { login: "ada", mergedPullRequests: 1 },
+    ]);
+    expect(() => plan(snapshot, { pool: "0" })).toThrow(/zero pool/);
+    expect(() =>
+      plan(snapshot, {
+        model: "whatever-v9" as unknown as DistributionModelId,
+      }),
+    ).toThrow(/unknown distribution model/);
+    expect(() =>
+      plan(snapshot, { currency: "GBP" as unknown as PayoutCurrencyCode }),
+    ).toThrow(/unknown payout currency/);
+    expect(() => plan(snapshot, { minimumPoints: -1 })).toThrow(
+      /non-negative integer/,
+    );
+  });
+
+  it("refuses a plan that cannot cite its source", () => {
+    const snapshot = planningSnapshot([
+      { login: "ada", mergedPullRequests: 1 },
+    ]);
+    expect(() =>
+      createPayoutPlan({
+        snapshot,
+        source: {
+          path: "public/data/leaderboard.json",
+          digest: "not-a-digest",
+        },
+        rule: {
+          model: "proportional-by-points-v1",
+          pool: "100",
+          currency: "USD",
+          minimumPoints: 0,
+        },
+        now: planTime(snapshot),
+      }),
+    ).toThrow(/sha256 digest/);
+  });
+});
+
+describe("command line", () => {
+  it("parses options and defaults", () => {
+    expect(
+      parsePayoutPlanArguments([
+        "--pool",
+        "10000",
+        "--model",
+        "proportional-by-points-v1",
+      ]),
+    ).toMatchObject({
+      pool: "10000",
+      currency: "USD",
+      model: "proportional-by-points-v1",
+      minimumPoints: 0,
+      outputPath: null,
+    });
+    expect(
+      parsePayoutPlanArguments([
+        "--pool",
+        "10000",
+        "--currency",
+        "USDC",
+        "--model",
+        "equal-share-v1",
+        "--minimum-points",
+        "10",
+      ]),
+    ).toMatchObject({
+      currency: "USDC",
+      model: "equal-share-v1",
+      minimumPoints: 10,
+    });
+  });
+
+  it("never assumes a pool or a distribution model", () => {
+    expect(() => parsePayoutPlanArguments([])).toThrow(/--pool <amount>/);
+    expect(() => parsePayoutPlanArguments(["--pool", "10000"])).toThrow(
+      /--model <id> is required; the planner never assumes a distribution model/,
+    );
+    expect(() => parsePayoutPlanArguments(["--pool", "10000"])).toThrow(
+      /no model is an approved payout rule/,
+    );
+  });
+
+  it("rejects missing, unknown, and malformed arguments", () => {
+    expect(() => parsePayoutPlanArguments(["--pool"])).toThrow(
+      /--pool requires a value/,
+    );
+    expect(() =>
+      parsePayoutPlanArguments([
+        "--pool",
+        "1",
+        "--model",
+        "equal-share-v1",
+        "--nope",
+      ]),
+    ).toThrow(/unknown argument --nope/);
+    expect(() => parsePayoutPlanArguments(["--pool", "1", "--model"])).toThrow(
+      /--model requires a value/,
+    );
+    expect(() =>
+      parsePayoutPlanArguments([
+        "--pool",
+        "1",
+        "--model",
+        "equal-share-v1",
+        "--minimum-points",
+        "-3",
+      ]),
+    ).toThrow(/non-negative integer/);
+    expect(() =>
+      parsePayoutPlanArguments(["--pool", "1", "--model", "nope"]),
+    ).toThrow(/unknown distribution model/);
+  });
+
+  it("never writes a plan into the published site directory", () => {
+    expect(() =>
+      assertOperatorOutputPath(
+        join(PUBLISHED_SITE_DIRECTORY, "data/plan.json"),
+      ),
+    ).toThrow(/never be written into the published site directory/);
+    expect(() => assertOperatorOutputPath(PUBLISHED_SITE_DIRECTORY)).toThrow(
+      /never be written into the published site directory/,
+    );
+  });
+
+  it("never writes a plan anywhere this public repository tracks", () => {
+    for (const trackedPath of [
+      join(REPOSITORY_ROOT, "draft.json"),
+      join(REPOSITORY_ROOT, "scripts/draft.json"),
+      join(OPERATOR_PLAN_DIRECTORY, "..", "planned.json"),
+      REPOSITORY_ROOT,
+    ]) {
+      expect(() => assertOperatorOutputPath(trackedPath)).toThrow(
+        /write it outside the working tree, or under the Git-ignored plans\/ directory/,
+      );
+    }
+    expect(
+      assertOperatorOutputPath(join(OPERATOR_PLAN_DIRECTORY, "d.json")),
+    ).toBe(join(OPERATOR_PLAN_DIRECTORY, "d.json"));
+    expect(assertOperatorOutputPath(join(tmpdir(), "d.json"))).toBe(
+      resolve(join(tmpdir(), "d.json")),
+    );
+  });
+
+  it("runs end to end through injected dependencies and writes the plan", async () => {
+    const snapshot = planningSnapshot([
+      { login: "ada", mergedPullRequests: 5 },
+      { login: "bo", mergedPullRequests: 3 },
+    ]);
+    const directory = await mkdtemp(join(tmpdir(), "eliza-army-payout-"));
+    const outputPath = join(directory, "nested", "plan.json");
+    try {
+      const source: SnapshotSource = {
+        path: "public/data/leaderboard.json",
+        digest: SNAPSHOT_DIGEST,
+        snapshot,
+      };
+      const payoutPlan = await runPayoutPlanner(
+        [
+          "--pool",
+          "10000",
+          "--model",
+          "proportional-by-points-v1",
+          "--out",
+          outputPath,
+        ],
+        {
+          readSource: async () => source,
+          write: writePlanAtomically,
+          now: () => planTime(snapshot),
+        },
+      );
+      expect(payoutPlan.allocations).toHaveLength(2);
+      expect(totalAllocated(payoutPlan)).toBe(1_000_000n);
+
+      const written = JSON.parse(
+        await readFile(outputPath, "utf8"),
+      ) as PayoutPlan;
+      expect(written.planId).toBe(payoutPlan.planId);
+      expect(written.movesMoney).toBe(false);
+      expect((await readFile(outputPath, "utf8")).endsWith("}\n")).toBe(true);
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("fails the run rather than planning from a stale snapshot", async () => {
+    const snapshot = planningSnapshot([
+      { login: "ada", mergedPullRequests: 1 },
+    ]);
+    await expect(
+      runPayoutPlanner(["--pool", "10000", "--model", "equal-share-v1"], {
+        readSource: async () => ({
+          path: "public/data/leaderboard.json",
+          digest: SNAPSHOT_DIGEST,
+          snapshot,
+        }),
+        write: async () => {
+          throw new Error("a refused plan must never be written");
+        },
+        now: () => planTime(snapshot, 9 * HOUR_MS),
+      }),
+    ).rejects.toThrow(/stale snapshot/);
+  });
+});
+
+describe("readable summary", () => {
+  it("states the dry run, the pool, and the unresolved payees", () => {
+    const snapshot = planningSnapshot([
+      { login: "ada", mergedPullRequests: 5 },
+      { login: "bo", mergedPullRequests: 3 },
+      { login: "cy", mergedPullRequests: 2 },
+    ]);
+    const summary = formatPayoutPlanSummary(plan(snapshot, { pool: "10000" }));
+    expect(summary).toContain("DRY RUN, moves no money");
+    expect(summary).toContain("does not determine payouts");
+    expect(summary).toContain("proportional-by-points-v1");
+    expect(summary).toContain("10000.00 USD");
+    expect(summary).toContain("0 linked Eliza Cloud accounts, 3 unresolved");
+    expect(summary).toContain(ELIGIBLE_ACTOR_REQUIREMENT);
+    expect(summary).toContain("eliza-cloud-account-linkage-unresolved");
+    expect(summary).toMatch(/ada .* 50\.00% .*5000\.00/);
+    expect(summary).toMatch(/eligible total .*100 .*100\.00% .*10000\.00/);
+  });
+
+  it("totals only the contributors the plan allocates to", () => {
+    const snapshot = planningSnapshot([
+      { login: "ada", mergedPullRequests: 5 },
+      { login: "bo", substantiveReviews: 1 },
+    ]);
+    const summary = formatPayoutPlanSummary(
+      plan(snapshot, { pool: "10000", minimumPoints: 10 }),
+    );
+    expect(summary).toContain(
+      "1 of 2 scoring contributors (minimum 10 points)",
+    );
+    expect(summary).toMatch(/eligible total .*50 .*100\.00% .*10000\.00/);
+    expect(summary).not.toContain("bo ");
+  });
+});

--- a/scripts/plan-payouts.ts
+++ b/scripts/plan-payouts.ts
@@ -1,0 +1,1147 @@
+/**
+ * Plans a hypothetical split of a contributor pool from the published
+ * contribution ledger. The distribution model is a required operator-supplied
+ * parameter because no payout rule exists yet: defaulting it would answer "how
+ * does money split?" on the program's behalf. Every input is recorded in the
+ * emitted plan and any plan can be recomputed from it. This command is a dry
+ * run: it moves no money, credits no balance, contacts no payment or account
+ * service, and does not determine who is paid.
+ */
+
+import { createHash } from "node:crypto";
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { dirname, relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  assertPublishableLeaderboardSnapshot,
+  type GitHubActorKind,
+  isBotActor,
+  type LeaderboardEntry,
+  type LeaderboardSnapshot,
+  type RepositoryId,
+  type ScoreEvent,
+  TARGET_REPOSITORIES,
+} from "../src/lib/leaderboard";
+
+export const PAYOUT_PLAN_SCHEMA_VERSION = "1" as const;
+export const PAYOUT_PLAN_KIND = "operator-payout-plan" as const;
+export const PAYOUT_PLAN_STATUS = "dry-run" as const;
+export const PAYOUT_PLAN_NOTICE =
+  "Operator dry run. This plan moves no money, credits no balance, and does not determine payouts. The distribution model is an unapproved planning parameter, not a published rule.";
+
+/**
+ * The site treats a snapshot older than eight hours as stale
+ * (`src/App.tsx`), and the local evidence command uses the same bound.
+ * `snapshot.stale` is always `false` by contract, so freshness must be derived
+ * from `generatedAt` exactly as the site derives it.
+ */
+export const MAX_SNAPSHOT_AGE_HOURS = 8;
+
+export const ROUNDING_MODE = "floor-then-largest-remainder" as const;
+export const REMAINDER_POLICY =
+  "largest-remainder-then-canonical-order" as const;
+export const ROUNDING_DESCRIPTION =
+  "Each share is computed in integer minor units as floor(pool * weight / totalWeight). The leftover minor units, always fewer than the eligible contributor count, are awarded one each by descending exact remainder and then by canonical order. Allocations therefore sum to the pool exactly, and no contributor receives more than one minor unit above their exact share.";
+
+export const ACCOUNT_LINKAGE_PROVIDER = "eliza-cloud" as const;
+export const ACCOUNT_LINKAGE_STATUS = "unresolved" as const;
+export const ACCOUNT_LINKAGE_NOTE =
+  "No GitHub-identity-to-Eliza-Cloud-account mapping exists. Every payee account in this plan is unresolved; a later step must supply and verify that mapping before any balance could be credited.";
+
+/**
+ * The published snapshot contract admits `Bot`, `Mannequin`, `Organization`,
+ * and `Unknown` actors, and the scoring contract's bot exclusion is enforced
+ * only in the generator. A money-shaped document must not inherit that trust,
+ * so the planner re-checks every leader itself.
+ */
+export const ELIGIBLE_ACTOR_KIND = "User" as const satisfies GitHubActorKind;
+export const ELIGIBLE_ACTOR_REQUIREMENT =
+  "Every payee is a non-bot GitHub user account (actor kind User); a bot or non-user leader refuses the plan.";
+
+export const EXECUTION_BLOCKERS = [
+  "no-approved-distribution-rule",
+  "eliza-cloud-account-linkage-unresolved",
+  "no-payout-execution-path",
+] as const;
+
+const SCRIPT_DIRECTORY = dirname(fileURLToPath(import.meta.url));
+export const REPOSITORY_ROOT = resolve(SCRIPT_DIRECTORY, "..");
+export const PUBLISHED_SITE_DIRECTORY = resolve(REPOSITORY_ROOT, "public");
+export const DEFAULT_SNAPSHOT_PATH = resolve(
+  PUBLISHED_SITE_DIRECTORY,
+  "data/leaderboard.json",
+);
+
+/**
+ * The only directory inside this working tree a plan may be written to. It is
+ * listed in `.gitignore`, so a plan left there cannot reach the public
+ * repository through `git add`.
+ */
+export const OPERATOR_PLAN_DIRECTORY_NAME = "plans" as const;
+export const OPERATOR_PLAN_DIRECTORY = resolve(
+  REPOSITORY_ROOT,
+  OPERATOR_PLAN_DIRECTORY_NAME,
+);
+
+export interface PayoutCurrency {
+  code: string;
+  minorUnitScale: number;
+  minorUnitName: string;
+}
+
+/** Minor-unit scales for the denominations an operator can plan in. */
+export const PAYOUT_CURRENCIES = {
+  USD: { code: "USD", minorUnitScale: 2, minorUnitName: "cent" },
+  USDC: { code: "USDC", minorUnitScale: 6, minorUnitName: "micro-USDC" },
+} as const satisfies Record<string, PayoutCurrency>;
+
+export type PayoutCurrencyCode = keyof typeof PAYOUT_CURRENCIES;
+
+export type DistributionModelId =
+  | "proportional-by-points-v1"
+  | "equal-share-v1";
+
+export interface DistributionModel {
+  id: DistributionModelId;
+  description: string;
+  weightFor: (entry: LeaderboardEntry) => bigint;
+}
+
+/**
+ * Candidate distribution models. None of these is an approved payout rule; they
+ * exist so an operator can compare concrete splits before a rule is written.
+ */
+export const DISTRIBUTION_MODELS = {
+  "proportional-by-points-v1": {
+    id: "proportional-by-points-v1",
+    description:
+      "Weight each eligible contributor by their published snapshot score and split the pool in proportion to those weights.",
+    weightFor: (entry: LeaderboardEntry) => BigInt(entry.score),
+  },
+  "equal-share-v1": {
+    id: "equal-share-v1",
+    description:
+      "Weight every eligible contributor equally and split the pool evenly regardless of score.",
+    weightFor: () => 1n,
+  },
+} as const satisfies Record<DistributionModelId, DistributionModel>;
+
+export interface PayoutRuleInput {
+  model: DistributionModelId;
+  pool: string;
+  currency: PayoutCurrencyCode;
+  minimumPoints: number;
+}
+
+export interface PayoutPlanSource {
+  path: string;
+  digest: string;
+}
+
+export interface CreatePayoutPlanInput {
+  snapshot: unknown;
+  source: PayoutPlanSource;
+  rule: PayoutRuleInput;
+  now?: number;
+}
+
+export interface PayoutPlanRepositoryPoints {
+  repository: RepositoryId;
+  points: number;
+  events: number;
+}
+
+export interface PayoutPlanAllocation {
+  order: number;
+  contributor: {
+    githubActorId: string;
+    githubLogin: string;
+    githubUrl: string;
+    githubActorKind: GitHubActorKind;
+    snapshotRank: number;
+  };
+  payee: {
+    provider: typeof ACCOUNT_LINKAGE_PROVIDER;
+    accountId: null;
+    linkageStatus: typeof ACCOUNT_LINKAGE_STATUS;
+    linkedAt: null;
+  };
+  weight: string;
+  share: {
+    numerator: string;
+    denominator: string;
+    basisPoints: number;
+  };
+  points: {
+    total: number;
+    mergedPullRequests: number;
+    resolvedIssues: number;
+    materialTestChanges: number;
+    evidence: number;
+    substantiveReviews: number;
+  };
+  ledger: {
+    eventCount: number;
+    byRepository: PayoutPlanRepositoryPoints[];
+  };
+  allocation: {
+    amountMinorUnits: string;
+    amount: string;
+    floorMinorUnits: string;
+    remainderNumerator: string;
+    remainderUnitAwarded: boolean;
+  };
+}
+
+export interface PayoutPlan {
+  schemaVersion: typeof PAYOUT_PLAN_SCHEMA_VERSION;
+  kind: typeof PAYOUT_PLAN_KIND;
+  status: typeof PAYOUT_PLAN_STATUS;
+  movesMoney: false;
+  determinesPayouts: false;
+  notice: string;
+  planId: string;
+  generatedAt: string;
+  rule: {
+    model: DistributionModelId;
+    description: string;
+    status: "unapproved-planning-parameter";
+    inputs: {
+      pool: string;
+      poolMinorUnits: string;
+      currency: string;
+      minorUnitScale: number;
+      minorUnitName: string;
+      minimumPoints: number;
+    };
+    rounding: {
+      mode: typeof ROUNDING_MODE;
+      remainderPolicy: typeof REMAINDER_POLICY;
+      description: string;
+    };
+  };
+  snapshot: {
+    path: string;
+    digest: string;
+    schemaVersion: string;
+    ruleVersion: string;
+    primaryRepository: string;
+    repositories: string[];
+    generatedAt: string;
+    sourceUpdatedAt: string;
+    ageMinutes: number;
+    maximumAgeHours: number;
+    window: { days: number; from: string; to: string };
+    verificationWindow: { days: number; from: string; to: string };
+    leaderCount: number;
+    ledgerEventCount: number;
+    ledgerPointTotal: number;
+  };
+  eligibility: {
+    criterion: string;
+    actorRequirement: string;
+    minimumPoints: number;
+    snapshotLeaders: number;
+    eligibleContributors: number;
+    excludedContributors: number;
+  };
+  totals: {
+    weight: string;
+    poolMinorUnits: string;
+    pool: string;
+    allocatedMinorUnits: string;
+    allocated: string;
+    unallocatedMinorUnits: string;
+    remainderUnitsDistributed: number;
+    zeroAllocationContributors: number;
+  };
+  accountLinkage: {
+    provider: typeof ACCOUNT_LINKAGE_PROVIDER;
+    status: typeof ACCOUNT_LINKAGE_STATUS;
+    mappingSource: "none";
+    linkedAccounts: number;
+    unlinkedAccounts: number;
+    note: string;
+  };
+  executionBlockers: string[];
+  allocations: PayoutPlanAllocation[];
+}
+
+function compareCodeUnits(left: string, right: string): number {
+  if (left === right) {
+    return 0;
+  }
+  return left < right ? -1 : 1;
+}
+
+function messageOf(cause: unknown): string {
+  return cause instanceof Error ? cause.message : String(cause);
+}
+
+const DECIMAL_AMOUNT_PATTERN = /^(\d{1,15})(?:\.(\d{1,18}))?$/;
+
+/**
+ * Parses an operator-supplied decimal amount into exact integer minor units.
+ * Money never becomes a float: the digits are read as text and widened to the
+ * currency's minor-unit scale.
+ */
+export function parseDecimalToMinorUnits(
+  amount: string,
+  minorUnitScale: number,
+): bigint {
+  if (typeof amount !== "string") {
+    throw new TypeError("a pool amount must be a decimal string");
+  }
+  if (!Number.isInteger(minorUnitScale) || minorUnitScale < 0) {
+    throw new TypeError("a minor-unit scale must be a non-negative integer");
+  }
+  const match = DECIMAL_AMOUNT_PATTERN.exec(amount.trim());
+  if (!match) {
+    throw new Error(
+      `pool amount "${amount}" must be a plain positive decimal number without a sign, exponent, or separators`,
+    );
+  }
+  const fraction = match[2] ?? "";
+  if (fraction.length > minorUnitScale) {
+    throw new Error(
+      `pool amount "${amount}" carries more than the ${minorUnitScale} decimal places this currency can express`,
+    );
+  }
+  return BigInt(`${match[1]}${fraction.padEnd(minorUnitScale, "0")}`);
+}
+
+/** Renders integer minor units back to a decimal string without floats. */
+export function formatMinorUnits(
+  amount: bigint,
+  minorUnitScale: number,
+): string {
+  if (amount < 0n) {
+    throw new Error("a payout amount cannot be negative");
+  }
+  if (!Number.isInteger(minorUnitScale) || minorUnitScale < 0) {
+    throw new TypeError("a minor-unit scale must be a non-negative integer");
+  }
+  if (minorUnitScale === 0) {
+    return amount.toString();
+  }
+  const digits = amount.toString().padStart(minorUnitScale + 1, "0");
+  const boundary = digits.length - minorUnitScale;
+  return `${digits.slice(0, boundary)}.${digits.slice(boundary)}`;
+}
+
+export interface WeightedCandidate {
+  entry: LeaderboardEntry;
+  weight: bigint;
+}
+
+export interface WeightedAllocation {
+  candidate: WeightedCandidate;
+  floorMinorUnits: bigint;
+  remainderNumerator: bigint;
+  remainderUnitAwarded: boolean;
+  amountMinorUnits: bigint;
+}
+
+/**
+ * Canonical allocation order: heaviest weight first, then the same lowercased
+ * login, login, and immutable actor ID tiebreak the published ledger uses. Rank
+ * is deliberately not an input, because equal scores receive different ranks
+ * purely by login.
+ */
+export function compareWeightedCandidates(
+  left: WeightedCandidate,
+  right: WeightedCandidate,
+): number {
+  if (left.weight !== right.weight) {
+    return left.weight > right.weight ? -1 : 1;
+  }
+  return (
+    compareCodeUnits(
+      left.entry.actor.login.toLowerCase(),
+      right.entry.actor.login.toLowerCase(),
+    ) ||
+    compareCodeUnits(left.entry.actor.login, right.entry.actor.login) ||
+    compareCodeUnits(left.entry.actor.id, right.entry.actor.id)
+  );
+}
+
+function assertAllocationsSettleExactly(
+  poolMinorUnits: bigint,
+  totalWeight: bigint,
+  allocations: readonly WeightedAllocation[],
+): void {
+  let allocated = 0n;
+  for (const allocation of allocations) {
+    const exactNumerator = poolMinorUnits * allocation.candidate.weight;
+    if (
+      allocation.floorMinorUnits * totalWeight +
+        allocation.remainderNumerator !==
+      exactNumerator
+    ) {
+      throw new Error(
+        "payout allocation lost its exact share decomposition; refusing to emit the plan",
+      );
+    }
+    const expected =
+      allocation.floorMinorUnits + (allocation.remainderUnitAwarded ? 1n : 0n);
+    if (allocation.amountMinorUnits !== expected) {
+      throw new Error(
+        "payout allocation does not match its floor and remainder award; refusing to emit the plan",
+      );
+    }
+    if (
+      allocation.amountMinorUnits * totalWeight >
+      exactNumerator + totalWeight
+    ) {
+      throw new Error(
+        `payout allocation for ${allocation.candidate.entry.actor.login} exceeds its exact share; refusing to emit the plan`,
+      );
+    }
+    allocated += allocation.amountMinorUnits;
+  }
+  if (allocated !== poolMinorUnits) {
+    throw new Error(
+      `payout allocations sum to ${allocated} minor units instead of the ${poolMinorUnits}-minor-unit pool; refusing to emit the plan`,
+    );
+  }
+}
+
+/**
+ * Splits a pool across weighted candidates in exact integer minor units using
+ * the largest-remainder method, so the allocations always sum to the pool.
+ */
+export function allocateByWeight(
+  poolMinorUnits: bigint,
+  candidates: readonly WeightedCandidate[],
+): WeightedAllocation[] {
+  if (poolMinorUnits <= 0n) {
+    throw new Error("a payout pool must be greater than zero");
+  }
+  if (candidates.length === 0) {
+    throw new Error("a payout plan needs at least one eligible contributor");
+  }
+  let totalWeight = 0n;
+  for (const candidate of candidates) {
+    if (candidate.weight < 0n) {
+      throw new Error(
+        `contributor ${candidate.entry.actor.login} carries a negative distribution weight`,
+      );
+    }
+    totalWeight += candidate.weight;
+  }
+  if (totalWeight <= 0n) {
+    throw new Error(
+      "the eligible contributors carry no distribution weight, so no split exists",
+    );
+  }
+
+  const allocations = [...candidates]
+    .sort(compareWeightedCandidates)
+    .map((candidate) => {
+      const exactNumerator = poolMinorUnits * candidate.weight;
+      const floorMinorUnits = exactNumerator / totalWeight;
+      return {
+        candidate,
+        floorMinorUnits,
+        remainderNumerator: exactNumerator % totalWeight,
+        remainderUnitAwarded: false,
+        amountMinorUnits: floorMinorUnits,
+      };
+    });
+
+  const flooredTotal = allocations.reduce(
+    (total, allocation) => total + allocation.floorMinorUnits,
+    0n,
+  );
+  let remainingUnits = poolMinorUnits - flooredTotal;
+  if (remainingUnits < 0n || remainingUnits >= BigInt(allocations.length)) {
+    throw new Error(
+      "payout remainder fell outside its proven bound; refusing to emit the plan",
+    );
+  }
+
+  const byRemainder = allocations
+    .map((allocation, index) => ({ allocation, index }))
+    .sort((left, right) => {
+      if (
+        left.allocation.remainderNumerator !==
+        right.allocation.remainderNumerator
+      ) {
+        return left.allocation.remainderNumerator >
+          right.allocation.remainderNumerator
+          ? -1
+          : 1;
+      }
+      return left.index - right.index;
+    });
+  for (const { allocation } of byRemainder) {
+    if (remainingUnits === 0n) {
+      break;
+    }
+    if (allocation.remainderNumerator === 0n) {
+      throw new Error(
+        "payout remainder cannot be awarded to an exact share; refusing to emit the plan",
+      );
+    }
+    allocation.remainderUnitAwarded = true;
+    allocation.amountMinorUnits = allocation.floorMinorUnits + 1n;
+    remainingUnits -= 1n;
+  }
+
+  assertAllocationsSettleExactly(poolMinorUnits, totalWeight, allocations);
+  return allocations;
+}
+
+interface ContributorLedgerSummary {
+  eventCount: number;
+  byRepository: Map<RepositoryId, { points: number; events: number }>;
+}
+
+function summarizeLedger(
+  ledger: readonly ScoreEvent[],
+): Map<string, ContributorLedgerSummary> {
+  const summaries = new Map<string, ContributorLedgerSummary>();
+  for (const event of ledger) {
+    let summary = summaries.get(event.actor.id);
+    if (!summary) {
+      summary = { eventCount: 0, byRepository: new Map() };
+      summaries.set(event.actor.id, summary);
+    }
+    summary.eventCount += 1;
+    const repository = summary.byRepository.get(event.repository) ?? {
+      points: 0,
+      events: 0,
+    };
+    repository.points += event.points;
+    repository.events += 1;
+    summary.byRepository.set(event.repository, repository);
+  }
+  return summaries;
+}
+
+function repositoryBreakdown(
+  summary: ContributorLedgerSummary,
+): PayoutPlanRepositoryPoints[] {
+  const breakdown: PayoutPlanRepositoryPoints[] = [];
+  for (const repository of TARGET_REPOSITORIES) {
+    const totals = summary.byRepository.get(repository.id);
+    if (totals) {
+      breakdown.push({
+        repository: repository.id,
+        points: totals.points,
+        events: totals.events,
+      });
+    }
+  }
+  return breakdown;
+}
+
+function resolveCurrency(code: unknown): PayoutCurrency {
+  if (typeof code !== "string" || !Object.hasOwn(PAYOUT_CURRENCIES, code)) {
+    throw new Error(
+      `unknown payout currency "${String(code)}"; supported currencies are ${Object.keys(PAYOUT_CURRENCIES).join(", ")}`,
+    );
+  }
+  return PAYOUT_CURRENCIES[code as PayoutCurrencyCode];
+}
+
+function resolveModel(id: unknown): DistributionModel {
+  if (typeof id !== "string" || !Object.hasOwn(DISTRIBUTION_MODELS, id)) {
+    throw new Error(
+      `unknown distribution model "${String(id)}"; supported models are ${Object.keys(DISTRIBUTION_MODELS).join(", ")}`,
+    );
+  }
+  return DISTRIBUTION_MODELS[id as DistributionModelId];
+}
+
+/**
+ * Refuses any snapshot whose leaders include an actor that cannot hold a pool
+ * share. A bot in `leaders` means the ledger already violates the published
+ * scoring contract, and a non-user actor has no human account to credit, so
+ * both fail the whole plan instead of quietly funding or dropping a row an
+ * operator cannot see in the summary.
+ */
+function assertHumanLeaders(snapshot: LeaderboardSnapshot): void {
+  for (const entry of snapshot.leaders) {
+    const actor = entry.actor;
+    if (isBotActor(actor)) {
+      throw new Error(
+        `refusing to plan from a snapshot whose leaders include the bot ${actor.login} (actor kind ${actor.kind}, rank ${entry.rank}, ${entry.score} points): the scoring contract excludes bots, so this ledger is wrong. Regenerate it before planning a pool.`,
+      );
+    }
+    if (actor.kind !== ELIGIBLE_ACTOR_KIND) {
+      throw new Error(
+        `refusing to plan from a snapshot whose leaders include ${actor.login} with GitHub actor kind ${actor.kind} (rank ${entry.rank}, ${entry.score} points): only a ${ELIGIBLE_ACTOR_KIND} account can hold a pool share.`,
+      );
+    }
+  }
+}
+
+function assertFreshSnapshot(
+  snapshot: LeaderboardSnapshot,
+  now: number,
+): number {
+  const ageMs = now - Date.parse(snapshot.generatedAt);
+  const maximumAgeMs = MAX_SNAPSHOT_AGE_HOURS * 60 * 60 * 1000;
+  if (ageMs > maximumAgeMs) {
+    const ageHours = Math.floor(ageMs / (60 * 60 * 1000));
+    throw new Error(
+      `refusing to plan from a stale snapshot: it was generated ${ageHours} hours ago (${snapshot.generatedAt}), past the ${MAX_SNAPSHOT_AGE_HOURS}-hour bound the site treats as fresh. Regenerate the ledger first.`,
+    );
+  }
+  return ageMs;
+}
+
+/**
+ * Builds a deterministic, auditable payout plan. Every input is recorded, and
+ * an unusable snapshot, an unusable rule, or an empty eligible set fails loudly
+ * instead of producing an empty or zero plan.
+ */
+export function createPayoutPlan(input: CreatePayoutPlanInput): PayoutPlan {
+  const now = input.now ?? Date.now();
+  if (!Number.isFinite(now)) {
+    throw new TypeError("a planning time must be finite");
+  }
+  const model = resolveModel(input.rule.model);
+  const currency = resolveCurrency(input.rule.currency);
+  const minimumPoints = input.rule.minimumPoints;
+  if (!Number.isInteger(minimumPoints) || minimumPoints < 0) {
+    throw new TypeError(
+      "the eligibility minimum must be a non-negative integer number of points",
+    );
+  }
+  const poolMinorUnits = parseDecimalToMinorUnits(
+    input.rule.pool,
+    currency.minorUnitScale,
+  );
+  if (poolMinorUnits <= 0n) {
+    throw new Error(
+      "refusing to plan a zero pool; supply the pool an operator intends to distribute",
+    );
+  }
+  if (typeof input.source.path !== "string" || input.source.path.length === 0) {
+    throw new TypeError("a plan must record the snapshot path it read");
+  }
+  if (
+    typeof input.source.digest !== "string" ||
+    !/^sha256:[0-9a-f]{64}$/.test(input.source.digest)
+  ) {
+    throw new TypeError("a plan must record a sha256 digest of its snapshot");
+  }
+
+  const snapshotValue = input.snapshot;
+  try {
+    assertPublishableLeaderboardSnapshot(snapshotValue, now);
+  } catch (cause) {
+    throw new Error(
+      `refusing to plan from a snapshot that fails the published leaderboard contract: ${messageOf(cause)}`,
+      { cause },
+    );
+  }
+  const snapshot: LeaderboardSnapshot = snapshotValue;
+  const ageMs = assertFreshSnapshot(snapshot, now);
+  assertHumanLeaders(snapshot);
+
+  const eligible = snapshot.leaders.filter(
+    (entry) => entry.score >= minimumPoints,
+  );
+  if (eligible.length === 0) {
+    throw new Error(
+      `refusing to emit an empty plan: no contributor in the snapshot reaches the ${minimumPoints}-point eligibility minimum`,
+    );
+  }
+
+  const allocations = allocateByWeight(
+    poolMinorUnits,
+    eligible.map((entry) => ({ entry, weight: model.weightFor(entry) })),
+  );
+  const totalWeight = allocations.reduce(
+    (total, allocation) => total + allocation.candidate.weight,
+    0n,
+  );
+  const summaries = summarizeLedger(snapshot.ledger);
+
+  const planAllocations = allocations.map((allocation, index) => {
+    const entry = allocation.candidate.entry;
+    const summary = summaries.get(entry.actor.id);
+    if (!summary) {
+      throw new Error(
+        `contributor ${entry.actor.login} scores in the snapshot but owns no ledger events; refusing to plan`,
+      );
+    }
+    return {
+      order: index + 1,
+      contributor: {
+        githubActorId: entry.actor.id,
+        githubLogin: entry.actor.login,
+        githubUrl: entry.actor.url,
+        githubActorKind: entry.actor.kind,
+        snapshotRank: entry.rank,
+      },
+      payee: {
+        provider: ACCOUNT_LINKAGE_PROVIDER,
+        accountId: null,
+        linkageStatus: ACCOUNT_LINKAGE_STATUS,
+        linkedAt: null,
+      },
+      weight: allocation.candidate.weight.toString(),
+      share: {
+        numerator: allocation.candidate.weight.toString(),
+        denominator: totalWeight.toString(),
+        basisPoints: Number(
+          (allocation.candidate.weight * 10000n) / totalWeight,
+        ),
+      },
+      points: {
+        total: entry.score,
+        mergedPullRequests: entry.points.mergedPullRequests,
+        resolvedIssues: entry.points.resolvedIssues,
+        materialTestChanges: entry.points.materialTestChanges,
+        evidence: entry.points.evidence,
+        substantiveReviews: entry.points.substantiveReviews,
+      },
+      ledger: {
+        eventCount: summary.eventCount,
+        byRepository: repositoryBreakdown(summary),
+      },
+      allocation: {
+        amountMinorUnits: allocation.amountMinorUnits.toString(),
+        amount: formatMinorUnits(
+          allocation.amountMinorUnits,
+          currency.minorUnitScale,
+        ),
+        floorMinorUnits: allocation.floorMinorUnits.toString(),
+        remainderNumerator: allocation.remainderNumerator.toString(),
+        remainderUnitAwarded: allocation.remainderUnitAwarded,
+      },
+    } satisfies PayoutPlanAllocation;
+  });
+
+  const allocatedMinorUnits = allocations.reduce(
+    (total, allocation) => total + allocation.amountMinorUnits,
+    0n,
+  );
+  const body = {
+    rule: {
+      model: model.id,
+      description: model.description,
+      status: "unapproved-planning-parameter" as const,
+      inputs: {
+        pool: formatMinorUnits(poolMinorUnits, currency.minorUnitScale),
+        poolMinorUnits: poolMinorUnits.toString(),
+        currency: currency.code,
+        minorUnitScale: currency.minorUnitScale,
+        minorUnitName: currency.minorUnitName,
+        minimumPoints,
+      },
+      rounding: {
+        mode: ROUNDING_MODE,
+        remainderPolicy: REMAINDER_POLICY,
+        description: ROUNDING_DESCRIPTION,
+      },
+    },
+    snapshot: {
+      path: input.source.path,
+      digest: input.source.digest,
+      schemaVersion: snapshot.schemaVersion,
+      ruleVersion: snapshot.ruleVersion,
+      primaryRepository: snapshot.repository,
+      repositories: snapshot.repositories.map((repository) => repository.id),
+      generatedAt: snapshot.generatedAt,
+      sourceUpdatedAt: snapshot.sourceUpdatedAt,
+      ageMinutes: Math.floor(ageMs / 60000),
+      maximumAgeHours: MAX_SNAPSHOT_AGE_HOURS,
+      window: { ...snapshot.window },
+      verificationWindow: { ...snapshot.source.verificationWindow },
+      leaderCount: snapshot.leaders.length,
+      ledgerEventCount: snapshot.ledger.length,
+      ledgerPointTotal: snapshot.ledger.reduce(
+        (total, event) => total + event.points,
+        0,
+      ),
+    },
+    eligibility: {
+      criterion:
+        "Every contributor the snapshot scores, at or above the recorded eligibility minimum. Eligibility is not a payout entitlement.",
+      actorRequirement: ELIGIBLE_ACTOR_REQUIREMENT,
+      minimumPoints,
+      snapshotLeaders: snapshot.leaders.length,
+      eligibleContributors: eligible.length,
+      excludedContributors: snapshot.leaders.length - eligible.length,
+    },
+    totals: {
+      weight: totalWeight.toString(),
+      poolMinorUnits: poolMinorUnits.toString(),
+      pool: formatMinorUnits(poolMinorUnits, currency.minorUnitScale),
+      allocatedMinorUnits: allocatedMinorUnits.toString(),
+      allocated: formatMinorUnits(allocatedMinorUnits, currency.minorUnitScale),
+      unallocatedMinorUnits: (poolMinorUnits - allocatedMinorUnits).toString(),
+      remainderUnitsDistributed: allocations.filter(
+        (allocation) => allocation.remainderUnitAwarded,
+      ).length,
+      zeroAllocationContributors: allocations.filter(
+        (allocation) => allocation.amountMinorUnits === 0n,
+      ).length,
+    },
+    accountLinkage: {
+      provider: ACCOUNT_LINKAGE_PROVIDER,
+      status: ACCOUNT_LINKAGE_STATUS,
+      mappingSource: "none" as const,
+      linkedAccounts: 0,
+      unlinkedAccounts: planAllocations.length,
+      note: ACCOUNT_LINKAGE_NOTE,
+    },
+    executionBlockers: [...EXECUTION_BLOCKERS],
+    allocations: planAllocations,
+  };
+
+  const planId = `sha256:${createHash("sha256").update(JSON.stringify(body)).digest("hex")}`;
+  return {
+    schemaVersion: PAYOUT_PLAN_SCHEMA_VERSION,
+    kind: PAYOUT_PLAN_KIND,
+    status: PAYOUT_PLAN_STATUS,
+    movesMoney: false,
+    determinesPayouts: false,
+    notice: PAYOUT_PLAN_NOTICE,
+    planId,
+    generatedAt: new Date(now).toISOString(),
+    ...body,
+  };
+}
+
+function formatBasisPoints(basisPoints: number): string {
+  const whole = Math.trunc(basisPoints / 100);
+  const fraction = Math.abs(basisPoints % 100)
+    .toString()
+    .padStart(2, "0");
+  return `${whole}.${fraction}%`;
+}
+
+function padStart(value: string, width: number): string {
+  return value.padStart(width, " ");
+}
+
+function padEnd(value: string, width: number): string {
+  return value.padEnd(width, " ");
+}
+
+/** Renders the operator-readable form of a plan. */
+export function formatPayoutPlanSummary(plan: PayoutPlan): string {
+  const loginWidth = Math.max(
+    "eligible total".length,
+    ...plan.allocations.map(
+      (allocation) => allocation.contributor.githubLogin.length,
+    ),
+  );
+  const amountWidth = Math.max(
+    plan.totals.allocated.length,
+    ...plan.allocations.map(
+      (allocation) => allocation.allocation.amount.length,
+    ),
+  );
+  const orderWidth = Math.max(2, String(plan.allocations.length).length);
+  const eligiblePoints = plan.allocations.reduce(
+    (total, allocation) => total + allocation.points.total,
+    0,
+  );
+  const pointsWidth = Math.max(6, String(eligiblePoints).length);
+
+  const lines = [
+    "eliza.army payout planner — DRY RUN, moves no money",
+    "",
+    plan.notice,
+    "",
+    `Plan        ${plan.planId}`,
+    `Model       ${plan.rule.model} (${plan.rule.status})`,
+    `Pool        ${plan.totals.pool} ${plan.rule.inputs.currency} (${plan.totals.poolMinorUnits} ${plan.rule.inputs.minorUnitName}s)`,
+    `Rounding    ${plan.rule.rounding.mode}; ${plan.totals.remainderUnitsDistributed} remainder ${plan.rule.inputs.minorUnitName}(s) awarded`,
+    `Snapshot    ${plan.snapshot.path} (${plan.snapshot.digest})`,
+    `            generated ${plan.snapshot.generatedAt}, ${plan.snapshot.ageMinutes} minutes old, rules ${plan.snapshot.ruleVersion}`,
+    `            ${plan.snapshot.leaderCount} leaders, ${plan.snapshot.ledgerEventCount} ledger events, ${plan.snapshot.ledgerPointTotal} points`,
+    `Eligible    ${plan.eligibility.eligibleContributors} of ${plan.eligibility.snapshotLeaders} scoring contributors (minimum ${plan.eligibility.minimumPoints} points)`,
+    `            ${plan.eligibility.actorRequirement}`,
+    `Payees      ${plan.accountLinkage.linkedAccounts} linked Eliza Cloud accounts, ${plan.accountLinkage.unlinkedAccounts} unresolved`,
+    "",
+    `  ${padStart("#", orderWidth)}  ${padEnd("contributor", loginWidth)}  ${padStart("points", pointsWidth)}  ${padStart("share", 8)}  ${padStart("amount", amountWidth)}`,
+  ];
+  for (const allocation of plan.allocations) {
+    lines.push(
+      `  ${padStart(String(allocation.order), orderWidth)}  ${padEnd(allocation.contributor.githubLogin, loginWidth)}  ${padStart(String(allocation.points.total), pointsWidth)}  ${padStart(formatBasisPoints(allocation.share.basisPoints), 8)}  ${padStart(allocation.allocation.amount, amountWidth)}`,
+    );
+  }
+  lines.push(
+    `  ${padStart("", orderWidth)}  ${padEnd("eligible total", loginWidth)}  ${padStart(String(eligiblePoints), pointsWidth)}  ${padStart("100.00%", 8)}  ${padStart(plan.totals.allocated, amountWidth)}`,
+    "",
+    `Unallocated ${plan.totals.unallocatedMinorUnits} ${plan.rule.inputs.minorUnitName}s. Shares are truncated for display; allocations are exact integer ${plan.rule.inputs.minorUnitName}s.`,
+  );
+  if (plan.totals.zeroAllocationContributors > 0) {
+    lines.push(
+      `Warning     ${plan.totals.zeroAllocationContributors} eligible contributor(s) allocate zero ${plan.rule.inputs.minorUnitName}s at this pool size.`,
+    );
+  }
+  lines.push(
+    `Blocked     ${plan.executionBlockers.join(", ")}`,
+    plan.accountLinkage.note,
+    "",
+  );
+  return lines.join("\n");
+}
+
+export interface PayoutPlanOptions {
+  snapshotPath: string;
+  pool: string;
+  currency: PayoutCurrencyCode;
+  model: DistributionModelId;
+  minimumPoints: number;
+  outputPath: string | null;
+}
+
+function requireValue(flag: string, value: string | undefined): string {
+  if (value === undefined || value.startsWith("--")) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+export function parsePayoutPlanArguments(
+  argv: readonly string[],
+): PayoutPlanOptions {
+  let pool: string | null = null;
+  let currency = "USD";
+  let model: string | null = null;
+  let minimumPoints = "0";
+  let snapshotPath = DEFAULT_SNAPSHOT_PATH;
+  let outputPath: string | null = null;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    switch (flag) {
+      case "--pool":
+        pool = requireValue(flag, value);
+        index += 1;
+        break;
+      case "--currency":
+        currency = requireValue(flag, value);
+        index += 1;
+        break;
+      case "--model":
+        model = requireValue(flag, value);
+        index += 1;
+        break;
+      case "--minimum-points":
+        minimumPoints = requireValue(flag, value);
+        index += 1;
+        break;
+      case "--snapshot":
+        snapshotPath = resolve(requireValue(flag, value));
+        index += 1;
+        break;
+      case "--out":
+        outputPath = resolve(requireValue(flag, value));
+        index += 1;
+        break;
+      default:
+        throw new Error(`unknown argument ${flag}`);
+    }
+  }
+
+  if (pool === null) {
+    throw new Error(
+      "--pool <amount> is required; the planner never assumes a pool size",
+    );
+  }
+  if (model === null) {
+    throw new Error(
+      `--model <id> is required; the planner never assumes a distribution model. Choose one of ${Object.keys(DISTRIBUTION_MODELS).join(", ")}; no model is an approved payout rule.`,
+    );
+  }
+  if (!/^\d{1,9}$/.test(minimumPoints)) {
+    throw new Error("--minimum-points must be a non-negative integer");
+  }
+  resolveCurrency(currency);
+  resolveModel(model);
+  return {
+    snapshotPath,
+    pool,
+    currency: currency as PayoutCurrencyCode,
+    model: model as DistributionModelId,
+    minimumPoints: Number(minimumPoints),
+    outputPath,
+  };
+}
+
+/** Records a snapshot path the way a plan should cite it, root-relative when possible. */
+export function describeSnapshotPath(snapshotPath: string): string {
+  const resolved = resolve(snapshotPath);
+  const fromRoot = relative(REPOSITORY_ROOT, resolved);
+  return fromRoot.length > 0 && !fromRoot.startsWith("..")
+    ? fromRoot
+    : resolved;
+}
+
+export interface SnapshotSource extends PayoutPlanSource {
+  snapshot: unknown;
+}
+
+export async function readSnapshotSource(
+  snapshotPath: string,
+): Promise<SnapshotSource> {
+  let text: string;
+  try {
+    text = await readFile(snapshotPath, "utf8");
+  } catch (cause) {
+    throw new Error(
+      `cannot read the leaderboard snapshot at ${snapshotPath}: ${messageOf(cause)}`,
+      { cause },
+    );
+  }
+  if (text.trim().length === 0) {
+    throw new Error(`the leaderboard snapshot at ${snapshotPath} is empty`);
+  }
+  let snapshot: unknown;
+  try {
+    snapshot = JSON.parse(text);
+  } catch (cause) {
+    throw new Error(
+      `the leaderboard snapshot at ${snapshotPath} is not valid JSON: ${messageOf(cause)}`,
+      { cause },
+    );
+  }
+  return {
+    path: describeSnapshotPath(snapshotPath),
+    digest: `sha256:${createHash("sha256").update(text).digest("hex")}`,
+    snapshot,
+  };
+}
+
+/**
+ * A payout plan is an operator artifact that names every scoring contributor
+ * beside a dollar amount. Writing one into the published site directory would
+ * ship it to eliza.army, and writing one anywhere Git can track would publish
+ * it to this public repository on the next `git add`, so both fail closed. The
+ * ignored operator directory is the sole in-tree destination.
+ */
+export function assertOperatorOutputPath(outputPath: string): string {
+  const resolved = resolve(outputPath);
+  if (
+    resolved === PUBLISHED_SITE_DIRECTORY ||
+    resolved.startsWith(`${PUBLISHED_SITE_DIRECTORY}${sep}`)
+  ) {
+    throw new Error(
+      "a payout plan is operator-only and must never be written into the published site directory",
+    );
+  }
+  const insideRepository =
+    resolved === REPOSITORY_ROOT ||
+    resolved.startsWith(`${REPOSITORY_ROOT}${sep}`);
+  if (
+    insideRepository &&
+    !resolved.startsWith(`${OPERATOR_PLAN_DIRECTORY}${sep}`)
+  ) {
+    throw new Error(
+      `a payout plan names every scoring contributor beside an amount and this repository is public: write it outside the working tree, or under the Git-ignored ${OPERATOR_PLAN_DIRECTORY_NAME}/ directory, not ${relative(REPOSITORY_ROOT, resolved) || resolved}`,
+    );
+  }
+  return resolved;
+}
+
+export async function writePlanAtomically(
+  plan: PayoutPlan,
+  outputPath: string,
+): Promise<void> {
+  const resolved = assertOperatorOutputPath(outputPath);
+  await mkdir(dirname(resolved), { recursive: true });
+  const temporaryPath = `${resolved}.${process.pid}.${Date.now()}.tmp`;
+  try {
+    await writeFile(
+      temporaryPath,
+      `${JSON.stringify(plan, null, 2)}\n`,
+      "utf8",
+    );
+    await rename(temporaryPath, resolved);
+  } finally {
+    // A failed atomic write may leave only its unique temporary file.
+    await rm(temporaryPath, { force: true });
+  }
+}
+
+export interface PayoutPlannerDependencies {
+  readSource: (snapshotPath: string) => Promise<SnapshotSource>;
+  write: (plan: PayoutPlan, outputPath: string) => Promise<void>;
+  now: () => number;
+}
+
+export async function runPayoutPlanner(
+  argv: readonly string[],
+  dependencies: PayoutPlannerDependencies = {
+    readSource: readSnapshotSource,
+    write: writePlanAtomically,
+    now: () => Date.now(),
+  },
+): Promise<PayoutPlan> {
+  const options = parsePayoutPlanArguments(argv);
+  const source = await dependencies.readSource(options.snapshotPath);
+  const plan = createPayoutPlan({
+    snapshot: source.snapshot,
+    source: { path: source.path, digest: source.digest },
+    rule: {
+      model: options.model,
+      pool: options.pool,
+      currency: options.currency,
+      minimumPoints: options.minimumPoints,
+    },
+    now: dependencies.now(),
+  });
+  if (options.outputPath !== null) {
+    await dependencies.write(plan, options.outputPath);
+  }
+  return plan;
+}
+
+export function payoutPlannerUsage(): string {
+  return `Usage: bun scripts/plan-payouts.ts --pool <amount> --model <id> [options]
+
+Plans a hypothetical split of a contributor pool from the published
+contribution ledger. Dry run only: it moves no money, credits no balance, and
+does not determine payouts. The plan document goes to stdout and the readable
+summary goes to stderr.
+
+Options:
+  --pool <amount>       Required. Pool size as a plain decimal, e.g. 10000 or 10000.00.
+  --model <id>          Required. ${Object.keys(DISTRIBUTION_MODELS).join(" | ")}.
+                        No model is an approved payout rule and the planner
+                        picks none for you, so state the split you want to see.
+  --currency <code>     ${Object.keys(PAYOUT_CURRENCIES).join(" | ")} (default USD). Selects the minor-unit scale.
+  --minimum-points <n>  Snapshot points a contributor needs to be eligible (default 0).
+  --snapshot <path>     Snapshot to plan from (default public/data/leaderboard.json).
+  --out <path>          Also write the plan document there. A plan names every
+                        scoring contributor beside an amount, so it must land
+                        outside this public working tree or in the ignored
+                        ${OPERATOR_PLAN_DIRECTORY_NAME}/ directory, never inside public/.
+  --help, -h            Show this help.
+
+The planner refuses a missing, empty, malformed, contract-violating, or
+older-than-${MAX_SNAPSHOT_AGE_HOURS}-hour snapshot, refuses a snapshot whose leaders include a bot
+or any non-user GitHub actor, and refuses an empty eligible set, rather than
+emitting an empty, zero, or non-human plan.
+`;
+}
+
+if (import.meta.main) {
+  const argv = process.argv.slice(2);
+  if (argv.includes("--help") || argv.includes("-h")) {
+    process.stdout.write(payoutPlannerUsage());
+  } else {
+    try {
+      const plan = await runPayoutPlanner(argv);
+      process.stderr.write(formatPayoutPlanSummary(plan));
+      process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
+    } catch (error) {
+      process.stderr.write(
+        `[eliza.army] payout plan failed: ${messageOf(error)}\n`,
+      );
+      process.exitCode = 1;
+    }
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,6 +45,9 @@ const REPOSITORY_LIST = new Intl.ListFormat("en", {
 const ADD_REPOSITORY_ISSUE_URL =
   "https://github.com/elizaOS/army/issues/new?template=add-repository.yml";
 
+const START_PROJECT_ISSUE_URL =
+  "https://github.com/elizaOS/army/issues/new?template=start-a-project.yml";
+
 const ELIZA_HUB_URL = "https://github.com/elizaOS/hub";
 
 type InstallOptionId = "prompt" | "codex" | "claude";
@@ -1112,6 +1115,21 @@ export function App() {
               href={ADD_REPOSITORY_ISSUE_URL}
             >
               Request repository onboarding <ArrowUpRight aria-hidden="true" />
+            </ExternalAnchor>
+          </div>
+          <div className="add-repo-body">
+            <p>
+              No repository yet, or want to fund one? Propose an agent-built
+              project instead. The issue form states what the program evaluates
+              — open source, bounded work, commands that verify a change, and
+              maintainers who review agent pull requests. Opening it starts an
+              evaluation and commits no funding, amount, or date.
+            </p>
+            <ExternalAnchor
+              className="button secondary"
+              href={START_PROJECT_ISSUE_URL}
+            >
+              Propose or sponsor a project <ArrowUpRight aria-hidden="true" />
             </ExternalAnchor>
           </div>
         </section>

--- a/tests/app.test.tsx
+++ b/tests/app.test.tsx
@@ -157,6 +157,12 @@ describe("App", () => {
       "href",
       "https://github.com/elizaOS/army/issues/new?template=add-repository.yml",
     );
+    expect(
+      screen.getByRole("link", { name: /propose or sponsor a project/i }),
+    ).toHaveAttribute(
+      "href",
+      "https://github.com/elizaOS/army/issues/new?template=start-a-project.yml",
+    );
   });
 
   it("explains bounded evidence verification without hiding retained scores", async () => {

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -121,6 +121,12 @@ test("loads latest snapshot, switches queues, and exposes provenance", async ({
     "href",
     "https://github.com/elizaOS/army/issues/new?template=add-repository.yml",
   );
+  await expect(
+    page.getByRole("link", { name: /Propose or sponsor a project/ }),
+  ).toHaveAttribute(
+    "href",
+    "https://github.com/elizaOS/army/issues/new?template=start-a-project.yml",
+  );
 
   await page.locator("#leaders").scrollIntoViewIfNeeded();
   const ledger = page.locator("#leaders");

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -16,6 +16,7 @@
     "scripts/**/*.ts",
     "src/lib/leaderboard.ts",
     "src/lib/install-command.ts",
+    "tests/fixtures.ts",
     "tests/install-authority-fixture.ts"
   ]
 }


### PR DESCRIPTION
Payouts are discretionary today and the scoring contract says points do not determine them. This builds the plumbing for the day that changes **without claiming it already has** — no public payout copy is touched.

## Payout planner — `bun run payouts:plan`

Reads the published ledger and computes what a pool would split into. It moves no money and makes no network calls.

- **`--model` is required and has no default.** Silently defaulting to points-proportional would make an unapproved rule look like policy. Omitting it refuses: *"the planner never assumes a distribution model … no model is an approved payout rule."*
- **Money math is integer-only.** `bigint` minor units throughout, floor-then-largest-remainder settlement. Before emitting, it re-proves the division identity, that every amount is exactly floor or floor+1, that nobody exceeds their exact share by a whole minor unit, and that allocations sum to the pool — otherwise it throws rather than emit. Verified across pools including 1, 2, 7, 999983, and 999999937.
- **Only non-bot user accounts are payable.** A `Bot`, `Organization`, or `Mannequin` leader refuses the plan instead of being allocated a share.
- **Deterministic**: byte-identical plans from reversed input; ties broken by exact remainder then canonical order, not by published rank (equal scores get different ranks purely by login).
- **Refuses** stale (>8h), invalid, wrong-schema, or empty snapshots, zero pools, and unknown models — never emits a plausible-looking empty plan.
- Every plan carries `status: dry-run`, `movesMoney: false`, `determinesPayouts: false`, and explicit `executionBlockers` — including that **GitHub-to-Eliza-Cloud account linkage does not exist yet**. That is an explicit `linkageStatus: unresolved` field on each payee rather than a silent assumption, so the gap is visible to whoever wires crediting later.

## Project proposal form

`.github/ISSUE_TEMPLATE/start-a-project.yml`, alongside the existing repository onboarding form, linked from the site and the hub landing page. States plainly that an issue commits no funding, amount, date, or registry placement, and that funding never buys leaderboard points or payouts. No custody, escrow, or payment mechanics — deliberately.

## Review

Adversarial review raised 21 findings; the three high-severity ones are fixed and independently re-verified here:
1. the CLI silently defaulted to points-proportional — the one assumption that must not be made;
2. `plans/` was not gitignored while the README taught `--out plans/draft.json`, so a payout plan could have been committed;
3. bots and non-user actors were allocated shares with no guard.

**Verified independently:** typecheck, lint, **198 vitest + 18 bun tests** all green; both CLI refusals exercised against the real snapshot. `CLAUDE.md`/`AGENTS.md` byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)