### PR TITLE
fix: fail closed on identity secret drift

### DIFF
--- a/scripts/deployment-contract.test.mjs
+++ b/scripts/deployment-contract.test.mjs
@@ -25,6 +25,10 @@ const identityWranglerConfiguration = readFileSync(
   join(packageRoot, "workers", "identity", "wrangler.toml"),
   "utf8",
 );
+const identityDeploymentGuide = readFileSync(
+  join(packageRoot, "workers", "identity", "README.md"),
+  "utf8",
+);
 const pagesHeaders = readFileSync(
   join(packageRoot, "public", "_headers"),
   "utf8",
@@ -196,5 +200,11 @@ describe("slop.cash deployment contract", () => {
     expect(identityWranglerConfiguration).toContain(
       'database_id = "1b453124-2709-45af-8389-151a8105c461"',
     );
+    expect(identityDeploymentGuide).toContain("- Account permissions: none.");
+    expect(
+      identityDeploymentGuide.match(
+        /randomBytes\(32\)\.toString\("base64url"\)/gu,
+      ),
+    ).toHaveLength(2);
   });
 });

--- a/workers/identity/README.md
+++ b/workers/identity/README.md
@@ -123,8 +123,9 @@ Create a GitHub App owned by the designated Slop operator organization:
 - Webhooks: disabled for this App
 - Repository permissions: none
 - Organization permissions: none
-- Account permissions: read-only metadata needed for the authenticated `/user`
-  identity lookup
+- Account permissions: none. The authenticated `/user` identity lookup uses
+  the user access token's intrinsic identity without requesting extra account
+  data.
 
 Use a dedicated App. Do not reuse an App that has repository, workflow, or
 administration permissions.
@@ -136,8 +137,10 @@ its actual `database_id` to the `IDENTITY_DB` entry in `wrangler.toml`, then:
 bunx wrangler d1 migrations apply slop-private --remote --config workers/identity/wrangler.toml
 bunx wrangler secret put GITHUB_APP_CLIENT_ID --config workers/identity/wrangler.toml
 bunx wrangler secret put GITHUB_APP_CLIENT_SECRET --config workers/identity/wrangler.toml
-bunx wrangler secret put IDENTITY_STATE_KEY --config workers/identity/wrangler.toml
-bunx wrangler secret put IDENTITY_ASSERTION_KEY --config workers/identity/wrangler.toml
+node -e 'process.stdout.write(require("node:crypto").randomBytes(32).toString("base64url"))' \
+  | bunx wrangler secret put IDENTITY_STATE_KEY --config workers/identity/wrangler.toml
+node -e 'process.stdout.write(require("node:crypto").randomBytes(32).toString("base64url"))' \
+  | bunx wrangler secret put IDENTITY_ASSERTION_KEY --config workers/identity/wrangler.toml
 bunx wrangler deploy --config workers/identity/wrangler.toml
 ```
 

--- a/workers/identity/handler.ts
+++ b/workers/identity/handler.ts
@@ -420,7 +420,10 @@ export async function handleIdentityRequest(
     }
     return json(404, { error: "not_found" });
   } catch (caught) {
-    const error = caught as ApiError;
+    const error =
+      typeof caught === "object" && caught !== null
+        ? (caught as Partial<ApiError>)
+        : {};
     const status =
       Number.isSafeInteger(error.status) &&
       Number(error.status) >= 400 &&
@@ -435,7 +438,10 @@ export async function handleIdentityRequest(
     if (status >= 500) console.error("slop identity request failed");
     return json(status, {
       error: code,
-      message: status >= 500 ? "Internal error" : error.message,
+      message:
+        status >= 500 || typeof error.message !== "string"
+          ? "Internal error"
+          : error.message,
     });
   }
 }

--- a/workers/identity/handler.ts
+++ b/workers/identity/handler.ts
@@ -421,11 +421,21 @@ export async function handleIdentityRequest(
     return json(404, { error: "not_found" });
   } catch (caught) {
     const error = caught as ApiError;
-    const status = error.status ?? 500;
-    if (status === 500) console.error("slop identity request failed");
+    const status =
+      Number.isSafeInteger(error.status) &&
+      Number(error.status) >= 400 &&
+      Number(error.status) <= 599
+        ? Number(error.status)
+        : 500;
+    const code =
+      typeof error.code === "string" &&
+      /^[a-z][a-z0-9_]{1,63}$/u.test(error.code)
+        ? error.code
+        : "internal_error";
+    if (status >= 500) console.error("slop identity request failed");
     return json(status, {
-      error: error.code ?? "internal_error",
-      message: status === 500 ? "Internal error" : error.message,
+      error: code,
+      message: status >= 500 ? "Internal error" : error.message,
     });
   }
 }

--- a/workers/identity/identity.test.ts
+++ b/workers/identity/identity.test.ts
@@ -349,6 +349,23 @@ describe("slop identity worker", () => {
     expect(resolved).toHaveLength(1);
   });
 
+  it("fails closed before persistence when the encryption secret is malformed", async () => {
+    const { deps, store } = dependencies();
+    deps.stateEncryptionSecret = "not-base64url";
+    const response = await handleIdentityRequest(
+      jsonRequest("identity.slop.cash", "/v1/oauth/start", {
+        audience: IDENTITY_AUDIENCE,
+      }),
+      deps,
+    );
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({
+      error: "internal_error",
+      message: "Internal error",
+    });
+    expect(store.flows.size).toBe(0);
+  });
+
   it("keeps assertion consumption internal and strictly fixes the callback", async () => {
     const { deps } = dependencies();
     const publicConsume = await handleIdentityRequest(

--- a/workers/identity/identity.test.ts
+++ b/workers/identity/identity.test.ts
@@ -366,6 +366,25 @@ describe("slop identity worker", () => {
     expect(store.flows.size).toBe(0);
   });
 
+  it("normalizes non-Error failures without dropping the response boundary", async () => {
+    const { deps, store } = dependencies();
+    deps.now = () => {
+      throw null;
+    };
+    const response = await handleIdentityRequest(
+      jsonRequest("identity.slop.cash", "/v1/oauth/start", {
+        audience: IDENTITY_AUDIENCE,
+      }),
+      deps,
+    );
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({
+      error: "internal_error",
+      message: "Internal error",
+    });
+    expect(store.flows.size).toBe(0);
+  });
+
   it("keeps assertion consumption internal and strictly fixes the callback", async () => {
     const { deps } = dependencies();
     const publicConsume = await handleIdentityRequest(


### PR DESCRIPTION
## Summary
- document exact independent 32-byte base64url generation for both identity crypto keys
- normalize non-API exceptions at the Worker boundary so DOMException numeric codes cannot escape in the public JSON contract
- fail closed before persisting an OAuth flow when encryption key material is malformed
- lock zero additional GitHub App account permissions and key-generation commands into the deployment contract

This follows merged #61. The initially uploaded, unused malformed keys were replaced in Cloudflare before any Worker deployment. Payouts remain disabled.

Refs #36

## Verification
- `bun run test` (338 Vitest + 50 skill tests)
- `bun run typecheck`
- `bun run lint:check` and `bun run format:check`
- `bun run build`
- real local Wrangler HTTPS Worker + D1 migration/start-flow/authorize redirect/PKCE flow; one pending row observed, then temporary state removed
- identity Worker dry-run and deployment workflow YAML parse