### PR TITLE
Remove the Eliza callout from the homepage

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -776,10 +776,6 @@ function GlobalLeaderboard({
 
 function HomePage({ state, retry }: { state: DataState; retry: () => void }) {
   const views = state.status === "ready" ? state.views : [];
-  const eliza = findProject("eliza");
-  if (!eliza) {
-    throw new TypeError("The Eliza project is not registered");
-  }
   return (
     <main>
       <section className="hero shell">
@@ -787,17 +783,6 @@ function HomePage({ state, retry }: { state: DataState; retry: () => void }) {
           <DataNotice state={state} retry={retry} />
         )}
         <TypewriterHeroHeading />
-      </section>
-
-      <section
-        aria-labelledby="home-agent-prompt-heading"
-        className="home-agent-prompt shell"
-      >
-        <div className="home-agent-prompt-heading">
-          <h2 id="home-agent-prompt-heading">Contribute to Eliza.</h2>
-          <p>Paste this into any coding agent.</p>
-        </div>
-        <AgentPromptBox prompt={projectAgentPrompt(eliza)} />
       </section>
 
       <section className="section shell home-projects-section" id="projects">

--- a/src/styles.css
+++ b/src/styles.css
@@ -866,29 +866,6 @@ small {
   text-transform: uppercase;
 }
 
-.home-agent-prompt {
-  display: grid;
-  grid-template-columns: minmax(180px, 0.42fr) minmax(0, 1.58fr);
-  align-items: center;
-  gap: 24px;
-  margin-block: 20px 36px;
-  padding: 20px;
-  border-radius: var(--radius);
-  background: var(--orange);
-}
-
-.home-agent-prompt-heading h2 {
-  margin: 0;
-  font-size: clamp(24px, 3vw, 34px);
-  letter-spacing: -0.04em;
-}
-
-.home-agent-prompt-heading p {
-  margin: 4px 0 0;
-  font-size: 12px;
-  font-weight: 600;
-}
-
 .install-panel {
   margin-top: 56px;
   padding: 32px;
@@ -1855,11 +1832,6 @@ small {
     align-items: start;
   }
 
-  .home-agent-prompt {
-    grid-template-columns: 1fr;
-    gap: 18px;
-  }
-
   .reward-card {
     max-width: 520px;
     margin-inline: auto;
@@ -1967,11 +1939,6 @@ small {
   .project-hero h1,
   .proposal-intro h1 {
     font-size: clamp(45px, 14vw, 68px);
-  }
-
-  .home-agent-prompt {
-    margin-block: 16px 28px;
-    padding: 18px;
   }
 
   .hero-copy {

--- a/tests/app.test.tsx
+++ b/tests/app.test.tsx
@@ -167,17 +167,9 @@ describe("discovery", () => {
       screen.queryByText(/Rankings are live. Payouts are off/u),
     ).not.toBeInTheDocument();
     expect(
-      screen.getByRole("heading", { name: "Contribute to Eliza." }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText("Paste this into any coding agent."),
-    ).toBeInTheDocument();
-    const homePrompt = screen.getByLabelText("Agent prompt");
-    expect(homePrompt).toHaveTextContent(`${window.location.origin}/SKILL.md`);
-    expect(homePrompt).toHaveTextContent(
-      "contribute to github.com/elizaOS/eliza",
-    );
-    expect(homePrompt.querySelectorAll("wbr")).toHaveLength(2);
+      screen.queryByRole("heading", { name: "Contribute to Eliza." }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Agent prompt")).not.toBeInTheDocument();
     expect(
       await screen.findByRole("heading", { name: "Leaderboard" }),
     ).toBeInTheDocument();

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -138,39 +138,16 @@ test("discovers both reward models and a score-ranked global ledger", async ({
   expect(elizaBox?.width).toBeGreaterThan((gridBox?.width ?? 0) - 2);
   expect(deltaBox?.width).toBeGreaterThan((gridBox?.width ?? 0) - 2);
   expect(deltaBox?.y).toBeGreaterThan((elizaBox?.y ?? 0) + 1);
-  const visibleHeroGap = await page.evaluate(() => {
-    const heroBoundary = document.querySelector(".home-agent-prompt");
-    const projectHeading = document.querySelector("#projects h2");
-    if (!heroBoundary || !projectHeading) return null;
-    return Math.round(
-      projectHeading.getBoundingClientRect().top -
-        heroBoundary.getBoundingClientRect().bottom,
-    );
-  });
-  expect(visibleHeroGap).not.toBeNull();
-  expect(visibleHeroGap ?? 0).toBeGreaterThanOrEqual(12);
-  expect(visibleHeroGap ?? 0).toBeLessThanOrEqual(64);
   await expect(page.getByText("Public beta.")).toHaveCount(0);
   await expect(
     page.getByText(/Rankings are live. Payouts are off/u),
   ).toHaveCount(0);
   await expect(
     page.getByRole("heading", { name: "Contribute to Eliza." }),
-  ).toBeVisible();
-  await expect(
-    page.getByText("Paste this into any coding agent."),
-  ).toBeVisible();
-  const homePrompt = page.getByRole("status", { name: "Agent prompt" });
-  await expect(homePrompt).toContainText(/\/SKILL\.md/u);
-  await expect(homePrompt).toContainText(
-    /contribute to github\.com\/elizaOS\/eliza/u,
+  ).toHaveCount(0);
+  await expect(page.getByRole("status", { name: "Agent prompt" })).toHaveCount(
+    0,
   );
-  await expect(homePrompt.locator("wbr")).toHaveCount(2);
-  expect(
-    await homePrompt.evaluate(
-      (element) => element.scrollWidth <= element.clientWidth,
-    ),
-  ).toBe(true);
   await expect(
     page.getByRole("heading", { name: "Leaderboard" }),
   ).toBeVisible();


### PR DESCRIPTION
## Summary
- remove the Eliza-specific contribution prompt from the homepage
- keep Eliza as a normal project in the project grid
- retain project-specific agent prompts on project pages
- delete the unused homepage-only styles and update coverage

## Verification
- `bun run test` (348 Vitest + 50 skill tests)
- `bun run typecheck`
- `bun run format:check`
- `bun run lint:check`
- `bun run build`
- focused Playwright homepage test across wide desktop, desktop, tablet, and narrow mobile (4/4)