### PR TITLE
fix(score): keep head-pinned evidence after non-author post-merge body edits

### DIFF
--- a/scripts/generate-leaderboard.test.ts
+++ b/scripts/generate-leaderboard.test.ts
@@ -61,6 +61,7 @@ function mergedPullRequestWithEvidence(
     createdAt: "2026-07-29T10:00:00.000Z",
     updatedAt: "2026-07-30T11:00:00.000Z",
     lastEditedAt: null,
+    editor: null,
     mergedAt: "2026-07-30T11:00:00.000Z",
     headRefOid,
     isDraft: false,
@@ -1000,6 +1001,12 @@ describe("rate-efficient query plan", () => {
       "headRefOid",
     );
     expect(LEADERBOARD_QUERY_DOCUMENTS.pullRequestDetails).toContain(
+      "lastEditedAt",
+    );
+    expect(LEADERBOARD_QUERY_DOCUMENTS.pullRequestDetails).toContain(
+      "editor { ...LeaderboardActor }",
+    );
+    expect(LEADERBOARD_QUERY_DOCUMENTS.pullRequestDetails).toContain(
       "commit { oid }",
     );
     expect(LEADERBOARD_QUERY_DOCUMENTS.moreReviews).toContain("headRefOid");
@@ -1396,6 +1403,7 @@ describe("current-head review selection", () => {
       createdAt,
       updatedAt,
       lastEditedAt: null,
+      editor: null,
       mergedAt: null,
       isDraft: false,
       headRefOid: currentHead,

--- a/scripts/generate-leaderboard.test.ts
+++ b/scripts/generate-leaderboard.test.ts
@@ -534,6 +534,76 @@ describe("remote leaderboard evidence", () => {
     });
     expect(fetcher).not.toHaveBeenCalled();
   });
+
+  it("still verifies head-pinned body after non-author post-merge edit (#17606)", async () => {
+    const head = "a".repeat(40);
+    const pullRequest = mergedPullRequestWithEvidence(
+      `<!-- evidence-row:backend-logs -->\nBackend logs: ${validLogUrl}`,
+      {
+        id: "PR_17606",
+        number: 17606,
+        author: actor("ss251"),
+        editor: actor("lalalune"),
+        createdAt: "2026-07-01T00:00:00.000Z",
+        updatedAt: "2026-07-30T10:30:00.000Z",
+        lastEditedAt: "2026-07-30T10:30:00.000Z",
+        mergedAt: "2026-07-30T09:00:00.000Z",
+        headRefOid: head,
+      },
+    );
+    const authorEdited = mergedPullRequestWithEvidence(
+      `<!-- evidence-row:backend-logs -->\nBackend logs: ${validLogUrl}`,
+      {
+        id: "PR_AUTHOR_FARM",
+        number: 17607,
+        author: actor("ss251"),
+        editor: actor("ss251"),
+        createdAt: "2026-07-01T00:00:00.000Z",
+        updatedAt: "2026-07-30T10:30:00.000Z",
+        lastEditedAt: "2026-07-30T10:30:00.000Z",
+        mergedAt: "2026-07-30T09:00:00.000Z",
+        headRefOid: head,
+      },
+    );
+    const fetcher = vi.fn(
+      async () =>
+        new Response(logDocument, {
+          status: 200,
+          headers: { "Content-Type": "text/plain; charset=utf-8" },
+        }),
+    );
+
+    const kept = await verifyPullRequestEvidence([pullRequest], {
+      evidenceFetch: fetcher,
+      evidenceTimeoutMs: 100,
+      evidenceToken: "test-token",
+    });
+    const voided = await verifyPullRequestEvidence([authorEdited], {
+      evidenceFetch: fetcher,
+      evidenceTimeoutMs: 100,
+      evidenceToken: "test-token",
+    });
+
+    expect(kept).toMatchObject({
+      status: "complete",
+      sourceCount: 1,
+      artifactCount: 1,
+      artifacts: [
+        expect.objectContaining({
+          pullRequestId: "PR_17606",
+          category: "logs",
+          artifactIdentity: validLogUrl,
+        }),
+      ],
+    });
+    expect(voided).toMatchObject({
+      status: "complete",
+      sourceCount: 0,
+      artifactCount: 0,
+      artifacts: [],
+    });
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("post-evidence open-PR revalidation", () => {

--- a/scripts/generate-leaderboard.ts
+++ b/scripts/generate-leaderboard.ts
@@ -2521,8 +2521,10 @@ export interface PullRequestEvidenceVerificationResult {
 }
 
 /**
- * Resolves score-bearing proof from the exact, unchanged contributor-authored
- * source that existed at merge or at the stable open-PR snapshot. The root
+ * Resolves score-bearing proof from eligible contributor-authored body sources.
+ * Merged PRs use bodies last edited at or before merge, or a non-author
+ * post-merge body edit that still pins the merged head via a single
+ * evidence-head marker. Open PRs use the stable live body snapshot. The root
  * evidence verifier owns URL trust, redirects, byte limits, and structure.
  */
 export async function verifyPullRequestEvidence(

--- a/scripts/generate-leaderboard.ts
+++ b/scripts/generate-leaderboard.ts
@@ -20,6 +20,7 @@ import {
   type GitHubTextSource,
   type IssueRecord,
   isBotActor,
+  isMergedPullRequestBodyEligibleForEvidence,
   type LeaderboardSnapshot,
   type LeaderboardSourceMetadata,
   type MergedPullRequestOutcome,
@@ -289,6 +290,7 @@ const PULL_REQUEST_FRAGMENT = `
     createdAt
     updatedAt
     lastEditedAt
+    editor { ...LeaderboardActor }
     mergedAt
     isDraft
     headRefOid
@@ -883,6 +885,7 @@ function parsePullRequest(value: unknown, path: string): ParsedPullRequest {
       createdAt: asString(node.createdAt, `${path}.createdAt`),
       updatedAt: asString(node.updatedAt, `${path}.updatedAt`),
       lastEditedAt: asNullableString(node.lastEditedAt, `${path}.lastEditedAt`),
+      editor: parseActor(node.editor, `${path}.editor`),
       mergedAt: asNullableString(node.mergedAt, `${path}.mergedAt`),
       isDraft: asBoolean(node.isDraft, `${path}.isDraft`),
       headRefOid: asFullCommitSha(node.headRefOid, `${path}.headRefOid`),
@@ -2451,9 +2454,19 @@ function evidenceVerificationCandidates(
         source.kind !== "body" ||
         !source.author ||
         isBotActor(source.author) ||
-        Date.parse(source.createdAt) > mergedAt ||
-        Date.parse(source.updatedAt) > mergedAt
+        Date.parse(source.createdAt) > mergedAt
       ) {
+        continue;
+      }
+      // Open PRs still require the live body to be no newer than "now"
+      // (mergedAt is +Infinity when open). Merged PRs may keep a body that was
+      // last edited after merge only when the editor is not the author and the
+      // evidence-head still pins the merged OID (maintainer drive-by edits).
+      if (pullRequest.mergedAt) {
+        if (!isMergedPullRequestBodyEligibleForEvidence(pullRequest, source)) {
+          continue;
+        }
+      } else if (Date.parse(source.updatedAt) > mergedAt) {
         continue;
       }
       if (evidenceHeadOid(source.body) !== pullRequest.headRefOid) continue;

--- a/src/lib/leaderboard.test.ts
+++ b/src/lib/leaderboard.test.ts
@@ -18,11 +18,13 @@ import {
   type GitHubActor,
   type GitHubTextSource,
   hasMaterialTestChange,
+  isMergedPullRequestBodyEligibleForEvidence,
   type IssueRecord,
   LEADERBOARD_REPOSITORY,
   type LeaderboardInput,
   MATERIAL_TEST_ADDITIONS,
   MATERIAL_TEST_CHURN,
+  parseEvidenceHeadOid,
   type PullRequestRecord,
   pullRequestTextSources,
   qualifiesResolvedIssue,
@@ -169,6 +171,7 @@ function pullRequest(
     createdAt: "2026-07-28T10:00:00.000Z",
     updatedAt: "2026-07-30T11:00:00.000Z",
     lastEditedAt: null,
+    editor: null,
     mergedAt: "2026-07-30T11:00:00.000Z",
     headRefOid: "a".repeat(40),
     isDraft: false,
@@ -942,6 +945,139 @@ describe("evidence assessment", () => {
     ).toMatchObject({ points: 0, categories: [] });
   });
 
+
+describe("merged PR body evidence eligibility", () => {
+  const head = "a".repeat(40);
+  const packageBody = [
+    `<!-- evidence-head:${head} -->`,
+    "<!-- evidence-row:after-screenshots -->",
+    "After: https://github.com/user-attachments/assets/12345678-1234-1234-1234-123456789abc",
+  ].join("\n");
+
+  function mergedPr(
+    overrides: Partial<PullRequestRecord> = {},
+  ): PullRequestRecord {
+    return {
+      id: "PR_EVIDENCE_ELIG",
+      number: 17606,
+      title: "fix: evidence package",
+      url: "https://github.com/elizaOS/eliza/pull/17606",
+      body: packageBody,
+      createdAt: "2026-07-01T00:00:00.000Z",
+      updatedAt: "2026-07-30T10:00:00.000Z",
+      lastEditedAt: "2026-07-30T10:00:00.000Z",
+      editor: null,
+      mergedAt: "2026-07-30T09:00:00.000Z",
+      headRefOid: head,
+      isDraft: false,
+      reviewDecision: null,
+      activeReviewRequestCount: 0,
+      author: actor("ss251"),
+      assignees: [],
+      labels: [],
+      files: [],
+      comments: [],
+      reviews: [],
+      closingIssueIds: [],
+      additions: 1,
+      deletions: 0,
+      changedFiles: 1,
+      commitCount: 1,
+      ...overrides,
+    };
+  }
+
+  function bodySource(
+    updatedAt: string,
+    body = packageBody,
+  ): GitHubTextSource {
+    return {
+      id: "PR_EVIDENCE_ELIG:body",
+      artifactId: "PR_EVIDENCE_ELIG",
+      kind: "body",
+      body,
+      url: "https://github.com/elizaOS/eliza/pull/17606",
+      createdAt: "2026-07-01T00:00:00.000Z",
+      updatedAt,
+      author: actor("ss251"),
+    };
+  }
+
+  it("parses a single evidence-head marker and rejects multiples", () => {
+    expect(parseEvidenceHeadOid(packageBody)).toBe(head);
+    expect(parseEvidenceHeadOid("no marker")).toBeNull();
+    expect(
+      parseEvidenceHeadOid(
+        `<!-- evidence-head:${head} -->\n<!-- evidence-head:${"b".repeat(40)} -->`,
+      ),
+    ).toBeNull();
+  });
+
+  it("accepts a body last edited at or before merge", () => {
+    const pr = mergedPr({ lastEditedAt: "2026-07-30T08:59:00.000Z", editor: actor("ss251") });
+    expect(
+      isMergedPullRequestBodyEligibleForEvidence(
+        pr,
+        bodySource("2026-07-30T08:59:00.000Z"),
+      ),
+    ).toBe(true);
+  });
+
+  it("voids author post-merge body edits even when evidence-head still matches", () => {
+    const pr = mergedPr({
+      lastEditedAt: "2026-07-30T10:00:00.000Z",
+      editor: actor("ss251"),
+    });
+    expect(
+      isMergedPullRequestBodyEligibleForEvidence(
+        pr,
+        bodySource("2026-07-30T10:00:00.000Z"),
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps a head-pinned package after a non-author post-merge body edit", () => {
+    const pr = mergedPr({
+      lastEditedAt: "2026-07-30T10:00:00.000Z",
+      editor: actor("lalalune"),
+    });
+    expect(
+      isMergedPullRequestBodyEligibleForEvidence(
+        pr,
+        bodySource("2026-07-30T10:00:00.000Z"),
+      ),
+    ).toBe(true);
+  });
+
+  it("still voids non-author post-merge edits when the evidence-head no longer matches", () => {
+    const pr = mergedPr({
+      lastEditedAt: "2026-07-30T10:00:00.000Z",
+      editor: actor("lalalune"),
+      headRefOid: "c".repeat(40),
+    });
+    expect(
+      isMergedPullRequestBodyEligibleForEvidence(
+        pr,
+        bodySource("2026-07-30T10:00:00.000Z"),
+      ),
+    ).toBe(false);
+  });
+
+  it("fails closed when the post-merge editor is unknown", () => {
+    const pr = mergedPr({
+      lastEditedAt: "2026-07-30T10:00:00.000Z",
+      editor: null,
+    });
+    expect(
+      isMergedPullRequestBodyEligibleForEvidence(
+        pr,
+        bodySource("2026-07-30T10:00:00.000Z"),
+      ),
+    ).toBe(false);
+  });
+});
+
+
   it("scores the verifier identity for an inline-code artifact URL", () => {
     const source = textSource(
       "COMMENT_INLINE_CODE",
@@ -1310,6 +1446,7 @@ describe("scoring and caps", () => {
         "After screenshot: https://github.com/user-attachments/assets/pre-merge",
       ].join("\n"),
       lastEditedAt: "2026-07-30T10:00:00.000Z",
+      editor: null,
       comments: [commentCopy],
     });
     const snapshot = createLeaderboardSnapshot(

--- a/src/lib/leaderboard.test.ts
+++ b/src/lib/leaderboard.test.ts
@@ -18,14 +18,14 @@ import {
   type GitHubActor,
   type GitHubTextSource,
   hasMaterialTestChange,
-  isMergedPullRequestBodyEligibleForEvidence,
   type IssueRecord,
+  isMergedPullRequestBodyEligibleForEvidence,
   LEADERBOARD_REPOSITORY,
   type LeaderboardInput,
   MATERIAL_TEST_ADDITIONS,
   MATERIAL_TEST_CHURN,
-  parseEvidenceHeadOid,
   type PullRequestRecord,
+  parseEvidenceHeadOid,
   pullRequestTextSources,
   qualifiesResolvedIssue,
   SCORE_CAPS,
@@ -945,138 +945,197 @@ describe("evidence assessment", () => {
     ).toMatchObject({ points: 0, categories: [] });
   });
 
+  describe("merged PR body evidence eligibility", () => {
+    const head = "a".repeat(40);
+    const packageBody = [
+      `<!-- evidence-head:${head} -->`,
+      "<!-- evidence-row:after-screenshots -->",
+      "After: https://github.com/user-attachments/assets/12345678-1234-1234-1234-123456789abc",
+    ].join("\n");
 
-describe("merged PR body evidence eligibility", () => {
-  const head = "a".repeat(40);
-  const packageBody = [
-    `<!-- evidence-head:${head} -->`,
-    "<!-- evidence-row:after-screenshots -->",
-    "After: https://github.com/user-attachments/assets/12345678-1234-1234-1234-123456789abc",
-  ].join("\n");
+    function mergedPr(
+      overrides: Partial<PullRequestRecord> = {},
+    ): PullRequestRecord {
+      return {
+        id: "PR_EVIDENCE_ELIG",
+        number: 17606,
+        title: "fix: evidence package",
+        url: "https://github.com/elizaOS/eliza/pull/17606",
+        body: packageBody,
+        createdAt: "2026-07-01T00:00:00.000Z",
+        updatedAt: "2026-07-30T10:00:00.000Z",
+        lastEditedAt: "2026-07-30T10:00:00.000Z",
+        editor: null,
+        mergedAt: "2026-07-30T09:00:00.000Z",
+        headRefOid: head,
+        isDraft: false,
+        reviewDecision: null,
+        activeReviewRequestCount: 0,
+        author: actor("ss251"),
+        assignees: [],
+        labels: [],
+        files: [],
+        comments: [],
+        reviews: [],
+        closingIssueIds: [],
+        additions: 1,
+        deletions: 0,
+        changedFiles: 1,
+        commitCount: 1,
+        ...overrides,
+      };
+    }
 
-  function mergedPr(
-    overrides: Partial<PullRequestRecord> = {},
-  ): PullRequestRecord {
-    return {
-      id: "PR_EVIDENCE_ELIG",
-      number: 17606,
-      title: "fix: evidence package",
-      url: "https://github.com/elizaOS/eliza/pull/17606",
-      body: packageBody,
-      createdAt: "2026-07-01T00:00:00.000Z",
-      updatedAt: "2026-07-30T10:00:00.000Z",
-      lastEditedAt: "2026-07-30T10:00:00.000Z",
-      editor: null,
-      mergedAt: "2026-07-30T09:00:00.000Z",
-      headRefOid: head,
-      isDraft: false,
-      reviewDecision: null,
-      activeReviewRequestCount: 0,
-      author: actor("ss251"),
-      assignees: [],
-      labels: [],
-      files: [],
-      comments: [],
-      reviews: [],
-      closingIssueIds: [],
-      additions: 1,
-      deletions: 0,
-      changedFiles: 1,
-      commitCount: 1,
-      ...overrides,
-    };
-  }
+    function bodySource(
+      updatedAt: string,
+      body = packageBody,
+    ): GitHubTextSource {
+      return {
+        id: "PR_EVIDENCE_ELIG:body",
+        artifactId: "PR_EVIDENCE_ELIG",
+        kind: "body",
+        body,
+        url: "https://github.com/elizaOS/eliza/pull/17606",
+        createdAt: "2026-07-01T00:00:00.000Z",
+        updatedAt,
+        author: actor("ss251"),
+      };
+    }
 
-  function bodySource(
-    updatedAt: string,
-    body = packageBody,
-  ): GitHubTextSource {
-    return {
-      id: "PR_EVIDENCE_ELIG:body",
-      artifactId: "PR_EVIDENCE_ELIG",
-      kind: "body",
-      body,
-      url: "https://github.com/elizaOS/eliza/pull/17606",
-      createdAt: "2026-07-01T00:00:00.000Z",
-      updatedAt,
-      author: actor("ss251"),
-    };
-  }
-
-  it("parses a single evidence-head marker and rejects multiples", () => {
-    expect(parseEvidenceHeadOid(packageBody)).toBe(head);
-    expect(parseEvidenceHeadOid("no marker")).toBeNull();
-    expect(
-      parseEvidenceHeadOid(
-        `<!-- evidence-head:${head} -->\n<!-- evidence-head:${"b".repeat(40)} -->`,
-      ),
-    ).toBeNull();
-  });
-
-  it("accepts a body last edited at or before merge", () => {
-    const pr = mergedPr({ lastEditedAt: "2026-07-30T08:59:00.000Z", editor: actor("ss251") });
-    expect(
-      isMergedPullRequestBodyEligibleForEvidence(
-        pr,
-        bodySource("2026-07-30T08:59:00.000Z"),
-      ),
-    ).toBe(true);
-  });
-
-  it("voids author post-merge body edits even when evidence-head still matches", () => {
-    const pr = mergedPr({
-      lastEditedAt: "2026-07-30T10:00:00.000Z",
-      editor: actor("ss251"),
+    it("parses a single evidence-head marker and rejects multiples", () => {
+      expect(parseEvidenceHeadOid(packageBody)).toBe(head);
+      expect(parseEvidenceHeadOid("no marker")).toBeNull();
+      expect(
+        parseEvidenceHeadOid(
+          `<!-- evidence-head:${head} -->\n<!-- evidence-head:${"b".repeat(40)} -->`,
+        ),
+      ).toBeNull();
     });
-    expect(
-      isMergedPullRequestBodyEligibleForEvidence(
-        pr,
-        bodySource("2026-07-30T10:00:00.000Z"),
-      ),
-    ).toBe(false);
-  });
 
-  it("keeps a head-pinned package after a non-author post-merge body edit", () => {
-    const pr = mergedPr({
-      lastEditedAt: "2026-07-30T10:00:00.000Z",
-      editor: actor("lalalune"),
+    it("accepts a body last edited at or before merge", () => {
+      const pr = mergedPr({
+        lastEditedAt: "2026-07-30T08:59:00.000Z",
+        editor: actor("ss251"),
+      });
+      expect(
+        isMergedPullRequestBodyEligibleForEvidence(
+          pr,
+          bodySource("2026-07-30T08:59:00.000Z"),
+        ),
+      ).toBe(true);
     });
-    expect(
-      isMergedPullRequestBodyEligibleForEvidence(
-        pr,
-        bodySource("2026-07-30T10:00:00.000Z"),
-      ),
-    ).toBe(true);
-  });
 
-  it("still voids non-author post-merge edits when the evidence-head no longer matches", () => {
-    const pr = mergedPr({
-      lastEditedAt: "2026-07-30T10:00:00.000Z",
-      editor: actor("lalalune"),
-      headRefOid: "c".repeat(40),
+    it("voids author post-merge body edits even when evidence-head still matches", () => {
+      const pr = mergedPr({
+        lastEditedAt: "2026-07-30T10:00:00.000Z",
+        editor: actor("ss251"),
+      });
+      expect(
+        isMergedPullRequestBodyEligibleForEvidence(
+          pr,
+          bodySource("2026-07-30T10:00:00.000Z"),
+        ),
+      ).toBe(false);
     });
-    expect(
-      isMergedPullRequestBodyEligibleForEvidence(
-        pr,
-        bodySource("2026-07-30T10:00:00.000Z"),
-      ),
-    ).toBe(false);
-  });
 
-  it("fails closed when the post-merge editor is unknown", () => {
-    const pr = mergedPr({
-      lastEditedAt: "2026-07-30T10:00:00.000Z",
-      editor: null,
+    it("keeps a head-pinned package after a non-author post-merge body edit", () => {
+      const pr = mergedPr({
+        lastEditedAt: "2026-07-30T10:00:00.000Z",
+        editor: actor("lalalune"),
+      });
+      expect(
+        isMergedPullRequestBodyEligibleForEvidence(
+          pr,
+          bodySource("2026-07-30T10:00:00.000Z"),
+        ),
+      ).toBe(true);
     });
-    expect(
-      isMergedPullRequestBodyEligibleForEvidence(
-        pr,
-        bodySource("2026-07-30T10:00:00.000Z"),
-      ),
-    ).toBe(false);
-  });
-});
 
+    it("still voids non-author post-merge edits when the evidence-head no longer matches", () => {
+      const pr = mergedPr({
+        lastEditedAt: "2026-07-30T10:00:00.000Z",
+        editor: actor("lalalune"),
+        headRefOid: "c".repeat(40),
+      });
+      expect(
+        isMergedPullRequestBodyEligibleForEvidence(
+          pr,
+          bodySource("2026-07-30T10:00:00.000Z"),
+        ),
+      ).toBe(false);
+    });
+
+    it("fails closed when the post-merge editor is unknown", () => {
+      const pr = mergedPr({
+        lastEditedAt: "2026-07-30T10:00:00.000Z",
+        editor: null,
+      });
+      expect(
+        isMergedPullRequestBodyEligibleForEvidence(
+          pr,
+          bodySource("2026-07-30T10:00:00.000Z"),
+        ),
+      ).toBe(false);
+    });
+
+    it("scores head-pinned evidence after a non-author post-merge body edit (#17606)", () => {
+      // Repro shape: ss251 package pre-merge; lalalune edits body after merge;
+      // evidence-head still matches merged OID — must keep score-bearing source.
+      const scored = pullRequest({
+        id: "PR_17606",
+        number: 17606,
+        title: "fix: evidence package survives maintainer body edit",
+        body: packageBody,
+        author: actor("ss251"),
+        createdAt: "2026-07-01T00:00:00.000Z",
+        updatedAt: "2026-07-30T10:00:00.000Z",
+        lastEditedAt: "2026-07-30T10:00:00.000Z",
+        editor: actor("lalalune"),
+        mergedAt: "2026-07-30T09:00:00.000Z",
+        headRefOid: head,
+      });
+      const voidedAuthorEdit = pullRequest({
+        id: "PR_AUTHOR_FARM",
+        number: 17607,
+        title: "author post-merge body edit must void package",
+        body: packageBody,
+        author: actor("ss251"),
+        createdAt: "2026-07-01T00:00:00.000Z",
+        updatedAt: "2026-07-30T10:00:00.000Z",
+        lastEditedAt: "2026-07-30T10:00:00.000Z",
+        editor: actor("ss251"),
+        mergedAt: "2026-07-30T09:00:00.000Z",
+        headRefOid: head,
+      });
+
+      const kept = createLeaderboardSnapshot(
+        input({
+          mergedPullRequests: [scored],
+          verifiedEvidence: verifiedPullRequestEvidence([scored]),
+        }),
+      );
+      const voided = createLeaderboardSnapshot(
+        input({
+          mergedPullRequests: [voidedAuthorEdit],
+          verifiedEvidence: verifiedPullRequestEvidence([voidedAuthorEdit]),
+        }),
+      );
+
+      expect(kept.leaders[0]).toMatchObject({
+        actor: { login: "ss251" },
+        points: { evidence: 1 },
+      });
+      expect(
+        kept.ledger
+          .filter((event) => event.category === "evidence")
+          .map((event) => event.source.number),
+      ).toEqual([17606]);
+      expect(voided.leaders[0]?.points.evidence ?? 0).toBe(0);
+      expect(
+        voided.ledger.filter((event) => event.category === "evidence"),
+      ).toEqual([]);
+    });
+  });
 
   it("scores the verifier identity for an inline-code artifact URL", () => {
     const source = textSource(

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -112,6 +112,12 @@ export interface PullRequestRecord {
   createdAt: string;
   updatedAt: string;
   lastEditedAt: string | null;
+  /**
+   * GitHub's last body editor. Used only to distinguish author post-merge
+   * evidence farming from third-party (usually maintainer) body touches that
+   * must not void a head-pinned pre-merge evidence package.
+   */
+  editor: GitHubActor | null;
   mergedAt: string | null;
   headRefOid: string;
   isDraft: boolean;
@@ -1501,7 +1507,7 @@ function methodology(): LeaderboardMethodology {
         points: "up to 6",
         cap: `one award per evidence category per merged pull request, six per pull request, ${SCORE_CAPS.evidencePoints} evidence points per contributor, project, and UTC calendar month`,
         qualification:
-          "For the author's newest five base-scored merged pull requests per project and UTC month, contributor-authored proof existed unchanged at merge, appears in a stable evidence row in the canonical PR body, uses an immutable GitHub attachment URL, and passes bounded remote byte and structure verification. Mutable release assets, comment copies, inline text, N/A rows, unreachable artifacts, and third-party claims do not qualify.",
+          "For the author's newest five base-scored merged pull requests per project and UTC month, contributor-authored proof is bound to the merged head via a single evidence-head marker, appears in a stable evidence row in the canonical PR body, uses an immutable GitHub attachment URL, and passes bounded remote byte and structure verification. Author post-merge body edits still void the package; a non-author post-merge body edit keeps the package only while the evidence-head still matches the merged OID. Mutable release assets, comment copies, inline text, N/A rows, unreachable artifacts, and third-party claims do not qualify.",
       },
       {
         id: "substantive-review",
@@ -1694,22 +1700,6 @@ function recordTextActivity(
   }
 }
 
-function evidenceSourcesAtMerge(
-  pullRequest: PullRequestRecord,
-  sources: GitHubTextSource[],
-): GitHubTextSource[] {
-  if (!pullRequest.mergedAt) {
-    return [];
-  }
-  const mergedAt = parseIsoTime(pullRequest.mergedAt);
-  return sources.filter(
-    (source) =>
-      source.kind !== "review" &&
-      parseIsoTime(source.createdAt) <= mergedAt &&
-      parseIsoTime(source.updatedAt) <= mergedAt,
-  );
-}
-
 function sameActor(
   left: GitHubActor | null,
   right: GitHubActor | null,
@@ -1720,6 +1710,96 @@ function sameActor(
     (left.id === right.id ||
       left.login.toLowerCase() === right.login.toLowerCase())
   );
+}
+
+/**
+ * Parses the single `<!-- evidence-head:<40 hex> -->` marker used to bind a
+ * PR body evidence package to an exact head. Zero or multiple markers → null.
+ */
+export function parseEvidenceHeadOid(body: string): string | null {
+  const matches = [
+    ...String(body ?? "").matchAll(
+      /<!--\s*evidence-head:([a-f0-9]{40})\s*-->/gi,
+    ),
+  ];
+  return matches.length === 1 ? matches[0][1].toLowerCase() : null;
+}
+
+/**
+ * Whether a merged PR's current body may still be used as the evidence source.
+ *
+ * Intent of the merge-time freeze: stop authors from adding score-bearing
+ * proof after merge. A non-author post-merge body edit (common: maintainer
+ * typo/scope note) must not void a package that remains head-pinned to the
+ * merged OID — see elizaOS/eliza#17606 (editor lalalune after merge).
+ *
+ * Fail closed when the editor is missing or is the PR author.
+ */
+export function isMergedPullRequestBodyEligibleForEvidence(
+  pullRequest: Pick<
+    PullRequestRecord,
+    | "mergedAt"
+    | "createdAt"
+    | "lastEditedAt"
+    | "headRefOid"
+    | "body"
+    | "author"
+    | "editor"
+  >,
+  bodySource: Pick<GitHubTextSource, "createdAt" | "updatedAt" | "body">,
+): boolean {
+  if (!pullRequest.mergedAt) {
+    return false;
+  }
+  const mergedAt = parseIsoTime(pullRequest.mergedAt);
+  if (parseIsoTime(bodySource.createdAt) > mergedAt) {
+    return false;
+  }
+  if (parseIsoTime(bodySource.updatedAt) <= mergedAt) {
+    return true;
+  }
+  // Body touched after merge.
+  const evidenceHead = parseEvidenceHeadOid(bodySource.body);
+  if (
+    evidenceHead === null ||
+    evidenceHead !== pullRequest.headRefOid.toLowerCase()
+  ) {
+    return false;
+  }
+  if (!pullRequest.editor || !pullRequest.author) {
+    return false;
+  }
+  if (sameActor(pullRequest.editor, pullRequest.author)) {
+    return false;
+  }
+  return true;
+}
+
+function evidenceSourcesAtMerge(
+  pullRequest: PullRequestRecord,
+  sources: GitHubTextSource[],
+): GitHubTextSource[] {
+  if (!pullRequest.mergedAt) {
+    return [];
+  }
+  const mergedAt = parseIsoTime(pullRequest.mergedAt);
+  return sources.filter((source) => {
+    if (source.kind === "review") {
+      return false;
+    }
+    if (parseIsoTime(source.createdAt) > mergedAt) {
+      return false;
+    }
+    if (parseIsoTime(source.updatedAt) <= mergedAt) {
+      return true;
+    }
+    // Post-merge source mutation: only the PR body can survive, and only when
+    // the last editor is not the author and the package is still head-pinned.
+    if (source.kind === "body" && source.id === `${pullRequest.id}:body`) {
+      return isMergedPullRequestBodyEligibleForEvidence(pullRequest, source);
+    }
+    return false;
+  });
 }
 
 function pullRequestBodySource(

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -1535,7 +1535,7 @@ function methodology(): LeaderboardMethodology {
       "reviews of bot-authored or unattributed pull requests",
       "self-reviews",
       "reviews submitted after merge",
-      "pull-request bodies or comments created or edited after merge",
+      "pull-request comments created or edited after merge; bodies created after merge; author post-merge body edits; and non-author post-merge body edits that no longer pin the merged head via a single evidence-head marker",
       "duplicate immutable GitHub node IDs",
       "repeated reviews by the same reviewer on the same pull request",
       "arbitrary external media links, bare checksums, and unstructured evidence claims",


### PR DESCRIPTION
## Summary

Closes #18.

The merge-time evidence freeze correctly stops **authors** from farming proof after merge. Using body `updatedAt`/`lastEditedAt` alone also voided packages when a **non-author** (typically a maintainer) edited the PR body after merge while the head-pinned evidence package was still intact.

Concrete case: [elizaOS/eliza#17606](https://github.com/elizaOS/eliza/pull/17606) — six in-row opaque-upload candidates, head pin matched, remote verify OK; `lastEditedAt` ~9 minutes after merge by `lalalune` dropped the body from `evidenceSourcesAtMerge` / `evidenceVerificationCandidates`. Snapshot evidence for the author stayed 0.

## Behavior

| Case | Eligible? |
|---|---|
| Body last edited at/before merge | Yes |
| Author post-merge body edit | **No** (unchanged anti-farming) |
| Non-author post-merge edit + single `evidence-head` == `headRefOid` + editor present | **Yes** (new) |
| Missing editor / mismatched head / multi-marker head | **No** |

Unchanged: opaque-upload only, stable `evidence-row` markers, N/A and inline transcripts do not score.

## Implementation

- Fetch `editor { ...LeaderboardActor }` on detailed PRs
- `parseEvidenceHeadOid` + `isMergedPullRequestBodyEligibleForEvidence` in `src/lib/leaderboard.ts`
- Shared by `evidenceSourcesAtMerge` and `evidenceVerificationCandidates`
- Methodology qualification text updated
- Unit tests for the eligibility matrix + GraphQL fragment assertion

## Scoring after merge

Not a hand ledger edit. After this lands on `develop` and generate + production deploy succeed, live re-score in the 35-day window / newest-5 may award evidence under normal caps (≤6/PR) for still-eligible merges.

## Validation

- `bun test src/lib/leaderboard.test.ts scripts/generate-leaderboard.test.ts` — pass
- no-mistakes pipeline: intent/rebase/review/test/document/lint **passed**; push to `elizaOS/army` **403** (no direct write) — branch pushed to `ss251/army` instead

## Evidence (this PR)

N/A - scoring-rule / TypeScript change only; no UI surface, no user-exercisable flow.

## Attribution

AI assistance: yes  
Model(s) used: xai/grok-4.5  
Client / agent tooling: Claude Code via CLIProxyAPI  
Skill revision: N/A - army scoring change; not an eliza contribute-to-eliza delivery  
Attribution status: self-reported  

— [claude-code-ss251]
<!-- elizaos-contribution-attribution:v1 {"provider":"xai","model":"grok-4.5","client":"Claude Code via CLIProxyAPI","skill_revision":"N/A - army scoring change"} -->