### PR TITLE
Add breathing room below the homepage leaderboard

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -288,7 +288,7 @@ p {
 }
 
 .home-leaderboard-section {
-  padding-block: 36px 56px;
+  padding-block: 36px 96px;
 }
 
 .home-leaderboard-heading {
@@ -1954,7 +1954,7 @@ small {
   }
 
   .home-leaderboard-section {
-    padding-block: 28px 44px;
+    padding-block: 28px 72px;
   }
 
   .section-heading {

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -212,6 +212,18 @@ test("discovers both reward models and a score-ranked global ledger", async ({
       ).toBe(true);
     }
   }
+  const leaderboardBottomSpace = await page.evaluate(() => {
+    const panel = document.querySelector("#leaderboard-current-panel");
+    const footer = document.querySelector(".site-footer");
+    if (!panel || !footer) return null;
+    return Math.round(
+      footer.getBoundingClientRect().top - panel.getBoundingClientRect().bottom,
+    );
+  });
+  expect(leaderboardBottomSpace).not.toBeNull();
+  expect(leaderboardBottomSpace ?? 0).toBeGreaterThanOrEqual(
+    (page.viewportSize()?.width ?? 0) <= 680 ? 64 : 80,
+  );
   await page.getByRole("tab", { name: "All-time record" }).click();
   await expect(
     page.getByRole("table", { name: "All-time accepted-work record" }),


### PR DESCRIPTION
## Summary
- increase the leaderboard section bottom spacing to 96px on larger screens
- use 72px on mobile so the section no longer runs into the footer
- add a browser regression check for the visible gap

## Verification
- `bun run test` (348 Vitest + 50 skill tests)
- `bun run typecheck`
- `bun run format:check`
- `bun run lint:check`
- focused Playwright test across wide desktop, desktop, tablet, and narrow mobile (4/4)