### PR TITLE
fix: halve homepage hero gap

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -59,8 +59,10 @@ colored words or faux terminal syntax to the hero.
 ### Discovery
 
 The all-caps hero uses a fixed `MAKE MONEY` first line and a typed/deleted orange
-second line. It sits high in a compact first viewport, reserves the tallest
-phrase, and respects reduced motion. Nothing else competes inside the hero.
+second line. The typed line scales independently so long desktop phrases remain
+on one line. It sits high in a compact first viewport, reserves the tallest
+phrase, and respects reduced motion. A small responsive gap separates that
+stable type box from Projects. Nothing else competes inside the hero.
 Each full-rail project row shows its name, one manifest-backed sentence, and
 money; monthly bounties and external prizes remain textually distinct. The
 global leaderboard follows immediately and shows score, relevant tokens, live

--- a/src/styles.css
+++ b/src/styles.css
@@ -124,7 +124,7 @@ input:focus-visible {
   flex-direction: column;
   align-items: flex-start;
   justify-content: flex-start;
-  padding-block: clamp(56px, 6vh, 72px) 24px;
+  padding-block: clamp(56px, 6vh, 72px) clamp(28px, 6.25vw, 90px);
 }
 
 .data-notice {
@@ -232,7 +232,16 @@ p {
 .hero-switch {
   display: grid;
   color: var(--orange);
+  font-size: clamp(30px, 7vw, 94px);
+  letter-spacing: -0.065em;
+  line-height: 0.84;
   text-wrap: balance;
+}
+
+@media (min-width: 681px) {
+  .hero-switch {
+    white-space: nowrap;
+  }
 }
 
 .hero-switch-sizer,

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -74,6 +74,8 @@ test("discovers both reward models and a score-ranked global ledger", async ({
   page,
   request,
 }) => {
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await page.reload({ waitUntil: "networkidle" });
   const snapshot = await loadSnapshot(request);
   await loadCycles(request);
 
@@ -125,6 +127,23 @@ test("discovers both reward models and a score-ranked global ledger", async ({
   expect(elizaBox?.width).toBeGreaterThan((gridBox?.width ?? 0) - 2);
   expect(deltaBox?.width).toBeGreaterThan((gridBox?.width ?? 0) - 2);
   expect(deltaBox?.y).toBeGreaterThan((elizaBox?.y ?? 0) + 1);
+  const visibleHeroGap = await page.evaluate(() => {
+    const typewriter = document.querySelector(".hero-typewriter");
+    const projectHeading = document.querySelector("#projects h2");
+    const textNode = typewriter?.firstChild;
+    if (!textNode || !projectHeading) return null;
+    const range = document.createRange();
+    range.selectNodeContents(textNode);
+    const textRects = Array.from(range.getClientRects());
+    const lastTextRect = textRects.at(-1);
+    if (!lastTextRect) return null;
+    return Math.round(
+      projectHeading.getBoundingClientRect().top - lastTextRect.bottom,
+    );
+  });
+  expect(visibleHeroGap).not.toBeNull();
+  expect(visibleHeroGap ?? 0).toBeGreaterThanOrEqual(16);
+  expect(visibleHeroGap ?? 0).toBeLessThanOrEqual(72);
   await expect(
     page.getByRole("heading", { name: "Leaderboard" }),
   ).toBeVisible();


### PR DESCRIPTION
Closes #21.

## What changed

- Scales the animated orange phrase independently so long desktop messages stay on one stable line.
- Reduces the visible typewriter-to-Projects gap to a compact responsive range.
- Preserves tallest-phrase reservation, reduced-motion behavior, and mobile wrapping.
- Adds a rendered-glyph geometry assertion across every supported viewport.

## Verification

- Project, evaluation, cycle, and dependency audits
- Formatting, lint, and TypeScript checks
- 285 unit/integration tests and 26 skill tests
- Production build
- 32 browser tests across desktop, tablet, and mobile
- Exact-commit desktop/mobile screenshots and walkthrough
- Zero console, page, or first-party network errors
