### PR TITLE
feat: simplify GitArmy around paid work

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -57,10 +57,11 @@ colored words or faux terminal syntax to the hero.
 
 ### Discovery
 
-The rotating all-caps hero occupies one stable line and respects reduced motion.
-Immediately below it: a two-sentence promise, “Find work,” “Fund a project,”
-and three proof signals. Project cards show reward first, then current score and
-contributors. The global leaderboard shows score, relevant tokens, live
+The all-caps hero uses a fixed `MAKE MONEY` first line and a typed/deleted orange
+second line. It reserves the tallest phrase and respects reduced motion. Nothing
+else competes inside the hero. Project cards show only project name and money;
+monthly bounties and external prizes remain textually distinct. The global
+leaderboard follows the project grid and shows score, relevant tokens, live
 projection, and total paid without defaulting to the richest contributor.
 
 ### Project
@@ -110,13 +111,14 @@ contributor skill, reviewer skill, safety review, and funding label explicit.
 
 ## Motion
 
-The hero line switches every 2.8 seconds with a short vertical fade at each
-edge of the cycle. Its grid reserves the tallest phrase so the page does not
+The hero holds each complete phrase, deletes it character by character, then
+types the next phrase. Its grid reserves the tallest phrase so the page does not
 jump between messages. With `prefers-reduced-motion: reduce`, it remains on the
-first message without animation. The rotating copy is not a live-region
-announcement. Other motion is limited to 100–220ms hover and feedback
-transitions. Do not animate counts, money, leaderboard order, or lifecycle
-truth.
+first complete message without a cursor. Partial typing is visual only; the
+heading exposes the complete current phrase as its accessible name and is not a
+live-region announcement. Other motion is limited to 100–220ms hover and
+feedback transitions. Do not animate counts, money, leaderboard order, or
+lifecycle truth.
 
 ## Accessibility
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -73,7 +73,8 @@ owed money. Use these financial states consistently:
 
 ### Discover
 
-The home page leads with rotating statements:
+The home page leads with one oversized `MAKE MONEY` heading. Its second line
+types and deletes these statements in sequence:
 
 - MAKE MONEY SHIPPING CODE.
 - MAKE MONEY PROVING MATH.
@@ -85,8 +86,10 @@ The home page leads with rotating statements:
 - MAKE MONEY ADVANCING SCIENCE.
 - MAKE MONEY BUILDING AGENTS.
 
-Each project card shows the goal, exact reward type, current contributors, and
-cycle score. Pledged and external funding are unmistakably different.
+Reduced-motion users see the complete first statement without the typing
+effect. The hero has no status badge, eyebrow, explanatory copy, or proof
+chips. Project cards show only the project name and its monthly bounty or
+clearly labeled external prize. The global leaderboard follows immediately.
 
 ### Start
 

--- a/scripts/record-evidence.mjs
+++ b/scripts/record-evidence.mjs
@@ -492,9 +492,15 @@ try {
     await page.goto(`${baseUrl}/?evidence=${cacheKey}`, {
       waitUntil: "networkidle",
     });
+    await page.locator('h1[aria-label^="MAKE MONEY "]').waitFor({
+      state: "visible",
+      timeout: 20_000,
+    });
     await page
-      .getByText(/^GitHub ledger \+ reward records live/u)
-      .waitFor({ state: "visible", timeout: 20_000 });
+      .locator(".hero-typewriter")
+      .filter({ hasText: /^PROVING MATH\.$/u })
+      .waitFor({ state: "visible", timeout: 10_000 });
+    await page.locator("#projects").waitFor({ state: "visible" });
     await page.locator("#leaderboard table").waitFor({ state: "visible" });
     if (previewServer && previewState) {
       assertPreviewRunning(previewServer, previewState);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,10 +11,8 @@ import {
   CircleAlert,
   Clipboard,
   ExternalLink,
-  GitPullRequest,
   Menu,
   RotateCcw,
-  ShieldCheck,
   X,
 } from "lucide-react";
 import {
@@ -35,7 +33,6 @@ import {
   type GitHubActor,
   type LeaderboardSnapshot,
   type ScoreEvent,
-  type WorkItem,
 } from "./lib/leaderboard";
 import {
   formatMonthlyCapDisplay,
@@ -54,22 +51,27 @@ import {
 import { isSolanaAddress } from "./lib/wallets";
 
 const SOURCE_REPOSITORY = "https://github.com/elizaOS/army";
+const HUB_ORIGIN = "https://git.eliza.army";
 const PROJECT_PROPOSAL_ROOT = `${SOURCE_REPOSITORY}/new/develop`;
 const SNAPSHOT_TIMEOUT_MS = 12_000;
 const SNAPSHOT_RETRIES = 1;
 const MAX_LEADERBOARD_BYTES = 32 * 1024 * 1024;
 const MAX_CYCLE_INDEX_BYTES = 8 * 1024 * 1024;
-const HERO_LINES = [
-  "MAKE MONEY SHIPPING CODE.",
-  "MAKE MONEY PROVING MATH.",
-  "MAKE MONEY DISCOVERING DRUGS.",
-  "MAKE MONEY HARDENING THE WEB.",
-  "MAKE MONEY FIXING BUGS.",
-  "MAKE MONEY SECURING THE INTERNET.",
-  "MAKE MONEY SOLVING MATH.",
-  "MAKE MONEY ADVANCING SCIENCE.",
-  "MAKE MONEY BUILDING AGENTS.",
+const HERO_ACTIONS = [
+  "SHIPPING CODE.",
+  "PROVING MATH.",
+  "DISCOVERING DRUGS.",
+  "HARDENING THE WEB.",
+  "FIXING BUGS.",
+  "SECURING THE INTERNET.",
+  "SOLVING MATH.",
+  "ADVANCING SCIENCE.",
+  "BUILDING AGENTS.",
 ] as const;
+const HERO_HOLD_MS = 1_800;
+const HERO_TYPE_MS = 55;
+const HERO_DELETE_MS = 30;
+const HERO_GAP_MS = 220;
 
 type DataState =
   | { status: "loading" }
@@ -356,7 +358,7 @@ function Header() {
         <nav className={open ? "nav-links nav-links-open" : "nav-links"}>
           <Link href="/#projects">Projects</Link>
           <Link href="/#leaderboard">Leaderboard</Link>
-          <Link href="/projects/new">Add a project</Link>
+          <ExternalLinkAnchor href={HUB_ORIGIN}>Hub</ExternalLinkAnchor>
           <ExternalLinkAnchor className="nav-source" href={SOURCE_REPOSITORY}>
             Source <ExternalLink aria-hidden="true" size={14} />
           </ExternalLinkAnchor>
@@ -380,7 +382,7 @@ function Footer() {
           <ExternalLinkAnchor href={SOURCE_REPOSITORY}>
             GitHub
           </ExternalLinkAnchor>
-          <Link href="/projects/new">Add a project</Link>
+          <ExternalLinkAnchor href={HUB_ORIGIN}>Hub</ExternalLinkAnchor>
           <ExternalLinkAnchor href={`${SOURCE_REPOSITORY}/issues/9`}>
             Protocol
           </ExternalLinkAnchor>
@@ -434,89 +436,79 @@ function DataNotice({ state, retry }: { state: DataState; retry: () => void }) {
   );
 }
 
-function RotatingHeroLine() {
+function TypewriterHeroHeading() {
   const [index, setIndex] = useState(0);
+  const [characters, setCharacters] = useState(HERO_ACTIONS[0].length);
+  const [phase, setPhase] = useState<"deleting" | "holding" | "typing">(
+    "holding",
+  );
   useEffect(() => {
     if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
-    const timer = window.setInterval(
-      () => setIndex((value) => (value + 1) % HERO_LINES.length),
-      2_800,
-    );
-    return () => window.clearInterval(timer);
-  }, []);
+    const target = HERO_ACTIONS[index];
+    let delay = 1;
+    let advance: () => void;
+    if (phase === "holding") {
+      delay = HERO_HOLD_MS;
+      advance = () => setPhase("deleting");
+    } else if (phase === "deleting" && characters > 0) {
+      delay = HERO_DELETE_MS;
+      advance = () => setCharacters((value) => Math.max(0, value - 1));
+    } else if (phase === "deleting") {
+      delay = HERO_GAP_MS;
+      advance = () => {
+        setIndex((value) => (value + 1) % HERO_ACTIONS.length);
+        setPhase("typing");
+      };
+    } else if (characters < target.length) {
+      delay = HERO_TYPE_MS;
+      advance = () => setCharacters((value) => value + 1);
+    } else {
+      advance = () => setPhase("holding");
+    }
+    const timer = window.setTimeout(advance, delay);
+    return () => window.clearTimeout(timer);
+  }, [characters, index, phase]);
+  const action = HERO_ACTIONS[index];
   return (
-    <span className="hero-switch">
-      {HERO_LINES.map((line, lineIndex) => (
-        <span
-          aria-hidden={lineIndex === index ? undefined : true}
-          className={
-            lineIndex === index
-              ? "hero-switch-text hero-switch-text-active"
-              : "hero-switch-text"
-          }
-          key={line}
-        >
-          {line}
+    <h1 aria-label={`MAKE MONEY ${action}`}>
+      <span aria-hidden="true" className="hero-message">
+        <span>MAKE MONEY</span>
+        <span className="hero-switch">
+          {HERO_ACTIONS.map((candidate) => (
+            <span className="hero-switch-sizer" key={candidate}>
+              {candidate}
+            </span>
+          ))}
+          <span className="hero-typewriter">
+            {action.slice(0, characters)}
+            <span className="hero-typewriter-caret" />
+          </span>
         </span>
-      ))}
-    </span>
+      </span>
+    </h1>
   );
 }
 
-function rewardLabel(project: ProjectDefinition): string {
-  return project.reward.kind === "monthly-pool"
-    ? `${project.reward.monthlyCapDisplay} / month`
-    : `${project.reward.externalOpportunity?.advertisedAmountDisplay ?? "External"} opportunity`;
-}
-
-function ProjectCard({
-  project,
-  view,
-}: {
-  project: ProjectDefinition;
-  view?: ProjectView;
-}) {
-  const contributors = view?.leaders.length ?? null;
-  const score = view?.leaders.reduce(
-    (total, leader) => total + leader.score,
-    0,
-  );
+function ProjectCard({ project }: { project: ProjectDefinition }) {
+  const amount =
+    project.reward.kind === "monthly-pool"
+      ? project.reward.monthlyCapDisplay
+      : (project.reward.externalOpportunity?.advertisedAmountDisplay ??
+        "External");
   return (
     <Link className="project-card" href={`/projects/${project.slug}`}>
-      <div className="card-topline">
-        <span className="project-index">0{PROJECTS.indexOf(project) + 1}</span>
-        <span
-          className={
-            project.reward.kind === "monthly-pool"
-              ? "funding-chip"
-              : "funding-chip external-chip"
-          }
-        >
+      <div className="project-card-heading">
+        <h3>{project.name}</h3>
+        <ArrowRight aria-hidden="true" />
+      </div>
+      <p className="project-bounty">
+        <strong>{amount}</strong>
+        <span>
           {project.reward.kind === "monthly-pool"
-            ? "PLEDGED"
-            : "EXTERNAL PRIZE"}
+            ? "/ month"
+            : "external prize"}
         </span>
-      </div>
-      <p className="eyebrow">{project.eyebrow}</p>
-      <h3>{project.headline}</h3>
-      <p className="project-description">{project.description}</p>
-      <div className="project-card-stats">
-        <span>
-          <strong>{rewardLabel(project)}</strong>
-          <small>reward</small>
-        </span>
-        <span>
-          <strong>{contributors === null ? "—" : contributors}</strong>
-          <small>contributors</small>
-        </span>
-        <span>
-          <strong>{score === undefined ? "—" : score}</strong>
-          <small>cycle score</small>
-        </span>
-      </div>
-      <span className="card-action">
-        View project <ArrowRight aria-hidden="true" size={18} />
-      </span>
+      </p>
     </Link>
   );
 }
@@ -633,16 +625,7 @@ function GlobalLeaderboard({
   const leaders = globalLeaders(views, cycleIndex);
   return (
     <section className="section shell" id="leaderboard">
-      <div className="section-heading">
-        <div>
-          <p className="eyebrow">Across every project</p>
-          <h2>People shipping work.</h2>
-        </div>
-        <p>
-          Ranked by accepted outcome score. Tokens are public supporting
-          evidence.
-        </p>
-      </div>
+      <h2 className="home-section-title">Leaderboard</h2>
       {leaders.length === 0 ? (
         <EmptyState text="No accepted outcomes in the active cycles yet." />
       ) : (
@@ -705,133 +688,28 @@ function GlobalLeaderboard({
   );
 }
 
-function HowItWorks() {
-  const steps = [
-    [
-      "01",
-      "Pick a project",
-      "See the money, goal, repositories, active work, and exact rules before you start.",
-    ],
-    [
-      "02",
-      "Run one command",
-      "Install the project skill. It selects the frontier model and starts bounded usage capture.",
-    ],
-    [
-      "03",
-      "Ship proof",
-      "Open a PR, add real tests and evidence, and publish the signed run receipt GitHub can index.",
-    ],
-    [
-      "04",
-      "Get reviewed",
-      "Automated checks propose credit. Maintainers review, adjust with reasons, then settle publicly.",
-    ],
-  ] as const;
-  return (
-    <section className="how-section">
-      <div className="shell">
-        <div className="section-heading light-heading">
-          <div>
-            <p className="eyebrow">The complete loop</p>
-            <h2>Work in. Money out.</h2>
-          </div>
-          <p>
-            No new work tracker. No opaque claim system. GitHub is the operating
-            surface.
-          </p>
-        </div>
-        <div className="step-grid">
-          {steps.map(([number, title, body]) => (
-            <article key={number}>
-              <span>{number}</span>
-              <h3>{title}</h3>
-              <p>{body}</p>
-            </article>
-          ))}
-        </div>
-      </div>
-    </section>
-  );
-}
-
 function HomePage({ state, retry }: { state: DataState; retry: () => void }) {
   const views = state.status === "ready" ? state.views : [];
   return (
     <main>
       <section className="hero shell">
-        <DataNotice state={state} retry={retry} />
-        <p className="eyebrow hero-eyebrow">THE GITARMY NETWORK</p>
-        <h1>
-          <RotatingHeroLine />
-        </h1>
-        <p className="hero-copy">
-          Give the best agents a hard problem. Ship accepted work on GitHub.
-          Build a public reputation and earn from clearly labeled project pools.
-        </p>
-        <div className="hero-actions">
-          <a className="button primary-button" href="#projects">
-            Find work <ArrowRight aria-hidden="true" />
-          </a>
-          <Link className="button text-button" href="/projects/new">
-            Fund a project
-          </Link>
-        </div>
-        <div className="hero-proof">
-          <span>
-            <ShieldCheck aria-hidden="true" /> Device-signed usage
-          </span>
-          <span>
-            <GitPullRequest aria-hidden="true" /> GitHub-native proof
-          </span>
-          <span>
-            <Check aria-hidden="true" /> Public payout records
-          </span>
-        </div>
+        {state.status === "ready" ? null : (
+          <DataNotice state={state} retry={retry} />
+        )}
+        <TypewriterHeroHeading />
       </section>
 
       <section className="section shell" id="projects">
-        <div className="section-heading">
-          <div>
-            <p className="eyebrow">Open projects</p>
-            <h2>Choose something real.</h2>
-          </div>
-          <p>
-            Funded work sorts first. Pledges and external opportunities stay
-            visibly labeled.
-          </p>
-        </div>
+        <h2 className="home-section-title">Projects</h2>
         <div className="project-grid">
           {PROJECTS.map((project) => (
-            <ProjectCard
-              key={project.id}
-              project={project}
-              view={views.find((view) => view.project.id === project.id)}
-            />
+            <ProjectCard key={project.id} project={project} />
           ))}
         </div>
       </section>
-      <HowItWorks />
       {state.status === "ready" ? (
         <GlobalLeaderboard cycleIndex={state.cycleIndex} views={views} />
       ) : null}
-      <section className="creator-cta">
-        <div className="shell creator-cta-inner">
-          <div>
-            <p className="eyebrow">Have an open problem?</p>
-            <h2>Put money behind the work.</h2>
-          </div>
-          <div>
-            <p>
-              Define a public repository, project skill, evaluation policy, and
-              monthly cap. Submit one reviewable proposal through GitHub.
-            </p>
-            <Link className="button inverse-button" href="/projects/new">
-              Add a project <ArrowRight aria-hidden="true" />
-            </Link>
-          </div>
-        </div>
-      </section>
     </main>
   );
 }
@@ -1093,58 +971,6 @@ function ProjectLeaderboard({ view }: { view: ProjectView }) {
   );
 }
 
-function WorkQueue({ view }: { view: ProjectView }) {
-  const items = [...view.workQueue.issues, ...view.workQueue.pullRequests]
-    .filter((item) => item.selection.status === "candidate")
-    .slice(0, 8);
-  return (
-    <section className="section work-section">
-      <div className="section-heading">
-        <div>
-          <p className="eyebrow">Live from GitHub</p>
-          <h2>Work worth doing.</h2>
-        </div>
-        <p>No platform claims. Recheck the issue or PR before beginning.</p>
-      </div>
-      {items.length === 0 ? (
-        <EmptyState text="No unblocked candidates passed the public filter." />
-      ) : (
-        <div className="work-list">
-          {items.map((item) => (
-            <WorkRow item={item} key={item.id} />
-          ))}
-        </div>
-      )}
-      <ExternalLinkAnchor
-        className="inline-link"
-        href={view.project.links.issues}
-      >
-        See every GitHub issue <ArrowRight aria-hidden="true" size={17} />
-      </ExternalLinkAnchor>
-    </section>
-  );
-}
-
-function WorkRow({ item }: { item: WorkItem }) {
-  return (
-    <ExternalLinkAnchor className="work-row" href={item.url}>
-      <span
-        className={`work-kind ${item.kind === "pull-request" ? "pr-kind" : ""}`}
-      >
-        {item.kind === "pull-request" ? "PR" : "ISSUE"}
-      </span>
-      <span>
-        <strong>{item.title}</strong>
-        <small>
-          #{item.number} · {item.priority} priority · {item.commentCount}{" "}
-          comments
-        </small>
-      </span>
-      <ChevronRight aria-hidden="true" />
-    </ExternalLinkAnchor>
-  );
-}
-
 function EmptyState({ text }: { text: string }) {
   return <div className="empty-state">{text}</div>;
 }
@@ -1260,68 +1086,9 @@ function ProjectPage({
       <div className="shell">
         <InstallPanel project={project} />
         {project.reward.kind === "monthly-pool" ? <WalletPanel /> : null}
-        {view ? (
-          <>
-            <ProjectLeaderboard view={view} />
-            <WorkQueue view={view} />
-            <TrustSection view={view} />
-          </>
-        ) : null}
+        {view ? <ProjectLeaderboard view={view} /> : null}
       </div>
     </main>
-  );
-}
-
-function TrustSection({ view }: { view: ProjectView }) {
-  return (
-    <section className="section trust-section">
-      <div className="section-heading">
-        <div>
-          <p className="eyebrow">How credit survives review</p>
-          <h2>Useful work wins.</h2>
-        </div>
-        <p>
-          Automation proposes; maintainers retain judgment. Every reduction
-          needs a public reason and review delay.
-        </p>
-      </div>
-      <div className="trust-grid">
-        <article>
-          <ShieldCheck aria-hidden="true" />
-          <h3>Verify the outcome</h3>
-          <p>
-            Merged PRs, linked fixes, material tests, evidence, and substantive
-            reviews score. Unmerged work can earn only through an explicit
-            evaluator finding.
-          </p>
-        </article>
-        <article>
-          <CircleAlert aria-hidden="true" />
-          <h3>Detect abuse</h3>
-          <p>
-            Invalid signatures, replayed runs, copied markers, wrong
-            repositories, wrong models, unrelated usage, duplicate work, and
-            suspicious flooding are held for review.
-          </p>
-        </article>
-        <article>
-          <Check aria-hidden="true" />
-          <h3>Approve and settle</h3>
-          <p>
-            Proposals remain editable for 14 days. Approved wallet rows become
-            immutable payout intents; finalized Solana signatures close the
-            cycle.
-          </p>
-        </article>
-      </div>
-      {view.receiptConflicts.length > 0 ? (
-        <p className="risk-note">
-          {view.receiptConflicts.length} conflicting run receipt
-          {view.receiptConflicts.length === 1 ? " is" : "s are"} excluded from
-          this view.
-        </p>
-      ) : null}
-    </section>
   );
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -119,12 +119,12 @@ input:focus-visible {
 }
 
 .hero {
-  min-height: 690px;
+  min-height: min(760px, calc(100vh - 72px));
   display: flex;
   flex-direction: column;
   align-items: flex-start;
   justify-content: center;
-  padding-block: 104px 84px;
+  padding-block: 96px;
 }
 
 .data-notice {
@@ -195,10 +195,6 @@ input:focus-visible {
   text-transform: uppercase;
 }
 
-.hero-eyebrow {
-  margin-bottom: 24px;
-}
-
 h1,
 h2,
 h3,
@@ -220,38 +216,52 @@ p {
   line-height: 0.92;
 }
 
+.hero h1 {
+  width: 100%;
+  max-width: none;
+  margin: 0;
+  font-size: clamp(62px, 10.6vw, 150px);
+  line-height: 0.84;
+}
+
+.hero-message {
+  display: flex;
+  flex-direction: column;
+}
+
 .hero-switch {
   display: grid;
+  color: var(--orange);
   text-wrap: balance;
 }
 
-.hero-switch-text {
+.hero-switch-sizer,
+.hero-typewriter {
   grid-area: 1 / 1;
+}
+
+.hero-switch-sizer {
   visibility: hidden;
-  opacity: 0;
 }
 
-.hero-switch-text-active {
-  visibility: visible;
-  animation: hero-line-cycle 2.8s ease-in-out both;
+.hero-typewriter {
+  position: relative;
+  align-self: start;
 }
 
-@keyframes hero-line-cycle {
-  0% {
+.hero-typewriter-caret {
+  display: inline-block;
+  width: 0.055em;
+  height: 0.78em;
+  margin-left: 0.04em;
+  background: currentColor;
+  transform: translateY(0.04em);
+  animation: typewriter-caret 720ms steps(1, end) infinite;
+}
+
+@keyframes typewriter-caret {
+  50% {
     opacity: 0;
-    transform: translateY(0.12em);
-  }
-  8% {
-    opacity: 1;
-    transform: translateY(0);
-  }
-  92% {
-    opacity: 1;
-    transform: translateY(0);
-  }
-  100% {
-    opacity: 0;
-    transform: translateY(-0.08em);
   }
 }
 
@@ -318,30 +328,16 @@ p {
   background: #ffddcc;
 }
 
-.hero-proof {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 22px;
-  margin-top: 56px;
-  color: var(--muted);
-  font-size: 11px;
-  font-weight: 600;
-}
-
-.hero-proof span {
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-}
-
-.hero-proof svg {
-  width: 16px;
-  height: 16px;
-  color: var(--orange);
-}
-
 .section {
   padding-block: 108px;
+}
+
+.home-section-title {
+  margin: 0 0 42px;
+  font-size: clamp(42px, 6vw, 76px);
+  font-weight: 800;
+  letter-spacing: -0.06em;
+  line-height: 0.95;
 }
 
 .section-heading {
@@ -353,7 +349,6 @@ p {
 }
 
 .section-heading h2,
-.creator-cta h2,
 .proposal-checklist h2 {
   max-width: 760px;
   margin: 0;
@@ -363,8 +358,7 @@ p {
   line-height: 0.98;
 }
 
-.section-heading > p,
-.creator-cta p {
+.section-heading > p {
   margin: 0;
   color: var(--muted);
   font-size: 14px;
@@ -378,10 +372,11 @@ p {
 }
 
 .project-card {
-  min-height: 520px;
+  min-height: 300px;
   display: flex;
   flex-direction: column;
-  padding: 30px;
+  justify-content: space-between;
+  padding: 32px;
   border: 1px solid var(--line);
   border-radius: var(--radius);
   background: rgba(255, 253, 248, 0.72);
@@ -397,61 +392,33 @@ p {
   box-shadow: 0 24px 50px rgba(57, 39, 22, 0.08);
 }
 
-.card-topline {
+.project-card-heading {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 64px;
-}
-
-.project-index {
-  color: #a39c90;
-  font-size: 12px;
-  font-weight: 700;
-}
-
-.funding-chip {
-  padding: 7px 10px;
-  border-radius: 999px;
-  background: #dff4e8;
-  color: #147447;
-  font-size: 9px;
-  font-weight: 800;
-  letter-spacing: 0.1em;
-}
-
-.external-chip {
-  background: #eee8dc;
-  color: #665d4f;
+  gap: 20px;
 }
 
 .project-card h3 {
-  max-width: 520px;
-  margin-bottom: 20px;
-  font-size: clamp(31px, 3.6vw, 52px);
+  margin: 0;
+  font-size: clamp(30px, 3.2vw, 46px);
   font-weight: 800;
   letter-spacing: -0.055em;
   line-height: 1;
 }
 
-.project-description {
-  max-width: 520px;
-  margin-bottom: 36px;
-  color: var(--muted);
-  font-size: 14px;
-  line-height: 1.65;
+.project-card-heading svg {
+  flex: 0 0 auto;
+  color: var(--orange-dark);
 }
 
-.project-card-stats {
-  display: grid;
-  grid-template-columns: 1.3fr 1fr 1fr;
-  gap: 12px;
-  margin-top: auto;
-  padding-top: 22px;
-  border-top: 1px solid var(--line);
+.project-bounty {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 0;
 }
 
-.project-card-stats span,
 .person-cell span,
 .project-stat-strip div,
 .profile-totals div {
@@ -460,76 +427,23 @@ p {
   flex-direction: column;
 }
 
-.project-card-stats strong {
-  overflow: hidden;
-  font-size: 13px;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+.project-bounty strong {
+  font-size: clamp(45px, 5.6vw, 78px);
+  letter-spacing: -0.065em;
+  line-height: 0.9;
 }
 
-small,
-.project-card-stats small {
+small {
   margin-top: 5px;
   color: var(--muted);
   font-size: 10px;
 }
 
-.card-action {
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-  margin-top: 28px;
-  color: var(--orange-dark);
-  font-size: 12px;
+.project-bounty span {
+  color: var(--muted);
+  font-size: 13px;
   font-weight: 700;
-}
-
-.how-section {
-  padding-block: 112px;
-  background: var(--ink);
-  color: var(--white);
-}
-
-.light-heading > p,
-.how-section .step-grid p {
-  color: #aaa398;
-}
-
-.light-heading .eyebrow {
-  color: #ff8a58;
-}
-
-.step-grid {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 1px;
-  border: 1px solid rgba(255, 255, 255, 0.14);
-  border-radius: var(--radius);
-  overflow: hidden;
-  background: rgba(255, 255, 255, 0.14);
-}
-
-.step-grid article {
-  min-height: 280px;
-  padding: 26px;
-  background: var(--ink);
-}
-
-.step-grid article > span {
-  color: #ff8a58;
-  font-size: 11px;
-  font-weight: 800;
-}
-
-.step-grid h3 {
-  margin: 74px 0 14px;
-  font-size: 21px;
-  letter-spacing: -0.03em;
-}
-
-.step-grid p {
-  font-size: 12px;
-  line-height: 1.65;
+  text-transform: uppercase;
 }
 
 .leader-table {
@@ -651,28 +565,6 @@ small,
   color: var(--muted);
   font-size: 13px;
   text-align: center;
-}
-
-.creator-cta {
-  padding-block: 92px;
-  background: var(--orange);
-  color: var(--ink);
-}
-
-.creator-cta-inner {
-  display: grid;
-  grid-template-columns: 1.35fr 0.65fr;
-  align-items: end;
-  gap: 64px;
-}
-
-.creator-cta .eyebrow,
-.creator-cta p {
-  color: var(--ink);
-}
-
-.creator-cta p {
-  margin-bottom: 24px;
 }
 
 .site-footer {
@@ -1037,9 +929,7 @@ small,
   padding-left: 20px;
 }
 
-.project-leader-section,
-.work-section,
-.trust-section {
+.project-leader-section {
   padding-bottom: 0;
 }
 
@@ -1048,7 +938,6 @@ small,
   grid-template-columns: 62px minmax(190px, 1.4fr) 0.5fr 0.75fr 0.8fr 0.7fr;
 }
 
-.work-list,
 .event-list,
 .profile-projects {
   overflow: hidden;
@@ -1058,7 +947,6 @@ small,
   background: rgba(255, 253, 248, 0.7);
 }
 
-.work-row,
 .event-list > a,
 .profile-projects > a {
   display: grid;
@@ -1070,92 +958,27 @@ small,
   border-bottom: 1px solid var(--line);
 }
 
-.work-row:last-child,
 .event-list > a:last-child,
 .profile-projects > a:last-child {
   border-bottom: 0;
 }
 
-.work-row:hover,
 .event-list > a:hover,
 .profile-projects > a:hover {
   background: rgba(255, 90, 25, 0.055);
 }
 
-.work-row > span:nth-child(2),
 .event-list > a > span:nth-child(2) {
   display: flex;
   min-width: 0;
   flex-direction: column;
 }
 
-.work-row strong,
 .event-list strong {
   overflow: hidden;
   font-size: 13px;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-.work-kind {
-  min-width: 48px;
-  padding: 6px 8px;
-  border-radius: 6px;
-  background: #eee8dc;
-  color: #635b50;
-  font-size: 8px;
-  font-weight: 800;
-  letter-spacing: 0.08em;
-  text-align: center;
-}
-
-.pr-kind {
-  background: #e4efe9;
-  color: #1a7049;
-}
-
-.inline-link {
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-  color: var(--orange-dark);
-  font-size: 12px;
-  font-weight: 700;
-}
-
-.trust-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 16px;
-}
-
-.trust-grid article {
-  min-height: 260px;
-  padding: 26px;
-  border: 1px solid var(--line);
-  border-radius: var(--radius);
-  background: rgba(255, 253, 248, 0.62);
-}
-
-.trust-grid svg {
-  color: var(--orange);
-}
-
-.trust-grid h3 {
-  margin: 58px 0 12px;
-  font-size: 18px;
-  letter-spacing: -0.03em;
-}
-
-.trust-grid p,
-.risk-note {
-  color: var(--muted);
-  font-size: 11px;
-  line-height: 1.65;
-}
-
-.risk-note {
-  margin-top: 16px;
 }
 
 .profile-hero {
@@ -1540,7 +1363,6 @@ small,
 
 @media (max-width: 900px) {
   .section-heading,
-  .creator-cta-inner,
   .project-hero-grid,
   .cycle-hero,
   .wallet-panel,
@@ -1548,14 +1370,9 @@ small,
     grid-template-columns: 1fr;
   }
 
-  .step-grid,
   .cycle-status-grid,
   .proposal-checklist > div {
     grid-template-columns: repeat(2, 1fr);
-  }
-
-  .trust-grid {
-    grid-template-columns: 1fr;
   }
 
   .artifact-links {
@@ -1629,8 +1446,8 @@ small,
   }
 
   .hero {
-    min-height: 620px;
-    padding-block: 72px 64px;
+    min-height: 540px;
+    padding-block: 72px;
   }
 
   .hero h1,
@@ -1648,12 +1465,6 @@ small,
     width: 100%;
   }
 
-  .hero-proof {
-    flex-direction: column;
-    gap: 11px;
-    margin-top: 38px;
-  }
-
   .section {
     padding-block: 76px;
   }
@@ -1664,37 +1475,19 @@ small,
   }
 
   .section-heading h2,
-  .creator-cta h2,
   .proposal-checklist h2 {
     font-size: 39px;
   }
 
   .project-grid,
-  .step-grid,
   .cycle-status-grid,
   .proposal-checklist > div {
     grid-template-columns: 1fr;
   }
 
   .project-card {
-    min-height: 470px;
+    min-height: 260px;
     padding: 22px;
-  }
-
-  .project-card-stats {
-    grid-template-columns: 1.4fr 1fr;
-  }
-
-  .project-card-stats span:last-child {
-    display: none;
-  }
-
-  .step-grid article {
-    min-height: 190px;
-  }
-
-  .step-grid h3 {
-    margin-top: 48px;
   }
 
   .leader-table {
@@ -1703,10 +1496,6 @@ small,
 
   .leader-row {
     min-width: 840px;
-  }
-
-  .creator-cta {
-    padding-block: 70px;
   }
 
   .footer-grid {
@@ -1770,15 +1559,6 @@ small,
     justify-self: start;
   }
 
-  .work-row {
-    grid-template-columns: auto minmax(190px, 1fr) auto;
-    min-width: 520px;
-  }
-
-  .work-list {
-    overflow-x: auto;
-  }
-
   .profile-hero {
     align-items: flex-start;
     flex-direction: column;
@@ -1810,10 +1590,8 @@ small,
   html {
     scroll-behavior: auto;
   }
-  .hero-switch-text-active {
-    animation: none;
-    opacity: 1;
-    transform: none;
+  .hero-typewriter-caret {
+    display: none;
   }
   *,
   *::before,

--- a/tests/app.test.tsx
+++ b/tests/app.test.tsx
@@ -12,6 +12,7 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { App } from "../src/App";
@@ -126,21 +127,26 @@ describe("discovery", () => {
       screen.getByRole("heading", { name: "MAKE MONEY SHIPPING CODE." }),
     ).toBeInTheDocument();
     expect(
-      await screen.findByText("GitHub ledger + reward records live", {
-        exact: false,
-      }),
+      await screen.findByRole("heading", { name: "Leaderboard" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("heading", { name: "Make money building agents." }),
+      screen.getByRole("heading", { name: "Projects" }),
     ).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Eliza" })).toBeInTheDocument();
     expect(
-      screen.getByRole("heading", { name: "Make money solving math." }),
+      screen.getByRole("heading", { name: "Delta Star" }),
     ).toBeInTheDocument();
-    expect(screen.getByText("$10,000 / month")).toBeInTheDocument();
-    expect(screen.getByText("$1,000,000 opportunity")).toBeInTheDocument();
+    const elizaCard = screen.getByRole("link", { name: /^Eliza /u });
+    expect(within(elizaCard).getByText("$10,000")).toBeInTheDocument();
+    expect(within(elizaCard).getByText("/ month")).toBeInTheDocument();
+    const deltaCard = screen.getByRole("link", { name: /^Delta Star /u });
+    expect(within(deltaCard).getByText("$1,000,000")).toBeInTheDocument();
+    expect(within(deltaCard).getByText("external prize")).toBeInTheDocument();
     expect(
-      screen.getByRole("heading", { name: "People shipping work." }),
-    ).toBeInTheDocument();
+      screen.queryByText(/GitHub ledger \+ reward records live/u),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("THE GITARMY NETWORK")).not.toBeInTheDocument();
+    expect(screen.queryByText("Work in. Money out.")).not.toBeInTheDocument();
     expect(screen.getByText("finish-line")).toBeInTheDocument();
   });
 
@@ -160,19 +166,37 @@ describe("discovery", () => {
     expect(
       screen.getByRole("heading", { name: "MAKE MONEY SHIPPING CODE." }),
     ).toBeInTheDocument();
-    for (const line of [
-      "MAKE MONEY PROVING MATH.",
-      "MAKE MONEY DISCOVERING DRUGS.",
-      "MAKE MONEY HARDENING THE WEB.",
-      "MAKE MONEY FIXING BUGS.",
-      "MAKE MONEY SECURING THE INTERNET.",
-      "MAKE MONEY SOLVING MATH.",
-      "MAKE MONEY ADVANCING SCIENCE.",
-      "MAKE MONEY BUILDING AGENTS.",
+    const visibleAction = () =>
+      document.querySelector(".hero-typewriter")?.textContent ?? "";
+    expect(visibleAction()).toBe("SHIPPING CODE.");
+    act(() => vi.advanceTimersToNextTimer());
+    act(() => vi.advanceTimersToNextTimer());
+    expect(visibleAction()).toBe("SHIPPING CODE");
+
+    for (const action of [
+      "PROVING MATH.",
+      "DISCOVERING DRUGS.",
+      "HARDENING THE WEB.",
+      "FIXING BUGS.",
+      "SECURING THE INTERNET.",
+      "SOLVING MATH.",
+      "ADVANCING SCIENCE.",
+      "BUILDING AGENTS.",
     ]) {
-      act(() => vi.advanceTimersByTime(2_800));
-      expect(screen.getByRole("heading", { name: line })).toBeInTheDocument();
-      expect(screen.getByText(line)).toHaveClass("hero-switch-text-active");
+      let attempts = 0;
+      while (
+        (screen.queryByRole("heading", { name: `MAKE MONEY ${action}` }) ===
+          null ||
+          visibleAction() !== action) &&
+        attempts < 100
+      ) {
+        act(() => vi.advanceTimersToNextTimer());
+        attempts += 1;
+      }
+      expect(
+        screen.getByRole("heading", { name: `MAKE MONEY ${action}` }),
+      ).toBeInTheDocument();
+      expect(visibleAction()).toBe(action);
     }
   });
 
@@ -261,6 +285,10 @@ describe("project routes", () => {
       `python3 - '${window.location.origin}/projects/eliza'`,
     );
     expect(command?.value).toContain("skills/contribute-to-eliza");
+    expect(screen.queryByText("Live from GitHub")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("How credit survives review"),
+    ).not.toBeInTheDocument();
     fireEvent.click(
       screen.getByRole("button", { name: "Copy install command" }),
     );

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -84,25 +84,38 @@ test("discovers both reward models and a score-ranked global ledger", async ({
     }),
   ).toBeVisible();
   await expect(
-    page.getByText(/GitHub ledger \+ reward records live|Snapshot stale/u),
-  ).toBeVisible();
-  await expect(
     page.getByRole("heading", {
       exact: true,
-      name: "Make money building agents.",
+      name: "Projects",
     }),
   ).toBeVisible();
   await expect(
     page.getByRole("heading", {
       exact: true,
-      name: "Make money solving math.",
+      name: "Eliza",
     }),
   ).toBeVisible();
-  await expect(page.getByText("$10,000 / month")).toBeVisible();
-  await expect(page.getByText("$1,000,000 opportunity")).toBeVisible();
   await expect(
-    page.getByRole("heading", { name: "People shipping work." }),
+    page.getByRole("heading", { exact: true, name: "Delta Star" }),
   ).toBeVisible();
+  const elizaCard = page.locator('a.project-card[href="/projects/eliza"]');
+  await expect(elizaCard.getByText("$10,000", { exact: true })).toBeVisible();
+  await expect(elizaCard.getByText("/ month", { exact: true })).toBeVisible();
+  const deltaCard = page.locator('a.project-card[href="/projects/delta-star"]');
+  await expect(
+    deltaCard.getByText("$1,000,000", { exact: true }),
+  ).toBeVisible();
+  await expect(
+    deltaCard.getByText("external prize", { exact: true }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Leaderboard" }),
+  ).toBeVisible();
+  await expect(
+    page.getByText(/GitHub ledger \+ reward records live/u),
+  ).toHaveCount(0);
+  await expect(page.getByText("THE GITARMY NETWORK")).toHaveCount(0);
+  await expect(page.getByText("Work in. Money out.")).toHaveCount(0);
 
   const rows = page.locator("#leaderboard tbody .leader-row");
   if (snapshot.leaders.length === 0) await expect(rows).toHaveCount(0);
@@ -134,6 +147,8 @@ test("starts Eliza in one command and generates a public payout marker", async (
     `<!-- gitarmy-wallet:v1 {"chain":"solana","address":"${address}"} -->`,
   );
   await expect(page.getByText(/Never paste a seed phrase/u)).toBeVisible();
+  await expect(page.getByText("Live from GitHub")).toHaveCount(0);
+  await expect(page.getByText("How credit survives review")).toHaveCount(0);
 });
 
 test("never presents Delta Star's external prize as platform money", async ({
@@ -302,6 +317,10 @@ test("keeps primary routes accessible and inside the viewport", async ({
           name: "MAKE MONEY DISCOVERING DRUGS.",
         }),
       ).toBeVisible({ timeout: 8_000 });
+      await expect(page.locator(".hero-typewriter")).toHaveText(
+        "DISCOVERING DRUGS.",
+        { timeout: 8_000 },
+      );
     }
     const results = await new AxeBuilder({ page })
       .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])


### PR DESCRIPTION
Closes #14.

## What changed

- Rebuilt the hero as one oversized `MAKE MONEY` H1 with a typed/deleted orange action line.
- Added all approved code, math, science, security, and agent phrases, plus stable layout reservation and reduced-motion behavior.
- Reduced the homepage to projects and the score-ranked leaderboard.
- Reduced project cards to the project name and honest money label: Eliza at `$10,000 / month`, Delta Star as a `$1,000,000` external prize.
- Removed the status/update strip, network eyebrow, explanatory copy, proof chips, process section, creator CTA, homepage issue/PR content, project work queue, and review explainer.
- Pointed project management at the existing Eliza Hub.
- Updated product/design contracts, component coverage, end-to-end coverage, and the evidence recorder.

## Validation

- `bun run format:check`
- `bun run lint:check`
- `bun run typecheck`
- `bun run test` — 277 Vitest tests and 26 skill tests passed
- `bun run projects:check`
- `bun run evaluations:check`
- `bun run cycles:check`
- `bun run audit:dependencies` — no vulnerabilities
- `bun run build`
- `bun run test:e2e` — 32 responsive Chromium tests passed across wide desktop, desktop, tablet, and 320px mobile
- `bun run test:e2e:record` on commit `dda3fa3c0b776b9ae734ba91a977d09ccd5d9df8`

The recorded desktop/mobile captures and walkthrough were visually reviewed. Browser evidence reported zero console errors, page errors, failed requests, or non-success responses. The protected `develop` workflow remains the only production Cloudflare deployment path.
