### PR TITLE
fix(skills): repair symlinked entrypoint and claude-code usage capture

### DIFF
--- a/skill-tests/contribute-to-eliza.test.ts
+++ b/skill-tests/contribute-to-eliza.test.ts
@@ -6,6 +6,8 @@
 import assert from "node:assert";
 import { spawnSync } from "node:child_process";
 import {
+  chmodSync,
+  cpSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -16,7 +18,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { describe, it } from "node:test";
 import { fileURLToPath } from "node:url";
 import {
@@ -32,6 +34,10 @@ import {
   readGhPages,
   renderMarkdown,
 } from "../skills/contribute-to-eliza/scripts/live-report.mjs";
+import {
+  normalizeSessionReport,
+  usageDelta,
+} from "../skills/contribute-to-eliza/scripts/run-receipt.mjs";
 
 const testDir = dirname(fileURLToPath(import.meta.url));
 const skillDir = join(testDir, "..", "skills", "contribute-to-eliza");
@@ -1488,6 +1494,242 @@ describe("live report behavior", () => {
           ),
         /cannot prove a current-head (?:APPROVED|CHANGES_REQUESTED) decision/,
       );
+    }
+  });
+});
+
+describe("run receipt CLI", () => {
+  const runReceiptPath = join(skillDir, "scripts", "run-receipt.mjs");
+
+  function runGit(cwd: string, args: string[]) {
+    const result = spawnSync("git", args, { cwd, encoding: "utf8" });
+    assert.strictEqual(result.status, 0, result.stderr);
+    return result.stdout.trim();
+  }
+
+  function encodedDirectoryName(path: string) {
+    return path
+      .replaceAll("\\", "/")
+      .replace(/\/$/u, "")
+      .replaceAll(/[^A-Za-z0-9]/gu, "-");
+  }
+
+  function session(
+    sessionId: string,
+    projectPath: string | null,
+    totalTokens: number,
+  ) {
+    return {
+      sessionId,
+      ...(projectPath === null ? {} : { projectPath }),
+      inputTokens: totalTokens,
+      outputTokens: 0,
+      totalTokens,
+    };
+  }
+
+  it("runs the CLI when its entrypoint reaches the module through a symlink", () => {
+    const fixtureRoot = mkdtempSync(
+      join(tmpdir(), "contribute-to-eliza-run-receipt-"),
+    );
+    const linkedEntrypoint = join(fixtureRoot, "run-receipt.mjs");
+    try {
+      symlinkSync(runReceiptPath, linkedEntrypoint);
+      assert.notStrictEqual(linkedEntrypoint, realpathSync(linkedEntrypoint));
+
+      const result = spawnSync(process.execPath, [linkedEntrypoint], {
+        encoding: "utf8",
+      });
+
+      assert.strictEqual(result.status, 1, result.stdout);
+      assert.match(
+        result.stderr,
+        /project run receipt failed: action must be start or finish/,
+      );
+    } finally {
+      rmSync(fixtureRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("attributes ccusage's encoded Claude Code project directories to the repository root", () => {
+    const repositoryRoot = resolve(tmpdir(), "contribute-to-eliza-usage");
+    const normalizedRoot = repositoryRoot
+      .replaceAll("\\", "/")
+      .replace(/\/$/u, "");
+    const encoded = encodedDirectoryName(repositoryRoot);
+
+    const report = normalizeSessionReport(
+      {
+        sessions: [
+          session("encoded-dialect", encoded, 12),
+          session("real-path-dialect", normalizedRoot, 2),
+          session("foreign-encoded", "-Users-someone-else-repository", 18),
+          session("unattributed", null, 6),
+        ],
+      },
+      repositoryRoot,
+    );
+
+    const kept = Object.values(report.sessions);
+    assert.deepStrictEqual(
+      kept.map((entry) => entry.totalTokens).sort((a, b) => a - b),
+      [2, 6, 12],
+    );
+    assert.deepStrictEqual(
+      kept
+        .filter((entry) => entry.pathMatched)
+        .map((entry) => entry.totalTokens)
+        .sort((a, b) => a - b),
+      [2, 12],
+    );
+
+    const before = normalizeSessionReport(
+      { sessions: [session("encoded-dialect", encoded, 16)] },
+      repositoryRoot,
+    );
+    const after = normalizeSessionReport(
+      { sessions: [session("encoded-dialect", encoded, 166)] },
+      repositoryRoot,
+    );
+    const delta = usageDelta(before, after, "claude-code");
+    assert.strictEqual(delta.confidence, "exact");
+    assert.strictEqual(delta.totalTokens, 150);
+  });
+
+  it("starts and finishes a measured run without passing --project to ccusage", () => {
+    const fixtureRoot = realpathSync(
+      mkdtempSync(join(tmpdir(), "contribute-to-eliza-start-")),
+    );
+    try {
+      const repoRoot = join(fixtureRoot, "repo");
+      mkdirSync(repoRoot, { recursive: true });
+      runGit(repoRoot, ["init", "--quiet"]);
+      runGit(repoRoot, [
+        "remote",
+        "add",
+        "origin",
+        "git@github.com:elizaOS/eliza.git",
+      ]);
+      cpSync(skillDir, join(repoRoot, "skills", "contribute-to-eliza"), {
+        recursive: true,
+      });
+      runGit(repoRoot, ["add", "."]);
+      runGit(repoRoot, [
+        "-c",
+        "user.email=skill-tests@example.com",
+        "-c",
+        "user.name=skill-tests",
+        "commit",
+        "--quiet",
+        "-m",
+        "fixture",
+      ]);
+
+      const shimDir = join(fixtureRoot, "bin");
+      mkdirSync(shimDir);
+      const argsLog = join(fixtureRoot, "ccusage-args.log");
+      const fixturePayload = join(fixtureRoot, "ccusage-report.json");
+      const shimSource = [
+        "#!/bin/sh",
+        'if [ "$1" = "--version" ]; then',
+        "  echo 1.3.14",
+        "  exit 0",
+        "fi",
+        'if [ "$CCUSAGE_MODE" = "fail" ]; then',
+        "  exit 7",
+        "fi",
+        `printf '%s\\n' "$*" >> "$CCUSAGE_ARGS_LOG"`,
+        'cat "$CCUSAGE_FIXTURE"',
+        "",
+      ].join("\n");
+      writeFileSync(join(shimDir, "bun"), shimSource);
+      chmodSync(join(shimDir, "bun"), 0o755);
+
+      const encodedRepo = encodedDirectoryName(repoRoot);
+      const environment = {
+        ...process.env,
+        PATH: `${shimDir}:${process.env.PATH}`,
+        XDG_CONFIG_HOME: join(fixtureRoot, "config"),
+        CCUSAGE_ARGS_LOG: argsLog,
+        CCUSAGE_FIXTURE: fixturePayload,
+      };
+      const entrypoint = join(
+        repoRoot,
+        "skills",
+        "contribute-to-eliza",
+        "scripts",
+        "run-receipt.mjs",
+      );
+      const cliArguments = [
+        "--repo-root",
+        repoRoot,
+        "--client",
+        "claude-code",
+        "--model",
+        "claude-fable-5",
+        "--lane",
+        "skill-tests",
+        "--json",
+      ];
+
+      writeFileSync(
+        fixturePayload,
+        JSON.stringify({
+          sessions: [session("fixture-session", encodedRepo, 16)],
+        }),
+      );
+      const started = spawnSync(
+        process.execPath,
+        [entrypoint, "start", ...cliArguments],
+        { encoding: "utf8", env: environment },
+      );
+      assert.strictEqual(started.status, 0, started.stderr);
+      const startReport = JSON.parse(started.stdout);
+      assert.strictEqual(startReport.usageStatus, "capturing");
+      assert.match(startReport.runId, /^run_[0-9A-HJKMNP-TV-Z]{26}$/);
+
+      const ccusageInvocations = readFileSync(argsLog, "utf8")
+        .trim()
+        .split("\n");
+      assert.deepStrictEqual(ccusageInvocations, [
+        "x ccusage@20.0.19 claude session --json --mode calculate",
+      ]);
+
+      writeFileSync(
+        fixturePayload,
+        JSON.stringify({
+          sessions: [session("fixture-session", encodedRepo, 166)],
+        }),
+      );
+      const finished = spawnSync(
+        process.execPath,
+        [entrypoint, "finish", ...cliArguments, "--run", startReport.runId],
+        { encoding: "utf8", env: environment },
+      );
+      assert.strictEqual(finished.status, 0, finished.stderr);
+      const finishReport = JSON.parse(finished.stdout);
+      assert.strictEqual(finishReport.receipt.usage.confidence, "exact");
+      assert.strictEqual(finishReport.receipt.usage.totalTokens, 150);
+      assert.match(
+        finishReport.footer,
+        /Compute receipt: 150 project-attributed tokens \(exact/,
+      );
+
+      const failedCapture = spawnSync(
+        process.execPath,
+        [entrypoint, "start", ...cliArguments],
+        {
+          encoding: "utf8",
+          env: { ...environment, CCUSAGE_MODE: "fail" },
+        },
+      );
+      assert.strictEqual(failedCapture.status, 0, failedCapture.stderr);
+      assert.strictEqual(
+        JSON.parse(failedCapture.stdout).usageStatus,
+        "unavailable",
+      );
+    } finally {
+      rmSync(fixtureRoot, { force: true, recursive: true });
     }
   });
 });

--- a/skills/contribute-to-delta-star/scripts/run-receipt.mjs
+++ b/skills/contribute-to-delta-star/scripts/run-receipt.mjs
@@ -21,6 +21,7 @@ import {
   lstatSync,
   mkdirSync,
   readFileSync,
+  realpathSync,
   renameSync,
   rmSync,
   statSync,
@@ -83,6 +84,10 @@ function normalizePath(value) {
   return resolve(value).replaceAll("\\", "/").replace(/\/$/u, "");
 }
 
+function claudeProjectDirectoryName(value) {
+  return value.replaceAll(/[^A-Za-z0-9]/gu, "-");
+}
+
 /** Reduces ccusage's source-specific session dialects to non-sensitive totals. */
 export function normalizeSessionReport(payload, repositoryRoot) {
   if (
@@ -94,6 +99,7 @@ export function normalizeSessionReport(payload, repositoryRoot) {
   }
   const expectedRoot = normalizePath(repositoryRoot);
   const expectedName = basename(expectedRoot).toLowerCase();
+  const expectedDirectoryName = claudeProjectDirectoryName(expectedRoot);
   const sessions = {};
   for (const value of payload.sessions) {
     if (!value || typeof value !== "object" || Array.isArray(value)) continue;
@@ -107,7 +113,9 @@ export function normalizeSessionReport(payload, repositoryRoot) {
       "path",
     ]);
     const normalizedProject = projectPath ? normalizePath(projectPath) : null;
-    const pathMatched = normalizedProject === expectedRoot;
+    const pathMatched =
+      normalizedProject === expectedRoot ||
+      projectPath === expectedDirectoryName;
     const nameMatched =
       normalizedProject !== null &&
       basename(normalizedProject).toLowerCase() === expectedName;
@@ -252,9 +260,6 @@ function collectUsage(client, repositoryRoot) {
     "--mode",
     "calculate",
   ];
-  if (client === "claude-code") {
-    args.push("--project", basename(repositoryRoot));
-  }
   const result = spawnSync(runner.command, args, {
     cwd: repositoryRoot,
     encoding: "utf8",
@@ -669,8 +674,10 @@ export function main(args = process.argv.slice(2)) {
 }
 
 const invokedDirectly =
-  process.argv[1] &&
-  resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+  typeof process.argv[1] === "string" &&
+  existsSync(process.argv[1]) &&
+  realpathSync(fileURLToPath(import.meta.url)) ===
+    realpathSync(process.argv[1]);
 if (invokedDirectly) {
   try {
     main();

--- a/skills/contribute-to-eliza/scripts/run-receipt.mjs
+++ b/skills/contribute-to-eliza/scripts/run-receipt.mjs
@@ -21,6 +21,7 @@ import {
   lstatSync,
   mkdirSync,
   readFileSync,
+  realpathSync,
   renameSync,
   rmSync,
   statSync,
@@ -83,6 +84,10 @@ function normalizePath(value) {
   return resolve(value).replaceAll("\\", "/").replace(/\/$/u, "");
 }
 
+function claudeProjectDirectoryName(value) {
+  return value.replaceAll(/[^A-Za-z0-9]/gu, "-");
+}
+
 /** Reduces ccusage's source-specific session dialects to non-sensitive totals. */
 export function normalizeSessionReport(payload, repositoryRoot) {
   if (
@@ -94,6 +99,7 @@ export function normalizeSessionReport(payload, repositoryRoot) {
   }
   const expectedRoot = normalizePath(repositoryRoot);
   const expectedName = basename(expectedRoot).toLowerCase();
+  const expectedDirectoryName = claudeProjectDirectoryName(expectedRoot);
   const sessions = {};
   for (const value of payload.sessions) {
     if (!value || typeof value !== "object" || Array.isArray(value)) continue;
@@ -107,7 +113,9 @@ export function normalizeSessionReport(payload, repositoryRoot) {
       "path",
     ]);
     const normalizedProject = projectPath ? normalizePath(projectPath) : null;
-    const pathMatched = normalizedProject === expectedRoot;
+    const pathMatched =
+      normalizedProject === expectedRoot ||
+      projectPath === expectedDirectoryName;
     const nameMatched =
       normalizedProject !== null &&
       basename(normalizedProject).toLowerCase() === expectedName;
@@ -252,9 +260,6 @@ function collectUsage(client, repositoryRoot) {
     "--mode",
     "calculate",
   ];
-  if (client === "claude-code") {
-    args.push("--project", basename(repositoryRoot));
-  }
   const result = spawnSync(runner.command, args, {
     cwd: repositoryRoot,
     encoding: "utf8",
@@ -669,8 +674,10 @@ export function main(args = process.argv.slice(2)) {
 }
 
 const invokedDirectly =
-  process.argv[1] &&
-  resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+  typeof process.argv[1] === "string" &&
+  existsSync(process.argv[1]) &&
+  realpathSync(fileURLToPath(import.meta.url)) ===
+    realpathSync(process.argv[1]);
 if (invokedDirectly) {
   try {
     main();


### PR DESCRIPTION
## Summary

Fixes the two `run-receipt.mjs` defects in elizaOS/army#30. The entrypoint guard compared `resolve(process.argv[1])` against Node's realpath-resolved `import.meta.url`, so under the installer's symlinked activation every documented invocation exited 0 without running `main` — no run started, no error shown. Independently, `collectUsage` passed `--project` to `ccusage@20.0.19 claude session`, which rejects that flag, and `normalizeSessionReport` dropped ccusage's encoded Claude Code project directories (`-Users-x-repo` style), so even a successful capture would have attributed zero sessions. Every claude-code contributor at the current revision publishes zero-usage receipts as a result; codex contributors hit only the symlink defect.

The guard now realpath-compares both sides — the shape `live-report.mjs` already uses, with its existing symlink regression test — `collectUsage` drops the unsupported flag, and session attribution additionally matches the encoded project-directory dialect. `contribute-to-delta-star` receives the byte-identical script per the `project-skills` parity contract. Imports remain side-effect-free.

## Validation

```
bun install --frozen-lockfile   # clean
bun run typecheck               # clean
bun run lint:check              # clean, 100 files
bun run test                    # vitest + bun test: 29 pass, 0 fail
bun run build                   # prepare-site validation + vite build green
bun run test:e2e                # fails on missing CI-generated /data/*.json;
                                # identical failures on unmodified develop
                                # (verified by stashing the diff and rerunning)
```

New regression coverage in `skill-tests/contribute-to-eliza.test.ts`: the CLI runs through a symlinked entrypoint; encoded/real-path/foreign/unattributed session attribution; and a full start→finish through the real CLI against a committed fixture repo with a shimmed `bun`, asserting the exact ccusage invocation (no `--project`), an `exact`-confidence 150-token receipt, and the fail-closed `unavailable` path when ccusage exits nonzero.

## Evidence

- Before screenshots: N/A - CLI-only change; before-state transcripts below.
- After screenshots: N/A - CLI-only change.
- Walkthrough video: N/A - CLI-only change; deterministic transcripts below.
- Backend logs:

  <details><summary>Before (revision 9259107, installed via symlink)</summary>

  ```
  $ node ~/.claude/skills/contribute-to-eliza/scripts/run-receipt.mjs start \
      --repo-root "$PWD" --client claude-code --model claude-fable-5 --lane prabhat1308
  $ echo $?
  0            # no output, no state file written

  $ bun x ccusage@20.0.19 claude session --json --mode calculate --project eliza
  Unknown session option '--project'
  ```
  </details>

  <details><summary>After (this branch, same symlinked layout, real ccusage)</summary>

  ```
  $ ln -s <checkout>/skills/contribute-to-eliza <tmp>/contribute-to-eliza
  $ XDG_CONFIG_HOME=<tmp>/config node <tmp>/contribute-to-eliza/scripts/run-receipt.mjs start \
      --repo-root /Users/.../projects/eliza --client claude-code --model claude-fable-5 \
      --lane prabhat1308 --json
  {
    "runId": "run_01KZTSD1H9HX13ZSK19DA2JQZF",
    "message": "Project run started. Keep this id: run_01KZTSD1H9HX13ZSK19DA2JQZF",
    "usageStatus": "capturing"
  }
  ```
  </details>

- Frontend console/network logs: N/A - no browser surface touched.
- Real-LLM trajectory: N/A - deterministic CLI tooling fix; no model behavior involved.
- Domain artifacts: on the reporting machine, real `ccusage@20.0.19` output holds 152 sessions across all projects; the fixed attribution keeps exactly 1 `pathMatched` session for the eliza repository root. A complete real start→finish through the symlinked layout against real ccusage produced the first non-zero receipt this tooling has emitted on this device:

  ```json
  {
   "source": "ccusage-session-v20",
   "confidence": "exact",
   "inputTokens": 14,
   "outputTokens": 6978,
   "cacheCreationTokens": 7511,
   "cacheReadTokens": 2054453,
   "totalTokens": 2068956,
   "costMicroUsd": "2553713",
   "sessionCount": 1
  }
  ```

  Footer line: `Compute receipt: 2068956 project-attributed tokens (exact; device-signed, locally reported)`. The committed fixture test additionally finishes a shimmed run with `usage.confidence: "exact"` and `usage.totalTokens: 150`.

## Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-fable-5
- Client / agent tooling: claude-code
- Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
- Attribution status: self-reported

## Slop protocol changes

- Contributor skill (`skills/contribute-to-eliza/`): `scripts/run-receipt.mjs` entrypoint guard, ccusage invocation, and session attribution repaired.
- Contributor skill (`skills/contribute-to-delta-star/`): byte-identical `scripts/run-receipt.mjs` sync required by the parity contract.

## Safety review

- [x] No private key, seed phrase, API token, raw private trajectory, or secret was added.
- [x] Untrusted project code is not executed with repository or deployment credentials.
- [x] New telemetry is bounded, disclosed, project-attributed, and covered by adversarial tests.
- [x] Money state is derived from validated manifests and finalized on-chain evidence, not a transaction signature alone. (No money state is touched by this change.)

— [prabhat1308]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza"} -->
