### PR TITLE
fix(skills): preflight Eliza review attribution compatibility

### DIFF
--- a/skill-tests/project-skills.test.ts
+++ b/skill-tests/project-skills.test.ts
@@ -68,6 +68,8 @@ describe("project skill contracts", () => {
       "utf8",
     );
     assert.match(eliza, /elizaOS\/eliza/u);
+    assert.match(eliza, /review-preflight\.mjs/u);
+    assert.match(eliza, /supported-with-documentation-drift/u);
     assert.doesNotMatch(eliza, /lalalune\/ArkLib/u);
     assert.match(delta, /lalalune\/ArkLib/u);
     assert.match(delta, /sorry.*admit.*axiom/is);
@@ -233,6 +235,21 @@ describe("project skill contracts", () => {
           reportResult.stdout,
           /^Usage: node scripts\/live-report\.mjs/m,
         );
+        if (project.id === "eliza") {
+          const preflightResult = spawnSync(
+            process.execPath,
+            [
+              join(installedSkill, "scripts", "review-preflight.mjs"),
+              "--unsupported",
+            ],
+            { encoding: "utf8" },
+          );
+          assert.notStrictEqual(preflightResult.status, 0);
+          assert.match(
+            preflightResult.stderr,
+            /Usage: node scripts\/review-preflight\.mjs/u,
+          );
+        }
       }
     } finally {
       rmSync(fixtureRoot, { force: true, recursive: true });

--- a/skill-tests/review-preflight.test.ts
+++ b/skill-tests/review-preflight.test.ts
@@ -1,0 +1,117 @@
+/** Tests the Eliza review compatibility classifier with deterministic live-path fixtures. */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { assessReviewCompatibility } from "../skills/contribute-to-eliza/scripts/review-preflight.mjs";
+
+const branchSha = "1".repeat(40);
+const commitId = "65455082b87f12ddf5ea4a40e4e8734dbae9e961";
+const marker = {
+  provider: "openai",
+  model: "gpt-5.6-sol",
+  client: "codex",
+  skill_revision: `elizaOS/slopdotcash@${"2".repeat(40)}:skills/contribute-to-eliza`,
+  run: {
+    schema_version: "1",
+    run_id: "run_01M001JJ3EJEXAR11GKPE15MXM",
+    project: "eliza",
+    repository: "elizaOS/eliza",
+    signature_algorithm: "ed25519",
+    device_public_key: "public-key",
+    device_signature: "signature",
+  },
+};
+
+function fixture() {
+  return {
+    branchSha,
+    policy:
+      "Every review ends with <!-- eliza-computer-attribution:v1 {...} -->",
+    proofReview: {
+      id: 4936838769,
+      commit_id: commitId,
+      html_url:
+        "https://github.com/elizaOS/eliza/pull/19560#pullrequestreview-4936838769",
+      submitted_at: "2026-08-14T11:48:42Z",
+      state: "CHANGES_REQUESTED",
+      body: `Verified review\n<!-- slop-contribution-attribution:v1 ${JSON.stringify(marker)} -->`,
+    },
+    validator: "const marker = 'eliza-computer-attribution:v1';",
+    workflows: [
+      {
+        path: ".github/workflows/pr.yaml",
+        source:
+          "on:\n  pull_request:\nsteps:\n  - run: node scripts/check-agent-comment-attribution.mjs",
+      },
+      {
+        path: ".github/workflows/claude.yml",
+        source: "on:\n  pull_request_review:\nsteps:\n  - run: echo unrelated",
+      },
+    ],
+  };
+}
+
+describe("Eliza review compatibility preflight", () => {
+  it("reports documentation drift without inventing a publishing blocker", () => {
+    const result = assessReviewCompatibility(fixture());
+    assert.equal(result.status, "supported-with-documentation-drift");
+    assert.equal(result.safeToPublish, true);
+    assert.equal(result.documentation, "legacy-only-drift");
+    assert.equal(result.enforcement, "not-wired-for-reviews");
+    assert.equal(result.forwardProof.valid, true);
+  });
+
+  it("blocks when a review-event workflow invokes the incompatible validator", () => {
+    const input = fixture();
+    input.workflows.push({
+      path: ".github/workflows/review-policy.yml",
+      source:
+        "on:\n  pull_request_review:\nsteps:\n  - run: node scripts/check-agent-comment-attribution.mjs",
+    });
+    const result = assessReviewCompatibility(input);
+    assert.equal(result.status, "blocked");
+    assert.equal(result.safeToPublish, false);
+    assert.equal(result.enforcement, "incompatible");
+    assert.deepEqual(result.enforcingWorkflows, [
+      ".github/workflows/review-policy.yml",
+    ]);
+  });
+
+  it("accepts explicit Slop-aware review enforcement", () => {
+    const input = fixture();
+    input.validator += "\nconst slop = 'slop-contribution-attribution:v1';";
+    input.policy +=
+      "\nSigned reviews may end with slop-contribution-attribution:v1.";
+    input.workflows.push({
+      path: ".github/workflows/review-policy.yml",
+      source:
+        "on:\n  pull_request_review:\nsteps:\n  - run: node scripts/check-agent-comment-attribution.mjs\n# slop-contribution-attribution:v1",
+    });
+    const result = assessReviewCompatibility(input);
+    assert.equal(result.status, "supported");
+    assert.equal(result.safeToPublish, true);
+    assert.equal(result.documentation, "aligned");
+    assert.equal(result.enforcement, "compatible");
+  });
+
+  it("fails closed when the known proof loses its terminal marker", () => {
+    const input = fixture();
+    input.proofReview.body += "\ntrailing prose";
+    const result = assessReviewCompatibility(input);
+    assert.equal(result.status, "unknown");
+    assert.equal(result.safeToPublish, false);
+    assert.equal(result.forwardProof.valid, false);
+  });
+
+  it("rejects unbounded or malformed workflow inventories", () => {
+    const input = fixture();
+    input.workflows = Array.from({ length: 129 }, (_, index) => ({
+      path: `.github/workflows/${index}.yml`,
+      source: "on: pull_request",
+    }));
+    assert.throws(
+      () => assessReviewCompatibility(input),
+      /workflow inventory is missing or unbounded/u,
+    );
+  });
+});

--- a/skills/contribute-to-eliza/SKILL.md
+++ b/skills/contribute-to-eliza/SKILL.md
@@ -32,7 +32,17 @@ The skill cannot change the model hosting this session.
    work that does not pass its demand, mission, and materiality gates. Then read
    [evidence-review-rubric.md](references/evidence-review-rubric.md)
    before deciding what proof the contribution needs.
-4. Preview the exact local usage directories, state writes, network access,
+4. Before selecting or publishing an independent review, run the GET-only live
+   review preflight. It separates the Slop writer, target documentation,
+   GitHub event enforcement, and a known signed forward-path artifact. A
+   `supported-with-documentation-drift` result is not a publishing blocker;
+   stop only when the command reports `blocked`, `unknown`, or fails:
+
+```bash
+node <skill-directory>/scripts/review-preflight.mjs
+```
+
+5. Preview the exact local usage directories, state writes, network access,
    public fields, and exclusions before reading usage logs. Then run the local
    doctor, which verifies repository, skill, model policy, and runner
    availability without reading those logs:
@@ -45,7 +55,7 @@ node <skill-directory>/scripts/run-receipt.mjs doctor \
   --allow-package-execution
 ```
 
-5. After the operator has authorized the previewed local aggregate-usage read,
+6. After the operator has authorized the previewed local aggregate-usage read,
    start capture. Replace the lane with a stable public agent or worker label
    and keep the returned run id:
 
@@ -78,6 +88,12 @@ than the newer `--slurp` flag, which first shipped in gh 2.48 and is absent from
 the gh 2.45 packaged with Ubuntu 24.04. A blank result is a valid empty
 collection; command failures and malformed or truncated records fail closed
 with endpoint context.
+
+Do not infer that review publication is blocked from `CONTRIBUTING.md` or a
+standalone validator alone. Re-run `review-preflight.mjs` against the current
+integration-branch workflows and forward proof. Report documentation drift as
+drift, event enforcement as enforcement, and Slop marker acceptance as writer
+compatibility; never collapse those independent states into one assumption.
 
 Before any claim, issue, branch, or code change, write a private selection note
 with the authorized demand, affected user path, observed failure or missing

--- a/skills/contribute-to-eliza/review-compatibility.json
+++ b/skills/contribute-to-eliza/review-compatibility.json
@@ -1,0 +1,16 @@
+{
+  "schemaVersion": "1",
+  "artifact": "pull-request-review",
+  "repositoryId": "elizaOS/eliza",
+  "integrationBranch": "develop",
+  "writerMarker": "slop-contribution-attribution:v1",
+  "legacyMarker": "eliza-computer-attribution:v1",
+  "policyDocument": "CONTRIBUTING.md",
+  "validatorPath": "scripts/check-agent-comment-attribution.mjs",
+  "forwardProof": {
+    "pullRequest": 19560,
+    "reviewId": 4936838769,
+    "commitId": "65455082b87f12ddf5ea4a40e4e8734dbae9e961",
+    "url": "https://github.com/elizaOS/eliza/pull/19560#pullrequestreview-4936838769"
+  }
+}

--- a/skills/contribute-to-eliza/scripts/review-preflight.mjs
+++ b/skills/contribute-to-eliza/scripts/review-preflight.mjs
@@ -1,0 +1,362 @@
+#!/usr/bin/env node
+/**
+ * Verifies the live Eliza review-publication path before an agent treats
+ * attribution-policy drift as a blocker. The check is GET-only: it separates
+ * writer identity, target workflow enforcement, documentation, and a known
+ * signed forward-path artifact instead of inferring publishability from one
+ * policy file or standalone validator.
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const skillDirectory = dirname(scriptDirectory);
+const CONFIG = JSON.parse(
+  readFileSync(join(skillDirectory, "review-compatibility.json"), "utf8"),
+);
+const SHA_RE = /^[0-9a-f]{40}$/u;
+const MAX_API_BYTES = 16 * 1024 * 1024;
+const MAX_WORKFLOWS = 128;
+const MAX_WORKFLOW_BYTES = 1024 * 1024;
+
+function fail(message) {
+  throw new TypeError(message);
+}
+
+function record(value, field) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    fail(`${field} must be an object`);
+  }
+  return value;
+}
+
+function exactKeys(value, keys, field) {
+  if (Object.keys(value).sort().join("\0") !== [...keys].sort().join("\0")) {
+    fail(`${field} has unexpected or missing fields`);
+  }
+}
+
+function canonicalRepositoryPath(value, field) {
+  if (
+    typeof value !== "string" ||
+    !/^[A-Za-z0-9._/-]+$/u.test(value) ||
+    value.startsWith("/") ||
+    value.split("/").some((part) => part.length === 0 || part === "..")
+  ) {
+    fail(`${field} is not a canonical repository path`);
+  }
+  return value;
+}
+
+function validateConfiguration(value = CONFIG) {
+  const config = record(value, "review compatibility configuration");
+  exactKeys(
+    config,
+    [
+      "artifact",
+      "forwardProof",
+      "integrationBranch",
+      "legacyMarker",
+      "policyDocument",
+      "repositoryId",
+      "schemaVersion",
+      "validatorPath",
+      "writerMarker",
+    ],
+    "review compatibility configuration",
+  );
+  if (
+    config.schemaVersion !== "1" ||
+    config.artifact !== "pull-request-review" ||
+    config.repositoryId !== "elizaOS/eliza" ||
+    config.integrationBranch !== "develop" ||
+    config.writerMarker !== "slop-contribution-attribution:v1" ||
+    config.legacyMarker !== "eliza-computer-attribution:v1" ||
+    config.policyDocument !== "CONTRIBUTING.md" ||
+    config.validatorPath !== "scripts/check-agent-comment-attribution.mjs"
+  ) {
+    fail("review compatibility configuration has an unsupported identity");
+  }
+  const proof = record(config.forwardProof, "forward proof");
+  exactKeys(
+    proof,
+    ["commitId", "pullRequest", "reviewId", "url"],
+    "forward proof",
+  );
+  if (
+    !Number.isSafeInteger(proof.pullRequest) ||
+    proof.pullRequest <= 0 ||
+    !Number.isSafeInteger(proof.reviewId) ||
+    proof.reviewId <= 0 ||
+    !SHA_RE.test(proof.commitId) ||
+    proof.url !==
+      `https://github.com/${config.repositoryId}/pull/${proof.pullRequest}#pullrequestreview-${proof.reviewId}`
+  ) {
+    fail("forward proof has an invalid identity");
+  }
+  return config;
+}
+
+function markerFromTerminalLine(body, markerName) {
+  if (typeof body !== "string" || body.length === 0) return null;
+  const terminal = body.trimEnd().split(/\r?\n/u).at(-1) ?? "";
+  const prefix = `<!-- ${markerName} `;
+  if (!terminal.startsWith(prefix) || !terminal.endsWith(" -->")) return null;
+  try {
+    return JSON.parse(terminal.slice(prefix.length, -4));
+  } catch {
+    return null;
+  }
+}
+
+function validProofReview(review, config) {
+  const value = record(review, "forward proof review");
+  const marker = markerFromTerminalLine(value.body, config.writerMarker);
+  return (
+    value.id === config.forwardProof.reviewId &&
+    value.commit_id === config.forwardProof.commitId &&
+    value.html_url === config.forwardProof.url &&
+    typeof value.submitted_at === "string" &&
+    Number.isFinite(Date.parse(value.submitted_at)) &&
+    typeof value.state === "string" &&
+    marker !== null &&
+    marker.run?.schema_version === "1" &&
+    marker.run?.project === "eliza" &&
+    marker.run?.repository === config.repositoryId &&
+    marker.run?.signature_algorithm === "ed25519" &&
+    typeof marker.run?.device_public_key === "string" &&
+    typeof marker.run?.device_signature === "string" &&
+    marker.skill_revision?.startsWith("elizaOS/slopdotcash@")
+  );
+}
+
+function workflowEnforcesReviewAttribution(source, config) {
+  if (typeof source !== "string") fail("workflow source must be text");
+  return (
+    /\bpull_request_review\b/u.test(source) &&
+    (source.includes(config.validatorPath) ||
+      source.includes(config.validatorPath.split("/").at(-1)))
+  );
+}
+
+/** Classifies the exact review path without turning documentation drift into a block. */
+export function assessReviewCompatibility(input, configuration = CONFIG) {
+  const config = validateConfiguration(configuration);
+  const value = record(input, "review compatibility input");
+  exactKeys(
+    value,
+    ["branchSha", "policy", "proofReview", "validator", "workflows"],
+    "review compatibility input",
+  );
+  if (!SHA_RE.test(value.branchSha))
+    fail("branch SHA must be a full commit id");
+  if (typeof value.policy !== "string" || typeof value.validator !== "string") {
+    fail("policy and validator sources must be text");
+  }
+  if (
+    !Array.isArray(value.workflows) ||
+    value.workflows.length > MAX_WORKFLOWS
+  ) {
+    fail("workflow inventory is missing or unbounded");
+  }
+  const enforcingWorkflows = value.workflows
+    .map((workflow, index) => {
+      const item = record(workflow, `workflows[${index}]`);
+      exactKeys(item, ["path", "source"], `workflows[${index}]`);
+      const path = canonicalRepositoryPath(
+        item.path,
+        `workflows[${index}].path`,
+      );
+      if (
+        !path.startsWith(".github/workflows/") ||
+        !/\.ya?ml$/u.test(path) ||
+        typeof item.source !== "string" ||
+        Buffer.byteLength(item.source) > MAX_WORKFLOW_BYTES
+      ) {
+        fail(`workflows[${index}] is invalid`);
+      }
+      return { path, source: item.source };
+    })
+    .filter((workflow) =>
+      workflowEnforcesReviewAttribution(workflow.source, config),
+    );
+  const incompatibleWorkflows = enforcingWorkflows.filter(
+    ({ source }) => !source.includes(config.writerMarker),
+  );
+  const proofValid = validProofReview(value.proofReview, config);
+  const policyMentionsWriter = value.policy.includes(config.writerMarker);
+  const policyMentionsLegacy = value.policy.includes(config.legacyMarker);
+  const validatorAcceptsWriter = value.validator.includes(config.writerMarker);
+  const documentation = policyMentionsWriter
+    ? "aligned"
+    : policyMentionsLegacy
+      ? "legacy-only-drift"
+      : "undocumented";
+  const enforcement =
+    enforcingWorkflows.length === 0
+      ? "not-wired-for-reviews"
+      : incompatibleWorkflows.length === 0 && validatorAcceptsWriter
+        ? "compatible"
+        : "incompatible";
+  const safeToPublish = proofValid && enforcement !== "incompatible";
+  const status = safeToPublish
+    ? documentation === "aligned"
+      ? "supported"
+      : "supported-with-documentation-drift"
+    : proofValid
+      ? "blocked"
+      : "unknown";
+  return {
+    artifact: config.artifact,
+    branchSha: value.branchSha,
+    documentation,
+    enforcement,
+    enforcingWorkflows: enforcingWorkflows.map(({ path }) => path).sort(),
+    forwardProof: {
+      url: config.forwardProof.url,
+      valid: proofValid,
+    },
+    repositoryId: config.repositoryId,
+    safeToPublish,
+    status,
+    writerMarker: config.writerMarker,
+  };
+}
+
+function gh(args) {
+  const result = spawnSync("gh", args, {
+    encoding: "utf8",
+    maxBuffer: MAX_API_BYTES,
+    timeout: 30_000,
+    windowsHide: true,
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0 || result.signal) {
+    const detail = result.stderr.trim();
+    throw new Error(`gh ${args[0]} failed${detail ? `: ${detail}` : ""}`);
+  }
+  return result.stdout;
+}
+
+function ghJson(endpoint) {
+  try {
+    return JSON.parse(gh(["api", "--method", "GET", endpoint]));
+  } catch (error) {
+    throw new Error(`GitHub returned invalid JSON for ${endpoint}`, {
+      cause: error,
+    });
+  }
+}
+
+function ghText(endpoint) {
+  return gh([
+    "api",
+    "--method",
+    "GET",
+    "-H",
+    "Accept: application/vnd.github.raw+json",
+    endpoint,
+  ]);
+}
+
+export function readLiveReviewCompatibility(configuration = CONFIG) {
+  const config = validateConfiguration(configuration);
+  const ref = ghJson(
+    `repos/${config.repositoryId}/git/ref/heads/${config.integrationBranch}`,
+  );
+  const branchSha = ref?.object?.sha;
+  if (!SHA_RE.test(branchSha ?? "")) fail("integration branch has no full SHA");
+  const tree = ghJson(
+    `repos/${config.repositoryId}/git/trees/${branchSha}?recursive=1`,
+  );
+  if (tree?.truncated || !Array.isArray(tree?.tree)) {
+    fail("target repository workflow tree is missing or truncated");
+  }
+  const workflowEntries = tree.tree.filter(
+    (entry) =>
+      entry?.type === "blob" &&
+      typeof entry.path === "string" &&
+      entry.path.startsWith(".github/workflows/") &&
+      /\.ya?ml$/u.test(entry.path),
+  );
+  if (
+    workflowEntries.length === 0 ||
+    workflowEntries.length > MAX_WORKFLOWS ||
+    workflowEntries.some(
+      (entry) =>
+        !Number.isSafeInteger(entry.size) ||
+        entry.size < 0 ||
+        entry.size > MAX_WORKFLOW_BYTES,
+    )
+  ) {
+    fail("target repository workflow inventory is missing or unbounded");
+  }
+  const atRef = (path) =>
+    `repos/${config.repositoryId}/contents/${canonicalRepositoryPath(path, "GitHub content path")}?ref=${branchSha}`;
+  return assessReviewCompatibility(
+    {
+      branchSha,
+      policy: ghText(atRef(config.policyDocument)),
+      proofReview: ghJson(
+        `repos/${config.repositoryId}/pulls/${config.forwardProof.pullRequest}/reviews/${config.forwardProof.reviewId}`,
+      ),
+      validator: ghText(atRef(config.validatorPath)),
+      workflows: workflowEntries.map((entry) => ({
+        path: entry.path,
+        source: ghText(atRef(entry.path)),
+      })),
+    },
+    config,
+  );
+}
+
+function render(result) {
+  const workflowDetail =
+    result.enforcingWorkflows.length === 0
+      ? "none"
+      : result.enforcingWorkflows.join(", ");
+  return [
+    `Slop review compatibility: ${result.status}`,
+    `Writer: ${result.writerMarker}`,
+    `Target: ${result.repositoryId}@${result.branchSha}`,
+    `Documentation: ${result.documentation}`,
+    `Review enforcement: ${result.enforcement} (${workflowDetail})`,
+    `Forward proof: ${result.forwardProof.valid ? "valid" : "invalid"} ${result.forwardProof.url}`,
+    result.safeToPublish
+      ? "The exact review path is supported. Do not infer a blocker from documentation drift alone."
+      : "Stop before publishing: the exact review path is blocked or no longer proven.",
+  ].join("\n");
+}
+
+function main(args = process.argv.slice(2)) {
+  if (args.some((argument) => argument !== "--json") || args.length > 1) {
+    fail("Usage: node scripts/review-preflight.mjs [--json]");
+  }
+  const result = readLiveReviewCompatibility();
+  process.stdout.write(
+    args[0] === "--json"
+      ? `${JSON.stringify(result, null, 2)}\n`
+      : `${render(result)}\n`,
+  );
+  if (!result.safeToPublish) process.exitCode = 1;
+}
+
+const invokedDirectly =
+  typeof process.argv[1] === "string" &&
+  existsSync(process.argv[1]) &&
+  realpathSync(fileURLToPath(import.meta.url)) ===
+    realpathSync(process.argv[1]);
+if (invokedDirectly) {
+  try {
+    main();
+  } catch (error) {
+    // error-policy:J1 CLI boundary returns an explicit failed preflight.
+    process.stderr.write(
+      `Slop review compatibility refused: ${error instanceof Error ? error.message : "unknown error"}\n`,
+    );
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
## Summary

Progresses #36.

This prevents contributors from inventing an Eliza review-publishing blocker from stale documentation alone. It adds a GET-only, fail-closed preflight that checks the exact current `develop` revision, distinguishes policy wording from review-event enforcement, validates a known forward-path review, and tells the contribution skill when publishing is actually safe.

- Add versioned Eliza review compatibility metadata and forward-proof identity.
- Classify documentation, event wiring, writer compatibility, and proof validity independently.
- Require the preflight before selecting or publishing an independent Eliza review.
- Treat legacy-only documentation drift as drift—not as an operational blocker—when no incompatible review enforcement is wired.
- Stop on incompatible enforcement, invalid proof, malformed workflow inventory, or unknown state.
- Cover supported, blocked, drift, changed-proof, bounded-inventory, and installed-skill symlink paths.

The root cause was that an agent compared static policy text with a standalone validator and inferred runtime enforcement without tracing the actual `pull_request_review` workflow path or checking the already-successful signed review artifact.

## Validation

Verified on commit `b65d6ab2216c989d7f9b1913758408b37bf13b44` with pinned Bun `1.3.14`:

- `bun install --frozen-lockfile`
- `bun run projects:check`
- `bun run typecheck`
- `bun run format:check`
- `bun run lint:check`
- `bun run test` — 318 Vitest tests and 48 Bun skill tests passed
- `bun run build` — packaged skill contains the new compatibility metadata and preflight
- `bun run leaderboard:generate` — generated current authenticated public data (95 leaders, 2,291 score events)
- `bun run test:e2e` — 32/32 passed across wide desktop, desktop, tablet, and narrow mobile
- `node skills/contribute-to-eliza/scripts/review-preflight.mjs` — live result: `supported-with-documentation-drift`, `safeToPublish: true`, target `elizaOS/eliza@9a0120bd3927919e06ebd80a3aefaf83004b5a2b`

Live preflight evidence:

```text
Slop review compatibility: supported-with-documentation-drift
Writer: slop-contribution-attribution:v1
Target: elizaOS/eliza@9a0120bd3927919e06ebd80a3aefaf83004b5a2b
Documentation: legacy-only-drift
Review enforcement: not-wired-for-reviews (none)
Forward proof: valid https://github.com/elizaOS/eliza/pull/19560#pullrequestreview-4936838769
The exact review path is supported. Do not infer a blocker from documentation drift alone.
```

## Evidence

- Before/after screenshots: N/A — no UI or rendered-product behavior changed.
- Walkthrough video: N/A — deterministic CLI/skill-policy change only.
- Frontend logs: `bun run test:e2e` passed 32/32 and verified byte-consistent published skill artifacts.
- Backend/domain artifact: production build packaged `review-compatibility.json` and `scripts/review-preflight.mjs` from the exact commit above.
- Real-LLM trajectory: N/A — no model prompt, runtime agent behavior, or live integration path changed.

## Contribution provenance

- AI assistance: yes
- Provider/model: OpenAI `gpt-5.6-sol`, medium reasoning (verified from Codex configuration)
- Client: Codex Desktop
- Contribution skill revision: `elizaOS/slopdotcash@1bde21d6d8229678f20bbd450f8e49f9fd95f989:skills/contribute-to-eliza`
- Attribution status: self-reported

## Slop protocol changes

- Project manifest: N/A
- Contributor skill: updated with exact-path compatibility preflight
- Reviewer skill: N/A
- Evaluation contract: N/A
- Reward contract: N/A

## Safety review

- [x] No secrets, credentials, wallet material, or private issue data added.
- [x] Preflight is read-only and uses only GitHub GET requests.
- [x] No telemetry, money movement, reward scoring, deployment, or write-side GitHub behavior added.
- [x] Failure modes are explicit and fail closed.
