### PR TITLE
fix(leaderboard): match deep-inspection tiebreak to base merged-PR score

### DIFF
--- a/scripts/generate-leaderboard.test.ts
+++ b/scripts/generate-leaderboard.test.ts
@@ -1187,6 +1187,45 @@ describe("rate-efficient query plan", () => {
     ).toThrow("verificationWindowFrom must be a valid date");
   });
 
+  it("deep-inspects the newest cap-relevant outcomes by number when merge timestamps tie", () => {
+    const mergedAt = "2026-07-15T12:00:00.000Z";
+    const outcome = (id: string): MergedPullRequestOutcome => ({
+      id,
+      number: Number(id.replace(/\D/gu, "")) || 1,
+      title: id,
+      url: `https://github.com/elizaOS/eliza/pull/${id}`,
+      body: "",
+      createdAt: "2026-07-01T00:00:00.000Z",
+      updatedAt: mergedAt,
+      mergedAt,
+      author: actor("alice"),
+      additions: 1,
+      deletions: 0,
+    });
+    // Six PRs by the same author, project, and month merged in the same second
+    // (batch merge / merge queue produce identical second-precision timestamps).
+    // The base merged-PR score keeps the newest five by `number`, so the
+    // deep-inspection set must select the same five, otherwise a non-base-scored
+    // PR could earn detail-dependent bonuses.
+    const candidates = [
+      "PR_101",
+      "PR_102",
+      "PR_103",
+      "PR_104",
+      "PR_105",
+      "PR_106",
+    ].map((id) => ({ outcome: outcome(id), projectId: "eliza" }));
+
+    expect(
+      [
+        ...selectDetailedMergedPullRequestIds(
+          candidates,
+          new Date("2026-06-01T00:00:00.000Z"),
+        ),
+      ].sort(),
+    ).toEqual(["PR_102", "PR_103", "PR_104", "PR_105", "PR_106"].sort());
+  });
+
   it("recollects only typed concurrent changes to the non-scoring queue", async () => {
     let attempts = 0;
     await expect(

--- a/scripts/generate-leaderboard.ts
+++ b/scripts/generate-leaderboard.ts
@@ -2118,6 +2118,7 @@ export function selectDetailedMergedPullRequestIds(
   for (const candidate of [...candidates].sort(
     (left, right) =>
       right.outcome.mergedAt.localeCompare(left.outcome.mergedAt) ||
+      right.outcome.number - left.outcome.number ||
       left.outcome.id.localeCompare(right.outcome.id),
   )) {
     const { outcome, projectId } = candidate;


### PR DESCRIPTION
## Summary

`selectDetailedMergedPullRequestIds` selects the deep-inspection set (the only outcomes eligible for detail-dependent bonuses: material-test-change, evidence, substantive-review) ordering by `mergedAt desc, id asc`. It omits the `number desc` tiebreak that the base merged-PR scorer uses in `src/lib/leaderboard.ts` (`mergedAt desc, number desc, id asc`).

When more than five merged PRs by the same author, project, and UTC month share an identical `mergedAt` second (batch merge or merge queue produce identical second-precision timestamps, and GitHub node ids are opaque and uncorrelated with PR number), the two orderings select different newest-five subsets. A PR that is not base-scored can then earn detail-dependent bonuses, while a base-scored PR silently loses them, which contradicts the documented rule that only the newest five base-scored PRs earn bonuses. The doc comment on the function already states the set is bounded by the same newest-per-cycle cap as the base score.

## Change

Add the `number desc` tiebreak before the id tiebreak so the deep-inspection order matches the base scorer exactly.

## Validation

- `bun run typecheck` -> clean (`tsc -b`)
- `bunx vitest run scripts/generate-leaderboard.test.ts` -> 49 passed (48 existing + 1 new)
- Regression guard: with the one-line fix stashed, the new test fails, the selector returns `{PR_101..PR_105}` instead of the base-scored `{PR_102..PR_106}`; with the fix applied it passes
- `bunx @biomejs/biome check scripts/generate-leaderboard.ts scripts/generate-leaderboard.test.ts` -> no fixes

## Evidence

- Before screenshots: N/A - scoring library change, no UI surface
- After screenshots: N/A - scoring library change, no UI surface
- Walkthrough video: N/A - covered by the added unit test
- Backend logs: N/A - deterministic pure function, covered by the added unit test
- Frontend console/network logs: N/A - no frontend change
- Real-LLM trajectory: N/A - no agent or LLM runtime path touched
- Domain artifacts: N/A - no schema or manifest change

## Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic/claude-opus-4-8
- Client / agent tooling: Claude Code
- Contribution skill revision: N/A - direct repository fix, not submitted through a Slop contribution skill
- Attribution status: self-reported

## Slop protocol changes

- None - no project manifest, contributor skill, reviewer skill, award, or reward-cycle files are touched.

## Safety review

Deterministic ordering fix in a scoring helper. It aligns the deep-inspection order with the existing base scorer, adds one unit test, and introduces no new inputs, network calls, or privileges. The existing `assertPublishableLeaderboardSnapshot` caps are unchanged.
