### PR TITLE
Update the Proximity Prize browser contract

### DIFF
--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -134,7 +134,7 @@ test("discovers both reward models and a score-ranked global ledger", async ({
     deltaCard.getByText("external prize", { exact: true }),
   ).toBeVisible();
   await expect(
-    deltaCard.getByText(/Advance ArkLib's machine-checked/u),
+    deltaCard.getByText(/Advance machine-checked Reed–Solomon/u),
   ).toBeVisible();
   const [gridBox, elizaBox, deltaBox] = await Promise.all([
     page.locator(".project-grid").boundingBox(),


### PR DESCRIPTION
## Summary
- replace the stale ArkLib card-copy assertion after the repository migration
- bind the browser test to the current Proximity Prize project description

## Verification
- format, lint, and typecheck pass
- focused homepage browser test passes at wide desktop, desktop, tablet, and 320px mobile
- live ledger regenerated against the migrated repository registry