### PR TITLE
fix: harden production evidence capture

### DIFF
--- a/functions/index.test.ts
+++ b/functions/index.test.ts
@@ -47,5 +47,41 @@ describe("hostname-aware social metadata", () => {
       'content="https://slop.tech/og-shipping-slop-tech.png"',
     );
     expect(response.headers.get("vary")).toBe("Host");
+    expect(response.headers.get("cache-control")).toBe("no-transform");
+  });
+
+  it("prevents edge transformations without changing slop.cash HTML", async () => {
+    const response = await onRequest({
+      request: new Request("https://slop.cash/projects/eliza"),
+      next: async () =>
+        new Response(indexHtml, {
+          headers: {
+            "cache-control": "public, max-age=0, must-revalidate",
+            "content-type": "text/html; charset=utf-8",
+          },
+        }),
+    });
+
+    expect(await response.text()).toBe(indexHtml);
+    expect(response.headers.get("cache-control")).toBe(
+      "public, max-age=0, must-revalidate, no-transform",
+    );
+    expect(response.headers.get("vary")).toBeNull();
+  });
+
+  it("does not alter non-HTML responses", async () => {
+    const original = new Response('{"ok":true}', {
+      headers: {
+        "cache-control": "public, max-age=300",
+        "content-type": "application/json",
+      },
+    });
+    const response = await onRequest({
+      request: new Request("https://slop.cash/data/leaderboard.json"),
+      next: async () => original,
+    });
+
+    expect(response).toBe(original);
+    expect(response.headers.get("cache-control")).toBe("public, max-age=300");
   });
 });

--- a/functions/index.ts
+++ b/functions/index.ts
@@ -77,10 +77,6 @@ export async function onRequest(context: PagesContext): Promise<Response> {
   if (context.request.method !== "GET") return context.next();
 
   const hostname = new URL(context.request.url).hostname;
-  if (publicSocialMetadata(hostname).domain === CASH_DOMAIN) {
-    return context.next();
-  }
-
   const response = await context.next();
   if (!response.headers.get("content-type")?.includes("text/html")) {
     return response;
@@ -88,6 +84,27 @@ export async function onRequest(context: PagesContext): Promise<Response> {
 
   const headers = new Headers(response.headers);
   headers.delete("content-length");
+  const cacheControl = headers.get("cache-control");
+  if (
+    !cacheControl
+      ?.toLowerCase()
+      .split(/\s*,\s*/u)
+      .includes("no-transform")
+  ) {
+    headers.set(
+      "cache-control",
+      cacheControl === null ? "no-transform" : `${cacheControl}, no-transform`,
+    );
+  }
+
+  if (publicSocialMetadata(hostname).domain === CASH_DOMAIN) {
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    });
+  }
+
   const vary = headers.get("vary");
   if (vary === null) headers.set("vary", "Host");
   else if (

--- a/scripts/record-evidence.mjs
+++ b/scripts/record-evidence.mjs
@@ -497,8 +497,10 @@ try {
       state: "visible",
       timeout: 20_000,
     });
+    const visibleHeroAction =
+      viewport.width <= 680 ? ".hero-mobile-action" : ".hero-typewriter";
     await page
-      .locator(".hero-typewriter")
+      .locator(visibleHeroAction)
       .filter({ hasText: /^SHIPPING SLOP\.$/u })
       .waitFor({ state: "visible", timeout: 10_000 });
     await page.locator("#projects").waitFor({ state: "visible" });


### PR DESCRIPTION
## What changed

- wait for the responsive hero action that is actually visible on each production viewport
- mark HTML responses `no-transform` so Cloudflare does not inject a RUM beacon that the strict CSP correctly blocks
- preserve asset, JSON, skill, and download response behavior

## Why

The post-deploy recorder exposed two production-only evidence failures after #49 merged:

1. mobile intentionally renders `.hero-mobile-action`, but the recorder always waited for the hidden desktop `.hero-typewriter`
2. Cloudflare automatically injected `static.cloudflareinsights.com`, creating CSP console errors even though the deployed bundle itself was clean

The HTML response directive follows Cloudflare's documented mechanism for preventing automatic response transformation, keeping the existing strict `script-src 'self'` policy intact.

## Verification

- `bun run test` — 318 Vitest + 43 skill tests
- `bun run typecheck`
- `bun run format:check`
- `bun run lint:check`
- `bun run build` — 142-file deployment manifest
- `bun run test:e2e` — 32/32 Chromium tests
- focused Pages Function/evidence/deployment tests — 19/19
- `git diff --check`

Payouts remain disabled. This change does not alter scoring, rewards, wallets, settlement, or public data.
