### PR TITLE
fix(skills): paginate overflowing live activity

### DIFF
--- a/skill-tests/contribute-to-eliza.test.ts
+++ b/skill-tests/contribute-to-eliza.test.ts
@@ -27,6 +27,7 @@ import {
   CLAIM_RECENCY_DAYS,
   collectLiveReport,
   isBotAccount,
+  MAX_ACTIVITY_CONNECTION_ITEMS,
   parseCliArguments,
   parseModelDisclosure,
   parsePaginatedJson,
@@ -413,12 +414,251 @@ describe("live report parsing", () => {
     assert.strictEqual(calls.length, 2);
     assert.ok(calls.every((args) => args.includes("graphql")));
     assert.ok(calls.every((args) => args.includes("--paginate")));
+    assert.ok(
+      calls.every((args) => args[args.indexOf("--method") + 1] === "POST"),
+    );
+    assert.ok(
+      calls.every((args) => {
+        const query = args.find((argument) => argument.startsWith("query="));
+        return query?.includes("query(") && !/\bmutation\b/i.test(query);
+      }),
+    );
     assert.strictEqual(activity.issues.get(1)?.[0].user.id, 42);
     assert.strictEqual(activity.pulls.get(2)?.reviews[0].commit_id, HEAD_SHA);
     assert.strictEqual(activity.pulls.get(2)?.inlineComments.length, 1);
   });
 
-  it("fails closed when nested GraphQL activity would be truncated", () => {
+  it("paginates overflowing issue activity through bounded GET-only REST", () => {
+    const actor = {
+      __typename: "User",
+      databaseId: 42,
+      id: "U_42",
+      login: "reviewer",
+    };
+    const graphqlComments = Array.from({ length: 100 }, (_, index) => ({
+      databaseId: index + 1,
+      url: `https://github.com/elizaOS/eliza/issues/1#issuecomment-${index + 1}`,
+      body: `Comment ${index + 1}`,
+      createdAt: "2026-01-18T12:00:00.000Z",
+      authorAssociation: "MEMBER",
+      author: actor,
+    }));
+    const restComments = Array.from({ length: 351 }, (_, index) => ({
+      id: index + 1,
+      html_url: `https://github.com/elizaOS/eliza/issues/1#issuecomment-${index + 1}`,
+      body: `Comment ${index + 1}`,
+      created_at: "2026-01-18T12:00:00.000Z",
+      author_association: "MEMBER",
+      user: { id: 42, login: "reviewer", type: "User" },
+    }));
+    const calls: string[][] = [];
+    const activity = readGhOpenActivity("elizaOS/eliza", (_command, args) => {
+      calls.push(args);
+      if (args.includes("graphql")) {
+        return {
+          status: 0,
+          stderr: "",
+          stdout: args.at(-1)?.includes(".issues.")
+            ? `${JSON.stringify({
+                number: 1,
+                comments: { totalCount: 351, nodes: graphqlComments },
+              })}\n`
+            : "",
+        };
+      }
+      assert.ok(args.includes("--method"));
+      assert.strictEqual(args[args.indexOf("--method") + 1], "GET");
+      assert.ok(args.includes("--paginate"));
+      assert.ok(
+        args.includes("repos/elizaOS/eliza/issues/1/comments?per_page=100"),
+      );
+      return {
+        status: 0,
+        stderr: "",
+        stdout: `${restComments.map((value) => JSON.stringify(value)).join("\n")}\n`,
+      };
+    });
+
+    assert.strictEqual(calls.length, 3);
+    assert.strictEqual(activity.issues.get(1)?.length, 351);
+    assert.strictEqual(activity.issues.get(1)?.at(-1)?.id, 351);
+  });
+
+  it("paginates every overflowing pull-request activity surface", () => {
+    const actor = {
+      __typename: "User",
+      databaseId: 42,
+      id: "U_42",
+      login: "reviewer",
+    };
+    const graphqlComment = (id: number) => ({
+      databaseId: id,
+      url: `https://github.com/elizaOS/eliza/pull/2#issuecomment-${id}`,
+      body: `Comment ${id}`,
+      createdAt: "2026-01-18T12:00:00.000Z",
+      authorAssociation: "MEMBER",
+      author: actor,
+    });
+    const restComment = (id: number) => ({
+      id,
+      html_url: `https://github.com/elizaOS/eliza/pull/2#comment-${id}`,
+      body: `Comment ${id}`,
+      created_at: "2026-01-18T12:00:00.000Z",
+      author_association: "MEMBER",
+      user: { id: 42, login: "reviewer", type: "User" },
+    });
+    const graphqlReview = (id: number) => ({
+      databaseId: id,
+      url: `https://github.com/elizaOS/eliza/pull/2#pullrequestreview-${id}`,
+      body: `Review ${id}`,
+      submittedAt: "2026-01-18T12:00:00.000Z",
+      state: "COMMENTED",
+      commit: { oid: HEAD_SHA },
+      author: actor,
+    });
+    const restReview = (id: number) => ({
+      id,
+      html_url: `https://github.com/elizaOS/eliza/pull/2#pullrequestreview-${id}`,
+      body: `Review ${id}`,
+      submitted_at: "2026-01-18T12:00:00.000Z",
+      state: "COMMENTED",
+      commit_id: HEAD_SHA,
+      user: { id: 42, login: "reviewer", type: "User" },
+    });
+    const pullNode = {
+      number: 2,
+      comments: {
+        totalCount: 101,
+        nodes: Array.from({ length: 100 }, (_, index) =>
+          graphqlComment(index + 1),
+        ),
+      },
+      reviews: {
+        totalCount: 102,
+        nodes: Array.from({ length: 100 }, (_, index) =>
+          graphqlReview(index + 1),
+        ),
+      },
+      reviewThreads: {
+        totalCount: 101,
+        nodes: Array.from({ length: 100 }, (_, index) => ({
+          comments: {
+            totalCount: 1,
+            nodes: [graphqlComment(index + 1)],
+          },
+        })),
+      },
+    };
+    const calls: string[][] = [];
+    const activity = readGhOpenActivity("elizaOS/eliza", (_command, args) => {
+      calls.push(args);
+      if (args.includes("graphql")) {
+        return {
+          status: 0,
+          stderr: "",
+          stdout: args.at(-1)?.includes(".pullRequests.")
+            ? `${JSON.stringify(pullNode)}\n`
+            : "",
+        };
+      }
+      const endpoint = args.at(-1);
+      let records: Array<Record<string, unknown>>;
+      if (endpoint === "repos/elizaOS/eliza/issues/2/comments?per_page=100") {
+        records = Array.from({ length: 101 }, (_, index) =>
+          restComment(index + 1),
+        );
+      } else if (
+        endpoint === "repos/elizaOS/eliza/pulls/2/reviews?per_page=100"
+      ) {
+        records = Array.from({ length: 102 }, (_, index) =>
+          restReview(index + 1),
+        );
+      } else {
+        assert.strictEqual(
+          endpoint,
+          "repos/elizaOS/eliza/pulls/2/comments?per_page=100",
+        );
+        records = Array.from({ length: 151 }, (_, index) =>
+          restComment(index + 1),
+        );
+      }
+      return {
+        status: 0,
+        stderr: "",
+        stdout: `${records.map((value) => JSON.stringify(value)).join("\n")}\n`,
+      };
+    });
+
+    assert.strictEqual(calls.length, 5);
+    assert.strictEqual(activity.pulls.get(2)?.issueComments.length, 101);
+    assert.strictEqual(activity.pulls.get(2)?.reviews.length, 102);
+    assert.strictEqual(activity.pulls.get(2)?.inlineComments.length, 151);
+  });
+
+  it("paginates a single overflowing review thread through flat REST", () => {
+    const actor = {
+      __typename: "User",
+      databaseId: 42,
+      id: "U_42",
+      login: "reviewer",
+    };
+    const graphqlComment = (id: number) => ({
+      databaseId: id,
+      url: `https://github.com/elizaOS/eliza/pull/2#discussion_r${id}`,
+      body: `Comment ${id}`,
+      createdAt: "2026-01-18T12:00:00.000Z",
+      authorAssociation: "MEMBER",
+      author: actor,
+    });
+    const restComments = Array.from({ length: 101 }, (_, index) => ({
+      id: index + 1,
+      html_url: `https://github.com/elizaOS/eliza/pull/2#discussion_r${index + 1}`,
+      body: `Comment ${index + 1}`,
+      created_at: "2026-01-18T12:00:00.000Z",
+      author_association: "MEMBER",
+      user: { id: 42, login: "reviewer", type: "User" },
+    }));
+    const activity = readGhOpenActivity("elizaOS/eliza", (_command, args) => {
+      if (args.includes("graphql")) {
+        return {
+          status: 0,
+          stderr: "",
+          stdout: args.at(-1)?.includes(".pullRequests.")
+            ? `${JSON.stringify({
+                number: 2,
+                comments: { totalCount: 0, nodes: [] },
+                reviews: { totalCount: 0, nodes: [] },
+                reviewThreads: {
+                  totalCount: 1,
+                  nodes: [
+                    {
+                      comments: {
+                        totalCount: 101,
+                        nodes: Array.from({ length: 100 }, (_, index) =>
+                          graphqlComment(index + 1),
+                        ),
+                      },
+                    },
+                  ],
+                },
+              })}\n`
+            : "",
+        };
+      }
+      assert.ok(
+        args.includes("repos/elizaOS/eliza/pulls/2/comments?per_page=100"),
+      );
+      return {
+        status: 0,
+        stderr: "",
+        stdout: `${restComments.map((value) => JSON.stringify(value)).join("\n")}\n`,
+      };
+    });
+
+    assert.strictEqual(activity.pulls.get(2)?.inlineComments.length, 101);
+  });
+
+  it("fails closed when nested GraphQL activity exceeds the bounded fallback", () => {
     assert.throws(
       () =>
         readGhOpenActivity("elizaOS/eliza", (_command, args) => ({
@@ -427,11 +667,97 @@ describe("live report parsing", () => {
           stdout: args.at(-1)?.includes(".issues.")
             ? `${JSON.stringify({
                 number: 1,
-                comments: { totalCount: 101, nodes: [] },
+                comments: {
+                  totalCount: MAX_ACTIVITY_CONNECTION_ITEMS + 1,
+                  nodes: Array.from({ length: 100 }, () => ({})),
+                },
               })}\n`
             : "",
         })),
-      /exceeds the complete 100-record activity bound/,
+      /exceeds the complete 1000-record activity bound/,
+    );
+  });
+
+  it("fails closed on an incomplete initial GraphQL activity page", () => {
+    assert.throws(
+      () =>
+        readGhOpenActivity("elizaOS/eliza", (_command, args) => ({
+          status: 0,
+          stderr: "",
+          stdout: args.at(-1)?.includes(".issues.")
+            ? `${JSON.stringify({
+                number: 1,
+                comments: {
+                  totalCount: 351,
+                  nodes: Array.from({ length: 99 }, () => ({})),
+                },
+              })}\n`
+            : "",
+        })),
+      /returned 99 of the expected 100 initial activity records/,
+    );
+  });
+
+  it("fails closed when paginated REST activity exceeds the bound", () => {
+    const graphqlComments = Array.from({ length: 100 }, (_, index) => ({
+      databaseId: index + 1,
+      url: `https://github.com/elizaOS/eliza/issues/1#issuecomment-${index + 1}`,
+      body: "",
+      createdAt: "2026-01-18T12:00:00.000Z",
+      authorAssociation: "MEMBER",
+      author: null,
+    }));
+    const restComments = Array.from(
+      { length: MAX_ACTIVITY_CONNECTION_ITEMS + 1 },
+      (_, index) => ({ id: index + 1 }),
+    );
+
+    assert.throws(
+      () =>
+        readGhOpenActivity("elizaOS/eliza", (_command, args) => ({
+          status: 0,
+          stderr: "",
+          stdout: args.includes("graphql")
+            ? args.at(-1)?.includes(".issues.")
+              ? `${JSON.stringify({
+                  number: 1,
+                  comments: { totalCount: 101, nodes: graphqlComments },
+                })}\n`
+              : ""
+            : `${restComments.map((value) => JSON.stringify(value)).join("\n")}\n`,
+        })),
+      /exceeds the complete 1000-record activity bound/,
+    );
+  });
+
+  it("fails closed when paginated REST activity disagrees with GraphQL", () => {
+    const graphqlComments = Array.from({ length: 100 }, (_, index) => ({
+      databaseId: index + 1,
+      url: `https://github.com/elizaOS/eliza/issues/1#issuecomment-${index + 1}`,
+      body: "",
+      createdAt: "2026-01-18T12:00:00.000Z",
+      authorAssociation: "MEMBER",
+      author: null,
+    }));
+    const restComments = Array.from({ length: 100 }, (_, index) => ({
+      id: index + 1,
+    }));
+
+    assert.throws(
+      () =>
+        readGhOpenActivity("elizaOS/eliza", (_command, args) => ({
+          status: 0,
+          stderr: "",
+          stdout: args.includes("graphql")
+            ? args.at(-1)?.includes(".issues.")
+              ? `${JSON.stringify({
+                  number: 1,
+                  comments: { totalCount: 101, nodes: graphqlComments },
+                })}\n`
+              : ""
+            : `${restComments.map((value) => JSON.stringify(value)).join("\n")}\n`,
+        })),
+      /returned 100 records after reporting 101/,
     );
   });
 

--- a/skill-tests/contribute-to-eliza.test.ts
+++ b/skill-tests/contribute-to-eliza.test.ts
@@ -26,6 +26,7 @@ import {
   auditPrEvidence,
   CLAIM_RECENCY_DAYS,
   collectLiveReport,
+  createGhCommandBudget,
   isBotAccount,
   MAX_ACTIVITY_CONNECTION_ITEMS,
   parseCliArguments,
@@ -122,6 +123,18 @@ function evidenceBody() {
       `<!-- evidence-row:${id} -->\n- [x] ${id}: N/A - no affected ${id} surface.`,
   ).join("\n\n");
   return `${rows}\n\nAI provider/model: OpenAI / gpt-5.6-codex`;
+}
+
+function pagedStdout(args: string[], records: unknown[]) {
+  const endpoint = args.at(-1);
+  assert.strictEqual(typeof endpoint, "string");
+  const pageMatch = endpoint.match(/[?&]page=(\d+)$/);
+  assert.ok(pageMatch, `missing explicit page in ${endpoint}`);
+  const start = (Number(pageMatch[1]) - 1) * 100;
+  const page = records.slice(start, start + 100);
+  return page.length === 0
+    ? ""
+    : `${page.map((value) => JSON.stringify(value)).join("\n")}\n`;
 }
 
 describe("contribute-to-eliza skill structure", () => {
@@ -452,7 +465,7 @@ describe("live report parsing", () => {
       user: { id: 42, login: "reviewer", type: "User" },
     }));
     const calls: string[][] = [];
-    const activity = readGhOpenActivity("elizaOS/eliza", (_command, args) => {
+    const commandBudget = createGhCommandBudget((_command, args) => {
       calls.push(args);
       if (args.includes("graphql")) {
         return {
@@ -468,18 +481,24 @@ describe("live report parsing", () => {
       }
       assert.ok(args.includes("--method"));
       assert.strictEqual(args[args.indexOf("--method") + 1], "GET");
-      assert.ok(args.includes("--paginate"));
+      assert.ok(!args.includes("--paginate"));
       assert.ok(
-        args.includes("repos/elizaOS/eliza/issues/1/comments?per_page=100"),
+        args
+          .at(-1)
+          ?.startsWith(
+            "repos/elizaOS/eliza/issues/1/comments?per_page=100&page=",
+          ),
       );
       return {
         status: 0,
         stderr: "",
-        stdout: `${restComments.map((value) => JSON.stringify(value)).join("\n")}\n`,
+        stdout: pagedStdout(args, restComments),
       };
     });
+    const activity = readGhOpenActivity("elizaOS/eliza", commandBudget.run);
 
-    assert.strictEqual(calls.length, 3);
+    assert.strictEqual(calls.length, 6);
+    assert.strictEqual(commandBudget.count, 6);
     assert.strictEqual(activity.issues.get(1)?.length, 351);
     assert.strictEqual(activity.issues.get(1)?.at(-1)?.id, 351);
   });
@@ -561,22 +580,29 @@ describe("live report parsing", () => {
             : "",
         };
       }
-      const endpoint = args.at(-1);
+      const endpoint = args.at(-1) ?? "";
       let records: Array<Record<string, unknown>>;
-      if (endpoint === "repos/elizaOS/eliza/issues/2/comments?per_page=100") {
+      if (
+        endpoint.startsWith(
+          "repos/elizaOS/eliza/issues/2/comments?per_page=100&page=",
+        )
+      ) {
         records = Array.from({ length: 101 }, (_, index) =>
           restComment(index + 1),
         );
       } else if (
-        endpoint === "repos/elizaOS/eliza/pulls/2/reviews?per_page=100"
+        endpoint.startsWith(
+          "repos/elizaOS/eliza/pulls/2/reviews?per_page=100&page=",
+        )
       ) {
         records = Array.from({ length: 102 }, (_, index) =>
           restReview(index + 1),
         );
       } else {
-        assert.strictEqual(
-          endpoint,
-          "repos/elizaOS/eliza/pulls/2/comments?per_page=100",
+        assert.ok(
+          endpoint.startsWith(
+            "repos/elizaOS/eliza/pulls/2/comments?per_page=100&page=",
+          ),
         );
         records = Array.from({ length: 151 }, (_, index) =>
           restComment(index + 1),
@@ -585,11 +611,11 @@ describe("live report parsing", () => {
       return {
         status: 0,
         stderr: "",
-        stdout: `${records.map((value) => JSON.stringify(value)).join("\n")}\n`,
+        stdout: pagedStdout(args, records),
       };
     });
 
-    assert.strictEqual(calls.length, 5);
+    assert.strictEqual(calls.length, 8);
     assert.strictEqual(activity.pulls.get(2)?.issueComments.length, 101);
     assert.strictEqual(activity.pulls.get(2)?.reviews.length, 102);
     assert.strictEqual(activity.pulls.get(2)?.inlineComments.length, 151);
@@ -618,7 +644,9 @@ describe("live report parsing", () => {
       author_association: "MEMBER",
       user: { id: 42, login: "reviewer", type: "User" },
     }));
+    const calls: string[][] = [];
     const activity = readGhOpenActivity("elizaOS/eliza", (_command, args) => {
+      calls.push(args);
       if (args.includes("graphql")) {
         return {
           status: 0,
@@ -646,15 +674,20 @@ describe("live report parsing", () => {
         };
       }
       assert.ok(
-        args.includes("repos/elizaOS/eliza/pulls/2/comments?per_page=100"),
+        args
+          .at(-1)
+          ?.startsWith(
+            "repos/elizaOS/eliza/pulls/2/comments?per_page=100&page=",
+          ),
       );
       return {
         status: 0,
         stderr: "",
-        stdout: `${restComments.map((value) => JSON.stringify(value)).join("\n")}\n`,
+        stdout: pagedStdout(args, restComments),
       };
     });
 
+    assert.strictEqual(calls.length, 4);
     assert.strictEqual(activity.pulls.get(2)?.inlineComments.length, 101);
   });
 
@@ -699,35 +732,43 @@ describe("live report parsing", () => {
   });
 
   it("fails closed when paginated REST activity exceeds the bound", () => {
-    const graphqlComments = Array.from({ length: 100 }, (_, index) => ({
-      databaseId: index + 1,
-      url: `https://github.com/elizaOS/eliza/issues/1#issuecomment-${index + 1}`,
-      body: "",
-      createdAt: "2026-01-18T12:00:00.000Z",
-      authorAssociation: "MEMBER",
-      author: null,
-    }));
     const restComments = Array.from(
       { length: MAX_ACTIVITY_CONNECTION_ITEMS + 1 },
       (_, index) => ({ id: index + 1 }),
     );
+    const calls: string[][] = [];
 
     assert.throws(
       () =>
-        readGhOpenActivity("elizaOS/eliza", (_command, args) => ({
-          status: 0,
-          stderr: "",
-          stdout: args.includes("graphql")
-            ? args.at(-1)?.includes(".issues.")
-              ? `${JSON.stringify({
-                  number: 1,
-                  comments: { totalCount: 101, nodes: graphqlComments },
-                })}\n`
-              : ""
-            : `${restComments.map((value) => JSON.stringify(value)).join("\n")}\n`,
-        })),
+        readGhOpenActivity("elizaOS/eliza", (_command, args) => {
+          calls.push(args);
+          if (args.includes("graphql")) {
+            return {
+              status: 0,
+              stderr: "",
+              stdout: args.at(-1)?.includes(".pullRequests.")
+                ? `${JSON.stringify({
+                    number: 2,
+                    comments: { totalCount: 0, nodes: [] },
+                    reviews: { totalCount: 0, nodes: [] },
+                    reviewThreads: {
+                      totalCount: 101,
+                      nodes: Array.from({ length: 100 }, () => ({})),
+                    },
+                  })}\n`
+                : "",
+            };
+          }
+          return {
+            status: 0,
+            stderr: "",
+            stdout: pagedStdout(args, restComments),
+          };
+        }),
       /exceeds the complete 1000-record activity bound/,
     );
+    assert.strictEqual(calls.length, 13);
+    assert.match(calls.at(-1)?.at(-1) ?? "", /[?&]page=11$/);
   });
 
   it("fails closed when paginated REST activity disagrees with GraphQL", () => {
@@ -755,10 +796,32 @@ describe("live report parsing", () => {
                   comments: { totalCount: 101, nodes: graphqlComments },
                 })}\n`
               : ""
-            : `${restComments.map((value) => JSON.stringify(value)).join("\n")}\n`,
+            : pagedStdout(args, restComments),
         })),
       /returned 100 records after reporting 101/,
     );
+  });
+
+  it("rejects the seventeenth GitHub command before spawning it", () => {
+    let invocations = 0;
+    const commandBudget = createGhCommandBudget(() => {
+      invocations += 1;
+      return { status: 0, stderr: "", stdout: "" };
+    });
+    for (let index = 0; index < 16; index += 1) {
+      commandBudget.run("gh", ["api", "endpoint"], { encoding: "utf8" });
+    }
+    assert.strictEqual(commandBudget.count, 16);
+    assert.strictEqual(invocations, 16);
+    assert.throws(
+      () =>
+        commandBudget.run("gh", ["api", "endpoint"], {
+          encoding: "utf8",
+        }),
+      /exceeds the 16-command safety bound/,
+    );
+    assert.strictEqual(commandBudget.count, 16);
+    assert.strictEqual(invocations, 16);
   });
 
   it("accepts exact provider/model pairs and rejects placeholders", () => {

--- a/skills/contribute-to-asi/scripts/live-report.mjs
+++ b/skills/contribute-to-asi/scripts/live-report.mjs
@@ -472,12 +472,60 @@ function graphqlConnection(record, field, context) {
   };
 }
 
-function readOverflowActivity(endpoint, expectedCount, context, spawn) {
-  const records = readGhPages(endpoint, spawn);
-  if (records.length > MAX_ACTIVITY_CONNECTION_ITEMS) {
+function readGhActivityPage(endpoint, pageNumber, context, spawn) {
+  const separator = endpoint.includes("?") ? "&" : "?";
+  const pagedEndpoint = `${endpoint}${separator}page=${pageNumber}`;
+  const result = spawn(
+    "gh",
+    ["api", "--method", "GET", "--jq", ".[]", pagedEndpoint],
+    {
+      encoding: "utf8",
+      maxBuffer: 64 * 1024 * 1024,
+      windowsHide: true,
+    },
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const detail =
+      typeof result.stderr === "string" && result.stderr.trim().length > 0
+        ? `: ${result.stderr.trim()}`
+        : "";
+    throw new Error(`gh api failed for ${context} page ${pageNumber}${detail}`);
+  }
+  const records = parsePaginatedJson(
+    result.stdout,
+    `${context} page ${pageNumber}`,
+  );
+  if (records.length > ACTIVITY_PAGE_SIZE) {
     throw new RangeError(
-      `${context} exceeds the complete ${MAX_ACTIVITY_CONNECTION_ITEMS}-record activity bound`,
+      `${context} page ${pageNumber} returned ${records.length} records, exceeding the ${ACTIVITY_PAGE_SIZE}-record page bound`,
     );
+  }
+  return records;
+}
+
+function readOverflowActivity(endpoint, expectedCount, context, spawn) {
+  const records = [];
+  const maximumPages = Math.ceil(
+    MAX_ACTIVITY_CONNECTION_ITEMS / ACTIVITY_PAGE_SIZE,
+  );
+  for (let pageNumber = 1; pageNumber <= maximumPages + 1; pageNumber += 1) {
+    const page = readGhActivityPage(endpoint, pageNumber, context, spawn);
+    if (pageNumber > maximumPages) {
+      if (page.length > 0) {
+        throw new RangeError(
+          `${context} exceeds the complete ${MAX_ACTIVITY_CONNECTION_ITEMS}-record activity bound`,
+        );
+      }
+      break;
+    }
+    records.push(...page);
+    if (expectedCount !== null && records.length > expectedCount) {
+      throw new RangeError(
+        `${context} returned more than the ${expectedCount} records it reported`,
+      );
+    }
+    if (page.length < ACTIVITY_PAGE_SIZE) break;
   }
   if (expectedCount !== null && records.length !== expectedCount) {
     throw new RangeError(
@@ -568,6 +616,24 @@ function readGraphqlActivityNodes(repo, query, selector, spawn, context) {
     throw new Error(`gh api graphql failed for ${context}${detail}`);
   }
   return parsePaginatedJson(result.stdout, context);
+}
+
+export function createGhCommandBudget(spawn = spawnSync) {
+  let count = 0;
+  return {
+    get count() {
+      return count;
+    },
+    run: (command, args, options) => {
+      if (count >= MAX_API_READS) {
+        throw new RangeError(
+          `Live discovery exceeds the ${MAX_API_READS}-command safety bound`,
+        );
+      }
+      count += 1;
+      return spawn(command, args, options);
+    },
+  };
 }
 
 /** Reads open activity in two batches plus bounded overflow pagination. */
@@ -1666,20 +1732,11 @@ export function main(args = process.argv.slice(2)) {
     process.stdout.write(usage());
     return;
   }
-  let apiReads = 0;
-  const boundedSpawn = (command, commandArgs, spawnOptions) => {
-    apiReads += 1;
-    if (apiReads > MAX_API_READS) {
-      throw new RangeError(
-        `Live discovery exceeds the ${MAX_API_READS}-command safety bound`,
-      );
-    }
-    return spawnSync(command, commandArgs, spawnOptions);
-  };
+  const commandBudget = createGhCommandBudget();
   const boundedRead = (endpoint) => {
-    return readGhPages(endpoint, boundedSpawn);
+    return readGhPages(endpoint, commandBudget.run);
   };
-  const openActivity = readGhOpenActivity(options.repo, boundedSpawn);
+  const openActivity = readGhOpenActivity(options.repo, commandBudget.run);
   const report = collectLiveReport(
     options.repo,
     boundedRead,
@@ -1687,7 +1744,7 @@ export function main(args = process.argv.slice(2)) {
     ({ phase, current, total }) => {
       if (current === 0 || current === total || current % 10 === 0) {
         process.stderr.write(
-          `[Slop] scanning ${phase}: ${current}/${total} (${apiReads} bounded GitHub commands)\n`,
+          `[Slop] scanning ${phase}: ${current}/${total} (${commandBudget.count} bounded GitHub commands)\n`,
         );
       }
     },

--- a/skills/contribute-to-asi/scripts/live-report.mjs
+++ b/skills/contribute-to-asi/scripts/live-report.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 /**
  * Builds a stable, read-only inventory of open elizaOS issues and pull requests
- * for contribution selection. GitHub pagination stays behind one GET-only
- * adapter so callers and tests can verify that this script never mutates state.
+ * for contribution selection. REST pagination stays behind one GET-only
+ * adapter; GraphQL uses explicit read-only queries over GitHub's POST endpoint.
  */
 
 import { spawnSync } from "node:child_process";
@@ -22,6 +22,7 @@ export const REQUIRED_EVIDENCE_ROWS = [
 export const CLAIM_RECENCY_DAYS = 7;
 export const MAX_OPEN_ITEMS = 1_000;
 export const MAX_API_READS = 16;
+export const MAX_ACTIVITY_CONNECTION_ITEMS = 1_000;
 
 const REPOSITORY_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const PLACEHOLDER_RE =
@@ -365,7 +366,7 @@ export function readGhPages(endpoint, spawn = spawnSync) {
   return parsePaginatedJson(result.stdout, endpoint);
 }
 
-const ACTIVITY_CONNECTION_LIMIT = 100;
+const ACTIVITY_PAGE_SIZE = 100;
 const GRAPHQL_ACTOR_FIELDS = `
   login
   __typename
@@ -453,12 +454,37 @@ function graphqlConnection(record, field, context) {
     `${context}.${field}`,
   );
   const nodes = asArrayField(connection, "nodes", `${context}.${field}`);
-  if (totalCount > ACTIVITY_CONNECTION_LIMIT || nodes.length !== totalCount) {
+  if (totalCount > MAX_ACTIVITY_CONNECTION_ITEMS) {
     throw new RangeError(
-      `${context}.${field} exceeds the complete ${ACTIVITY_CONNECTION_LIMIT}-record activity bound`,
+      `${context}.${field} exceeds the complete ${MAX_ACTIVITY_CONNECTION_ITEMS}-record activity bound`,
     );
   }
-  return nodes;
+  const expectedPageSize = Math.min(totalCount, ACTIVITY_PAGE_SIZE);
+  if (nodes.length !== expectedPageSize) {
+    throw new RangeError(
+      `${context}.${field} returned ${nodes.length} of the expected ${expectedPageSize} initial activity records`,
+    );
+  }
+  return {
+    needsPagination: totalCount > ACTIVITY_PAGE_SIZE,
+    nodes,
+    totalCount,
+  };
+}
+
+function readOverflowActivity(endpoint, expectedCount, context, spawn) {
+  const records = readGhPages(endpoint, spawn);
+  if (records.length > MAX_ACTIVITY_CONNECTION_ITEMS) {
+    throw new RangeError(
+      `${context} exceeds the complete ${MAX_ACTIVITY_CONNECTION_ITEMS}-record activity bound`,
+    );
+  }
+  if (expectedCount !== null && records.length !== expectedCount) {
+    throw new RangeError(
+      `${context} returned ${records.length} records after reporting ${expectedCount}`,
+    );
+  }
+  return records;
 }
 
 function graphqlAccount(value, context) {
@@ -517,6 +543,8 @@ function readGraphqlActivityNodes(repo, query, selector, spawn, context) {
     [
       "api",
       "graphql",
+      "--method",
+      "POST",
       "--paginate",
       "-f",
       `query=${query}`,
@@ -542,7 +570,7 @@ function readGraphqlActivityNodes(repo, query, selector, spawn, context) {
   return parsePaginatedJson(result.stdout, context);
 }
 
-/** Reads all open issue/PR activity in connection-sized batches, never N+1. */
+/** Reads open activity in two batches plus bounded overflow pagination. */
 export function readGhOpenActivity(repo, spawn = spawnSync) {
   if (!REPOSITORY_RE.test(repo)) {
     throw new TypeError("Repository must use the owner/name form");
@@ -573,12 +601,19 @@ export function readGhOpenActivity(repo, spawn = spawnSync) {
     const number = asNumberField(node, "number", context);
     if (issues.has(number))
       throw new TypeError(`duplicate issue activity for #${number}`);
+    const comments = graphqlConnection(node, "comments", context);
     issues.set(
       number,
-      graphqlConnection(node, "comments", context).map(
-        (comment, commentIndex) =>
-          graphqlComment(comment, `${context}.comments[${commentIndex}]`),
-      ),
+      comments.needsPagination
+        ? readOverflowActivity(
+            issueCommentsEndpoint(repo, number),
+            comments.totalCount,
+            `${context}.comments`,
+            spawn,
+          )
+        : comments.nodes.map((comment, commentIndex) =>
+            graphqlComment(comment, `${context}.comments[${commentIndex}]`),
+          ),
     );
   }
   const pulls = new Map();
@@ -588,26 +623,69 @@ export function readGhOpenActivity(repo, spawn = spawnSync) {
     const number = asNumberField(node, "number", context);
     if (pulls.has(number))
       throw new TypeError(`duplicate pull activity for #${number}`);
-    const issueComments = graphqlConnection(node, "comments", context).map(
-      (comment, commentIndex) =>
-        graphqlComment(comment, `${context}.comments[${commentIndex}]`),
-    );
-    const reviews = graphqlConnection(node, "reviews", context).map(
-      (review, reviewIndex) =>
-        graphqlReview(review, `${context}.reviews[${reviewIndex}]`),
-    );
-    const inlineComments = graphqlConnection(
-      node,
-      "reviewThreads",
-      context,
-    ).flatMap((thread, threadIndex) => {
-      const threadContext = `${context}.reviewThreads[${threadIndex}]`;
-      const record = asRecord(thread, threadContext);
-      return graphqlConnection(record, "comments", threadContext).map(
-        (comment, commentIndex) =>
-          graphqlComment(comment, `${threadContext}.comments[${commentIndex}]`),
+    const commentConnection = graphqlConnection(node, "comments", context);
+    const issueComments = commentConnection.needsPagination
+      ? readOverflowActivity(
+          issueCommentsEndpoint(repo, number),
+          commentConnection.totalCount,
+          `${context}.comments`,
+          spawn,
+        )
+      : commentConnection.nodes.map((comment, commentIndex) =>
+          graphqlComment(comment, `${context}.comments[${commentIndex}]`),
+        );
+    const reviewConnection = graphqlConnection(node, "reviews", context);
+    const reviews = reviewConnection.needsPagination
+      ? readOverflowActivity(
+          pullReviewsEndpoint(repo, number),
+          reviewConnection.totalCount,
+          `${context}.reviews`,
+          spawn,
+        )
+      : reviewConnection.nodes.map((review, reviewIndex) =>
+          graphqlReview(review, `${context}.reviews[${reviewIndex}]`),
+        );
+    const threadConnection = graphqlConnection(node, "reviewThreads", context);
+    let inlineComments;
+    if (threadConnection.needsPagination) {
+      inlineComments = readOverflowActivity(
+        pullReviewCommentsEndpoint(repo, number),
+        null,
+        `${context}.review comments`,
+        spawn,
       );
-    });
+    } else {
+      let expectedInlineComments = 0;
+      let nestedPaginationNeeded = false;
+      const initialInlineComments = threadConnection.nodes.flatMap(
+        (thread, threadIndex) => {
+          const threadContext = `${context}.reviewThreads[${threadIndex}]`;
+          const record = asRecord(thread, threadContext);
+          const comments = graphqlConnection(record, "comments", threadContext);
+          expectedInlineComments += comments.totalCount;
+          if (expectedInlineComments > MAX_ACTIVITY_CONNECTION_ITEMS) {
+            throw new RangeError(
+              `${context}.review comments exceeds the complete ${MAX_ACTIVITY_CONNECTION_ITEMS}-record activity bound`,
+            );
+          }
+          nestedPaginationNeeded ||= comments.needsPagination;
+          return comments.nodes.map((comment, commentIndex) =>
+            graphqlComment(
+              comment,
+              `${threadContext}.comments[${commentIndex}]`,
+            ),
+          );
+        },
+      );
+      inlineComments = nestedPaginationNeeded
+        ? readOverflowActivity(
+            pullReviewCommentsEndpoint(repo, number),
+            expectedInlineComments,
+            `${context}.review comments`,
+            spawn,
+          )
+        : initialInlineComments;
+    }
     pulls.set(number, { issueComments, inlineComments, reviews });
   }
   return { issues, pulls };
@@ -1589,17 +1667,19 @@ export function main(args = process.argv.slice(2)) {
     return;
   }
   let apiReads = 0;
-  const boundedRead = (endpoint) => {
+  const boundedSpawn = (command, commandArgs, spawnOptions) => {
     apiReads += 1;
     if (apiReads > MAX_API_READS) {
       throw new RangeError(
-        `Live discovery exceeds the ${MAX_API_READS}-request safety bound`,
+        `Live discovery exceeds the ${MAX_API_READS}-command safety bound`,
       );
     }
-    return readGhPages(endpoint);
+    return spawnSync(command, commandArgs, spawnOptions);
   };
-  apiReads += 2;
-  const openActivity = readGhOpenActivity(options.repo);
+  const boundedRead = (endpoint) => {
+    return readGhPages(endpoint, boundedSpawn);
+  };
+  const openActivity = readGhOpenActivity(options.repo, boundedSpawn);
   const report = collectLiveReport(
     options.repo,
     boundedRead,
@@ -1607,7 +1687,7 @@ export function main(args = process.argv.slice(2)) {
     ({ phase, current, total }) => {
       if (current === 0 || current === total || current % 10 === 0) {
         process.stderr.write(
-          `[Slop] scanning ${phase}: ${current}/${total} (${apiReads} bounded GitHub reads)\n`,
+          `[Slop] scanning ${phase}: ${current}/${total} (${apiReads} bounded GitHub commands)\n`,
         );
       }
     },

--- a/skills/contribute-to-delta-star/scripts/live-report.mjs
+++ b/skills/contribute-to-delta-star/scripts/live-report.mjs
@@ -472,12 +472,60 @@ function graphqlConnection(record, field, context) {
   };
 }
 
-function readOverflowActivity(endpoint, expectedCount, context, spawn) {
-  const records = readGhPages(endpoint, spawn);
-  if (records.length > MAX_ACTIVITY_CONNECTION_ITEMS) {
+function readGhActivityPage(endpoint, pageNumber, context, spawn) {
+  const separator = endpoint.includes("?") ? "&" : "?";
+  const pagedEndpoint = `${endpoint}${separator}page=${pageNumber}`;
+  const result = spawn(
+    "gh",
+    ["api", "--method", "GET", "--jq", ".[]", pagedEndpoint],
+    {
+      encoding: "utf8",
+      maxBuffer: 64 * 1024 * 1024,
+      windowsHide: true,
+    },
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const detail =
+      typeof result.stderr === "string" && result.stderr.trim().length > 0
+        ? `: ${result.stderr.trim()}`
+        : "";
+    throw new Error(`gh api failed for ${context} page ${pageNumber}${detail}`);
+  }
+  const records = parsePaginatedJson(
+    result.stdout,
+    `${context} page ${pageNumber}`,
+  );
+  if (records.length > ACTIVITY_PAGE_SIZE) {
     throw new RangeError(
-      `${context} exceeds the complete ${MAX_ACTIVITY_CONNECTION_ITEMS}-record activity bound`,
+      `${context} page ${pageNumber} returned ${records.length} records, exceeding the ${ACTIVITY_PAGE_SIZE}-record page bound`,
     );
+  }
+  return records;
+}
+
+function readOverflowActivity(endpoint, expectedCount, context, spawn) {
+  const records = [];
+  const maximumPages = Math.ceil(
+    MAX_ACTIVITY_CONNECTION_ITEMS / ACTIVITY_PAGE_SIZE,
+  );
+  for (let pageNumber = 1; pageNumber <= maximumPages + 1; pageNumber += 1) {
+    const page = readGhActivityPage(endpoint, pageNumber, context, spawn);
+    if (pageNumber > maximumPages) {
+      if (page.length > 0) {
+        throw new RangeError(
+          `${context} exceeds the complete ${MAX_ACTIVITY_CONNECTION_ITEMS}-record activity bound`,
+        );
+      }
+      break;
+    }
+    records.push(...page);
+    if (expectedCount !== null && records.length > expectedCount) {
+      throw new RangeError(
+        `${context} returned more than the ${expectedCount} records it reported`,
+      );
+    }
+    if (page.length < ACTIVITY_PAGE_SIZE) break;
   }
   if (expectedCount !== null && records.length !== expectedCount) {
     throw new RangeError(
@@ -568,6 +616,24 @@ function readGraphqlActivityNodes(repo, query, selector, spawn, context) {
     throw new Error(`gh api graphql failed for ${context}${detail}`);
   }
   return parsePaginatedJson(result.stdout, context);
+}
+
+export function createGhCommandBudget(spawn = spawnSync) {
+  let count = 0;
+  return {
+    get count() {
+      return count;
+    },
+    run: (command, args, options) => {
+      if (count >= MAX_API_READS) {
+        throw new RangeError(
+          `Live discovery exceeds the ${MAX_API_READS}-command safety bound`,
+        );
+      }
+      count += 1;
+      return spawn(command, args, options);
+    },
+  };
 }
 
 /** Reads open activity in two batches plus bounded overflow pagination. */
@@ -1666,20 +1732,11 @@ export function main(args = process.argv.slice(2)) {
     process.stdout.write(usage());
     return;
   }
-  let apiReads = 0;
-  const boundedSpawn = (command, commandArgs, spawnOptions) => {
-    apiReads += 1;
-    if (apiReads > MAX_API_READS) {
-      throw new RangeError(
-        `Live discovery exceeds the ${MAX_API_READS}-command safety bound`,
-      );
-    }
-    return spawnSync(command, commandArgs, spawnOptions);
-  };
+  const commandBudget = createGhCommandBudget();
   const boundedRead = (endpoint) => {
-    return readGhPages(endpoint, boundedSpawn);
+    return readGhPages(endpoint, commandBudget.run);
   };
-  const openActivity = readGhOpenActivity(options.repo, boundedSpawn);
+  const openActivity = readGhOpenActivity(options.repo, commandBudget.run);
   const report = collectLiveReport(
     options.repo,
     boundedRead,
@@ -1687,7 +1744,7 @@ export function main(args = process.argv.slice(2)) {
     ({ phase, current, total }) => {
       if (current === 0 || current === total || current % 10 === 0) {
         process.stderr.write(
-          `[Slop] scanning ${phase}: ${current}/${total} (${apiReads} bounded GitHub commands)\n`,
+          `[Slop] scanning ${phase}: ${current}/${total} (${commandBudget.count} bounded GitHub commands)\n`,
         );
       }
     },

--- a/skills/contribute-to-delta-star/scripts/live-report.mjs
+++ b/skills/contribute-to-delta-star/scripts/live-report.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 /**
  * Builds a stable, read-only inventory of open elizaOS issues and pull requests
- * for contribution selection. GitHub pagination stays behind one GET-only
- * adapter so callers and tests can verify that this script never mutates state.
+ * for contribution selection. REST pagination stays behind one GET-only
+ * adapter; GraphQL uses explicit read-only queries over GitHub's POST endpoint.
  */
 
 import { spawnSync } from "node:child_process";
@@ -22,6 +22,7 @@ export const REQUIRED_EVIDENCE_ROWS = [
 export const CLAIM_RECENCY_DAYS = 7;
 export const MAX_OPEN_ITEMS = 1_000;
 export const MAX_API_READS = 16;
+export const MAX_ACTIVITY_CONNECTION_ITEMS = 1_000;
 
 const REPOSITORY_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const PLACEHOLDER_RE =
@@ -365,7 +366,7 @@ export function readGhPages(endpoint, spawn = spawnSync) {
   return parsePaginatedJson(result.stdout, endpoint);
 }
 
-const ACTIVITY_CONNECTION_LIMIT = 100;
+const ACTIVITY_PAGE_SIZE = 100;
 const GRAPHQL_ACTOR_FIELDS = `
   login
   __typename
@@ -453,12 +454,37 @@ function graphqlConnection(record, field, context) {
     `${context}.${field}`,
   );
   const nodes = asArrayField(connection, "nodes", `${context}.${field}`);
-  if (totalCount > ACTIVITY_CONNECTION_LIMIT || nodes.length !== totalCount) {
+  if (totalCount > MAX_ACTIVITY_CONNECTION_ITEMS) {
     throw new RangeError(
-      `${context}.${field} exceeds the complete ${ACTIVITY_CONNECTION_LIMIT}-record activity bound`,
+      `${context}.${field} exceeds the complete ${MAX_ACTIVITY_CONNECTION_ITEMS}-record activity bound`,
     );
   }
-  return nodes;
+  const expectedPageSize = Math.min(totalCount, ACTIVITY_PAGE_SIZE);
+  if (nodes.length !== expectedPageSize) {
+    throw new RangeError(
+      `${context}.${field} returned ${nodes.length} of the expected ${expectedPageSize} initial activity records`,
+    );
+  }
+  return {
+    needsPagination: totalCount > ACTIVITY_PAGE_SIZE,
+    nodes,
+    totalCount,
+  };
+}
+
+function readOverflowActivity(endpoint, expectedCount, context, spawn) {
+  const records = readGhPages(endpoint, spawn);
+  if (records.length > MAX_ACTIVITY_CONNECTION_ITEMS) {
+    throw new RangeError(
+      `${context} exceeds the complete ${MAX_ACTIVITY_CONNECTION_ITEMS}-record activity bound`,
+    );
+  }
+  if (expectedCount !== null && records.length !== expectedCount) {
+    throw new RangeError(
+      `${context} returned ${records.length} records after reporting ${expectedCount}`,
+    );
+  }
+  return records;
 }
 
 function graphqlAccount(value, context) {
@@ -517,6 +543,8 @@ function readGraphqlActivityNodes(repo, query, selector, spawn, context) {
     [
       "api",
       "graphql",
+      "--method",
+      "POST",
       "--paginate",
       "-f",
       `query=${query}`,
@@ -542,7 +570,7 @@ function readGraphqlActivityNodes(repo, query, selector, spawn, context) {
   return parsePaginatedJson(result.stdout, context);
 }
 
-/** Reads all open issue/PR activity in connection-sized batches, never N+1. */
+/** Reads open activity in two batches plus bounded overflow pagination. */
 export function readGhOpenActivity(repo, spawn = spawnSync) {
   if (!REPOSITORY_RE.test(repo)) {
     throw new TypeError("Repository must use the owner/name form");
@@ -573,12 +601,19 @@ export function readGhOpenActivity(repo, spawn = spawnSync) {
     const number = asNumberField(node, "number", context);
     if (issues.has(number))
       throw new TypeError(`duplicate issue activity for #${number}`);
+    const comments = graphqlConnection(node, "comments", context);
     issues.set(
       number,
-      graphqlConnection(node, "comments", context).map(
-        (comment, commentIndex) =>
-          graphqlComment(comment, `${context}.comments[${commentIndex}]`),
-      ),
+      comments.needsPagination
+        ? readOverflowActivity(
+            issueCommentsEndpoint(repo, number),
+            comments.totalCount,
+            `${context}.comments`,
+            spawn,
+          )
+        : comments.nodes.map((comment, commentIndex) =>
+            graphqlComment(comment, `${context}.comments[${commentIndex}]`),
+          ),
     );
   }
   const pulls = new Map();
@@ -588,26 +623,69 @@ export function readGhOpenActivity(repo, spawn = spawnSync) {
     const number = asNumberField(node, "number", context);
     if (pulls.has(number))
       throw new TypeError(`duplicate pull activity for #${number}`);
-    const issueComments = graphqlConnection(node, "comments", context).map(
-      (comment, commentIndex) =>
-        graphqlComment(comment, `${context}.comments[${commentIndex}]`),
-    );
-    const reviews = graphqlConnection(node, "reviews", context).map(
-      (review, reviewIndex) =>
-        graphqlReview(review, `${context}.reviews[${reviewIndex}]`),
-    );
-    const inlineComments = graphqlConnection(
-      node,
-      "reviewThreads",
-      context,
-    ).flatMap((thread, threadIndex) => {
-      const threadContext = `${context}.reviewThreads[${threadIndex}]`;
-      const record = asRecord(thread, threadContext);
-      return graphqlConnection(record, "comments", threadContext).map(
-        (comment, commentIndex) =>
-          graphqlComment(comment, `${threadContext}.comments[${commentIndex}]`),
+    const commentConnection = graphqlConnection(node, "comments", context);
+    const issueComments = commentConnection.needsPagination
+      ? readOverflowActivity(
+          issueCommentsEndpoint(repo, number),
+          commentConnection.totalCount,
+          `${context}.comments`,
+          spawn,
+        )
+      : commentConnection.nodes.map((comment, commentIndex) =>
+          graphqlComment(comment, `${context}.comments[${commentIndex}]`),
+        );
+    const reviewConnection = graphqlConnection(node, "reviews", context);
+    const reviews = reviewConnection.needsPagination
+      ? readOverflowActivity(
+          pullReviewsEndpoint(repo, number),
+          reviewConnection.totalCount,
+          `${context}.reviews`,
+          spawn,
+        )
+      : reviewConnection.nodes.map((review, reviewIndex) =>
+          graphqlReview(review, `${context}.reviews[${reviewIndex}]`),
+        );
+    const threadConnection = graphqlConnection(node, "reviewThreads", context);
+    let inlineComments;
+    if (threadConnection.needsPagination) {
+      inlineComments = readOverflowActivity(
+        pullReviewCommentsEndpoint(repo, number),
+        null,
+        `${context}.review comments`,
+        spawn,
       );
-    });
+    } else {
+      let expectedInlineComments = 0;
+      let nestedPaginationNeeded = false;
+      const initialInlineComments = threadConnection.nodes.flatMap(
+        (thread, threadIndex) => {
+          const threadContext = `${context}.reviewThreads[${threadIndex}]`;
+          const record = asRecord(thread, threadContext);
+          const comments = graphqlConnection(record, "comments", threadContext);
+          expectedInlineComments += comments.totalCount;
+          if (expectedInlineComments > MAX_ACTIVITY_CONNECTION_ITEMS) {
+            throw new RangeError(
+              `${context}.review comments exceeds the complete ${MAX_ACTIVITY_CONNECTION_ITEMS}-record activity bound`,
+            );
+          }
+          nestedPaginationNeeded ||= comments.needsPagination;
+          return comments.nodes.map((comment, commentIndex) =>
+            graphqlComment(
+              comment,
+              `${threadContext}.comments[${commentIndex}]`,
+            ),
+          );
+        },
+      );
+      inlineComments = nestedPaginationNeeded
+        ? readOverflowActivity(
+            pullReviewCommentsEndpoint(repo, number),
+            expectedInlineComments,
+            `${context}.review comments`,
+            spawn,
+          )
+        : initialInlineComments;
+    }
     pulls.set(number, { issueComments, inlineComments, reviews });
   }
   return { issues, pulls };
@@ -1589,17 +1667,19 @@ export function main(args = process.argv.slice(2)) {
     return;
   }
   let apiReads = 0;
-  const boundedRead = (endpoint) => {
+  const boundedSpawn = (command, commandArgs, spawnOptions) => {
     apiReads += 1;
     if (apiReads > MAX_API_READS) {
       throw new RangeError(
-        `Live discovery exceeds the ${MAX_API_READS}-request safety bound`,
+        `Live discovery exceeds the ${MAX_API_READS}-command safety bound`,
       );
     }
-    return readGhPages(endpoint);
+    return spawnSync(command, commandArgs, spawnOptions);
   };
-  apiReads += 2;
-  const openActivity = readGhOpenActivity(options.repo);
+  const boundedRead = (endpoint) => {
+    return readGhPages(endpoint, boundedSpawn);
+  };
+  const openActivity = readGhOpenActivity(options.repo, boundedSpawn);
   const report = collectLiveReport(
     options.repo,
     boundedRead,
@@ -1607,7 +1687,7 @@ export function main(args = process.argv.slice(2)) {
     ({ phase, current, total }) => {
       if (current === 0 || current === total || current % 10 === 0) {
         process.stderr.write(
-          `[Slop] scanning ${phase}: ${current}/${total} (${apiReads} bounded GitHub reads)\n`,
+          `[Slop] scanning ${phase}: ${current}/${total} (${apiReads} bounded GitHub commands)\n`,
         );
       }
     },

--- a/skills/contribute-to-eliza/scripts/live-report.mjs
+++ b/skills/contribute-to-eliza/scripts/live-report.mjs
@@ -472,12 +472,60 @@ function graphqlConnection(record, field, context) {
   };
 }
 
-function readOverflowActivity(endpoint, expectedCount, context, spawn) {
-  const records = readGhPages(endpoint, spawn);
-  if (records.length > MAX_ACTIVITY_CONNECTION_ITEMS) {
+function readGhActivityPage(endpoint, pageNumber, context, spawn) {
+  const separator = endpoint.includes("?") ? "&" : "?";
+  const pagedEndpoint = `${endpoint}${separator}page=${pageNumber}`;
+  const result = spawn(
+    "gh",
+    ["api", "--method", "GET", "--jq", ".[]", pagedEndpoint],
+    {
+      encoding: "utf8",
+      maxBuffer: 64 * 1024 * 1024,
+      windowsHide: true,
+    },
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const detail =
+      typeof result.stderr === "string" && result.stderr.trim().length > 0
+        ? `: ${result.stderr.trim()}`
+        : "";
+    throw new Error(`gh api failed for ${context} page ${pageNumber}${detail}`);
+  }
+  const records = parsePaginatedJson(
+    result.stdout,
+    `${context} page ${pageNumber}`,
+  );
+  if (records.length > ACTIVITY_PAGE_SIZE) {
     throw new RangeError(
-      `${context} exceeds the complete ${MAX_ACTIVITY_CONNECTION_ITEMS}-record activity bound`,
+      `${context} page ${pageNumber} returned ${records.length} records, exceeding the ${ACTIVITY_PAGE_SIZE}-record page bound`,
     );
+  }
+  return records;
+}
+
+function readOverflowActivity(endpoint, expectedCount, context, spawn) {
+  const records = [];
+  const maximumPages = Math.ceil(
+    MAX_ACTIVITY_CONNECTION_ITEMS / ACTIVITY_PAGE_SIZE,
+  );
+  for (let pageNumber = 1; pageNumber <= maximumPages + 1; pageNumber += 1) {
+    const page = readGhActivityPage(endpoint, pageNumber, context, spawn);
+    if (pageNumber > maximumPages) {
+      if (page.length > 0) {
+        throw new RangeError(
+          `${context} exceeds the complete ${MAX_ACTIVITY_CONNECTION_ITEMS}-record activity bound`,
+        );
+      }
+      break;
+    }
+    records.push(...page);
+    if (expectedCount !== null && records.length > expectedCount) {
+      throw new RangeError(
+        `${context} returned more than the ${expectedCount} records it reported`,
+      );
+    }
+    if (page.length < ACTIVITY_PAGE_SIZE) break;
   }
   if (expectedCount !== null && records.length !== expectedCount) {
     throw new RangeError(
@@ -568,6 +616,24 @@ function readGraphqlActivityNodes(repo, query, selector, spawn, context) {
     throw new Error(`gh api graphql failed for ${context}${detail}`);
   }
   return parsePaginatedJson(result.stdout, context);
+}
+
+export function createGhCommandBudget(spawn = spawnSync) {
+  let count = 0;
+  return {
+    get count() {
+      return count;
+    },
+    run: (command, args, options) => {
+      if (count >= MAX_API_READS) {
+        throw new RangeError(
+          `Live discovery exceeds the ${MAX_API_READS}-command safety bound`,
+        );
+      }
+      count += 1;
+      return spawn(command, args, options);
+    },
+  };
 }
 
 /** Reads open activity in two batches plus bounded overflow pagination. */
@@ -1666,20 +1732,11 @@ export function main(args = process.argv.slice(2)) {
     process.stdout.write(usage());
     return;
   }
-  let apiReads = 0;
-  const boundedSpawn = (command, commandArgs, spawnOptions) => {
-    apiReads += 1;
-    if (apiReads > MAX_API_READS) {
-      throw new RangeError(
-        `Live discovery exceeds the ${MAX_API_READS}-command safety bound`,
-      );
-    }
-    return spawnSync(command, commandArgs, spawnOptions);
-  };
+  const commandBudget = createGhCommandBudget();
   const boundedRead = (endpoint) => {
-    return readGhPages(endpoint, boundedSpawn);
+    return readGhPages(endpoint, commandBudget.run);
   };
-  const openActivity = readGhOpenActivity(options.repo, boundedSpawn);
+  const openActivity = readGhOpenActivity(options.repo, commandBudget.run);
   const report = collectLiveReport(
     options.repo,
     boundedRead,
@@ -1687,7 +1744,7 @@ export function main(args = process.argv.slice(2)) {
     ({ phase, current, total }) => {
       if (current === 0 || current === total || current % 10 === 0) {
         process.stderr.write(
-          `[Slop] scanning ${phase}: ${current}/${total} (${apiReads} bounded GitHub commands)\n`,
+          `[Slop] scanning ${phase}: ${current}/${total} (${commandBudget.count} bounded GitHub commands)\n`,
         );
       }
     },

--- a/skills/contribute-to-eliza/scripts/live-report.mjs
+++ b/skills/contribute-to-eliza/scripts/live-report.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 /**
  * Builds a stable, read-only inventory of open elizaOS issues and pull requests
- * for contribution selection. GitHub pagination stays behind one GET-only
- * adapter so callers and tests can verify that this script never mutates state.
+ * for contribution selection. REST pagination stays behind one GET-only
+ * adapter; GraphQL uses explicit read-only queries over GitHub's POST endpoint.
  */
 
 import { spawnSync } from "node:child_process";
@@ -22,6 +22,7 @@ export const REQUIRED_EVIDENCE_ROWS = [
 export const CLAIM_RECENCY_DAYS = 7;
 export const MAX_OPEN_ITEMS = 1_000;
 export const MAX_API_READS = 16;
+export const MAX_ACTIVITY_CONNECTION_ITEMS = 1_000;
 
 const REPOSITORY_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const PLACEHOLDER_RE =
@@ -365,7 +366,7 @@ export function readGhPages(endpoint, spawn = spawnSync) {
   return parsePaginatedJson(result.stdout, endpoint);
 }
 
-const ACTIVITY_CONNECTION_LIMIT = 100;
+const ACTIVITY_PAGE_SIZE = 100;
 const GRAPHQL_ACTOR_FIELDS = `
   login
   __typename
@@ -453,12 +454,37 @@ function graphqlConnection(record, field, context) {
     `${context}.${field}`,
   );
   const nodes = asArrayField(connection, "nodes", `${context}.${field}`);
-  if (totalCount > ACTIVITY_CONNECTION_LIMIT || nodes.length !== totalCount) {
+  if (totalCount > MAX_ACTIVITY_CONNECTION_ITEMS) {
     throw new RangeError(
-      `${context}.${field} exceeds the complete ${ACTIVITY_CONNECTION_LIMIT}-record activity bound`,
+      `${context}.${field} exceeds the complete ${MAX_ACTIVITY_CONNECTION_ITEMS}-record activity bound`,
     );
   }
-  return nodes;
+  const expectedPageSize = Math.min(totalCount, ACTIVITY_PAGE_SIZE);
+  if (nodes.length !== expectedPageSize) {
+    throw new RangeError(
+      `${context}.${field} returned ${nodes.length} of the expected ${expectedPageSize} initial activity records`,
+    );
+  }
+  return {
+    needsPagination: totalCount > ACTIVITY_PAGE_SIZE,
+    nodes,
+    totalCount,
+  };
+}
+
+function readOverflowActivity(endpoint, expectedCount, context, spawn) {
+  const records = readGhPages(endpoint, spawn);
+  if (records.length > MAX_ACTIVITY_CONNECTION_ITEMS) {
+    throw new RangeError(
+      `${context} exceeds the complete ${MAX_ACTIVITY_CONNECTION_ITEMS}-record activity bound`,
+    );
+  }
+  if (expectedCount !== null && records.length !== expectedCount) {
+    throw new RangeError(
+      `${context} returned ${records.length} records after reporting ${expectedCount}`,
+    );
+  }
+  return records;
 }
 
 function graphqlAccount(value, context) {
@@ -517,6 +543,8 @@ function readGraphqlActivityNodes(repo, query, selector, spawn, context) {
     [
       "api",
       "graphql",
+      "--method",
+      "POST",
       "--paginate",
       "-f",
       `query=${query}`,
@@ -542,7 +570,7 @@ function readGraphqlActivityNodes(repo, query, selector, spawn, context) {
   return parsePaginatedJson(result.stdout, context);
 }
 
-/** Reads all open issue/PR activity in connection-sized batches, never N+1. */
+/** Reads open activity in two batches plus bounded overflow pagination. */
 export function readGhOpenActivity(repo, spawn = spawnSync) {
   if (!REPOSITORY_RE.test(repo)) {
     throw new TypeError("Repository must use the owner/name form");
@@ -573,12 +601,19 @@ export function readGhOpenActivity(repo, spawn = spawnSync) {
     const number = asNumberField(node, "number", context);
     if (issues.has(number))
       throw new TypeError(`duplicate issue activity for #${number}`);
+    const comments = graphqlConnection(node, "comments", context);
     issues.set(
       number,
-      graphqlConnection(node, "comments", context).map(
-        (comment, commentIndex) =>
-          graphqlComment(comment, `${context}.comments[${commentIndex}]`),
-      ),
+      comments.needsPagination
+        ? readOverflowActivity(
+            issueCommentsEndpoint(repo, number),
+            comments.totalCount,
+            `${context}.comments`,
+            spawn,
+          )
+        : comments.nodes.map((comment, commentIndex) =>
+            graphqlComment(comment, `${context}.comments[${commentIndex}]`),
+          ),
     );
   }
   const pulls = new Map();
@@ -588,26 +623,69 @@ export function readGhOpenActivity(repo, spawn = spawnSync) {
     const number = asNumberField(node, "number", context);
     if (pulls.has(number))
       throw new TypeError(`duplicate pull activity for #${number}`);
-    const issueComments = graphqlConnection(node, "comments", context).map(
-      (comment, commentIndex) =>
-        graphqlComment(comment, `${context}.comments[${commentIndex}]`),
-    );
-    const reviews = graphqlConnection(node, "reviews", context).map(
-      (review, reviewIndex) =>
-        graphqlReview(review, `${context}.reviews[${reviewIndex}]`),
-    );
-    const inlineComments = graphqlConnection(
-      node,
-      "reviewThreads",
-      context,
-    ).flatMap((thread, threadIndex) => {
-      const threadContext = `${context}.reviewThreads[${threadIndex}]`;
-      const record = asRecord(thread, threadContext);
-      return graphqlConnection(record, "comments", threadContext).map(
-        (comment, commentIndex) =>
-          graphqlComment(comment, `${threadContext}.comments[${commentIndex}]`),
+    const commentConnection = graphqlConnection(node, "comments", context);
+    const issueComments = commentConnection.needsPagination
+      ? readOverflowActivity(
+          issueCommentsEndpoint(repo, number),
+          commentConnection.totalCount,
+          `${context}.comments`,
+          spawn,
+        )
+      : commentConnection.nodes.map((comment, commentIndex) =>
+          graphqlComment(comment, `${context}.comments[${commentIndex}]`),
+        );
+    const reviewConnection = graphqlConnection(node, "reviews", context);
+    const reviews = reviewConnection.needsPagination
+      ? readOverflowActivity(
+          pullReviewsEndpoint(repo, number),
+          reviewConnection.totalCount,
+          `${context}.reviews`,
+          spawn,
+        )
+      : reviewConnection.nodes.map((review, reviewIndex) =>
+          graphqlReview(review, `${context}.reviews[${reviewIndex}]`),
+        );
+    const threadConnection = graphqlConnection(node, "reviewThreads", context);
+    let inlineComments;
+    if (threadConnection.needsPagination) {
+      inlineComments = readOverflowActivity(
+        pullReviewCommentsEndpoint(repo, number),
+        null,
+        `${context}.review comments`,
+        spawn,
       );
-    });
+    } else {
+      let expectedInlineComments = 0;
+      let nestedPaginationNeeded = false;
+      const initialInlineComments = threadConnection.nodes.flatMap(
+        (thread, threadIndex) => {
+          const threadContext = `${context}.reviewThreads[${threadIndex}]`;
+          const record = asRecord(thread, threadContext);
+          const comments = graphqlConnection(record, "comments", threadContext);
+          expectedInlineComments += comments.totalCount;
+          if (expectedInlineComments > MAX_ACTIVITY_CONNECTION_ITEMS) {
+            throw new RangeError(
+              `${context}.review comments exceeds the complete ${MAX_ACTIVITY_CONNECTION_ITEMS}-record activity bound`,
+            );
+          }
+          nestedPaginationNeeded ||= comments.needsPagination;
+          return comments.nodes.map((comment, commentIndex) =>
+            graphqlComment(
+              comment,
+              `${threadContext}.comments[${commentIndex}]`,
+            ),
+          );
+        },
+      );
+      inlineComments = nestedPaginationNeeded
+        ? readOverflowActivity(
+            pullReviewCommentsEndpoint(repo, number),
+            expectedInlineComments,
+            `${context}.review comments`,
+            spawn,
+          )
+        : initialInlineComments;
+    }
     pulls.set(number, { issueComments, inlineComments, reviews });
   }
   return { issues, pulls };
@@ -1589,17 +1667,19 @@ export function main(args = process.argv.slice(2)) {
     return;
   }
   let apiReads = 0;
-  const boundedRead = (endpoint) => {
+  const boundedSpawn = (command, commandArgs, spawnOptions) => {
     apiReads += 1;
     if (apiReads > MAX_API_READS) {
       throw new RangeError(
-        `Live discovery exceeds the ${MAX_API_READS}-request safety bound`,
+        `Live discovery exceeds the ${MAX_API_READS}-command safety bound`,
       );
     }
-    return readGhPages(endpoint);
+    return spawnSync(command, commandArgs, spawnOptions);
   };
-  apiReads += 2;
-  const openActivity = readGhOpenActivity(options.repo);
+  const boundedRead = (endpoint) => {
+    return readGhPages(endpoint, boundedSpawn);
+  };
+  const openActivity = readGhOpenActivity(options.repo, boundedSpawn);
   const report = collectLiveReport(
     options.repo,
     boundedRead,
@@ -1607,7 +1687,7 @@ export function main(args = process.argv.slice(2)) {
     ({ phase, current, total }) => {
       if (current === 0 || current === total || current % 10 === 0) {
         process.stderr.write(
-          `[Slop] scanning ${phase}: ${current}/${total} (${apiReads} bounded GitHub reads)\n`,
+          `[Slop] scanning ${phase}: ${current}/${total} (${apiReads} bounded GitHub commands)\n`,
         );
       }
     },


### PR DESCRIPTION
## Summary

- Preserve the two batched, read-only GraphQL activity queries.
- Replace the 100-record hard failure with bounded GET-paginated REST overflow reads.
- Fetch overflow one page at a time so the 1,000-record and 16-command limits are enforced before excess work continues.
- Cover issue comments, pull conversation comments, reviews, review threads, and nested review-thread comments.
- Keep all three contributor-skill reporter copies byte-identical.

ArkLib issue [#466](https://github.com/lalalune/ArkLib/issues/466) has 351 comments. The reporter queried `comments(first: 100)` and rejected any connection whose `totalCount` exceeded 100, preventing Delta Star from building its required complete live inventory.

Closes #44

## Validation

- `bun run typecheck` — passed
- `bun run format:check` — passed
- `bun run lint:check` — passed
- `bun run test` — 31 Vitest files / 308 tests and 39 Bun skill tests passed
- `bun run build` — passed
- `bun run leaderboard:generate` — passed (91 leaders, 709 score events)
- `bun run test:e2e` — attempted; the production preview built and launched, but the local Playwright runner emitted no test result and was terminated after a bounded wait
- `node skills/contribute-to-delta-star/scripts/live-report.mjs --repo lalalune/ArkLib --json` — passed in eight bounded GitHub commands and retained all 351 comments for #466
- Reporter SHA-256 parity — all three copies: `1b69d6ef02f25a4ccff4f8e5b0a3d34e95a5e4d099b592062092a4ef074e4ad8`

## Evidence

- Before screenshots: N/A - command-line reporter defect with deterministic regression fixtures.
- After screenshots: N/A - no visual surface changed.
- Walkthrough video: N/A - no interactive workflow changed.
- Backend logs: Live ArkLib report completed with 4 open issues, 5 open pull requests, and 8 bounded GitHub commands.
- Frontend console/network logs: N/A - no frontend code changed.
- Real-LLM trajectory: N/A - reporter behavior is deterministic and does not invoke an LLM.
- Domain artifacts: Issue #44, ArkLib issue #466, commits `b5c8344` and `ed0ad9e`, and the validation commands above.

## Contribution provenance

- AI assistance: yes
- AI provider/model: OpenAI / gpt-5.6-sol
- Client / agent tooling: Codex
- Contribution skill revision: cb667870cd6d7f6bbcfa841f9b243836c7c8e64f
- Attribution status: self-reported

## Slop protocol changes

- Project manifest (`projects/<id>/project.json`): N/A - no manifest change.
- Contributor skill (`skills/contribute-to-<id>/`): Updated the shared live reporter in contribute-to-eliza, contribute-to-asi, and contribute-to-delta-star.
- Isolated reviewer skill (`skills/review-<id>-contributions/`): N/A - no reviewer policy change.
- Evaluated-contribution award (`evaluations/<id>/award-*.json`): N/A - no award change.
- Reward-cycle transition (`cycles/<id>/<YYYY-MM>/`): N/A - no reward-cycle change.

## Safety review

- [x] No private key, seed phrase, API token, raw private trajectory, or secret was added.
- [x] Untrusted project code is not executed with repository or deployment credentials.
- [x] New telemetry is bounded, disclosed, project-attributed, and covered by adversarial tests.
- [x] Money state is derived from validated manifests and finalized on-chain evidence, not a transaction signature alone.
