### PR TITLE
fix(skills): trace delegated Eliza review enforcement

### DIFF
--- a/skill-tests/review-preflight.test.ts
+++ b/skill-tests/review-preflight.test.ts
@@ -1,6 +1,7 @@
 /** Tests the Eliza review compatibility classifier with deterministic live-path fixtures. */
 
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { describe, it } from "node:test";
 import { assessReviewCompatibility } from "../skills/contribute-to-eliza/scripts/review-preflight.mjs";
 
@@ -37,7 +38,7 @@ function fixture() {
       body: `Verified review\n<!-- slop-contribution-attribution:v1 ${JSON.stringify(marker)} -->`,
     },
     validator: "const marker = 'eliza-computer-attribution:v1';",
-    workflows: [
+    automationFiles: [
       {
         path: ".github/workflows/pr.yaml",
         source:
@@ -63,7 +64,7 @@ describe("Eliza review compatibility preflight", () => {
 
   it("blocks when a review-event workflow invokes the incompatible validator", () => {
     const input = fixture();
-    input.workflows.push({
+    input.automationFiles.push({
       path: ".github/workflows/review-policy.yml",
       source:
         "on:\n  pull_request_review:\nsteps:\n  - run: node scripts/check-agent-comment-attribution.mjs",
@@ -82,7 +83,7 @@ describe("Eliza review compatibility preflight", () => {
     input.validator += "\nconst slop = 'slop-contribution-attribution:v1';";
     input.policy +=
       "\nSigned reviews may end with slop-contribution-attribution:v1.";
-    input.workflows.push({
+    input.automationFiles.push({
       path: ".github/workflows/review-policy.yml",
       source:
         "on:\n  pull_request_review:\nsteps:\n  - run: node scripts/check-agent-comment-attribution.mjs\n# slop-contribution-attribution:v1",
@@ -92,6 +93,75 @@ describe("Eliza review compatibility preflight", () => {
     assert.equal(result.safeToPublish, true);
     assert.equal(result.documentation, "aligned");
     assert.equal(result.enforcement, "compatible");
+  });
+
+  it("traces review enforcement through reusable workflows and composite actions", () => {
+    const input = fixture();
+    input.automationFiles.push(
+      {
+        path: ".github/workflows/review-policy.yml",
+        source:
+          "on:\n  pull_request_review:\njobs:\n  policy:\n    uses: ./.github/workflows/reusable-policy.yml",
+      },
+      {
+        path: ".github/workflows/reusable-policy.yml",
+        source:
+          "on:\n  workflow_call:\njobs:\n  policy:\n    steps:\n      - uses: ./.github/actions/review-policy",
+      },
+      {
+        path: ".github/actions/review-policy/action.yml",
+        source:
+          "runs:\n  using: composite\n  steps:\n    - run: node scripts/check-agent-comment-attribution.mjs\n      shell: bash",
+      },
+    );
+    const result = assessReviewCompatibility(input);
+    assert.equal(result.status, "blocked");
+    assert.equal(result.safeToPublish, false);
+    assert.equal(result.enforcement, "incompatible");
+    assert.deepEqual(result.enforcingWorkflows, [
+      ".github/workflows/review-policy.yml",
+    ]);
+  });
+
+  it("accepts Slop-aware enforcement reached through local automation", () => {
+    const input = fixture();
+    input.validator += "\nconst slop = 'slop-contribution-attribution:v1';";
+    input.policy +=
+      "\nSigned reviews may end with slop-contribution-attribution:v1.";
+    input.automationFiles.push(
+      {
+        path: ".github/workflows/review-policy.yml",
+        source:
+          "on:\n  pull_request_review:\njobs:\n  policy:\n    uses: ./.github/workflows/reusable-policy.yml",
+      },
+      {
+        path: ".github/workflows/reusable-policy.yml",
+        source:
+          "on:\n  workflow_call:\njobs:\n  policy:\n    steps:\n      - uses: ./.github/actions/review-policy",
+      },
+      {
+        path: ".github/actions/review-policy/action.yaml",
+        source:
+          "runs:\n  using: composite\n  steps:\n    - run: node scripts/check-agent-comment-attribution.mjs\n      shell: bash\n# slop-contribution-attribution:v1",
+      },
+    );
+    const result = assessReviewCompatibility(input);
+    assert.equal(result.status, "supported");
+    assert.equal(result.safeToPublish, true);
+    assert.equal(result.enforcement, "compatible");
+  });
+
+  it("fails closed when a review workflow references missing local automation", () => {
+    const input = fixture();
+    input.automationFiles.push({
+      path: ".github/workflows/review-policy.yml",
+      source:
+        "on:\n  pull_request_review:\njobs:\n  policy:\n    uses: ./.github/workflows/missing.yml",
+    });
+    assert.throws(
+      () => assessReviewCompatibility(input),
+      /local automation target is missing/u,
+    );
   });
 
   it("fails closed when the known proof loses its terminal marker", () => {
@@ -105,13 +175,25 @@ describe("Eliza review compatibility preflight", () => {
 
   it("rejects unbounded or malformed workflow inventories", () => {
     const input = fixture();
-    input.workflows = Array.from({ length: 129 }, (_, index) => ({
+    input.automationFiles = Array.from({ length: 257 }, (_, index) => ({
       path: `.github/workflows/${index}.yml`,
       source: "on: pull_request",
     }));
     assert.throws(
       () => assessReviewCompatibility(input),
-      /workflow inventory is missing or unbounded/u,
+      /automation inventory is missing or unbounded/u,
     );
+  });
+
+  it("uses scoped Contents API inventory instead of a recursive repository tree", () => {
+    const source = readFileSync(
+      new URL(
+        "../skills/contribute-to-eliza/scripts/review-preflight.mjs",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+    assert.doesNotMatch(source, /recursive=1/u);
+    assert.match(source, /contents\/\$\{canonicalRepositoryPath/u);
   });
 });

--- a/skills/contribute-to-eliza/scripts/review-preflight.mjs
+++ b/skills/contribute-to-eliza/scripts/review-preflight.mjs
@@ -20,7 +20,11 @@ const CONFIG = JSON.parse(
 const SHA_RE = /^[0-9a-f]{40}$/u;
 const MAX_API_BYTES = 16 * 1024 * 1024;
 const MAX_WORKFLOWS = 128;
+const MAX_AUTOMATION_FILES = 256;
+const MAX_DIRECTORY_ENTRIES = 128;
 const MAX_WORKFLOW_BYTES = 1024 * 1024;
+const WORKFLOW_PATH_RE = /^\.github\/workflows\/[^/]+\.ya?ml$/u;
+const ACTION_MANIFEST_RE = /(?:^|\/)action\.ya?ml$/u;
 
 function fail(message) {
   throw new TypeError(message);
@@ -133,13 +137,84 @@ function validProofReview(review, config) {
   );
 }
 
-function workflowEnforcesReviewAttribution(source, config) {
-  if (typeof source !== "string") fail("workflow source must be text");
+function sourceRunsValidator(source, config) {
   return (
-    /\bpull_request_review\b/u.test(source) &&
-    (source.includes(config.validatorPath) ||
-      source.includes(config.validatorPath.split("/").at(-1)))
+    source.includes(config.validatorPath) ||
+    source.includes(config.validatorPath.split("/").at(-1))
   );
+}
+
+function localUsesTargets(source) {
+  if (typeof source !== "string") fail("automation source must be text");
+  const targets = [];
+  const pattern =
+    /^\s*(?:-\s*)?uses\s*:\s*["']?(\.\/[^"'#\s]+)["']?\s*(?:#.*)?$/gmu;
+  for (const match of source.matchAll(pattern)) {
+    const target = match[1].replace(/\/+$/u, "").slice(2);
+    targets.push(canonicalRepositoryPath(target, "local uses target"));
+  }
+  return targets;
+}
+
+function automationIndex(files) {
+  if (!Array.isArray(files) || files.length > MAX_AUTOMATION_FILES) {
+    fail("automation inventory is missing or unbounded");
+  }
+  const indexed = new Map();
+  for (const [index, file] of files.entries()) {
+    const item = record(file, `automationFiles[${index}]`);
+    exactKeys(item, ["path", "source"], `automationFiles[${index}]`);
+    const path = canonicalRepositoryPath(
+      item.path,
+      `automationFiles[${index}].path`,
+    );
+    if (
+      (!WORKFLOW_PATH_RE.test(path) && !ACTION_MANIFEST_RE.test(path)) ||
+      typeof item.source !== "string" ||
+      Buffer.byteLength(item.source) > MAX_WORKFLOW_BYTES ||
+      indexed.has(path)
+    ) {
+      fail(`automationFiles[${index}] is invalid`);
+    }
+    indexed.set(path, item.source);
+  }
+  return indexed;
+}
+
+function resolveLocalTarget(target, indexed) {
+  if (WORKFLOW_PATH_RE.test(target)) {
+    if (!indexed.has(target))
+      fail(`local automation target is missing: ${target}`);
+    return target;
+  }
+  const candidates = [`${target}/action.yml`, `${target}/action.yaml`].filter(
+    (path) => indexed.has(path),
+  );
+  if (candidates.length !== 1) {
+    fail(`local automation target is missing or ambiguous: ${target}`);
+  }
+  return candidates[0];
+}
+
+function reachableReviewPolicy(rootPath, indexed, config) {
+  const pending = [rootPath];
+  const visited = new Set();
+  let runsValidator = false;
+  let acceptsWriter = false;
+  while (pending.length > 0) {
+    const path = pending.pop();
+    if (visited.has(path)) continue;
+    visited.add(path);
+    const source = indexed.get(path);
+    if (typeof source !== "string")
+      fail(`automation source is missing: ${path}`);
+    runsValidator ||= sourceRunsValidator(source, config);
+    acceptsWriter ||= source.includes(config.writerMarker);
+    for (const target of localUsesTargets(source)) {
+      pending.push(resolveLocalTarget(target, indexed));
+    }
+  }
+  return { acceptsWriter, runsValidator };
 }
 
 /** Classifies the exact review path without turning documentation drift into a block. */
@@ -148,7 +223,7 @@ export function assessReviewCompatibility(input, configuration = CONFIG) {
   const value = record(input, "review compatibility input");
   exactKeys(
     value,
-    ["branchSha", "policy", "proofReview", "validator", "workflows"],
+    ["automationFiles", "branchSha", "policy", "proofReview", "validator"],
     "review compatibility input",
   );
   if (!SHA_RE.test(value.branchSha))
@@ -156,35 +231,20 @@ export function assessReviewCompatibility(input, configuration = CONFIG) {
   if (typeof value.policy !== "string" || typeof value.validator !== "string") {
     fail("policy and validator sources must be text");
   }
-  if (
-    !Array.isArray(value.workflows) ||
-    value.workflows.length > MAX_WORKFLOWS
-  ) {
+  const indexed = automationIndex(value.automationFiles);
+  const workflows = [...indexed]
+    .filter(([path]) => WORKFLOW_PATH_RE.test(path))
+    .map(([path, source]) => ({ path, source }));
+  if (workflows.length === 0 || workflows.length > MAX_WORKFLOWS) {
     fail("workflow inventory is missing or unbounded");
   }
-  const enforcingWorkflows = value.workflows
-    .map((workflow, index) => {
-      const item = record(workflow, `workflows[${index}]`);
-      exactKeys(item, ["path", "source"], `workflows[${index}]`);
-      const path = canonicalRepositoryPath(
-        item.path,
-        `workflows[${index}].path`,
-      );
-      if (
-        !path.startsWith(".github/workflows/") ||
-        !/\.ya?ml$/u.test(path) ||
-        typeof item.source !== "string" ||
-        Buffer.byteLength(item.source) > MAX_WORKFLOW_BYTES
-      ) {
-        fail(`workflows[${index}] is invalid`);
-      }
-      return { path, source: item.source };
-    })
-    .filter((workflow) =>
-      workflowEnforcesReviewAttribution(workflow.source, config),
-    );
+  const enforcingWorkflows = workflows.flatMap(({ path, source }) => {
+    if (!/\bpull_request_review\b/u.test(source)) return [];
+    const policy = reachableReviewPolicy(path, indexed, config);
+    return policy.runsValidator ? [{ path, ...policy }] : [];
+  });
   const incompatibleWorkflows = enforcingWorkflows.filter(
-    ({ source }) => !source.includes(config.writerMarker),
+    ({ acceptsWriter }) => !acceptsWriter,
   );
   const proofValid = validProofReview(value.proofReview, config);
   const policyMentionsWriter = value.policy.includes(config.writerMarker);
@@ -262,6 +322,26 @@ function ghText(endpoint) {
   ]);
 }
 
+function boundedDirectory(endpoint, field) {
+  const entries = ghJson(endpoint);
+  if (!Array.isArray(entries) || entries.length > MAX_DIRECTORY_ENTRIES) {
+    fail(`${field} is missing or unbounded`);
+  }
+  return entries;
+}
+
+function validateContentFile(entry, path, field) {
+  if (
+    entry?.type !== "file" ||
+    entry.path !== path ||
+    !Number.isSafeInteger(entry.size) ||
+    entry.size < 0 ||
+    entry.size > MAX_WORKFLOW_BYTES
+  ) {
+    fail(`${field} is invalid`);
+  }
+}
+
 export function readLiveReviewCompatibility(configuration = CONFIG) {
   const config = validateConfiguration(configuration);
   const ref = ghJson(
@@ -269,18 +349,16 @@ export function readLiveReviewCompatibility(configuration = CONFIG) {
   );
   const branchSha = ref?.object?.sha;
   if (!SHA_RE.test(branchSha ?? "")) fail("integration branch has no full SHA");
-  const tree = ghJson(
-    `repos/${config.repositoryId}/git/trees/${branchSha}?recursive=1`,
-  );
-  if (tree?.truncated || !Array.isArray(tree?.tree)) {
-    fail("target repository workflow tree is missing or truncated");
-  }
-  const workflowEntries = tree.tree.filter(
+  const atRef = (path) =>
+    `repos/${config.repositoryId}/contents/${canonicalRepositoryPath(path, "GitHub content path")}?ref=${branchSha}`;
+  const workflowEntries = boundedDirectory(
+    atRef(".github/workflows"),
+    "target repository workflow directory",
+  ).filter(
     (entry) =>
-      entry?.type === "blob" &&
+      entry?.type === "file" &&
       typeof entry.path === "string" &&
-      entry.path.startsWith(".github/workflows/") &&
-      /\.ya?ml$/u.test(entry.path),
+      WORKFLOW_PATH_RE.test(entry.path),
   );
   if (
     workflowEntries.length === 0 ||
@@ -294,20 +372,67 @@ export function readLiveReviewCompatibility(configuration = CONFIG) {
   ) {
     fail("target repository workflow inventory is missing or unbounded");
   }
-  const atRef = (path) =>
-    `repos/${config.repositoryId}/contents/${canonicalRepositoryPath(path, "GitHub content path")}?ref=${branchSha}`;
+  const automationFiles = workflowEntries.map((entry) => ({
+    path: entry.path,
+    source: ghText(atRef(entry.path)),
+  }));
+  const indexed = new Map(automationFiles.map((file) => [file.path, file]));
+  const pending = automationFiles
+    .filter(({ source }) => /\bpull_request_review\b/u.test(source))
+    .flatMap(({ source }) => localUsesTargets(source));
+  const visitedTargets = new Set();
+  while (pending.length > 0) {
+    const target = pending.pop();
+    if (visitedTargets.has(target)) continue;
+    visitedTargets.add(target);
+    if (WORKFLOW_PATH_RE.test(target)) {
+      const workflow = indexed.get(target);
+      if (!workflow) {
+        fail(`referenced workflow is missing from its directory: ${target}`);
+      }
+      pending.push(...localUsesTargets(workflow.source));
+      continue;
+    }
+    const manifests = boundedDirectory(
+      atRef(target),
+      `local action directory ${target}`,
+    ).filter(
+      (entry) =>
+        entry?.type === "file" &&
+        typeof entry.path === "string" &&
+        [`${target}/action.yml`, `${target}/action.yaml`].includes(entry.path),
+    );
+    if (manifests.length !== 1) {
+      fail(`local action manifest is missing or ambiguous: ${target}`);
+    }
+    const [manifest] = manifests;
+    validateContentFile(
+      manifest,
+      manifest.path,
+      `local action manifest ${manifest.path}`,
+    );
+    if (!indexed.has(manifest.path)) {
+      const file = {
+        path: manifest.path,
+        source: ghText(atRef(manifest.path)),
+      };
+      indexed.set(file.path, file);
+      automationFiles.push(file);
+      if (automationFiles.length > MAX_AUTOMATION_FILES) {
+        fail("automation inventory is missing or unbounded");
+      }
+      pending.push(...localUsesTargets(file.source));
+    }
+  }
   return assessReviewCompatibility(
     {
+      automationFiles,
       branchSha,
       policy: ghText(atRef(config.policyDocument)),
       proofReview: ghJson(
         `repos/${config.repositoryId}/pulls/${config.forwardProof.pullRequest}/reviews/${config.forwardProof.reviewId}`,
       ),
       validator: ghText(atRef(config.validatorPath)),
-      workflows: workflowEntries.map((entry) => ({
-        path: entry.path,
-        source: ghText(atRef(entry.path)),
-      })),
     },
     config,
   );


### PR DESCRIPTION
## Summary

Progresses #36.

Hardens the Eliza review compatibility preflight after the post-merge Copilot findings on #59:

- discovers workflows through the SHA-pinned, scoped Contents API instead of a recursive repository tree;
- follows only reachable local reusable workflows and composite actions from pull-request-review roots;
- fails closed on missing or ambiguous local targets and bounded inventory limits;
- preserves unrelated review automation as non-blocking.

This addresses the unique findings in [the delegated-enforcement thread](https://github.com/elizaOS/slopdotcash/pull/59#discussion_r3788046968) and [the recursive-tree thread](https://github.com/elizaOS/slopdotcash/pull/59#discussion_r3788046983). The second delegated-enforcement comment was a duplicate.

## Validation

- `bun install --frozen-lockfile` — passed with Bun 1.3.14
- `bun test skill-tests/review-preflight.test.ts skill-tests/project-skills.test.ts` — 22 passed
- `bun run test` — 35 Vitest files / 348 tests and 54 Bun skill tests passed
- `bun run format:check` — passed
- `bun run lint:check` — passed
- `bun run typecheck` — passed
- `bun run projects:check` — passed
- `bun run evaluations:check` — passed
- `bun run cycles:check` — passed
- `bun run protocol:check` — passed
- `bun run audit:dependencies` — no production vulnerabilities
- `bun run build` — passed
- `bun run test:e2e` — 32 passed; 4 baseline failures across the four viewports because the current Delta Star data from #72 says “Advance machine-checked Reed–Solomon proximity work” while the unchanged test still expects “Advance ArkLib machine-checked”. This branch does not change site, project, or E2E files.

## Evidence

- Before screenshots: N/A - backend preflight traversal only
- After screenshots: N/A - backend preflight traversal only
- Walkthrough video: N/A - no user interface change
- Backend logs: N/A - no deployed service path
- Frontend console/network logs: N/A - no frontend change
- Real-LLM trajectory: N/A - deterministic GitHub metadata classifier
- Domain artifacts: live preflight at Eliza develop SHA `658cd1f4f77119f652a881e4995ce8ab4716dd4b` returned `safeToPublish: true`, `enforcement: not-wired-for-reviews`, `status: supported-with-documentation-drift`, with the known forward proof valid

## Contribution provenance

- AI assistance: Yes
- AI provider/model: OpenAI gpt-5.6-sol, medium reasoning
- Client / agent tooling: Codex Desktop
- Contribution skill revision: `elizaOS/slopdotcash@f5d09ece24e47d47df6695813e1635b9ba815c80:skills/contribute-to-eliza`
- Attribution status: self-reported

## Slop protocol changes

- Project manifest (`projects/<id>/project.json`): N/A - unchanged
- Contributor skill (`skills/contribute-to-<id>/`): Eliza preflight script only
- Isolated reviewer skill (`skills/review-<id>-contributions/`): N/A - unchanged
- Evaluated-contribution award (`evaluations/<id>/award-*.json`): N/A - unchanged
- Reward-cycle transition (`cycles/<id>/<YYYY-MM>/`): N/A - unchanged

## Safety review

- [x] No private key, seed phrase, API token, raw private trajectory, or secret was added.
- [x] Untrusted project code is not executed with repository or deployment credentials.
- [x] New telemetry is bounded, disclosed, project-attributed, and covered by adversarial tests.
- [x] Money state is derived from validated manifests and finalized on-chain evidence, not a transaction signature alone.