### PR TITLE
fix(skills): accept canonical ccusage version output

### DIFF
--- a/skill-tests/contribute-to-eliza.test.ts
+++ b/skill-tests/contribute-to-eliza.test.ts
@@ -1842,7 +1842,7 @@ describe("run receipt CLI", () => {
         "fi",
         'if [ "$3" = "--version" ]; then',
         `  printf '%s\\n' "$*" >> ${quotedArgsLog}`,
-        "  echo 20.0.19",
+        "  echo ccusage 20.0.19",
         "  exit 0",
         "fi",
         `if [ -f ${quotedFailureFlag} ]; then`,
@@ -2514,7 +2514,7 @@ describe("run receipt CLI", () => {
 
       writeFileSync(
         join(shimDir, "bun"),
-        shimSource.replace("echo 20.0.19", "echo 120.0.19"),
+        shimSource.replace("echo ccusage 20.0.19", "echo ccusage 120.0.19"),
       );
       const npxShimSource = [
         "#!/bin/sh",
@@ -2524,7 +2524,7 @@ describe("run receipt CLI", () => {
         "fi",
         'if [ "$3" = "--version" ]; then',
         `  printf '%s\\n' "$*" >> ${quotedArgsLog}`,
-        "  echo 20.0.19",
+        "  echo ccusage 20.0.19",
         "  exit 0",
         "fi",
         "exit 7",
@@ -2555,7 +2555,7 @@ describe("run receipt CLI", () => {
 
       writeFileSync(
         join(shimDir, "npx"),
-        npxShimSource.replace("echo 20.0.19", "echo noisy-20.0.19"),
+        npxShimSource.replace("echo ccusage 20.0.19", "echo noisy-20.0.19"),
       );
       const wrongVersionDoctor = spawnSync(
         process.execPath,

--- a/skills/contribute-to-asi/scripts/run-receipt.mjs
+++ b/skills/contribute-to-asi/scripts/run-receipt.mjs
@@ -40,6 +40,7 @@ const PROJECT = JSON.parse(
   readFileSync(join(skillDirectory, "project.json"), "utf8"),
 );
 const CCUSAGE_VERSION = "20.0.19";
+const CCUSAGE_VERSION_OUTPUT = `ccusage ${CCUSAGE_VERSION}`;
 const MAX_REPORT_BYTES = 32 * 1024 * 1024;
 const MAX_TRAJECTORY_BYTES = 100 * 1024 * 1024;
 const CLOCK_SKEW_MS = 5 * 60 * 1000;
@@ -395,7 +396,7 @@ function inspectCcusageRunner() {
         result.status === 0 &&
         !result.signal &&
         !result.error &&
-        result.stdout.trim() === CCUSAGE_VERSION
+        result.stdout.trim() === CCUSAGE_VERSION_OUTPUT
       ) {
         return {
           runner: runner.command,

--- a/skills/contribute-to-delta-star/scripts/run-receipt.mjs
+++ b/skills/contribute-to-delta-star/scripts/run-receipt.mjs
@@ -40,6 +40,7 @@ const PROJECT = JSON.parse(
   readFileSync(join(skillDirectory, "project.json"), "utf8"),
 );
 const CCUSAGE_VERSION = "20.0.19";
+const CCUSAGE_VERSION_OUTPUT = `ccusage ${CCUSAGE_VERSION}`;
 const MAX_REPORT_BYTES = 32 * 1024 * 1024;
 const MAX_TRAJECTORY_BYTES = 100 * 1024 * 1024;
 const CLOCK_SKEW_MS = 5 * 60 * 1000;
@@ -395,7 +396,7 @@ function inspectCcusageRunner() {
         result.status === 0 &&
         !result.signal &&
         !result.error &&
-        result.stdout.trim() === CCUSAGE_VERSION
+        result.stdout.trim() === CCUSAGE_VERSION_OUTPUT
       ) {
         return {
           runner: runner.command,

--- a/skills/contribute-to-eliza/scripts/run-receipt.mjs
+++ b/skills/contribute-to-eliza/scripts/run-receipt.mjs
@@ -40,6 +40,7 @@ const PROJECT = JSON.parse(
   readFileSync(join(skillDirectory, "project.json"), "utf8"),
 );
 const CCUSAGE_VERSION = "20.0.19";
+const CCUSAGE_VERSION_OUTPUT = `ccusage ${CCUSAGE_VERSION}`;
 const MAX_REPORT_BYTES = 32 * 1024 * 1024;
 const MAX_TRAJECTORY_BYTES = 100 * 1024 * 1024;
 const CLOCK_SKEW_MS = 5 * 60 * 1000;
@@ -395,7 +396,7 @@ function inspectCcusageRunner() {
         result.status === 0 &&
         !result.signal &&
         !result.error &&
-        result.stdout.trim() === CCUSAGE_VERSION
+        result.stdout.trim() === CCUSAGE_VERSION_OUTPUT
       ) {
         return {
           runner: runner.command,


### PR DESCRIPTION
## Summary

Fixes the contributor-skill receipt preflight so the exact pinned
`ccusage@20.0.19` binary is recognized instead of being reported unavailable.

Closes #47.

The pinned CLI prints `ccusage 20.0.19`, while `inspectCcusageRunner()` compared
stdout with bare `20.0.19`. The preflight now compares against the exact canonical
output, preserving the fail-closed checks for exit status, signals, execution
errors, extra output, and wrong versions.

The shared receipt implementation remains byte-identical across the Eliza, ASI,
and Delta Star contributor packages. The integration fixture now emits the real
CLI output instead of the impossible bare-version form that masked the defect.

## Validation

- `bun install --frozen-lockfile` — passed, 171 packages installed.
- `bun test skill-tests/contribute-to-eliza.test.ts skill-tests/project-skills.test.ts`
  — 35 passed, 0 failed.
- Red mutation: restoring the former `stdout === CCUSAGE_VERSION` comparison makes
  `starts and finishes a measured run` fail at the expected `doctor.status === 0`
  assertion; restoring this patch makes it pass 1/1.
- `bun run typecheck` — passed.
- `bun run lint:check` — passed, 112 files checked.
- `bun run format:check` — passed, 111 files checked.
- `bun run test` — 315 Vitest tests and 35 Bun skill tests passed.
- `bun run build` — passed; all three contributor skills validated and packaged,
  and the production Vite build completed.
- Real committed-head preflight against the pinned package — passed:

  ```json
  {
    "ok": true,
    "ccusage": {
      "expectedVersion": "20.0.19",
      "version": "20.0.19",
      "runner": "bun",
      "status": "available",
      "logsRead": false
    },
    "message": "Slop receipt doctor passed for elizaOS/eliza; no usage logs were read."
  }
  ```

- `bunx playwright test --workers=1` — 20 passed; 12 existing data-dependent
  cases could not run from the clean checkout because
  `public/data/leaderboard.json` is absent, so Wrangler correctly returned the app
  shell for `/data/leaderboard.json`. This diff does not touch UI, the build server,
  or leaderboard generation. The initial default-worker run was also invalidated
  by local Wrangler contention; the serial result above is the bounded final run.

## Evidence

- Before screenshots: N/A - no rendered UI or visual behavior changed.
- After screenshots: N/A - no rendered UI or visual behavior changed.
- Walkthrough video: N/A - the changed surface is a receipt CLI preflight.
- Backend logs: the exact committed-head `doctor` result is included under
  Validation; it proves the real pinned package is recognized without reading
  usage logs.
- Frontend console/network logs: N/A - no frontend path changed. The unrelated
  clean-checkout ledger prerequisite for local E2E is recorded under Validation.
- Real-LLM trajectory: N/A - no prompt, provider, model, or LLM behavior changed.
- Domain artifacts: N/A - no database, wallet, reward-cycle, or settlement state
  changed; `bun run test` and `bun run build` validated the generated skill
  packages.

## Contribution provenance

- AI assistance: yes
- AI provider/model: OpenAI / gpt-5.6-sol
- Client / agent tooling: Codex
- Contribution skill revision: N/A - the platform repository is not a registered
  Slop project and has no platform-specific receipt package.
- Attribution status: self-reported. A locally completed
  `contribute-to-eliza` receipt is intentionally not attached because it is bound
  to `project=eliza` and `repository=elizaOS/eliza`, not this repository; publishing
  it here would be cross-repository misattribution.

## Slop protocol changes

- Project manifest (`projects/<id>/project.json`): N/A - policy is unchanged.
- Contributor skill (`skills/contribute-to-<id>/`): receipt preflight repaired
  byte-identically for Eliza, ASI, and Delta Star.
- Isolated reviewer skill (`skills/review-<id>-contributions/`): N/A - unchanged.
- Evaluated-contribution award (`evaluations/<id>/award-*.json`): N/A - unchanged.
- Reward-cycle transition (`cycles/<id>/<YYYY-MM>/`): N/A - unchanged.

## Safety review

- [x] No private key, seed phrase, API token, raw private trajectory, or secret was added.
- [x] Untrusted project code is not executed with repository or deployment credentials.
- [x] New telemetry is bounded, disclosed, project-attributed, and covered by adversarial tests; this change adds no telemetry.
- [x] Money state is derived from validated manifests and finalized on-chain evidence, not a transaction signature alone; this change does not alter money state.
