### PR TITLE
feat: animate and expand hero headlines

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -110,10 +110,13 @@ contributor skill, reviewer skill, safety review, and funding label explicit.
 
 ## Motion
 
-The hero line may switch every 2.8 seconds. With
-`prefers-reduced-motion: reduce`, it remains on the first message. Other motion
-is limited to 100–220ms hover and feedback transitions. Do not animate counts,
-money, leaderboard order, or lifecycle truth.
+The hero line switches every 2.8 seconds with a short vertical fade at each
+edge of the cycle. Its grid reserves the tallest phrase so the page does not
+jump between messages. With `prefers-reduced-motion: reduce`, it remains on the
+first message without animation. The rotating copy is not a live-region
+announcement. Other motion is limited to 100–220ms hover and feedback
+transitions. Do not animate counts, money, leaderboard order, or lifecycle
+truth.
 
 ## Accessibility
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -76,6 +76,9 @@ owed money. Use these financial states consistently:
 The home page leads with rotating statements:
 
 - MAKE MONEY SHIPPING CODE.
+- MAKE MONEY PROVING MATH.
+- MAKE MONEY DISCOVERING DRUGS.
+- MAKE MONEY HARDENING THE WEB.
 - MAKE MONEY FIXING BUGS.
 - MAKE MONEY SECURING THE INTERNET.
 - MAKE MONEY SOLVING MATH.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,6 +61,9 @@ const MAX_LEADERBOARD_BYTES = 32 * 1024 * 1024;
 const MAX_CYCLE_INDEX_BYTES = 8 * 1024 * 1024;
 const HERO_LINES = [
   "MAKE MONEY SHIPPING CODE.",
+  "MAKE MONEY PROVING MATH.",
+  "MAKE MONEY DISCOVERING DRUGS.",
+  "MAKE MONEY HARDENING THE WEB.",
   "MAKE MONEY FIXING BUGS.",
   "MAKE MONEY SECURING THE INTERNET.",
   "MAKE MONEY SOLVING MATH.",
@@ -442,8 +445,20 @@ function RotatingHeroLine() {
     return () => window.clearInterval(timer);
   }, []);
   return (
-    <span className="hero-switch" aria-live="polite">
-      {HERO_LINES[index]}
+    <span className="hero-switch">
+      {HERO_LINES.map((line, lineIndex) => (
+        <span
+          aria-hidden={lineIndex === index ? undefined : true}
+          className={
+            lineIndex === index
+              ? "hero-switch-text hero-switch-text-active"
+              : "hero-switch-text"
+          }
+          key={line}
+        >
+          {line}
+        </span>
+      ))}
     </span>
   );
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -221,8 +221,38 @@ p {
 }
 
 .hero-switch {
-  display: block;
+  display: grid;
   text-wrap: balance;
+}
+
+.hero-switch-text {
+  grid-area: 1 / 1;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.hero-switch-text-active {
+  visibility: visible;
+  animation: hero-line-cycle 2.8s ease-in-out both;
+}
+
+@keyframes hero-line-cycle {
+  0% {
+    opacity: 0;
+    transform: translateY(0.12em);
+  }
+  8% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  92% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-0.08em);
+  }
 }
 
 .hero-copy {
@@ -1779,6 +1809,11 @@ small,
 @media (prefers-reduced-motion: reduce) {
   html {
     scroll-behavior: auto;
+  }
+  .hero-switch-text-active {
+    animation: none;
+    opacity: 1;
+    transform: none;
   }
   *,
   *::before,

--- a/tests/app.test.tsx
+++ b/tests/app.test.tsx
@@ -160,15 +160,30 @@ describe("discovery", () => {
     expect(
       screen.getByRole("heading", { name: "MAKE MONEY SHIPPING CODE." }),
     ).toBeInTheDocument();
-    act(() => vi.advanceTimersByTime(2_800));
+    for (const line of [
+      "MAKE MONEY PROVING MATH.",
+      "MAKE MONEY DISCOVERING DRUGS.",
+      "MAKE MONEY HARDENING THE WEB.",
+      "MAKE MONEY FIXING BUGS.",
+      "MAKE MONEY SECURING THE INTERNET.",
+      "MAKE MONEY SOLVING MATH.",
+      "MAKE MONEY ADVANCING SCIENCE.",
+      "MAKE MONEY BUILDING AGENTS.",
+    ]) {
+      act(() => vi.advanceTimersByTime(2_800));
+      expect(screen.getByRole("heading", { name: line })).toBeInTheDocument();
+      expect(screen.getByText(line)).toHaveClass("hero-switch-text-active");
+    }
+  });
+
+  it("keeps the first hero statement fixed when reduced motion is requested", () => {
+    vi.useFakeTimers();
+    mockSnapshot();
+    render(<App />);
+
+    act(() => vi.advanceTimersByTime(28_000));
     expect(
-      screen.getByRole("heading", { name: "MAKE MONEY FIXING BUGS." }),
-    ).toBeInTheDocument();
-    act(() => vi.advanceTimersByTime(2_800));
-    expect(
-      screen.getByRole("heading", {
-        name: "MAKE MONEY SECURING THE INTERNET.",
-      }),
+      screen.getByRole("heading", { name: "MAKE MONEY SHIPPING CODE." }),
     ).toBeInTheDocument();
   });
 

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -299,7 +299,7 @@ test("keeps primary routes accessible and inside the viewport", async ({
       await expect(
         page.getByRole("heading", {
           exact: true,
-          name: "MAKE MONEY SECURING THE INTERNET.",
+          name: "MAKE MONEY DISCOVERING DRUGS.",
         }),
       ).toBeVisible({ timeout: 8_000 });
     }


### PR DESCRIPTION
## What changed

- add `MAKE MONEY PROVING MATH.`, `MAKE MONEY DISCOVERING DRUGS.`, and `MAKE MONEY HARDENING THE WEB.` to the homepage rotation
- replace abrupt text swaps with a brief vertical fade over the existing 2.8-second cycle
- reserve the tallest phrase in a shared grid so the hero does not jump as messages change
- keep the first statement fixed with no animation for reduced-motion users
- remove automatic live-region announcements while preserving the active heading's accessible name
- update the product/design contracts and exercise every message in unit coverage

## Why

The hero was already time-based, but it snapped between lines and its message set did not cover the new math, drug-discovery, and web-hardening positioning.

## Validation

- `bun run projects:check`
- `bun run evaluations:check`
- `bun run cycles:check`
- `bun run audit:dependencies`
- `bun run typecheck`
- `bun run format:check`
- `bun run lint:check`
- `bun run test` — 277 Vitest tests and 26 skill tests
- `bun run build` — 92-file deployment manifest
- `bun run test:e2e` — 32 Chromium cases across 1440, 1024, 768, and 320px
- `bun run test:e2e:record` — desktop/mobile captures plus a 10-second walkthrough; zero console, page, first-party request, or response failures

The rendered animation and both responsive captures were reviewed locally. Production remains gated on merge to `develop`.
