### PR TITLE
Remove SlopHub links from the public UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,7 +57,6 @@ import {
 import { feeForPrincipal } from "./lib/rewards";
 
 const SOURCE_REPOSITORY = "https://github.com/elizaOS/slopdotcash";
-const HUB_ORIGIN = "https://git.slop.cash";
 const PROJECT_PROPOSAL_ROOT = `${SOURCE_REPOSITORY}/new/develop`;
 const SNAPSHOT_TIMEOUT_MS = 12_000;
 const SNAPSHOT_RETRIES = 1;
@@ -416,7 +415,6 @@ function Footer() {
           <ExternalLinkAnchor href={SOURCE_REPOSITORY}>
             GitHub
           </ExternalLinkAnchor>
-          <ExternalLinkAnchor href={HUB_ORIGIN}>Slop Git</ExternalLinkAnchor>
         </div>
         <p className="footer-fine">
           Projections are estimates, not wages or guarantees. Project owners
@@ -1123,10 +1121,6 @@ function ProjectPage({
     state.status === "ready"
       ? state.views.find((candidate) => candidate.project.id === project.id)
       : undefined;
-  const repository = project.repositories[0]?.id;
-  if (!repository) {
-    throw new TypeError(`Project ${project.id} has no contribution repository`);
-  }
   const headlinePrefix = "Make money ";
   const headlineAction = project.headline.startsWith(headlinePrefix)
     ? project.headline.slice(headlinePrefix.length)
@@ -1186,10 +1180,6 @@ function ProjectPage({
                 <div className="reward-actions">
                   <ExternalLinkAnchor href={project.links.repository}>
                     View in GitHub
-                    <ExternalLink aria-hidden="true" size={14} />
-                  </ExternalLinkAnchor>
-                  <ExternalLinkAnchor href={`${HUB_ORIGIN}/${repository}`}>
-                    View in SlopHub
                     <ExternalLink aria-hidden="true" size={14} />
                   </ExternalLinkAnchor>
                 </div>

--- a/tests/app.test.tsx
+++ b/tests/app.test.tsx
@@ -164,8 +164,8 @@ describe("discovery", () => {
       within(footer).getByRole("link", { name: "GitHub" }),
     ).toHaveAttribute("href", "https://github.com/elizaOS/slopdotcash");
     expect(
-      within(footer).getByRole("link", { name: "Slop Git" }),
-    ).toHaveAttribute("href", "https://git.slop.cash");
+      within(footer).queryByRole("link", { name: "Slop Git" }),
+    ).not.toBeInTheDocument();
     expect(
       screen.queryByRole("link", { name: /^Home$/u }),
     ).not.toBeInTheDocument();
@@ -382,8 +382,8 @@ describe("project routes", () => {
       screen.getByRole("link", { name: /View in GitHub/u }),
     ).toHaveAttribute("href", "https://github.com/elizaOS/eliza");
     expect(
-      screen.getByRole("link", { name: /View in SlopHub/u }),
-    ).toHaveAttribute("href", "https://git.slop.cash/elizaOS/eliza");
+      screen.queryByRole("link", { name: /View in SlopHub/u }),
+    ).not.toBeInTheDocument();
     expect(
       screen.queryByText("1% platform fee · Solana"),
     ).not.toBeInTheDocument();

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -97,10 +97,7 @@ test("discovers both reward models and a score-ranked global ledger", async ({
     "href",
     "https://github.com/elizaOS/slopdotcash",
   );
-  await expect(footer.getByRole("link", { name: "Slop Git" })).toHaveAttribute(
-    "href",
-    "https://git.slop.cash",
-  );
+  await expect(footer.getByRole("link", { name: "Slop Git" })).toHaveCount(0);
   await expect(page.locator(".footer-wordmark")).toHaveText("slop.cash");
   await expect(page.getByRole("link", { name: "Protocol" })).toHaveCount(0);
   await expect(page.getByText("© 2026 slop.cash.")).toBeVisible();
@@ -279,7 +276,7 @@ test("starts Eliza with one prompt and no separate payout form", async ({
   ).toHaveAttribute("href", "https://github.com/elizaOS/eliza");
   await expect(
     page.getByRole("link", { name: /View in SlopHub/u }),
-  ).toHaveAttribute("href", "https://git.slop.cash/elizaOS/eliza");
+  ).toHaveCount(0);
   await expect(page.getByText("1% platform fee · Solana")).toHaveCount(0);
   const rewardStyle = await page.locator(".reward-card").evaluate((card) => {
     const amount = card.querySelector<HTMLElement>(".reward-amount-monthly");


### PR DESCRIPTION
## Summary
- remove the footer link to Slop Git
- remove project-page “View in SlopHub” links
- retain GitHub as the sole public source/repository destination
- add explicit absence checks in unit and browser coverage

## Verification
- `bun run test` (348 Vitest + 50 skill tests)
- `bun run typecheck`
- `bun run format:check`
- `bun run lint:check`
- 8 focused Playwright checks across wide desktop, desktop, tablet, and narrow mobile