### PR TITLE
fix: rate limit identity OAuth endpoints

### DIFF
--- a/scripts/deployment-contract.test.mjs
+++ b/scripts/deployment-contract.test.mjs
@@ -200,6 +200,23 @@ describe("slop.cash deployment contract", () => {
     expect(identityWranglerConfiguration).toContain(
       'database_id = "1b453124-2709-45af-8389-151a8105c461"',
     );
+    expect(identityWranglerConfiguration).toContain(
+      'name = "IDENTITY_START_LIMITER"',
+    );
+    expect(identityWranglerConfiguration).toContain('namespace_id = "81001"');
+    expect(identityWranglerConfiguration).toContain("limit = 12");
+    expect(identityWranglerConfiguration).toContain(
+      'name = "IDENTITY_POLL_LIMITER"',
+    );
+    expect(identityWranglerConfiguration).toContain('namespace_id = "81002"');
+    expect(identityWranglerConfiguration).toContain("limit = 120");
+    expect(identityWranglerConfiguration.match(/period = 60/gu)).toHaveLength(
+      2,
+    );
+    expect(identityWranglerConfiguration).toContain("invocation_logs = false");
+    expect(identityWranglerConfiguration).not.toContain(
+      "invocation_logs = true",
+    );
     expect(identityDeploymentGuide).toContain("- Account permissions: none.");
     expect(
       identityDeploymentGuide.match(

--- a/workers/identity/README.md
+++ b/workers/identity/README.md
@@ -107,12 +107,16 @@ returns the separate ten-minute contributor session described in
 - Poll capabilities and assertions are stored only as SHA-256 digests.
 - Assertions are fixed to `private-trace-api`, consumed atomically, and never
   carry an operator role. The identity Worker has no role-issuance endpoint.
+- Worker-native counters limit OAuth starts to 12 per minute and polls to 120
+  per minute per connecting address and Cloudflare location. Counters are
+  eventually consistent abuse controls, not accounting records, and never
+  enter D1.
 - Expired flows and assertions are removed hourly. Trace retention is
   unaffected.
 - Response bodies and application logs never contain GitHub codes or access
-  tokens. Cloudflare HTTP logs must be configured to redact query strings on
-  the OAuth callback because authorization codes arrive in the standard query
-  parameter.
+  tokens. Persisted Worker invocation logs are disabled because OAuth codes
+  arrive in the standard callback query parameter. Do not enable full-URL
+  Logpush fields or production request tails for this Worker.
 
 ## Provisioning
 
@@ -149,6 +153,7 @@ bunx wrangler deploy --config workers/identity/wrangler.toml
 `SLOP_IDENTITY`. Keep `workers_dev = false`; only the custom OAuth domain and
 service binding should invoke it.
 
-Before enabling clients, verify the custom domain's DNS and TLS separately,
-configure WAF/rate limits for start and poll routes, redact callback query
-strings from logs, and prove assertion replay and CSRF rejection in production.
+Before enabling clients, verify the custom domain's DNS and TLS separately and
+prove rate limiting, assertion replay, and CSRF rejection in production. Zone
+WAF rules remain defense in depth and must not replace the route-specific
+Worker counters.

--- a/workers/identity/index.ts
+++ b/workers/identity/index.ts
@@ -2,13 +2,88 @@ import { randomToken } from "./crypto";
 import { handleIdentityRequest } from "./handler";
 import { type D1Database, D1IdentityPersistence } from "./persistence";
 
+type RateLimitBinding = {
+  limit(options: { key: string }): Promise<{ success: boolean }>;
+};
+
 type Env = {
   IDENTITY_DB: D1Database;
+  IDENTITY_START_LIMITER: RateLimitBinding;
+  IDENTITY_POLL_LIMITER: RateLimitBinding;
   GITHUB_APP_CLIENT_ID: string;
   GITHUB_APP_CLIENT_SECRET: string;
   IDENTITY_STATE_KEY: string;
   IDENTITY_ASSERTION_KEY: string;
 };
+
+function rateLimitKey(request: Request): string {
+  const connectingIp = request.headers.get("cf-connecting-ip");
+  return connectingIp !== null && connectingIp.length <= 64
+    ? connectingIp
+    : "unattributed";
+}
+
+function rateLimitResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      error: "rate_limited",
+      message: "Too many requests. Try again later.",
+    }),
+    {
+      status: 429,
+      headers: {
+        "content-type": "application/json; charset=utf-8",
+        "retry-after": "60",
+        "x-content-type-options": "nosniff",
+      },
+    },
+  );
+}
+
+function limiterUnavailableResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      error: "service_unavailable",
+      message: "Identity service is temporarily unavailable.",
+    }),
+    {
+      status: 503,
+      headers: {
+        "content-type": "application/json; charset=utf-8",
+        "retry-after": "60",
+        "x-content-type-options": "nosniff",
+      },
+    },
+  );
+}
+
+export async function applyIdentityRateLimit(
+  request: Request,
+  env: Pick<Env, "IDENTITY_START_LIMITER" | "IDENTITY_POLL_LIMITER">,
+): Promise<Response | null> {
+  const url = new URL(request.url);
+  if (
+    url.protocol !== "https:" ||
+    url.hostname !== "identity.slop.cash" ||
+    request.method !== "POST"
+  ) {
+    return null;
+  }
+  const limiter =
+    url.pathname === "/v1/oauth/start"
+      ? env.IDENTITY_START_LIMITER
+      : url.pathname === "/v1/oauth/poll"
+        ? env.IDENTITY_POLL_LIMITER
+        : null;
+  if (limiter === null) return null;
+  try {
+    const result = await limiter.limit({ key: rateLimitKey(request) });
+    return result.success ? null : rateLimitResponse();
+  } catch {
+    console.error("slop identity rate limiter failed");
+    return limiterUnavailableResponse();
+  }
+}
 
 async function resolveGithubIdentity(
   code: string,
@@ -93,7 +168,9 @@ function dependencies(env: Env) {
 }
 
 export default {
-  fetch(request: Request, env: Env): Promise<Response> {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const limited = await applyIdentityRateLimit(request, env);
+    if (limited !== null) return limited;
     return handleIdentityRequest(request, dependencies(env));
   },
   async scheduled(_controller: unknown, env: Env): Promise<void> {

--- a/workers/identity/index.ts
+++ b/workers/identity/index.ts
@@ -32,7 +32,9 @@ function rateLimitResponse(): Response {
     {
       status: 429,
       headers: {
+        "cache-control": "no-store",
         "content-type": "application/json; charset=utf-8",
+        "referrer-policy": "no-referrer",
         "retry-after": "60",
         "x-content-type-options": "nosniff",
       },
@@ -49,7 +51,9 @@ function limiterUnavailableResponse(): Response {
     {
       status: 503,
       headers: {
+        "cache-control": "no-store",
         "content-type": "application/json; charset=utf-8",
+        "referrer-policy": "no-referrer",
         "retry-after": "60",
         "x-content-type-options": "nosniff",
       },

--- a/workers/identity/rate-limit.test.ts
+++ b/workers/identity/rate-limit.test.ts
@@ -1,0 +1,105 @@
+/** Exercises the identity Worker limiter boundary with the same bindings production uses. */
+import { describe, expect, it } from "vitest";
+import { applyIdentityRateLimit } from "./index";
+
+function limiter(success: boolean) {
+  const keys: string[] = [];
+  return {
+    keys,
+    async limit({ key }: { key: string }) {
+      keys.push(key);
+      return { success };
+    },
+  };
+}
+
+describe("identity rate limits", () => {
+  it.each([
+    ["/v1/oauth/start", "start"],
+    ["/v1/oauth/poll", "poll"],
+  ])("returns a stable 429 for %s", async (path, selected) => {
+    const start = limiter(selected !== "start");
+    const poll = limiter(selected !== "poll");
+    const response = await applyIdentityRateLimit(
+      new Request(`https://identity.slop.cash${path}`, {
+        method: "POST",
+        headers: { "cf-connecting-ip": "2001:db8::1" },
+      }),
+      {
+        IDENTITY_START_LIMITER: start,
+        IDENTITY_POLL_LIMITER: poll,
+      },
+    );
+
+    expect(response?.status).toBe(429);
+    expect(response?.headers.get("retry-after")).toBe("60");
+    expect(await response?.json()).toEqual({
+      error: "rate_limited",
+      message: "Too many requests. Try again later.",
+    });
+    expect(selected === "start" ? start.keys : poll.keys).toEqual([
+      "2001:db8::1",
+    ]);
+  });
+
+  it("allows requests below the limit", async () => {
+    const start = limiter(true);
+    const response = await applyIdentityRateLimit(
+      new Request("https://identity.slop.cash/v1/oauth/start", {
+        method: "POST",
+        headers: { "cf-connecting-ip": "192.0.2.1" },
+      }),
+      {
+        IDENTITY_START_LIMITER: start,
+        IDENTITY_POLL_LIMITER: limiter(true),
+      },
+    );
+
+    expect(response).toBeNull();
+    expect(start.keys).toEqual(["192.0.2.1"]);
+  });
+
+  it("fails closed when a limiter is unavailable", async () => {
+    const response = await applyIdentityRateLimit(
+      new Request("https://identity.slop.cash/v1/oauth/start", {
+        method: "POST",
+      }),
+      {
+        IDENTITY_START_LIMITER: {
+          limit: async () => {
+            throw new Error("provider detail must not escape");
+          },
+        },
+        IDENTITY_POLL_LIMITER: limiter(true),
+      },
+    );
+
+    expect(response?.status).toBe(503);
+    expect(response?.headers.get("retry-after")).toBe("60");
+    expect(await response?.json()).toEqual({
+      error: "service_unavailable",
+      message: "Identity service is temporarily unavailable.",
+    });
+  });
+
+  it.each([
+    ["GET", "/v1/oauth/authorize"],
+    ["GET", "/v1/oauth/callback"],
+    ["POST", "/v1/assertions/consume"],
+    ["POST", "/not-found"],
+  ])("does not count %s %s", async (method, path) => {
+    const start = limiter(false);
+    const poll = limiter(false);
+    const response = await applyIdentityRateLimit(
+      new Request(`https://identity.slop.cash${path}`, { method }),
+      {
+        IDENTITY_START_LIMITER: start,
+        IDENTITY_POLL_LIMITER: poll,
+      },
+    );
+
+    expect(response).toBeNull();
+    expect(start.keys).toEqual([]);
+    expect(poll.keys).toEqual([]);
+  });
+});

--- a/workers/identity/rate-limit.test.ts
+++ b/workers/identity/rate-limit.test.ts
@@ -32,6 +32,8 @@ describe("identity rate limits", () => {
     );
 
     expect(response?.status).toBe(429);
+    expect(response?.headers.get("cache-control")).toBe("no-store");
+    expect(response?.headers.get("referrer-policy")).toBe("no-referrer");
     expect(response?.headers.get("retry-after")).toBe("60");
     expect(await response?.json()).toEqual({
       error: "rate_limited",
@@ -75,6 +77,8 @@ describe("identity rate limits", () => {
     );
 
     expect(response?.status).toBe(503);
+    expect(response?.headers.get("cache-control")).toBe("no-store");
+    expect(response?.headers.get("referrer-policy")).toBe("no-referrer");
     expect(response?.headers.get("retry-after")).toBe("60");
     expect(await response?.json()).toEqual({
       error: "service_unavailable",

--- a/workers/identity/wrangler.toml
+++ b/workers/identity/wrangler.toml
@@ -13,5 +13,27 @@ database_name = "slop-private"
 database_id = "1b453124-2709-45af-8389-151a8105c461"
 migrations_dir = "../../migrations"
 
+[[ratelimits]]
+name = "IDENTITY_START_LIMITER"
+namespace_id = "81001"
+
+  [ratelimits.simple]
+  limit = 12
+  period = 60
+
+[[ratelimits]]
+name = "IDENTITY_POLL_LIMITER"
+namespace_id = "81002"
+
+  [ratelimits.simple]
+  limit = 120
+  period = 60
+
 [triggers]
 crons = ["17 * * * *"]
+
+[observability]
+enabled = true
+
+  [observability.logs]
+  invocation_logs = false


### PR DESCRIPTION
Closes the remaining public-abuse and callback-log gate in #36.

- adds independent Worker-native limits for OAuth start and poll
- fails closed with stable 429/503 responses
- disables persisted invocation URLs so callback codes are not retained in Worker logs
- keeps counters outside D1 and preserves the two-second poll contract

Verification:
- full suite: 346 Vitest + 50 skill tests
- typecheck, Biome, production build, Worker dry-run
- real local Wrangler/D1 runtime: 12 starts returned 201 then 429; 120 polls returned 400 then 429

Payouts remain disabled and token volume remains non-financial.