### PR TITLE
Simplify the site header

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -394,10 +394,6 @@ function Header({ isHome }: { isHome: boolean }) {
           <Link href="/#projects">Projects</Link>
           <Link href="/#leaderboard">Leaderboard</Link>
           <Link href="/projects/new">Add project</Link>
-          <ExternalLinkAnchor href={HUB_ORIGIN}>Slop Git</ExternalLinkAnchor>
-          <ExternalLinkAnchor className="nav-source" href={SOURCE_REPOSITORY}>
-            Source <ExternalLink aria-hidden="true" size={14} />
-          </ExternalLinkAnchor>
         </nav>
       </div>
     </header>

--- a/src/styles.css
+++ b/src/styles.css
@@ -94,13 +94,6 @@ textarea:focus-visible {
   color: var(--ink);
 }
 
-.nav-source {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 10px 0;
-}
-
 .menu-button {
   display: none;
   border: 0;
@@ -1918,11 +1911,6 @@ small {
 
   .nav-links-open a {
     padding: 13px;
-  }
-
-  .nav-source {
-    justify-content: space-between;
-    border: 0;
   }
 
   .hero {

--- a/tests/app.test.tsx
+++ b/tests/app.test.tsx
@@ -152,6 +152,20 @@ describe("discovery", () => {
     expect(screen.getByRole("link", { name: "Slop home" })).toHaveTextContent(
       "slop.cash",
     );
+    const header = screen.getByRole("banner");
+    expect(
+      within(header).queryByRole("link", { name: "Slop Git" }),
+    ).not.toBeInTheDocument();
+    expect(
+      within(header).queryByRole("link", { name: "Source" }),
+    ).not.toBeInTheDocument();
+    const footer = screen.getByRole("contentinfo");
+    expect(
+      within(footer).getByRole("link", { name: "GitHub" }),
+    ).toHaveAttribute("href", "https://github.com/elizaOS/slopdotcash");
+    expect(
+      within(footer).getByRole("link", { name: "Slop Git" }),
+    ).toHaveAttribute("href", "https://git.slop.cash");
     expect(
       screen.queryByRole("link", { name: /^Home$/u }),
     ).not.toBeInTheDocument();

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -89,6 +89,18 @@ test("discovers both reward models and a score-ranked global ledger", async ({
   await expect(page.getByRole("link", { name: "Slop home" })).toHaveText(
     "slop.cash",
   );
+  const header = page.locator(".site-header");
+  await expect(header.getByRole("link", { name: "Slop Git" })).toHaveCount(0);
+  await expect(header.getByRole("link", { name: "Source" })).toHaveCount(0);
+  const footer = page.locator(".site-footer");
+  await expect(footer.getByRole("link", { name: "GitHub" })).toHaveAttribute(
+    "href",
+    "https://github.com/elizaOS/slopdotcash",
+  );
+  await expect(footer.getByRole("link", { name: "Slop Git" })).toHaveAttribute(
+    "href",
+    "https://git.slop.cash",
+  );
   await expect(page.locator(".footer-wordmark")).toHaveText("slop.cash");
   await expect(page.getByRole("link", { name: "Protocol" })).toHaveCount(0);
   await expect(page.getByText("© 2026 slop.cash.")).toBeVisible();


### PR DESCRIPTION
## Summary
- remove Slop Git from the top navigation
- remove the duplicate GitHub source link from the top navigation
- keep GitHub and Slop Git in the footer
- remove dead header-link styling and add regression coverage

## Verification
- focused app tests: 21/21
- typecheck, format, and lint pass
- focused Playwright homepage test passes at wide desktop, desktop, tablet, and narrow mobile

## Full-suite note
The current shared working tree contains a separate, uncommitted Delta Star repository migration. It changes fixtures from ArkLib to Proximity Prize before the generated registry is synchronized, so the local full suite currently fails those unrelated registry-contract assertions. This PR contains none of that work; its clean CI run is authoritative.