### PR TITLE
docs: require verified GitHub contributor sessions

### DIFF
--- a/skill-tests/project-skills.test.ts
+++ b/skill-tests/project-skills.test.ts
@@ -59,6 +59,9 @@ describe("project skill contracts", () => {
       assert.match(source, /--trajectory <path>/u);
       assert.match(source, /permanent\s+private\s+upload/u);
       assert.match(source, /elizaOS\/slopdotcash/u);
+      assert.match(source, /gh auth status --hostname github\.com/u);
+      assert.match(source, /gh api user --jq '\.login'/u);
+      assert.match(source, /upstream\s+permission/is);
       assert.match(source, /stars are\s+optional/u);
       assert.match(source, /explicit authorization before\s+creating one/is);
       assert.match(source, /live-report\.mjs --repo/u);

--- a/skills/contribute-to-asi/SKILL.md
+++ b/skills/contribute-to-asi/SKILL.md
@@ -28,6 +28,11 @@ choice and token volume are diagnostic only and never change score or payout.
 2. Read the repository root `CLAUDE.md`/`AGENTS.md`, `RESEARCH_STATUS.md`,
    `NEGATIVE_RESULTS_LEDGER.md`, the runbook for the lane you touch, and
    [repository-contract.md](references/repository-contract.md).
+   Require `gh auth status --hostname github.com` and
+   `gh api user --jq '.login'` to succeed first. Show the login and stop if it
+   is absent, unexpected, or not the contributor the operator intends to use;
+   never handle their credential. Read the authenticated user's upstream
+   permission before choosing the push path.
    If a pull request requires a fork and the contributor lacks upstream write
    access, reuse their existing fork or obtain explicit authorization before
    creating one. Do not fork when an upstream branch is authorized. A

--- a/skills/contribute-to-delta-star/SKILL.md
+++ b/skills/contribute-to-delta-star/SKILL.md
@@ -24,6 +24,11 @@ choice and token volume are diagnostic only and never change score or share.
 2. Read ArkLib's `AGENTS.md`, `CONTRIBUTING.md`, the nearest `AGENTS.md` or
    `CLAUDE.md`, the live Delta Star frontier documents named by those guides,
    and [repository-contract.md](references/repository-contract.md).
+   Require `gh auth status --hostname github.com` and
+   `gh api user --jq '.login'` to succeed first. Show the login and stop if it
+   is absent, unexpected, or not the contributor the operator intends to use;
+   never handle their credential. Read the authenticated user's upstream
+   permission before choosing the push path.
    If a pull request requires a fork and the contributor lacks upstream write
    access, reuse their existing fork or obtain explicit authorization before
    creating one. Do not fork when an upstream branch is authorized. A

--- a/skills/contribute-to-eliza/SKILL.md
+++ b/skills/contribute-to-eliza/SKILL.md
@@ -24,6 +24,11 @@ choice and token volume are diagnostic only and never change score or payout.
    `CLAUDE.md`,
    `CONTRIBUTING.md`, `SECURITY.md`, the relevant package guide, and
    [repository-contract.md](references/repository-contract.md).
+   Require `gh auth status --hostname github.com` and
+   `gh api user --jq '.login'` to succeed first. Show the login and stop if it
+   is absent, unexpected, or not the contributor the operator intends to use;
+   never handle their credential. Read the authenticated user's upstream
+   permission before choosing the push path.
    If a pull request requires a fork and the contributor lacks upstream write
    access, reuse their existing fork or obtain explicit authorization before
    creating one. Do not fork when an upstream branch is authorized. A

--- a/skills/slop/SKILL.md
+++ b/skills/slop/SKILL.md
@@ -16,6 +16,12 @@ This workflow requires Git, GitHub CLI, Python 3, Node 24, and HTTPS access to
 slop.cash, api.slop.cash, and GitHub. Any model and agent client may join,
 including Grok and Kimi.
 
+Before any repository or installer action, require both
+`gh auth status --hostname github.com` and `gh api user --jq '.login'` to
+succeed. Show the returned login and stop if it is absent, unexpected, or not
+the contributor the operator intends to use. Ask the operator to complete
+GitHub sign-in; never enter, request, retain, or expose their credential.
+
 ## Identify the project
 
 1. Determine and retain the exact provider, model, and agent/client identifiers.
@@ -120,6 +126,7 @@ Device signatures prove byte continuity, not provider billing, model execution,
 skill adherence, hours worked, or contribution quality. Accepted outcomes and
 independent review—not token volume or installing this skill—determine merit.
 
+Read the authenticated user's upstream permission before choosing a push path.
 If a pull request requires a fork and the contributor lacks upstream write
 access, reuse their existing fork or obtain explicit authorization before
 creating one. Do not fork when an upstream branch is authorized. They may


### PR DESCRIPTION
## Outcome

Contributor skills now verify the active GitHub identity before repository or installer actions.

- requires `gh auth status --hostname github.com`
- reads and displays the exact authenticated login with `gh api user --jq '.login'`
- stops when the login is absent, unexpected, or not the intended contributor
- never handles the contributor's credential
- checks upstream permission before choosing an authorized branch or fork path
- keeps forks conditional and explicitly authorized
- keeps stars optional, manual, unscored, and unpaid

This applies to the bootstrap skill and every registered contributor skill. Any declared model/client, including Grok and Kimi, remains supported.

## Validation

- all 7 skills pass the skill validator
- 13 project-skill tests pass
- typecheck, lint, format, and production build pass
