### PR TITLE
feat: tighten homepage project layout

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -44,8 +44,9 @@ colored words or faux terminal syntax to the hero.
 ## Layout
 
 - Main rail: `min(100% - 32px, 1200px)`.
-- Major sections use generous vertical rhythm and full-width background changes.
-- Project cards may sit in a two-column grid; most other content stays one
+- Major sections use compact vertical rhythm on discovery and full-width
+  background changes where contrast is necessary.
+- Discovery project rows span the full main rail. Most other content stays one
   continuous document.
 - The project hero pairs the mission with one compact reward card.
 - Leaderboards use semantic row structure and an internally scrolling table on
@@ -58,10 +59,11 @@ colored words or faux terminal syntax to the hero.
 ### Discovery
 
 The all-caps hero uses a fixed `MAKE MONEY` first line and a typed/deleted orange
-second line. It reserves the tallest phrase and respects reduced motion. Nothing
-else competes inside the hero. Project cards show only project name and money;
-monthly bounties and external prizes remain textually distinct. The global
-leaderboard follows the project grid and shows score, relevant tokens, live
+second line. It sits high in a compact first viewport, reserves the tallest
+phrase, and respects reduced motion. Nothing else competes inside the hero.
+Each full-rail project row shows its name, one manifest-backed sentence, and
+money; monthly bounties and external prizes remain textually distinct. The
+global leaderboard follows immediately and shows score, relevant tokens, live
 projection, and total paid without defaulting to the richest contributor.
 
 ### Project

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -88,8 +88,10 @@ types and deletes these statements in sequence:
 
 Reduced-motion users see the complete first statement without the typing
 effect. The hero has no status badge, eyebrow, explanatory copy, or proof
-chips. Project cards show only the project name and its monthly bounty or
-clearly labeled external prize. The global leaderboard follows immediately.
+chips. It stays compact so funded work enters the page quickly. Each project
+spans the content rail and shows its name, one canonical mission sentence, and
+its monthly bounty or clearly labeled external prize. The global leaderboard
+follows immediately.
 
 ### Start
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -501,14 +501,17 @@ function ProjectCard({ project }: { project: ProjectDefinition }) {
         <h3>{project.name}</h3>
         <ArrowRight aria-hidden="true" />
       </div>
-      <p className="project-bounty">
-        <strong>{amount}</strong>
-        <span>
-          {project.reward.kind === "monthly-pool"
-            ? "/ month"
-            : "external prize"}
-        </span>
-      </p>
+      <div className="project-card-content">
+        <p className="project-summary">{project.description}</p>
+        <p className="project-bounty">
+          <strong>{amount}</strong>
+          <span>
+            {project.reward.kind === "monthly-pool"
+              ? "/ month"
+              : "external prize"}
+          </span>
+        </p>
+      </div>
     </Link>
   );
 }
@@ -624,7 +627,10 @@ function GlobalLeaderboard({
 }) {
   const leaders = globalLeaders(views, cycleIndex);
   return (
-    <section className="section shell" id="leaderboard">
+    <section
+      className="section shell home-leaderboard-section"
+      id="leaderboard"
+    >
       <h2 className="home-section-title">Leaderboard</h2>
       {leaders.length === 0 ? (
         <EmptyState text="No accepted outcomes in the active cycles yet." />
@@ -699,7 +705,7 @@ function HomePage({ state, retry }: { state: DataState; retry: () => void }) {
         <TypewriterHeroHeading />
       </section>
 
-      <section className="section shell" id="projects">
+      <section className="section shell home-projects-section" id="projects">
         <h2 className="home-section-title">Projects</h2>
         <div className="project-grid">
           {PROJECTS.map((project) => (

--- a/src/styles.css
+++ b/src/styles.css
@@ -119,12 +119,12 @@ input:focus-visible {
 }
 
 .hero {
-  min-height: min(760px, calc(100vh - 72px));
+  min-height: clamp(420px, 48vh, 500px);
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  justify-content: center;
-  padding-block: 96px;
+  justify-content: flex-start;
+  padding-block: clamp(56px, 6vh, 72px) 32px;
 }
 
 .data-notice {
@@ -333,11 +333,19 @@ p {
 }
 
 .home-section-title {
-  margin: 0 0 42px;
+  margin: 0 0 30px;
   font-size: clamp(42px, 6vw, 76px);
   font-weight: 800;
   letter-spacing: -0.06em;
   line-height: 0.95;
+}
+
+.home-projects-section {
+  padding-block: 40px 52px;
+}
+
+.home-leaderboard-section {
+  padding-block: 52px 80px;
 }
 
 .section-heading {
@@ -367,16 +375,16 @@ p {
 
 .project-grid {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 18px;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 16px;
 }
 
 .project-card {
-  min-height: 300px;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  padding: 32px;
+  min-height: 230px;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  gap: 52px;
+  padding: 34px;
   border: 1px solid var(--line);
   border-radius: var(--radius);
   background: rgba(255, 253, 248, 0.72);
@@ -412,11 +420,28 @@ p {
   color: var(--orange-dark);
 }
 
+.project-card-content {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: end;
+  gap: 56px;
+}
+
+.project-summary {
+  max-width: 660px;
+  margin: 0;
+  color: var(--muted);
+  font-size: clamp(16px, 1.55vw, 20px);
+  line-height: 1.45;
+}
+
 .project-bounty {
   display: flex;
+  align-items: flex-end;
   flex-direction: column;
   gap: 4px;
   margin: 0;
+  text-align: right;
 }
 
 .person-cell span,
@@ -1400,6 +1425,16 @@ small {
   .proposal-grid {
     gap: 18px;
   }
+
+  .project-card-content {
+    grid-template-columns: 1fr;
+    gap: 32px;
+  }
+
+  .project-bounty {
+    align-items: flex-start;
+    text-align: left;
+  }
 }
 
 @media (max-width: 680px) {
@@ -1446,8 +1481,8 @@ small {
   }
 
   .hero {
-    min-height: 540px;
-    padding-block: 72px;
+    min-height: 320px;
+    padding-block: 40px 20px;
   }
 
   .hero h1,
@@ -1469,6 +1504,14 @@ small {
     padding-block: 76px;
   }
 
+  .home-projects-section {
+    padding-block: 32px 42px;
+  }
+
+  .home-leaderboard-section {
+    padding-block: 42px 60px;
+  }
+
   .section-heading {
     gap: 20px;
     margin-bottom: 30px;
@@ -1486,8 +1529,13 @@ small {
   }
 
   .project-card {
-    min-height: 260px;
+    min-height: 0;
+    gap: 42px;
     padding: 22px;
+  }
+
+  .project-summary {
+    font-size: 15px;
   }
 
   .leader-table {

--- a/tests/app.test.tsx
+++ b/tests/app.test.tsx
@@ -139,9 +139,15 @@ describe("discovery", () => {
     const elizaCard = screen.getByRole("link", { name: /^Eliza /u });
     expect(within(elizaCard).getByText("$10,000")).toBeInTheDocument();
     expect(within(elizaCard).getByText("/ month")).toBeInTheDocument();
+    expect(
+      within(elizaCard).getByText(/Build and verify the elizaOS framework/u),
+    ).toBeInTheDocument();
     const deltaCard = screen.getByRole("link", { name: /^Delta Star /u });
     expect(within(deltaCard).getByText("$1,000,000")).toBeInTheDocument();
     expect(within(deltaCard).getByText("external prize")).toBeInTheDocument();
+    expect(
+      within(deltaCard).getByText(/Advance ArkLib's machine-checked/u),
+    ).toBeInTheDocument();
     expect(
       screen.queryByText(/GitHub ledger \+ reward records live/u),
     ).not.toBeInTheDocument();

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -101,6 +101,9 @@ test("discovers both reward models and a score-ranked global ledger", async ({
   const elizaCard = page.locator('a.project-card[href="/projects/eliza"]');
   await expect(elizaCard.getByText("$10,000", { exact: true })).toBeVisible();
   await expect(elizaCard.getByText("/ month", { exact: true })).toBeVisible();
+  await expect(
+    elizaCard.getByText(/Build and verify the elizaOS framework/u),
+  ).toBeVisible();
   const deltaCard = page.locator('a.project-card[href="/projects/delta-star"]');
   await expect(
     deltaCard.getByText("$1,000,000", { exact: true }),
@@ -108,6 +111,20 @@ test("discovers both reward models and a score-ranked global ledger", async ({
   await expect(
     deltaCard.getByText("external prize", { exact: true }),
   ).toBeVisible();
+  await expect(
+    deltaCard.getByText(/Advance ArkLib's machine-checked/u),
+  ).toBeVisible();
+  const [gridBox, elizaBox, deltaBox] = await Promise.all([
+    page.locator(".project-grid").boundingBox(),
+    elizaCard.boundingBox(),
+    deltaCard.boundingBox(),
+  ]);
+  expect(gridBox).not.toBeNull();
+  expect(elizaBox).not.toBeNull();
+  expect(deltaBox).not.toBeNull();
+  expect(elizaBox?.width).toBeGreaterThan((gridBox?.width ?? 0) - 2);
+  expect(deltaBox?.width).toBeGreaterThan((gridBox?.width ?? 0) - 2);
+  expect(deltaBox?.y).toBeGreaterThan((elizaBox?.y ?? 0) + 1);
   await expect(
     page.getByRole("heading", { name: "Leaderboard" }),
   ).toBeVisible();


### PR DESCRIPTION
Closes #16.

## What changed

- moves the animated money headline higher and removes excess homepage whitespace
- turns the project grid into full-width project rows
- adds each project's canonical manifest description beside its monthly bounty
- keeps the layout compact and readable from 320px mobile through wide desktop
- documents the tightened discovery hierarchy in the product and design contracts

## Verification

- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun run test` (277 app tests + 26 skill tests)
- project, evaluation, reward-cycle, and dependency audits
- `bun run build`
- `bun run test:e2e` (32/32 across wide desktop, desktop, tablet, and 320px mobile)
- `bun run test:e2e:record` on commit `b0119d94e66a5ec4340c420615eebff5dfc9290f`

The final evidence capture reports zero console errors, page errors, failed first-party requests, or failed first-party responses.
