### PR TITLE
feat: cross-project closed attempts feed

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -89,8 +89,9 @@ cumulative score and paid total. Historical-only contributors remain visible.
 Empty data, loading, stale data, invalid data, and zero accepted work are five
 different states. Profile opportunity rows lead with the next action, not a
 demerit; monthly caps appear as compact fill status, never a dropped-award list.
-The `/attempts` feed lists closed-unmerged pull requests and not-planned issues
-across projects as a public record, separate from accepted score.
+The `/attempts` feed (“Work that didn't land”) groups closed-unmerged pull
+requests and not-planned issues by project, leads each row with close status
+and the exact reason, and stays visually distinct from the accepted ledger.
 
 ### Cycle
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -89,6 +89,8 @@ cumulative score and paid total. Historical-only contributors remain visible.
 Empty data, loading, stale data, invalid data, and zero accepted work are five
 different states. Profile opportunity rows lead with the next action, not a
 demerit; monthly caps appear as compact fill status, never a dropped-award list.
+The `/attempts` feed lists closed-unmerged pull requests and not-planned issues
+across projects as a public record, separate from accepted score.
 
 ### Cycle
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -223,8 +223,9 @@ Track all of these without collapsing them into one vanity number:
 
 ## Post-v1 surfaces
 
-- cross-project feed of closed-unmerged pull requests and not-planned issues
-  at `/attempts` (distinct from per-profile still-open opportunities);
+- cross-project feed of work that didn't land (closed-unmerged pull requests
+  and not-planned issues) at `/attempts`, grouped by project and filtered in
+  the UI (distinct from per-profile still-open opportunities);
 
 ## Tone
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -218,11 +218,13 @@ Track all of these without collapsing them into one vanity number:
   work, but shared monthly pools and external shares are the launch path);
 - private repositories or non-code community/design work;
 - hosted model execution inside third-party project CI;
-- a cross-project feed of every rejected or maintainer-closed attempt
-  (per-profile still-open opportunities are in scope; a global rejection feed
-  is not);
 - autonomous banning;
 - raw prompt, response, source-file, or secret upload.
+
+## Post-v1 surfaces
+
+- cross-project feed of closed-unmerged pull requests and not-planned issues
+  at `/attempts` (distinct from per-profile still-open opportunities);
 
 ## Tone
 

--- a/public/_routes.json
+++ b/public/_routes.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
-  "include": ["/", "/projects/*", "/contributors/*", "/cycles/*"],
+  "include": ["/", "/projects/*", "/contributors/*", "/cycles/*", "/attempts"],
   "exclude": []
 }

--- a/scripts/evidence-contract.mjs
+++ b/scripts/evidence-contract.mjs
@@ -122,8 +122,8 @@ export function assertLiveLedgerReady(
       : contents,
     "leaderboard",
   );
-  if (snapshot.schemaVersion !== "5") {
-    throw new TypeError("leaderboard.schemaVersion must be 5");
+  if (snapshot.schemaVersion !== "6") {
+    throw new TypeError("leaderboard.schemaVersion must be 6");
   }
   if (snapshot.repository !== PRIMARY_REPOSITORY.id) {
     throw new TypeError(

--- a/scripts/evidence-contract.test.mjs
+++ b/scripts/evidence-contract.test.mjs
@@ -22,7 +22,7 @@ const now = Date.parse("2026-07-30T20:00:00.000Z");
 
 function liveLedger(overrides = {}) {
   return {
-    schemaVersion: "5",
+    schemaVersion: "6",
     repository: "elizaOS/eliza",
     repositories: [{ id: "elizaOS/eliza" }, { id: "lalalune/arklib" }],
     generatedAt: "2026-07-30T19:58:00.000Z",
@@ -102,7 +102,7 @@ describe("live ledger readiness", () => {
     ).toThrow("leaderboard.ledger must be a non-empty array");
     expect(() =>
       assertLiveLedgerReady(liveLedger({ schemaVersion: "1" }), { now }),
-    ).toThrow("leaderboard.schemaVersion must be 5");
+    ).toThrow("leaderboard.schemaVersion must be 6");
     expect(() =>
       assertLiveLedgerReady(
         liveLedger({ repositories: [{ id: "elizaOS/eliza" }] }),

--- a/scripts/generate-leaderboard.ts
+++ b/scripts/generate-leaderboard.ts
@@ -11,6 +11,7 @@ import { fileURLToPath } from "node:url";
 import { loadEvaluatorAwardEvents } from "../src/lib/evaluator-awards";
 import {
   assertPublishableLeaderboardSnapshot,
+  type ClosedUnmergedPullRequestRecord,
   createLeaderboardSnapshot,
   dedupeByNodeId,
   type EvidenceCategory,
@@ -24,6 +25,7 @@ import {
   type LeaderboardSnapshot,
   type LeaderboardSourceMetadata,
   type MergedPullRequestOutcome,
+  type NotPlannedIssueRecord,
   type PullRequestFile,
   type PullRequestRecord,
   type PullRequestReview,
@@ -370,7 +372,17 @@ const SEARCH_REFERENCES_QUERY = `
       pageInfo { hasNextPage endCursor }
       nodes {
         __typename
-        ... on Issue { id }
+        ... on Issue {
+          id
+          number
+          title
+          url
+          createdAt
+          updatedAt
+          closedAt
+          stateReason
+          author { ...LeaderboardActor }
+        }
         ... on PullRequest {
           id
           state
@@ -380,6 +392,7 @@ const SEARCH_REFERENCES_QUERY = `
           body
           createdAt
           updatedAt
+          closedAt
           mergedAt
           author { ...LeaderboardActor }
           additions
@@ -1370,13 +1383,158 @@ function parseSearchReference(
   if (kind !== expectedKind) {
     throw new Error(`${path} must be a ${expectedKind}`);
   }
+  const mergedAt =
+    kind === "PullRequest"
+      ? asNullableString(node.mergedAt, `${path}.mergedAt`)
+      : null;
   return {
     id: asString(node.id, `${path}.id`),
     kind,
     outcome:
-      kind === "PullRequest" ? parsePullRequestOutcome(node, path) : null,
+      kind === "PullRequest" && mergedAt !== null
+        ? parsePullRequestOutcome(node, path)
+        : null,
     openVersion: null,
   };
+}
+
+function parseClosedUnmergedPullRequestHit(
+  value: unknown,
+  path: string,
+): ClosedUnmergedPullRequestRecord {
+  const node = asRecord(value, path);
+  if (asString(node.__typename, `${path}.__typename`) !== "PullRequest") {
+    throw new Error(`${path} must be a PullRequest`);
+  }
+  if (asString(node.state, `${path}.state`) !== "CLOSED") {
+    throw new Error(`${path} must be CLOSED`);
+  }
+  const mergedAt = asNullableString(node.mergedAt, `${path}.mergedAt`);
+  if (mergedAt !== null) {
+    throw new Error(`${path} must not be merged`);
+  }
+  const closedAt = asNullableString(node.closedAt, `${path}.closedAt`);
+  if (!closedAt) {
+    throw new Error(`${path}.closedAt must be present`);
+  }
+  return {
+    id: asString(node.id, `${path}.id`),
+    number: asNumber(node.number, `${path}.number`),
+    title: asString(node.title, `${path}.title`),
+    url: asString(node.url, `${path}.url`),
+    closedAt,
+    author: parseActor(node.author, `${path}.author`),
+    mergedAt: null,
+  };
+}
+
+function parseNotPlannedIssueHit(
+  value: unknown,
+  path: string,
+): NotPlannedIssueRecord {
+  const node = asRecord(value, path);
+  if (asString(node.__typename, `${path}.__typename`) !== "Issue") {
+    throw new Error(`${path} must be an Issue`);
+  }
+  const stateReason = asNullableString(node.stateReason, `${path}.stateReason`);
+  if (stateReason !== "NOT_PLANNED") {
+    throw new Error(`${path}.stateReason must be NOT_PLANNED`);
+  }
+  const closedAt = asNullableString(node.closedAt, `${path}.closedAt`);
+  if (!closedAt) {
+    throw new Error(`${path}.closedAt must be present`);
+  }
+  return {
+    id: asString(node.id, `${path}.id`),
+    number: asNumber(node.number, `${path}.number`),
+    title: asString(node.title, `${path}.title`),
+    url: asString(node.url, `${path}.url`),
+    closedAt,
+    author: parseActor(node.author, `${path}.author`),
+    stateReason: "NOT_PLANNED",
+  };
+}
+
+async function collectClosedAttemptHits<T extends { id: string }>(
+  client: GraphqlExecutor,
+  repository: TargetRepository,
+  from: Date,
+  to: Date,
+  kindQualifier:
+    | "is:pr is:closed -is:merged"
+    | "is:issue is:closed reason:not-planned",
+  expectedKind: NodeReference["kind"],
+  parser: (value: unknown, path: string) => T,
+  stats: { searchSliceCount: number },
+): Promise<T[]> {
+  const searchQuery = `repo:${repository.id} ${kindQualifier} closed:${searchRange(from, to)}`;
+  stats.searchSliceCount += 1;
+  const firstData = await client.execute(SEARCH_REFERENCES_QUERY, {
+    searchQuery,
+    after: null,
+    pageSize: GRAPHQL_PAGE_SIZE,
+  });
+  const firstPage = parseSearchPage(firstData, parser);
+  if (firstPage.totalCount >= SEARCH_SAFE_RESULT_LIMIT) {
+    if (to.getTime() - from.getTime() <= MINIMUM_SEARCH_SLICE_MS) {
+      throw new Error(
+        `GitHub Search returned ${firstPage.totalCount} results in one minute (${searchRange(from, to)}); refusing a snapshot that could hit the 1,000-result cap`,
+      );
+    }
+    const split = midpoint(from, to);
+    const left = await collectClosedAttemptHits(
+      client,
+      repository,
+      from,
+      split,
+      kindQualifier,
+      expectedKind,
+      parser,
+      stats,
+    );
+    const right = await collectClosedAttemptHits(
+      client,
+      repository,
+      split,
+      to,
+      kindQualifier,
+      expectedKind,
+      parser,
+      stats,
+    );
+    return dedupeByNodeId([...left, ...right]);
+  }
+
+  const hits = [...firstPage.nodes];
+  const expectedCount = firstPage.totalCount;
+  let pageInfo = firstPage.pageInfo;
+  while (pageInfo.hasNextPage) {
+    if (!pageInfo.endCursor) {
+      throw new Error("GitHub Search reported another page without a cursor");
+    }
+    const data = await client.execute(SEARCH_REFERENCES_QUERY, {
+      searchQuery,
+      after: pageInfo.endCursor,
+      pageSize: GRAPHQL_PAGE_SIZE,
+    });
+    const page = parseSearchPage(data, parser);
+    if (page.totalCount !== expectedCount) {
+      throw new Error(
+        `GitHub Search changed from ${expectedCount} to ${page.totalCount} results while collecting ${searchRange(from, to)}; rerun for a coherent snapshot`,
+      );
+    }
+    hits.push(...page.nodes);
+    pageInfo = page.pageInfo;
+  }
+
+  const deduped = dedupeByNodeId(hits);
+  if (deduped.length !== expectedCount) {
+    throw new Error(
+      `GitHub Search returned ${deduped.length} unique closed attempts but reported ${expectedCount} for ${searchRange(from, to)}`,
+    );
+  }
+  void expectedKind;
+  return deduped;
 }
 
 function parseOpenReference(
@@ -1440,7 +1598,11 @@ export async function collectSearchReferences(
   from: Date,
   to: Date,
   qualifier: "closed" | "merged",
-  kindQualifier: "is:issue is:closed" | "is:pr is:merged",
+  kindQualifier:
+    | "is:issue is:closed"
+    | "is:pr is:merged"
+    | "is:pr is:closed -is:merged"
+    | "is:issue is:closed reason:not-planned",
   expectedKind: NodeReference["kind"],
   stats: { searchSliceCount: number },
 ): Promise<NodeReference[]> {
@@ -1523,7 +1685,11 @@ async function countSearchResults(
   from: Date,
   to: Date,
   qualifier: "closed" | "merged",
-  kindQualifier: "is:issue is:closed" | "is:pr is:merged",
+  kindQualifier:
+    | "is:issue is:closed"
+    | "is:pr is:merged"
+    | "is:pr is:closed -is:merged"
+    | "is:issue is:closed reason:not-planned",
   expectedKind: NodeReference["kind"],
   stats: { searchSliceCount: number },
 ): Promise<number> {
@@ -2688,6 +2854,8 @@ export async function generateLeaderboardFromGitHub(
   const mergedPullRequestOutcomes: MergedPullRequestOutcome[] = [];
   const mergedPullRequests: PullRequestRecord[] = [];
   const closedIssues: IssueRecord[] = [];
+  const closedUnmergedPullRequests: ClosedUnmergedPullRequestRecord[] = [];
+  const notPlannedIssues: NotPlannedIssueRecord[] = [];
   let closedIssueCount = 0;
 
   for (const [index, repository] of TARGET_REPOSITORIES.entries()) {
@@ -2730,6 +2898,30 @@ export async function generateLeaderboardFromGitHub(
       "is:issue is:closed",
       "Issue",
       stats,
+    );
+    closedUnmergedPullRequests.push(
+      ...(await collectClosedAttemptHits(
+        client,
+        repository,
+        windowFrom,
+        now,
+        "is:pr is:closed -is:merged",
+        "PullRequest",
+        parseClosedUnmergedPullRequestHit,
+        stats,
+      )),
+    );
+    notPlannedIssues.push(
+      ...(await collectClosedAttemptHits(
+        client,
+        repository,
+        windowFrom,
+        now,
+        "is:issue is:closed reason:not-planned",
+        "Issue",
+        parseNotPlannedIssueHit,
+        stats,
+      )),
     );
     const repositoryOutcomes = mergedPullRequestReferences.map((reference) => {
       if (!reference.outcome) {
@@ -2913,6 +3105,8 @@ export async function generateLeaderboardFromGitHub(
     resolvedIssues: dedupedClosedIssues,
     openIssues,
     openPullRequests,
+    closedUnmergedPullRequests: dedupeByNodeId(closedUnmergedPullRequests),
+    notPlannedIssues: dedupeByNodeId(notPlannedIssues),
     verificationWindowFrom: verificationWindowFrom.toISOString(),
     verifiedEvidence: evidenceVerification.artifacts,
     evaluatedContributions: options.evaluatedContributions ?? [],

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1241,6 +1241,11 @@ function AttemptsPage({
                 </section>
               ))
             )}
+            <p className="attempt-learning">
+              Looking for the next useful move? Browse{" "}
+              <Link href="/#projects">open project work</Link> or check a
+              contributor profile for still-open scoring opportunities.
+            </p>
           </>
         )}
       </section>
@@ -1251,19 +1256,29 @@ function AttemptsPage({
 function RejectedAttemptRow({ attempt }: { attempt: RejectedAttempt }) {
   const status = attemptStatusLabel(attempt.kind);
   return (
-    <ExternalLinkAnchor className="attempt-row" href={attempt.source.url}>
+    <article className="attempt-row">
       <span className="attempt-status">{status}</span>
       <span className="attempt-body">
-        <strong>{attempt.source.title}</strong>
+        <ExternalLinkAnchor href={attempt.source.url}>
+          <strong>{attempt.source.title}</strong>
+        </ExternalLinkAnchor>
         <small className="attempt-reason">{attempt.reason}</small>
-        <small>
-          {attempt.actor ? `${attempt.actor.login} · ` : ""}
-          {attempt.source.kind === "pull-request" ? "Pull request" : "Issue"} #
-          {attempt.source.number} · {formatDate(attempt.occurredAt)}
-        </small>
+        <span className="attempt-meta">
+          {attempt.actor ? (
+            <Link href={`/contributors/${attempt.actor.login}`}>
+              {attempt.actor.login}
+            </Link>
+          ) : null}
+          <small>
+            {attempt.source.kind === "pull-request" ? "Pull request" : "Issue"}{" "}
+            #{attempt.source.number} · {formatDate(attempt.occurredAt)}
+          </small>
+          <ExternalLinkAnchor href={attempt.source.url}>
+            GitHub <ExternalLink aria-hidden="true" size={14} />
+          </ExternalLinkAnchor>
+        </span>
       </span>
-      <ExternalLink aria-hidden="true" size={16} />
-    </ExternalLinkAnchor>
+    </article>
   );
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,7 @@ import {
   type GitHubActor,
   type LeaderboardSnapshot,
   PROFILE_OPPORTUNITY_LIMIT,
+  type RejectedAttempt,
   type ScoreEvent,
   type ScoreOpportunity,
 } from "./lib/leaderboard";
@@ -51,6 +52,7 @@ import {
   PROJECTS,
   type ProjectDefinition,
 } from "./lib/projects.mjs";
+import { findTargetRepositoryById } from "./lib/repositories.mjs";
 import { isSolanaAddress } from "./lib/wallets";
 
 const SOURCE_REPOSITORY = "https://github.com/elizaOS/army";
@@ -139,7 +141,14 @@ async function readBoundedJson(
 }
 
 interface Route {
-  kind: "cycle" | "home" | "new-project" | "profile" | "project" | "unknown";
+  kind:
+    | "attempts"
+    | "cycle"
+    | "home"
+    | "new-project"
+    | "profile"
+    | "project"
+    | "unknown";
   projectId?: string;
   cycleId?: string;
   login?: string;
@@ -148,6 +157,9 @@ interface Route {
 function internalRoute(pathname: string): Route {
   const segments = pathname.split("/").filter(Boolean).map(decodeURIComponent);
   if (segments.length === 0) return { kind: "home" };
+  if (segments[0] === "attempts" && segments.length === 1) {
+    return { kind: "attempts" };
+  }
   if (segments[0] === "projects" && segments[1] === "new") {
     return { kind: "new-project" };
   }
@@ -370,6 +382,7 @@ function Header() {
         <nav className={open ? "nav-links nav-links-open" : "nav-links"}>
           <Link href="/#projects">Projects</Link>
           <Link href="/#leaderboard">Leaderboard</Link>
+          <Link href="/attempts">Attempts</Link>
           <ExternalLinkAnchor href={HUB_ORIGIN}>Hub</ExternalLinkAnchor>
           <ExternalLinkAnchor className="nav-source" href={SOURCE_REPOSITORY}>
             Source <ExternalLink aria-hidden="true" size={14} />
@@ -390,6 +403,7 @@ function Footer() {
           <p>Accepted work. Public evidence. Digital-dollar rewards.</p>
         </div>
         <div className="footer-links">
+          <Link href="/attempts">Attempts</Link>
           <ExternalLinkAnchor href={SOURCE_REPOSITORY}>
             GitHub
           </ExternalLinkAnchor>
@@ -1106,6 +1120,74 @@ function ProjectPage({
         {view ? <ProjectLeaderboard view={view} /> : null}
       </div>
     </main>
+  );
+}
+
+function AttemptsPage({
+  state,
+  retry,
+}: {
+  state: DataState;
+  retry: () => void;
+}) {
+  if (state.status !== "ready") {
+    return (
+      <main className="shell route-main">
+        <DataNotice state={state} retry={retry} />
+      </main>
+    );
+  }
+  const attempts = state.snapshot.rejectedAttempts;
+  return (
+    <main className="shell route-main">
+      <DataNotice state={state} retry={retry} />
+      <section className="section">
+        <div className="section-heading">
+          <div>
+            <p className="eyebrow">Cross-project public record</p>
+            <h1>Closed attempts.</h1>
+          </div>
+          <p>
+            Pull requests closed without merge and issues closed as not planned
+            across every registered project. This is not the accepted ledger.
+          </p>
+        </div>
+        {attempts.length === 0 ? (
+          <EmptyState text="No closed attempts are published in the current window." />
+        ) : (
+          <div className="event-list">
+            {attempts.map((attempt) => (
+              <RejectedAttemptRow attempt={attempt} key={attempt.id} />
+            ))}
+          </div>
+        )}
+      </section>
+    </main>
+  );
+}
+
+function RejectedAttemptRow({ attempt }: { attempt: RejectedAttempt }) {
+  const repository = findTargetRepositoryById(attempt.repository);
+  const project = repository ? findProject(repository.projectId) : null;
+  const kindLabel =
+    attempt.kind === "closed-unmerged-pull-request"
+      ? "closed without merge"
+      : "not planned";
+  return (
+    <ExternalLinkAnchor href={attempt.source.url}>
+      <span className="event-points">
+        {attempt.source.kind === "pull-request" ? "PR" : "#"}
+      </span>
+      <span>
+        <strong>{attempt.source.title}</strong>
+        <small>
+          {project?.name ?? attempt.repository}
+          {attempt.actor ? ` · ${attempt.actor.login}` : ""} · {kindLabel} ·{" "}
+          {formatDate(attempt.occurredAt)}
+        </small>
+      </span>
+      <ExternalLink aria-hidden="true" size={16} />
+    </ExternalLinkAnchor>
   );
 }
 
@@ -1972,6 +2054,8 @@ export function App() {
   const [state, retry] = useSnapshot();
   let content: ReactNode;
   if (route.kind === "home") content = <HomePage retry={retry} state={state} />;
+  else if (route.kind === "attempts")
+    content = <AttemptsPage retry={retry} state={state} />;
   else if (route.kind === "new-project") content = <ProjectProposalPage />;
   else if (route.kind === "project") {
     const project = findProject(route.projectId ?? "");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -382,7 +382,7 @@ function Header() {
         <nav className={open ? "nav-links nav-links-open" : "nav-links"}>
           <Link href="/#projects">Projects</Link>
           <Link href="/#leaderboard">Leaderboard</Link>
-          <Link href="/attempts">Attempts</Link>
+          <Link href="/attempts">Didn't land</Link>
           <ExternalLinkAnchor href={HUB_ORIGIN}>Hub</ExternalLinkAnchor>
           <ExternalLinkAnchor className="nav-source" href={SOURCE_REPOSITORY}>
             Source <ExternalLink aria-hidden="true" size={14} />
@@ -403,7 +403,7 @@ function Footer() {
           <p>Accepted work. Public evidence. Digital-dollar rewards.</p>
         </div>
         <div className="footer-links">
-          <Link href="/attempts">Attempts</Link>
+          <Link href="/attempts">Work that didn't land</Link>
           <ExternalLinkAnchor href={SOURCE_REPOSITORY}>
             GitHub
           </ExternalLinkAnchor>
@@ -1123,6 +1123,12 @@ function ProjectPage({
   );
 }
 
+function attemptStatusLabel(kind: RejectedAttempt["kind"]): string {
+  return kind === "closed-unmerged-pull-request"
+    ? "Closed without merge"
+    : "Closed as not planned";
+}
+
 function AttemptsPage({
   state,
   retry,
@@ -1130,6 +1136,7 @@ function AttemptsPage({
   state: DataState;
   retry: () => void;
 }) {
+  const [projectFilter, setProjectFilter] = useState<string>("all");
   if (state.status !== "ready") {
     return (
       <main className="shell route-main">
@@ -1138,28 +1145,103 @@ function AttemptsPage({
     );
   }
   const attempts = state.snapshot.rejectedAttempts;
+  const projectCounts = new Map<string, number>();
+  for (const attempt of attempts) {
+    const repository = findTargetRepositoryById(attempt.repository);
+    const projectId = repository?.projectId ?? attempt.repository;
+    projectCounts.set(projectId, (projectCounts.get(projectId) ?? 0) + 1);
+  }
+  const filtered =
+    projectFilter === "all"
+      ? attempts
+      : attempts.filter((attempt) => {
+          const repository = findTargetRepositoryById(attempt.repository);
+          return repository?.projectId === projectFilter;
+        });
+  const grouped = new Map<
+    string,
+    { projectName: string; rows: RejectedAttempt[] }
+  >();
+  for (const attempt of filtered) {
+    const repository = findTargetRepositoryById(attempt.repository);
+    const projectId = repository?.projectId ?? attempt.repository;
+    const projectName =
+      findProject(projectId)?.name ?? repository?.displayName ?? projectId;
+    const bucket = grouped.get(projectId) ?? { projectName, rows: [] };
+    bucket.rows.push(attempt);
+    grouped.set(projectId, bucket);
+  }
   return (
-    <main className="shell route-main">
+    <main className="shell route-main attempts-page">
       <DataNotice state={state} retry={retry} />
       <section className="section">
         <div className="section-heading">
           <div>
-            <p className="eyebrow">Cross-project public record</p>
-            <h1>Closed attempts.</h1>
+            <p className="eyebrow">Public close record</p>
+            <h1>Work that didn't land.</h1>
           </div>
           <p>
-            Pull requests closed without merge and issues closed as not planned
-            across every registered project. This is not the accepted ledger.
+            Pull requests closed without merging and issues closed as not
+            planned. Exact GitHub state only—this is not the accepted score
+            ledger, and it is not a private grade.
           </p>
         </div>
         {attempts.length === 0 ? (
-          <EmptyState text="No closed attempts are published in the current window." />
+          <EmptyState text="Nothing in the current window closed without landing." />
         ) : (
-          <div className="event-list">
-            {attempts.map((attempt) => (
-              <RejectedAttemptRow attempt={attempt} key={attempt.id} />
-            ))}
-          </div>
+          <>
+            <fieldset className="attempt-filters">
+              <legend className="attempt-filters-legend">
+                Filter by project
+              </legend>
+              <button
+                aria-pressed={projectFilter === "all"}
+                className={
+                  projectFilter === "all"
+                    ? "attempt-filter attempt-filter-active"
+                    : "attempt-filter"
+                }
+                onClick={() => setProjectFilter("all")}
+                type="button"
+              >
+                All projects ({attempts.length})
+              </button>
+              {[...projectCounts.entries()]
+                .sort(([left], [right]) => left.localeCompare(right))
+                .map(([projectId, count]) => {
+                  const name = findProject(projectId)?.name ?? projectId;
+                  return (
+                    <button
+                      aria-pressed={projectFilter === projectId}
+                      className={
+                        projectFilter === projectId
+                          ? "attempt-filter attempt-filter-active"
+                          : "attempt-filter"
+                      }
+                      key={projectId}
+                      onClick={() => setProjectFilter(projectId)}
+                      type="button"
+                    >
+                      {name} ({count})
+                    </button>
+                  );
+                })}
+            </fieldset>
+            {filtered.length === 0 ? (
+              <EmptyState text="No closed work matches this project filter." />
+            ) : (
+              [...grouped.entries()].map(([projectId, group]) => (
+                <section className="attempt-project" key={projectId}>
+                  <h2>{group.projectName}</h2>
+                  <div className="attempt-list">
+                    {group.rows.map((attempt) => (
+                      <RejectedAttemptRow attempt={attempt} key={attempt.id} />
+                    ))}
+                  </div>
+                </section>
+              ))
+            )}
+          </>
         )}
       </section>
     </main>
@@ -1167,23 +1249,17 @@ function AttemptsPage({
 }
 
 function RejectedAttemptRow({ attempt }: { attempt: RejectedAttempt }) {
-  const repository = findTargetRepositoryById(attempt.repository);
-  const project = repository ? findProject(repository.projectId) : null;
-  const kindLabel =
-    attempt.kind === "closed-unmerged-pull-request"
-      ? "closed without merge"
-      : "not planned";
+  const status = attemptStatusLabel(attempt.kind);
   return (
-    <ExternalLinkAnchor href={attempt.source.url}>
-      <span className="event-points">
-        {attempt.source.kind === "pull-request" ? "PR" : "#"}
-      </span>
-      <span>
+    <ExternalLinkAnchor className="attempt-row" href={attempt.source.url}>
+      <span className="attempt-status">{status}</span>
+      <span className="attempt-body">
         <strong>{attempt.source.title}</strong>
+        <small className="attempt-reason">{attempt.reason}</small>
         <small>
-          {project?.name ?? attempt.repository}
-          {attempt.actor ? ` · ${attempt.actor.login}` : ""} · {kindLabel} ·{" "}
-          {formatDate(attempt.occurredAt)}
+          {attempt.actor ? `${attempt.actor.login} · ` : ""}
+          {attempt.source.kind === "pull-request" ? "Pull request" : "Issue"} #
+          {attempt.source.number} · {formatDate(attempt.occurredAt)}
         </small>
       </span>
       <ExternalLink aria-hidden="true" size={16} />

--- a/src/lib/leaderboard.test.ts
+++ b/src/lib/leaderboard.test.ts
@@ -2799,6 +2799,60 @@ describe("work queue claims and prioritization", () => {
     expect(snapshot.opportunities).toEqual([]);
   });
 
+  it("publishes a cross-project rejected-attempt feed from closed work", () => {
+    const author = actor("author");
+    const bot = actor("dependabot[bot]", "Bot");
+    const snapshot = createLeaderboardSnapshot(
+      input({
+        closedUnmergedPullRequests: [
+          {
+            id: "PR_CLOSED_1",
+            number: 70,
+            title: "Abandoned rewrite",
+            url: "https://github.com/elizaOS/eliza/pull/70",
+            closedAt: "2026-07-29T09:00:00.000Z",
+            author,
+            mergedAt: null,
+          },
+          {
+            id: "PR_CLOSED_BOT",
+            number: 71,
+            title: "Bot churn",
+            url: "https://github.com/elizaOS/eliza/pull/71",
+            closedAt: "2026-07-29T10:00:00.000Z",
+            author: bot,
+            mergedAt: null,
+          },
+        ],
+        notPlannedIssues: [
+          {
+            id: "ISSUE_NP_1",
+            number: 80,
+            title: "Not this path",
+            url: "https://github.com/lalalune/arklib/issues/80",
+            closedAt: "2026-07-28T09:00:00.000Z",
+            author,
+            stateReason: "NOT_PLANNED",
+          },
+        ],
+      }),
+    );
+
+    expect(snapshot.rejectedAttempts.map((row) => row.kind)).toEqual([
+      "closed-unmerged-pull-request",
+      "not-planned-issue",
+    ]);
+    expect(snapshot.rejectedAttempts[0]).toMatchObject({
+      source: { id: "PR_CLOSED_1" },
+      actor: { id: author.id },
+    });
+    expect(
+      snapshot.rejectedAttempts.some(
+        (row) => row.source.id === "PR_CLOSED_BOT",
+      ),
+    ).toBe(false);
+  });
+
   it("rejects malformed opportunity rows from the published schema", () => {
     const snapshot = createLeaderboardSnapshot(input({}));
     expect(() =>

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -27,8 +27,9 @@ export {
 
 /** Backward-compatible alias for the primary registry repository. */
 export const LEADERBOARD_REPOSITORY = PRIMARY_REPOSITORY.id;
-export const LEADERBOARD_SCHEMA_VERSION = "5" as const;
+export const LEADERBOARD_SCHEMA_VERSION = "6" as const;
 export const PROFILE_OPPORTUNITY_LIMIT = 5 as const;
+export const REJECTED_ATTEMPT_FEED_LIMIT = 100 as const;
 export const SCORE_RULE_VERSION = "gitarmy-v1" as const;
 // A 35-day collection window guarantees a complete prior UTC calendar month;
 // project reward views still exclude everything before their reward start.
@@ -304,6 +305,52 @@ export interface ScoreOpportunity {
   hint: string;
 }
 
+export type RejectedAttemptKind =
+  | "closed-unmerged-pull-request"
+  | "not-planned-issue";
+
+/**
+ * Cross-project feed of maintainer-closed or abandoned attempts that never
+ * became accepted score. Distinct from still-open profile opportunities.
+ */
+export interface RejectedAttempt {
+  id: string;
+  kind: RejectedAttemptKind;
+  actor: GitHubActor | null;
+  occurredAt: string;
+  repository: RepositoryId;
+  source: {
+    id: string;
+    kind: "issue" | "pull-request";
+    number: number;
+    title: string;
+    url: string;
+  };
+  reason: string;
+}
+
+/** Lightweight closed-PR row used only to build the rejected-attempt feed. */
+export interface ClosedUnmergedPullRequestRecord {
+  id: string;
+  number: number;
+  title: string;
+  url: string;
+  closedAt: string;
+  author: GitHubActor | null;
+  mergedAt: null;
+}
+
+/** Lightweight not-planned issue row used only to build the rejected-attempt feed. */
+export interface NotPlannedIssueRecord {
+  id: string;
+  number: number;
+  title: string;
+  url: string;
+  closedAt: string;
+  author: GitHubActor | null;
+  stateReason: "NOT_PLANNED";
+}
+
 export interface CapUsageBucket {
   used: number;
   cap: number;
@@ -494,6 +541,7 @@ export interface LeaderboardSnapshot {
   leaders: LeaderboardEntry[];
   ledger: ScoreEvent[];
   opportunities: ScoreOpportunity[];
+  rejectedAttempts: RejectedAttempt[];
   attributions: ModelAttribution[];
   invalidAttributionMarkers: InvalidAttributionMarker[];
   attributionCoverage: AttributionCoverage;
@@ -515,6 +563,8 @@ export interface LeaderboardInput {
   resolvedIssues: IssueRecord[];
   openIssues: IssueRecord[];
   openPullRequests: PullRequestRecord[];
+  closedUnmergedPullRequests?: ClosedUnmergedPullRequestRecord[];
+  notPlannedIssues?: NotPlannedIssueRecord[];
   verificationWindowFrom: string;
   verifiedEvidence: VerifiedEvidenceArtifact[];
   evaluatedContributions?: ScoreEvent[];
@@ -2348,6 +2398,78 @@ function compareWorkItems(left: WorkItem, right: WorkItem): number {
   );
 }
 
+function compareRejectedAttempts(
+  left: RejectedAttempt,
+  right: RejectedAttempt,
+): number {
+  return (
+    parseIsoTime(right.occurredAt) - parseIsoTime(left.occurredAt) ||
+    left.source.number - right.source.number ||
+    left.id.localeCompare(right.id)
+  );
+}
+
+function collectRejectedAttempts(
+  closedUnmergedPullRequests: ClosedUnmergedPullRequestRecord[],
+  notPlannedIssues: NotPlannedIssueRecord[],
+): RejectedAttempt[] {
+  const attempts: RejectedAttempt[] = [];
+  for (const pullRequest of closedUnmergedPullRequests) {
+    if (pullRequest.mergedAt !== null) {
+      throw new Error(
+        `Closed unmerged pull request ${pullRequest.id} must not have mergedAt`,
+      );
+    }
+    if (pullRequest.author && isBotActor(pullRequest.author)) {
+      continue;
+    }
+    attempts.push({
+      id: `${pullRequest.id}:rejected:closed-unmerged`,
+      kind: "closed-unmerged-pull-request",
+      actor: pullRequest.author,
+      occurredAt: pullRequest.closedAt,
+      repository: repositoryIdFromUrl(pullRequest.url),
+      source: {
+        id: pullRequest.id,
+        kind: "pull-request",
+        number: pullRequest.number,
+        title: pullRequest.title,
+        url: pullRequest.url,
+      },
+      reason:
+        "Pull request was closed without merging during the published window.",
+    });
+  }
+  for (const issue of notPlannedIssues) {
+    if (issue.stateReason !== "NOT_PLANNED") {
+      throw new Error(
+        `Not-planned issue ${issue.id} must carry stateReason NOT_PLANNED`,
+      );
+    }
+    if (issue.author && isBotActor(issue.author)) {
+      continue;
+    }
+    attempts.push({
+      id: `${issue.id}:rejected:not-planned`,
+      kind: "not-planned-issue",
+      actor: issue.author,
+      occurredAt: issue.closedAt,
+      repository: repositoryIdFromUrl(issue.url),
+      source: {
+        id: issue.id,
+        kind: "issue",
+        number: issue.number,
+        title: issue.title,
+        url: issue.url,
+      },
+      reason: "Issue was closed as not planned during the published window.",
+    });
+  }
+  return attempts
+    .sort(compareRejectedAttempts)
+    .slice(0, REJECTED_ATTEMPT_FEED_LIMIT);
+}
+
 function compareOpportunities(
   left: ScoreOpportunity,
   right: ScoreOpportunity,
@@ -2881,6 +3003,10 @@ export function createLeaderboardSnapshot(
     openPullRequests,
     verifiedEvidence,
   );
+  const rejectedAttempts = collectRejectedAttempts(
+    input.closedUnmergedPullRequests ?? [],
+    input.notPlannedIssues ?? [],
+  );
   const overallAttribution = assessModelAttribution(
     [...scoredAttributionSources.values()],
     { requireEverySource: true },
@@ -2944,6 +3070,7 @@ export function createLeaderboardSnapshot(
         left.id.localeCompare(right.id),
     ),
     opportunities,
+    rejectedAttempts,
     attributions,
     invalidAttributionMarkers: overallAttribution.invalidMarkers.sort(
       (left, right) =>
@@ -4106,6 +4233,57 @@ function assertOpportunityValue(
   }
 }
 
+function assertRejectedAttemptValue(
+  value: unknown,
+  path: string,
+): asserts value is RejectedAttempt {
+  const attempt = assertObject(value, path);
+  assertString(attempt.id, `${path}.id`);
+  assertEnum(
+    attempt.kind,
+    ["closed-unmerged-pull-request", "not-planned-issue"],
+    `${path}.kind`,
+  );
+  assertNullableActor(attempt.actor, `${path}.actor`);
+  if (attempt.actor && isBotActor(attempt.actor as GitHubActor)) {
+    throw new Error(`${path}.actor must not be a bot`);
+  }
+  assertIsoTimestamp(attempt.occurredAt, `${path}.occurredAt`);
+  assertString(attempt.reason, `${path}.reason`);
+  if (attempt.reason.length < 20) {
+    throw new Error(`${path}.reason must explain the closed attempt`);
+  }
+  assertEnum(
+    attempt.repository,
+    TARGET_REPOSITORIES.map((repository) => repository.id),
+    `${path}.repository`,
+  );
+  const source = assertObject(attempt.source, `${path}.source`);
+  assertString(source.id, `${path}.source.id`);
+  assertEnum(source.kind, ["issue", "pull-request"], `${path}.source.kind`);
+  assertPositiveInteger(source.number, `${path}.source.number`);
+  assertString(source.title, `${path}.source.title`);
+  assertRepositoryUrl(
+    source.url,
+    `${path}.source.url`,
+    source.kind,
+    source.number,
+    attempt.repository as RepositoryId,
+  );
+  const kind = attempt.kind as RejectedAttemptKind;
+  if (
+    kind === "closed-unmerged-pull-request" &&
+    source.kind !== "pull-request"
+  ) {
+    throw new Error(
+      `${path}.source.kind must be pull-request for closed-unmerged-pull-request`,
+    );
+  }
+  if (kind === "not-planned-issue" && source.kind !== "issue") {
+    throw new Error(`${path}.source.kind must be issue for not-planned-issue`);
+  }
+}
+
 function assertAttributionValue(
   value: unknown,
   path: string,
@@ -4295,6 +4473,42 @@ export function assertLeaderboardSnapshot(
     ) {
       throw new Error(
         "snapshot.opportunities must be ordered newest-first by occurredAt",
+      );
+    }
+  }
+
+  if (!Array.isArray(snapshot.rejectedAttempts)) {
+    throw new Error("snapshot.rejectedAttempts must be an array");
+  }
+  if (snapshot.rejectedAttempts.length > REJECTED_ATTEMPT_FEED_LIMIT) {
+    throw new Error(
+      `snapshot.rejectedAttempts cannot exceed ${REJECTED_ATTEMPT_FEED_LIMIT} rows`,
+    );
+  }
+  const validatedRejectedAttempts = snapshot.rejectedAttempts.map(
+    (attempt, index) => {
+      assertRejectedAttemptValue(
+        attempt,
+        `snapshot.rejectedAttempts[${index}]`,
+      );
+      return attempt;
+    },
+  );
+  if (
+    new Set(validatedRejectedAttempts.map((attempt) => attempt.id)).size !==
+    validatedRejectedAttempts.length
+  ) {
+    throw new Error("snapshot.rejectedAttempts must contain unique IDs");
+  }
+  for (let index = 1; index < validatedRejectedAttempts.length; index += 1) {
+    if (
+      compareRejectedAttempts(
+        validatedRejectedAttempts[index - 1],
+        validatedRejectedAttempts[index],
+      ) > 0
+    ) {
+      throw new Error(
+        "snapshot.rejectedAttempts must be ordered newest-first by occurredAt",
       );
     }
   }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1116,6 +1116,139 @@ small {
   white-space: normal;
 }
 
+.attempt-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin: 0 0 28px;
+  padding: 0;
+  border: 0;
+  min-inline-size: 0;
+}
+
+.attempt-filters-legend {
+  float: left;
+  width: 100%;
+  margin: 0 0 10px;
+  padding: 0;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.attempt-filter {
+  min-height: 44px;
+  padding: 10px 14px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: rgba(255, 253, 248, 0.7);
+  color: var(--ink);
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+}
+
+.attempt-filter:hover,
+.attempt-filter-active {
+  border-color: var(--orange);
+  background: rgba(255, 90, 25, 0.08);
+}
+
+.attempt-project {
+  margin-bottom: 32px;
+}
+
+.attempt-project h2 {
+  margin: 0 0 12px;
+  font-size: 18px;
+}
+
+.attempt-list {
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: rgba(255, 253, 248, 0.7);
+}
+
+.attempt-row {
+  display: grid;
+  grid-template-columns: minmax(9.5rem, 11rem) minmax(0, 1fr) auto;
+  align-items: start;
+  gap: 18px;
+  min-height: 88px;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--line);
+}
+
+.attempt-row:last-child {
+  border-bottom: 0;
+}
+
+.attempt-row:hover {
+  background: rgba(255, 90, 25, 0.055);
+}
+
+.attempt-status {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  line-height: 1.35;
+}
+
+.attempt-body {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.attempt-body strong {
+  font-size: 14px;
+}
+
+.attempt-reason,
+.attempt-body small {
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.attempt-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.attempt-learning {
+  margin: 28px 0 0;
+  padding: 16px 18px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: rgba(255, 253, 248, 0.7);
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.attempt-learning a {
+  color: var(--ink);
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+@media (max-width: 720px) {
+  .attempt-row {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .attempt-status {
+    grid-column: 1 / -1;
+  }
+}
+
 .cycle-hero {
   display: grid;
   grid-template-columns: 1.4fr 0.6fr;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1172,7 +1172,7 @@ small {
 
 .attempt-row {
   display: grid;
-  grid-template-columns: minmax(9.5rem, 11rem) minmax(0, 1fr) auto;
+  grid-template-columns: minmax(9.5rem, 11rem) minmax(0, 1fr);
   align-items: start;
   gap: 18px;
   min-height: 88px;
@@ -1217,8 +1217,15 @@ small {
 .attempt-meta {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: 10px;
   align-items: center;
+  margin-top: 2px;
+}
+
+.attempt-meta a {
+  color: var(--ink);
+  font-size: 12px;
+  font-weight: 600;
 }
 
 .attempt-learning {
@@ -1241,11 +1248,7 @@ small {
 
 @media (max-width: 720px) {
   .attempt-row {
-    grid-template-columns: minmax(0, 1fr) auto;
-  }
-
-  .attempt-status {
-    grid-column: 1 / -1;
+    grid-template-columns: minmax(0, 1fr);
   }
 }
 

--- a/tests/app.test.tsx
+++ b/tests/app.test.tsx
@@ -474,7 +474,7 @@ describe("public records", () => {
     render(<App />);
 
     expect(
-      await screen.findByRole("heading", { name: "Closed attempts." }),
+      await screen.findByRole("heading", { name: "Work that didn't land." }),
     ).toBeInTheDocument();
     expect(
       screen.getByText("Explore an abandoned queue rewrite"),
@@ -482,10 +482,18 @@ describe("public records", () => {
     expect(
       screen.getByText("Prototype an abandoned ark ingest path"),
     ).toBeInTheDocument();
-    expect(screen.getAllByText(/closed without merge/).length).toBeGreaterThan(
-      0,
-    );
-    expect(screen.getAllByText(/not planned/).length).toBeGreaterThan(0);
+    expect(screen.getByText("Closed without merge")).toBeInTheDocument();
+    expect(screen.getByText("Closed as not planned")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /All projects \(2\)/i }),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Delta Star/i }));
+    expect(
+      screen.queryByText("Explore an abandoned queue rewrite"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText("Prototype an abandoned ark ingest path"),
+    ).toBeInTheDocument();
   });
 
   it("shows an immutable public payout wallet on an archived profile", async () => {

--- a/tests/app.test.tsx
+++ b/tests/app.test.tsx
@@ -494,6 +494,13 @@ describe("public records", () => {
     expect(
       screen.getByText("Prototype an abandoned ark ingest path"),
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "open project work" }),
+    ).toHaveAttribute("href", "/#projects");
+    expect(screen.getByRole("link", { name: "finish-line" })).toHaveAttribute(
+      "href",
+      "/contributors/finish-line",
+    );
   });
 
   it("shows an immutable public payout wallet on an archived profile", async () => {

--- a/tests/app.test.tsx
+++ b/tests/app.test.tsx
@@ -468,6 +468,26 @@ describe("public records", () => {
     expect(screen.queryByText(/Open checklist 18005/)).not.toBeInTheDocument();
   });
 
+  it("shows the cross-project closed attempts feed", async () => {
+    route("/attempts");
+    mockSnapshot();
+    render(<App />);
+
+    expect(
+      await screen.findByRole("heading", { name: "Closed attempts." }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Explore an abandoned queue rewrite"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Prototype an abandoned ark ingest path"),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText(/closed without merge/).length).toBeGreaterThan(
+      0,
+    );
+    expect(screen.getAllByText(/not planned/).length).toBeGreaterThan(0);
+  });
+
   it("shows an immutable public payout wallet on an archived profile", async () => {
     route("/contributors/archive-only");
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input) =>

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -226,6 +226,11 @@ test("renders contributor and cycle records from validated public data", async (
   });
   await expect(page.getByRole("heading", { name: actor.login })).toBeVisible();
   await expect(page.getByText("total paid")).toBeVisible();
+  if (snapshot.opportunities?.some((row) => row.actor.id === actor.id)) {
+    await expect(
+      page.getByRole("heading", { name: "Things that could be worked on." }),
+    ).toBeVisible();
+  }
 
   const archived = cycles.cycles.find((cycle) =>
     cycle.contributors.some((entry) => entry.actor.id === actor.id),
@@ -251,6 +256,27 @@ test("renders contributor and cycle records from validated public data", async (
       page.getByRole("heading", { name: `Eliza · ${view.cycle.id}` }),
     ).toBeVisible();
     await expect(page.getByText("14-day review")).toBeVisible();
+  }
+});
+
+test("renders the work-that-didn't-land feed", async ({ page, request }) => {
+  const snapshot = await loadSnapshot(request);
+  await page.goto("/attempts", { waitUntil: "networkidle" });
+  await expect(
+    page.getByRole("heading", { name: "Work that didn't land." }),
+  ).toBeVisible();
+  await expect(page.getByRole("link", { name: "Didn't land" })).toBeVisible();
+  if ((snapshot.rejectedAttempts?.length ?? 0) > 0) {
+    await expect(
+      page.getByRole("button", { name: /All projects/u }),
+    ).toBeVisible();
+    await expect(
+      page.getByText(/Looking for the next useful move/u),
+    ).toBeVisible();
+  } else {
+    await expect(
+      page.getByText(/Nothing in the current window closed without landing/u),
+    ).toBeVisible();
   }
 });
 

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -28,7 +28,7 @@ export function snapshotFixture(): LeaderboardSnapshot {
     kind: "User",
   };
   return {
-    schemaVersion: "5",
+    schemaVersion: "6",
     repository: "elizaOS/eliza",
     repositories: TARGET_REPOSITORIES.map((repository) => ({ ...repository })),
     ruleVersion: "gitarmy-v1",
@@ -305,6 +305,39 @@ export function snapshotFixture(): LeaderboardSnapshot {
         reason:
           "Open pull request evidence is missing with 0 of 6 points verified.",
         hint: "Add verified screenshot, video, or log evidence before merge.",
+      },
+    ],
+    rejectedAttempts: [
+      {
+        id: "PR_closed_fixture:rejected:closed-unmerged",
+        kind: "closed-unmerged-pull-request",
+        actor: leaderActor,
+        occurredAt: "2026-07-28T16:00:00.000Z",
+        repository: "elizaOS/eliza",
+        source: {
+          id: "PR_closed_fixture",
+          kind: "pull-request",
+          number: 17310,
+          title: "Explore an abandoned queue rewrite",
+          url: "https://github.com/elizaOS/eliza/pull/17310",
+        },
+        reason:
+          "Pull request was closed without merging during the published window.",
+      },
+      {
+        id: "ISSUE_not_planned_fixture:rejected:not-planned",
+        kind: "not-planned-issue",
+        actor: leaderActor,
+        occurredAt: "2026-07-27T16:00:00.000Z",
+        repository: "lalalune/arklib",
+        source: {
+          id: "ISSUE_not_planned_fixture",
+          kind: "issue",
+          number: 44,
+          title: "Prototype an abandoned ark ingest path",
+          url: "https://github.com/lalalune/arklib/issues/44",
+        },
+        reason: "Issue was closed as not planned during the published window.",
       },
     ],
     attributions: [


### PR DESCRIPTION
## Summary
- Collect closed-unmerged PRs (`is:pr is:closed -is:merged`) and not-planned issues (`reason:not-planned`) via GitHub search into snapshot `rejectedAttempts` (schema **v6**).
- Add public `/attempts` feed with nav/footer links; bots excluded; newest-first; hard cap 100.
- Keep this distinct from per-profile still-open opportunities (#28). Move the roadmap item into PRODUCT post-v1 surfaces.

## Stacking
Depends on / stacks on **#28** (`feat/profile-opportunities`). Base is that branch so this PR only reviews the feed delta. Retarget to `develop` after #28 merges.

## Test plan
- [x] `bunx vitest run tests/app.test.tsx src/lib/leaderboard.test.ts src/lib/project-view.test.ts scripts/evidence-contract.test.mjs`
- [x] `bun run typecheck` / `lint:check` / `format:check`
- [ ] After #28 merges: rebase onto `develop`, retarget PR, regenerate live ledger (`schemaVersion: "6"`)
- [ ] Spot-check `/attempts` with a generated snapshot


Made with [Cursor](https://cursor.com)