### PR TITLE
fix: polish the mobile contribution prompt

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -542,9 +542,11 @@ function ProjectCard({ project }: { project: ProjectDefinition }) {
 
 function Avatar({
   actor,
+  loading = "lazy",
   size = "medium",
 }: {
   actor: GitHubActor;
+  loading?: "eager" | "lazy";
   size?: "large" | "medium" | "small";
 }) {
   return (
@@ -552,7 +554,7 @@ function Avatar({
       alt=""
       className={`avatar avatar-${size}`}
       height={size === "large" ? 80 : size === "small" ? 30 : 42}
-      loading="lazy"
+      loading={loading}
       src={actor.avatarUrl}
       width={size === "large" ? 80 : size === "small" ? 30 : 42}
     />
@@ -704,7 +706,7 @@ function GlobalLeaderboard({
                                 className="person-link"
                                 href={`/contributors/${encodeURIComponent(leader.actor.login)}`}
                               >
-                                <Avatar actor={leader.actor} />
+                                <Avatar actor={leader.actor} loading="eager" />
                                 <span>
                                   <strong>{leader.actor.login}</strong>
                                   <small>
@@ -889,7 +891,16 @@ function AgentPromptBox({ prompt }: { prompt: string }) {
   return (
     <div className="command-box agent-prompt-box">
       <output aria-label="Agent prompt" className="agent-prompt-copy">
-        <code>{prompt}</code>
+        <code>
+          {prompt
+            .split(/(https?:\/\/[^/\s]+\/|github\.com\/)/u)
+            .map((segment, index) => (
+              <span key={segment}>
+                {segment}
+                {index % 2 === 1 ? <wbr /> : null}
+              </span>
+            ))}
+        </code>
       </output>
       <button
         aria-label={

--- a/src/styles.css
+++ b/src/styles.css
@@ -1014,7 +1014,8 @@ small {
   font-family: inherit;
   font-size: 13px;
   line-height: 1.55;
-  overflow-wrap: anywhere;
+  overflow-wrap: normal;
+  word-break: normal;
   white-space: normal;
 }
 

--- a/tests/app.test.tsx
+++ b/tests/app.test.tsx
@@ -177,6 +177,7 @@ describe("discovery", () => {
     expect(homePrompt).toHaveTextContent(
       "contribute to github.com/elizaOS/eliza",
     );
+    expect(homePrompt.querySelectorAll("wbr")).toHaveLength(2);
     expect(
       await screen.findByRole("heading", { name: "Leaderboard" }),
     ).toBeInTheDocument();

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -165,6 +165,12 @@ test("discovers both reward models and a score-ranked global ledger", async ({
   await expect(homePrompt).toContainText(
     /contribute to github\.com\/elizaOS\/eliza/u,
   );
+  await expect(homePrompt.locator("wbr")).toHaveCount(2);
+  expect(
+    await homePrompt.evaluate(
+      (element) => element.scrollWidth <= element.clientWidth,
+    ),
+  ).toBe(true);
   await expect(
     page.getByRole("heading", { name: "Leaderboard" }),
   ).toBeVisible();


### PR DESCRIPTION
## What changed

- add semantic break opportunities after URL hosts so the one-prompt onboarding copy never splits `SKILL.md` mid-extension on 320px screens
- assert the prompt does not overflow at every tested viewport
- eagerly load only the 20 visible homepage leaderboard avatars so full-page evidence and first render are complete

## Verification

- manually reviewed fresh 320px full-page evidence: prompt wraps after `/`, all 20 avatars render
- `bun run typecheck`
- `bun run format:check`
- `bun run lint:check`
- `bun run test` — 318 Vitest + 43 skill tests
- `bun run build` — 142-file deployment manifest
- `bun run test:e2e` — 32/32 responsive browser tests
- `bun run test:e2e:record` — desktop/mobile JPG + MP4 + zero-error logs

No scoring, skill, reward, wallet, settlement, or payment behavior changes. Payouts remain disabled.
