### PR TITLE
chore: bind private Slop runtime resources

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -283,7 +283,7 @@ jobs:
               ;;
           esac
 
-      - name: Deploy to Cloudflare Pages
+      - name: Deploy private identity and Cloudflare Pages
         id: pages-deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -307,6 +307,97 @@ jobs:
             echo "::error::Live develop changed a slop.cash release input immediately before deployment."
             exit 1
           fi
+
+          identity_secrets="$RUNNER_TEMP/slop-identity-secrets.json"
+          ./node_modules/.bin/wrangler secret list \
+            --config workers/identity/wrangler.toml > "$identity_secrets"
+          node - "$identity_secrets" <<'NODE'
+          const { readFileSync } = require("node:fs");
+          const value = JSON.parse(readFileSync(process.argv[2], "utf8"));
+          const expected = [
+            "GITHUB_APP_CLIENT_ID",
+            "GITHUB_APP_CLIENT_SECRET",
+            "IDENTITY_ASSERTION_KEY",
+            "IDENTITY_STATE_KEY",
+          ];
+          if (!Array.isArray(value)) throw new TypeError("identity secret inventory must be an array");
+          const actual = value.map((entry) => entry?.name).sort();
+          if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+            throw new TypeError("identity Worker secret inventory is incomplete or contains unexpected entries");
+          }
+          NODE
+          ./node_modules/.bin/wrangler deploy \
+            --config workers/identity/wrangler.toml \
+            --minify
+
+          identity_response="$RUNNER_TEMP/slop-identity-start.json"
+          identity_status="$(
+            curl --silent --show-error \
+              --connect-timeout 10 \
+              --max-time 30 \
+              --output "$identity_response" \
+              --write-out "%{http_code}" \
+              --header "Content-Type: application/json" \
+              --data '{"audience":"private-trace-api"}' \
+              https://identity.slop.cash/v1/oauth/start
+          )"
+          if [ "$identity_status" != "201" ]; then
+            echo "::error::Identity start returned HTTP $identity_status; expected 201."
+            exit 1
+          fi
+          authorization_url="$(node - "$identity_response" <<'NODE'
+          const { readFileSync } = require("node:fs");
+          const value = JSON.parse(readFileSync(process.argv[2], "utf8"));
+          const expected = ["authorizationUrl", "expiresAt", "flowId", "pollAfterSeconds", "pollCapability"];
+          if (JSON.stringify(Object.keys(value).sort()) !== JSON.stringify(expected)) {
+            throw new TypeError("identity start response has an unexpected shape");
+          }
+          if (!/^flow_[A-Za-z0-9_-]{24}$/u.test(value.flowId)) throw new TypeError("invalid identity flow id");
+          if (!/^[A-Za-z0-9_-]{43}$/u.test(value.pollCapability)) throw new TypeError("invalid poll capability");
+          if (value.pollAfterSeconds !== 2 || !Number.isFinite(Date.parse(value.expiresAt))) {
+            throw new TypeError("invalid identity expiry contract");
+          }
+          const authorization = new URL(value.authorizationUrl);
+          if (authorization.origin !== "https://identity.slop.cash" || authorization.pathname !== "/v1/oauth/authorize") {
+            throw new TypeError("invalid identity authorization URL");
+          }
+          process.stdout.write(authorization.toString());
+          NODE
+          )"
+          authorization_headers="$RUNNER_TEMP/slop-identity-authorization.headers"
+          authorization_status="$(
+            curl --silent --show-error \
+              --connect-timeout 10 \
+              --max-time 30 \
+              --output /dev/null \
+              --dump-header "$authorization_headers" \
+              --write-out "%{http_code}" \
+              "$authorization_url"
+          )"
+          if [ "$authorization_status" != "302" ]; then
+            echo "::error::Identity authorization returned HTTP $authorization_status; expected 302."
+            exit 1
+          fi
+          node - "$authorization_headers" <<'NODE'
+          const { readFileSync } = require("node:fs");
+          const headers = readFileSync(process.argv[2], "utf8");
+          const match = headers.match(/^location:\s*(\S+)\s*$/imu);
+          if (!match) throw new TypeError("identity authorization omitted its redirect");
+          const location = new URL(match[1]);
+          if (location.origin !== "https://github.com" || location.pathname !== "/login/oauth/authorize") {
+            throw new TypeError("identity authorization did not target GitHub");
+          }
+          if (location.searchParams.get("redirect_uri") !== "https://identity.slop.cash/v1/oauth/callback") {
+            throw new TypeError("identity authorization callback drifted");
+          }
+          if (location.searchParams.get("code_challenge_method") !== "S256") {
+            throw new TypeError("identity authorization did not require PKCE S256");
+          }
+          if (!/^Iv[0-9A-Za-z]{18}$/u.test(location.searchParams.get("client_id") ?? "")) {
+            throw new TypeError("identity authorization omitted the GitHub App client id");
+          }
+          NODE
+
           printf '%s\n' "started_at=$(node -e 'process.stdout.write(Date.now().toString())')" >> "$GITHUB_OUTPUT"
           for attempt in 1 2 3; do
             if ./node_modules/.bin/wrangler pages deploy \

--- a/scripts/deployment-contract.test.mjs
+++ b/scripts/deployment-contract.test.mjs
@@ -21,6 +21,10 @@ const wranglerConfiguration = readFileSync(
   join(packageRoot, "wrangler.toml"),
   "utf8",
 );
+const identityWranglerConfiguration = readFileSync(
+  join(packageRoot, "workers", "identity", "wrangler.toml"),
+  "utf8",
+);
 const pagesHeaders = readFileSync(
   join(packageRoot, "public", "_headers"),
   "utf8",
@@ -155,6 +159,31 @@ describe("slop.cash deployment contract", () => {
     expect(pagesHeaders).toContain("/assets/*");
     expect(pagesHeaders).toContain(
       "Cache-Control: public, max-age=31536000, immutable",
+    );
+  });
+
+  it("binds the private trace and identity runtime through reviewed configuration", () => {
+    expect(wranglerConfiguration).toContain('binding = "SLOP_DB"');
+    expect(wranglerConfiguration).toContain('database_name = "slop-private"');
+    expect(wranglerConfiguration).toContain(
+      'database_id = "1b453124-2709-45af-8389-151a8105c461"',
+    );
+    expect(wranglerConfiguration).toContain('binding = "PRIVATE_TRACES"');
+    expect(wranglerConfiguration).toContain(
+      'bucket_name = "slop-private-traces"',
+    );
+    expect(wranglerConfiguration).toContain('binding = "SLOP_IDENTITY"');
+    expect(wranglerConfiguration).toContain('service = "slop-identity"');
+    expect(wranglerConfiguration).not.toContain("[env.preview");
+
+    expect(identityWranglerConfiguration).toContain('name = "slop-identity"');
+    expect(identityWranglerConfiguration).toContain("workers_dev = false");
+    expect(identityWranglerConfiguration).toContain(
+      '{ pattern = "identity.slop.cash", custom_domain = true }',
+    );
+    expect(identityWranglerConfiguration).toContain('binding = "IDENTITY_DB"');
+    expect(identityWranglerConfiguration).toContain(
+      'database_id = "1b453124-2709-45af-8389-151a8105c461"',
     );
   });
 });

--- a/scripts/deployment-contract.test.mjs
+++ b/scripts/deployment-contract.test.mjs
@@ -49,6 +49,17 @@ describe("slop.cash deployment contract", () => {
     );
     expect(deployJob).toContain(`node-version: ${"$"}{{ env.NODE_VERSION }}`);
     expect(deployJob).toContain("./node_modules/.bin/wrangler pages deploy \\");
+    expect(deployJob).toContain(
+      "./node_modules/.bin/wrangler deploy \\\n            --config workers/identity/wrangler.toml \\",
+    );
+    expect(deployJob).toContain(
+      "./node_modules/.bin/wrangler secret list \\\n            --config workers/identity/wrangler.toml",
+    );
+    expect(deployJob).toContain("https://identity.slop.cash/v1/oauth/start");
+    expect(deployJob).toContain("https://identity.slop.cash/v1/oauth/callback");
+    expect(deployJob.indexOf("wrangler deploy \\")).toBeLessThan(
+      deployJob.indexOf("wrangler pages deploy \\"),
+    );
     expect(deployJob).not.toContain("working-directory:");
     expect(deployJob).not.toContain("bunx wrangler");
     expect(deployJob).not.toContain("pages deploy dist");

--- a/workers/identity/wrangler.toml
+++ b/workers/identity/wrangler.toml
@@ -10,6 +10,7 @@ routes = [
 [[d1_databases]]
 binding = "IDENTITY_DB"
 database_name = "slop-private"
+database_id = "1b453124-2709-45af-8389-151a8105c461"
 migrations_dir = "../../migrations"
 
 [triggers]

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,5 +5,16 @@ compatibility_date = "2026-07-30"
 [vars]
 PUBLIC_SITE_URL = "https://slop.cash"
 
-[env.preview.vars]
-PUBLIC_SITE_URL = "https://slop.cash"
+[[d1_databases]]
+binding = "SLOP_DB"
+database_name = "slop-private"
+database_id = "1b453124-2709-45af-8389-151a8105c461"
+migrations_dir = "migrations"
+
+[[r2_buckets]]
+binding = "PRIVATE_TRACES"
+bucket_name = "slop-private-traces"
+
+[[services]]
+binding = "SLOP_IDENTITY"
+service = "slop-identity"


### PR DESCRIPTION
## Summary
- bind the existing `slop-private` D1 database and private `slop-private-traces` R2 bucket to Pages
- bind Pages to the private `slop-identity` service and pin the identity Worker to the same D1 database
- remove the partial preview override so Cloudflare does not drop non-inherited bindings
- deploy the identity Worker from the same protected exact-SHA release as Pages
- require the exact four Worker secrets and prove live D1 flow creation, TLS, PKCE S256, callback, and GitHub client routing before Pages publishes
- fail closed with a stable public error if a malformed secret or non-API exception reaches the Worker boundary
- document exact 32-byte base64url key generation and lock the resource/domain/deployment contract in tests

The Cloudflare D1 database, private R2 bucket, migrations, Worker secrets, GitHub App, and restricted GitHub prod-ops runner group now exist. This PR does not enable payouts, expose R2 publicly, grant an operator identity, or install the GitHub App into repositories.

Refs #36

## Verification
- `bun run test` (338 Vitest + 50 skill tests)
- `bun run typecheck`
- `bun run lint:check` and `bun run format:check`
- `bun run build`
- real local Wrangler HTTPS Worker + D1 migration/start-flow/authorize redirect/PKCE flow; one pending row observed, then temporary state removed
- `bunx wrangler deploy --dry-run --config workers/identity/wrangler.toml`
- `bunx wrangler pages functions build functions --outdir /tmp/slop-pages-functions-build --project-directory .`
- workflow YAML parsed successfully