### PR TITLE
fix(installer): authorize release candidates against the current repository name

### DIFF
--- a/src/lib/install-command.test.ts
+++ b/src/lib/install-command.test.ts
@@ -203,9 +203,9 @@ function candidatePull(
   overrides: Record<string, unknown> = {},
 ): Record<string, unknown> {
   return {
-    base: { ref: "develop", repo: { full_name: "elizaOS/army" } },
+    base: { ref: "develop", repo: { full_name: "elizaOS/slopdotcash" } },
     draft: false,
-    head: { repo: { full_name: "elizaOS/army" }, sha: revision },
+    head: { repo: { full_name: "elizaOS/slopdotcash" }, sha: revision },
     labels: [{ name: "gitarmy-release-candidate" }],
     number: 17424,
     state: "open",
@@ -396,7 +396,9 @@ describe("authenticated skill installer lifecycle", () => {
       ["unlabeled", { labels: [{ name: "safe-to-test" }] }],
       [
         "wrong head",
-        { head: { repo: { full_name: "elizaOS/army" }, sha: revisionB } },
+        {
+          head: { repo: { full_name: "elizaOS/slopdotcash" }, sha: revisionB },
+        },
       ],
     ] as const;
 
@@ -689,7 +691,7 @@ describe("authenticated skill installer lifecycle", () => {
       },
       developHead: revisionA,
       responseOverrides: {
-        "/repos/elizaOS/army/git/ref/heads/develop": {
+        "/repos/elizaOS/slopdotcash/git/ref/heads/develop": {
           object: { sha: revisionA, type: "commit" },
           ref: "refs/heads/not-develop",
         },
@@ -966,7 +968,7 @@ describe("authenticated skill installer lifecycle", () => {
     const symlinkRoot = freshRoot("source-symlink");
     const symlinkArtifact = writeArtifact(symlinkRoot, revisionA, archiveFiles);
     const contentsKey =
-      "/repos/elizaOS/army/contents/skills/contribute-to-eliza" +
+      "/repos/elizaOS/slopdotcash/contents/skills/contribute-to-eliza" +
       `?ref=${revisionA}`;
     const symlinkAuthority = configureAuthority(symlinkRoot, {
       developHead: revisionA,
@@ -1007,6 +1009,27 @@ describe("authenticated skill installer lifecycle", () => {
         },
       }),
     ).toThrow("must be an unparameterized file:// origin");
+  });
+
+  it("authorizes against the current GitHub name while writing the historical identity", () => {
+    const production = createInstallCommand(
+      "https://slop.cash",
+      `\${HOME}/.codex/skills`,
+    );
+
+    // GitHub reports elizaOS/slopdotcash in every API payload after the
+    // rename, so an authority comparison pinned to the old name matches
+    // nothing and refuses every install. The old name is also re-registrable,
+    // so it must never be what a release candidate is checked against.
+    expect(production).toContain('github_repository = "elizaOS/slopdotcash"');
+    expect(production).not.toMatch(/\/repos\/elizaOS\/army\//u);
+    expect(production).not.toContain('full_name") == repository');
+
+    // PROVENANCE.json and the authorization receipt keep the historical
+    // protocol identity until the slop-identity-v1 activation record lands,
+    // so these two identities are deliberately not unified.
+    expect(production).toContain('repository = "elizaOS/army"');
+    expect(production).toContain('"repository": repository');
   });
 
   it("uses a process-bound lock that recovers after an interrupted holder", async () => {

--- a/src/lib/install-command.ts
+++ b/src/lib/install-command.ts
@@ -115,6 +115,14 @@ from pathlib import PurePosixPath
 
 artifact_origin, api_origin, raw_origin, skills_root, operation, rollback_revision, skill_name, skill_repository_path = sys.argv[1:]
 repository = "elizaOS/army"
+# The GitHub repository was renamed to elizaOS/slopdotcash. GitHub reports the
+# current name in every API payload, so authority checks must compare against
+# it. The repository constant above stays on the historical protocol identity
+# that PROVENANCE.json and the authorization receipt are written with, until
+# the slop-identity-v1 activation record in PROTOCOL-MIGRATION.md lands.
+# Pinning the legacy name here would also trust whatever repository later
+# occupies it.
+github_repository = "elizaOS/slopdotcash"
 source_path = f"{skill_repository_path}/SKILL.md"
 release_label = "gitarmy-release-candidate"
 target_path = os.path.join(skills_root, skill_name)
@@ -245,7 +253,7 @@ def pull_records(revision):
     records = []
     for page in range(1, max_pull_pages + 1):
         response = api_json(
-            f"/repos/{repository}/commits/{revision}/pulls",
+            f"/repos/{github_repository}/commits/{revision}/pulls",
             (("page", str(page)), ("per_page", "100")),
         )
         if not isinstance(response, list):
@@ -264,7 +272,7 @@ def pull_timeline(number):
     records = []
     for page in range(1, max_timeline_pages + 1):
         response = api_json(
-            f"/repos/{repository}/issues/{number}/timeline",
+            f"/repos/{github_repository}/issues/{number}/timeline",
             (("page", str(page)), ("per_page", "100")),
         )
         if not isinstance(response, list) or len(response) > 100:
@@ -328,15 +336,15 @@ def pull_matches_repository_contract(pull, revision, *, require_open, require_la
         expected_state
         and pull.get("draft") is False
         and head.get("sha") == revision
-        and head_repository.get("full_name") == repository
+        and head_repository.get("full_name") == github_repository
         and base.get("ref") == "develop"
-        and base_repository.get("full_name") == repository
+        and base_repository.get("full_name") == github_repository
         and (not require_label or release_label in label_names)
     )
 
 
 def develop_head():
-    response = api_json(f"/repos/{repository}/git/ref/heads/develop")
+    response = api_json(f"/repos/{github_repository}/git/ref/heads/develop")
     if not isinstance(response, dict) or response.get("ref") != "refs/heads/develop":
         raise ValueError("GitHub develop ref response has the wrong identity")
     target = response.get("object")
@@ -398,7 +406,7 @@ def list_remote_skill_files(revision):
     while pending:
         directory = pending.pop()
         response = api_json(
-            f"/repos/{repository}/contents/{urllib.parse.quote(directory, safe='/')}",
+            f"/repos/{github_repository}/contents/{urllib.parse.quote(directory, safe='/')}",
             (("ref", revision),),
         )
         if not isinstance(response, list) or len(response) > 1000:
@@ -448,7 +456,7 @@ def remote_skill_bytes(revision):
     total = 0
     for path, entry in entries.items():
         raw_url = (
-            f"{raw_origin}/{repository}/{revision}/"
+            f"{raw_origin}/{github_repository}/{revision}/"
             f"{urllib.parse.quote(f'{skill_repository_path}/{path}', safe='/')}"
         )
         contents = fetch_bytes(raw_url, max_entry_bytes, raw_origin)
@@ -714,7 +722,7 @@ def extract_archive(archive_contents, extraction_root):
 
 
 def compare_is_ancestor(old_revision, new_revision):
-    comparison = api_json(f"/repos/{repository}/compare/{old_revision}...{new_revision}")
+    comparison = api_json(f"/repos/{github_repository}/compare/{old_revision}...{new_revision}")
     if not isinstance(comparison, dict):
         raise ValueError("GitHub compare response must be an object")
     base_commit = comparison.get("base_commit")

--- a/tests/install-authority-fixture.ts
+++ b/tests/install-authority-fixture.ts
@@ -9,7 +9,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { pathToFileURL } from "node:url";
 
-const REPOSITORY = "elizaOS/army";
+const REPOSITORY = "elizaOS/slopdotcash";
 const SKILL_PATH = "skills/contribute-to-eliza";
 
 export interface AuthorityRevision {


### PR DESCRIPTION
Fixes release-candidate authorization, which the repository rename broke.

### What broke

GitHub reports the current name in every API payload after a rename. `pull_matches_repository_contract` compared `head.repo.full_name` and `base.repo.full_name` against the pinned literal `elizaOS/army`, so it now matches nothing. Installing a labeled release candidate, and reauthorizing a candidate receipt during rollback, both refuse with *"archive revision is neither the current canonical develop skill nor an open labeled same-repository release candidate"*.

Reproduced against live GitHub — the installer's own query returns the new name on both sides:

```
$ gh api repos/elizaOS/army/commits/34953f5.../pulls
pr#37 head.repo.full_name=elizaOS/slopdotcash base.repo.full_name=elizaOS/slopdotcash
```

**Ordinary installs at the develop head were never affected** — that path authorizes through the git ref, not an associated pull request. I confirmed this by running the generated production command against live GitHub and the deployed artifacts: it installs `contribute-to-asi` at the verified develop head both before and after this change. That is also why nothing surfaced the bug.

The tests could not catch it either: the fixture minted its GitHub payloads from the same legacy literal the production code compared against, so both sides drifted together and stayed green.

### Why the comparison must follow the rename

A vacated name is re-registrable. Pinning authorization to `elizaOS/army` means trusting a labeled pull request in whatever repository later occupies that path — so this is the safer direction independent of liveness.

### What changed

Splits two identities that were conflated in one constant:

- `github_repository` addresses GitHub — API paths, raw content URLs, and the `full_name` authority comparisons.
- `repository` stays the historical protocol identity that `PROVENANCE.json` and the authorization receipt are written and validated with.

Migrating the second is the `slop-identity-v1` activation in `PROTOCOL-MIGRATION.md`, which must land atomically with its dual-readers, so this change deliberately leaves it alone. `prepare-site.mjs` and the three `run-receipt.mjs` copies keep agreeing on the legacy identity, untouched.

### Verification

- Candidate-acceptance test **fails** against GitHub-realistic payloads without the change and passes with it.
- Live end-to-end install succeeds before and after.
- Audit, lint, `tsc -b`, 298 vitest tests, 32 skill-tests all pass.
- New test pins the split so the two identities are not silently re-unified.
