### PR TITLE
Distill contributor profiles for faster review

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,7 +43,6 @@ import {
 } from "./lib/project-schema.mjs";
 import {
   createProjectView,
-  formatCapUsageLine,
   type ProjectContributor,
   type ProjectView,
   projectCycleHasOpened,
@@ -62,6 +61,7 @@ const SNAPSHOT_TIMEOUT_MS = 12_000;
 const SNAPSHOT_RETRIES = 1;
 const MAX_LEADERBOARD_BYTES = 32 * 1024 * 1024;
 const MAX_CYCLE_INDEX_BYTES = 8 * 1024 * 1024;
+const PROFILE_EVENT_PREVIEW_LIMIT = 10;
 
 export function publicFooterDomain(
   hostname: string,
@@ -1202,58 +1202,6 @@ function ProjectPage({
   );
 }
 
-function ContributorProgress({
-  accepted,
-  paidMinor,
-  wallet,
-}: {
-  accepted: number;
-  paidMinor: bigint;
-  wallet: CycleIndexEntry["contributors"][number]["wallet"] | undefined;
-}) {
-  const walletSource = wallet
-    ? "sourceIssueId" in wallet
-      ? "GitHub wallet claim recorded"
-      : "sourceClaimId" in wallet
-        ? "Recovered wallet claim recorded"
-        : "GitHub profile claim recorded"
-    : "No public claim; database recovery can restore a prior claim";
-  return (
-    <section className="section contributor-progress">
-      <h2>Progress</h2>
-      <ol>
-        <li>
-          <strong>Work</strong>
-          <span>
-            {accepted > 0
-              ? `${accepted} accepted outcome${accepted === 1 ? "" : "s"}`
-              : "No accepted outcome yet"}
-          </span>
-        </li>
-        <li>
-          <strong>Trace</strong>
-          <span>
-            Required for every agent run, retained permanently, and visible only
-            to Slop operators
-          </span>
-        </li>
-        <li>
-          <strong>Wallet</strong>
-          <span>{walletSource}</span>
-        </li>
-        <li>
-          <strong>Payment</strong>
-          <span>
-            {paidMinor > 0n
-              ? `${formatMicroUsdc(paidMinor.toString())} paid`
-              : "Nothing paid yet"}
-          </span>
-        </li>
-      </ol>
-    </section>
-  );
-}
-
 function ProfilePage({
   login,
   state,
@@ -1292,11 +1240,16 @@ function ProfilePage({
       )
       .map((opportunity) => ({ opportunity, project: view.project })),
   );
-  const globalLeader = createGlobalLeaders(
+  const globalLeaders = createGlobalLeaders(
     state.snapshot,
     state.views,
     state.cycleIndex,
-  ).find((leader) => leader.actor.login.toLowerCase() === login.toLowerCase());
+  );
+  const globalRank = globalLeaders.findIndex(
+    (leader) => leader.actor.login.toLowerCase() === login.toLowerCase(),
+  );
+  const globalLeader =
+    globalRank === -1 ? undefined : globalLeaders[globalRank];
   if (
     matches.length === 0 &&
     history.length === 0 &&
@@ -1349,60 +1302,59 @@ function ProfilePage({
   );
   const wallet = history.find(({ contributor }) => contributor.wallet)
     ?.contributor.wallet;
+  const featuredEvents = events.slice(0, PROFILE_EVENT_PREVIEW_LIMIT);
+  const remainingEvents = events.slice(PROFILE_EVENT_PREVIEW_LIMIT);
   return (
     <main className="shell route-main profile-page">
       <DataNotice state={state} retry={retry} />
       <p className="breadcrumb">
-        <Link href="/">Leaderboard</Link>
-        <span>/</span>
-        {actor.login}
+        <Link href="/">Back to leaderboard</Link>
       </p>
       <section className="profile-hero">
         <Avatar actor={actor} size="large" />
-        <div>
+        <div className="profile-identity">
           <h1>{actor.login}</h1>
           <div className="profile-links">
             <ExternalLinkAnchor href={actor.url}>
-              GitHub profile <ExternalLink aria-hidden="true" size={15} />
+              GitHub <ExternalLink aria-hidden="true" size={15} />
             </ExternalLinkAnchor>
             {wallet ? (
               <ExternalLinkAnchor href={wallet.sourceUrl}>
-                GitHub wallet claim · {wallet.address}{" "}
+                Wallet · {wallet.address}{" "}
                 <ExternalLink aria-hidden="true" size={15} />
               </ExternalLinkAnchor>
             ) : (
-              <span>
-                Wallet not claimed on GitHub · database recovery available
-              </span>
+              <span>Wallet not linked</span>
             )}
           </div>
         </div>
       </section>
       <div className="profile-totals">
+        {globalRank >= 0 ? (
+          <div>
+            <strong>#{globalRank + 1}</strong>
+            <span>overall rank</span>
+          </div>
+        ) : null}
         <div>
           <strong>{score}</strong>
-          <span>recorded score</span>
+          <span>all-time score</span>
         </div>
         <div>
           <strong>{formatCompact(acceptedOutcomes)}</strong>
-          <span>current accepted outcomes</span>
+          <span>accepted this month</span>
         </div>
         <div>
           <strong>{formatMicroUsdc(projected.toString())}</strong>
-          <span>current simulated share</span>
+          <span>monthly estimate</span>
         </div>
         <div>
           <strong>{formatMicroUsdc(paid.toString())}</strong>
-          <span>total paid</span>
+          <span>paid</span>
         </div>
       </div>
-      <ContributorProgress
-        accepted={acceptedOutcomes}
-        paidMinor={paid}
-        wallet={wallet}
-      />
-      <section className="section">
-        <div className="section-heading">
+      <section className="section profile-section">
+        <div className="profile-section-heading">
           <h2>Projects</h2>
         </div>
         <div className="profile-projects">
@@ -1410,29 +1362,25 @@ function ProfilePage({
             <EmptyState text="No accepted project score in the current cycles yet." />
           ) : (
             matches.map(({ leader, view }) => {
-              const capLine = formatCapUsageLine(leader.capUsage);
               return (
                 <div className="profile-project-block" key={view.project.id}>
                   <Link href={`/projects/${view.project.slug}`}>
-                    <span>
+                    <span className="profile-project-name">
                       <strong>{view.project.name}</strong>
                       <small>{view.cycle.id}</small>
                     </span>
-                    <span>
+                    <span className="profile-project-stat">
                       <strong>{leader.score} score</strong>
                       <small>
                         {leader.acceptedOutcomeCount} accepted outcome
                         {leader.acceptedOutcomeCount === 1 ? "" : "s"}
                       </small>
                     </span>
-                    <span>
+                    <span className="profile-project-stat">
                       <RewardValue leader={leader} />
                     </span>
                     <ChevronRight aria-hidden="true" />
                   </Link>
-                  {capLine ? (
-                    <p className="profile-cap-line">{capLine}</p>
-                  ) : null}
                 </div>
               );
             })
@@ -1440,18 +1388,18 @@ function ProfilePage({
         </div>
       </section>
       {opportunities.length > 0 ? (
-        <section className="section">
-          <div className="section-heading">
+        <section className="section profile-section">
+          <div className="profile-section-heading">
             <h2>Open work</h2>
-            <p>These actions can still change the score if they qualify.</p>
+            <span>{opportunities.length} available</span>
           </div>
           <OpportunityList opportunities={opportunities} />
         </section>
       ) : null}
       {history.length > 0 ? (
-        <section className="section">
-          <div className="section-heading">
-            <h2>Rewards</h2>
+        <section className="section profile-section">
+          <div className="profile-section-heading">
+            <h2>Past cycles</h2>
           </div>
           <div className="profile-projects">
             {history.map(({ contributor, cycle }) => (
@@ -1481,11 +1429,20 @@ function ProfilePage({
           </div>
         </section>
       ) : null}
-      <section className="section">
-        <div className="section-heading">
+      <section className="section profile-section">
+        <div className="profile-section-heading">
           <h2>Accepted work</h2>
+          <span>
+            {events.length} recent record{events.length === 1 ? "" : "s"}
+          </span>
         </div>
-        <EventList events={events} />
+        <EventList events={featuredEvents} />
+        {remainingEvents.length > 0 ? (
+          <details className="profile-work-more">
+            <summary>View all {events.length} records</summary>
+            <EventList events={remainingEvents} />
+          </details>
+        ) : null}
       </section>
     </main>
   );
@@ -1537,8 +1494,7 @@ function EventList({
 }: {
   events: Array<{ event: ScoreEvent; project: ProjectDefinition }>;
 }) {
-  if (events.length === 0)
-    return <EmptyState text="No accepted evidence is available." />;
+  if (events.length === 0) return <EmptyState text="No accepted work yet." />;
   return (
     <div className="event-list">
       {events.map(({ event, project }) => (

--- a/src/styles.css
+++ b/src/styles.css
@@ -1090,7 +1090,7 @@ small {
 .profile-hero h1 {
   margin: 0 0 8px;
   font-size: clamp(44px, 6vw, 72px);
-  letter-spacing: -0.055em;
+  letter-spacing: -0.04em;
   line-height: 0.98;
 }
 
@@ -1145,7 +1145,7 @@ small {
   margin: 0;
   font-size: clamp(34px, 4.6vw, 52px);
   font-weight: 800;
-  letter-spacing: -0.055em;
+  letter-spacing: -0.04em;
   line-height: 1;
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -1046,14 +1046,6 @@ small {
   border-bottom: 0;
 }
 
-.profile-cap-line {
-  margin: 0;
-  padding: 0 20px 14px;
-  color: var(--muted);
-  font-size: 12px;
-  line-height: 1.4;
-}
-
 .event-list > a,
 .profile-projects > a,
 .profile-projects > .profile-project-block > a {
@@ -1084,22 +1076,22 @@ small {
 }
 
 .event-list strong {
-  overflow: hidden;
   font-size: 13px;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  line-height: 1.4;
 }
 
 .profile-hero {
   display: flex;
   align-items: center;
-  gap: 26px;
-  padding-block: 8px 36px;
+  gap: 22px;
+  padding-block: 4px 30px;
 }
 
 .profile-hero h1 {
   margin: 0 0 8px;
-  font-size: clamp(48px, 7vw, 88px);
+  font-size: clamp(44px, 6vw, 72px);
+  letter-spacing: -0.055em;
+  line-height: 0.98;
 }
 
 .profile-hero a {
@@ -1113,9 +1105,10 @@ small {
 
 .profile-links {
   display: flex;
-  max-width: min(720px, 72vw);
-  flex-direction: column;
-  gap: 7px;
+  max-width: min(800px, 74vw);
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px 16px;
 }
 
 .profile-links a {
@@ -1124,25 +1117,95 @@ small {
 
 .profile-totals {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
   border-block: 1px solid var(--line);
 }
 
 .profile-totals div {
-  padding-block: 18px;
+  padding: 18px 14px 18px 0;
 }
 
-.profile-projects > a {
+.profile-section {
+  padding-block: 46px;
+}
+
+.profile-section + .profile-section {
+  border-top: 1px solid var(--line);
+}
+
+.profile-section-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 18px;
+}
+
+.profile-section-heading h2 {
+  margin: 0;
+  font-size: clamp(34px, 4.6vw, 52px);
+  font-weight: 800;
+  letter-spacing: -0.055em;
+  line-height: 1;
+}
+
+.profile-section-heading > span {
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.profile-page .event-list,
+.profile-page .profile-projects {
+  margin-bottom: 0;
+  border-width: 1px 0;
+  border-radius: 0;
+  background: transparent;
+}
+
+.profile-projects > a,
+.profile-projects > .profile-project-block > a {
   grid-template-columns: minmax(160px, 1fr) minmax(130px, 0.6fr) minmax(
       120px,
       0.5fr
     ) auto;
 }
 
-.profile-projects > a > span {
+.profile-projects > a > span,
+.profile-projects > .profile-project-block > a > span {
   display: flex;
   flex-direction: column;
   font-size: 12px;
+}
+
+.profile-page .event-list > a,
+.profile-page .profile-projects > a,
+.profile-page .profile-projects > .profile-project-block > a {
+  padding-inline: 0;
+}
+
+.profile-work-more {
+  margin-top: 18px;
+}
+
+.profile-work-more summary {
+  width: fit-content;
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  border-bottom: 2px solid var(--orange);
+  font-size: 12px;
+  font-weight: 750;
+  list-style: none;
+}
+
+.profile-work-more summary::-webkit-details-marker {
+  display: none;
+}
+
+.profile-work-more[open] summary {
+  margin-bottom: 18px;
 }
 
 .event-points {
@@ -1466,7 +1529,6 @@ small {
 }
 
 .simple-heading h2,
-.contributor-progress h2,
 .owner-section h2 {
   margin: 0;
   font-size: clamp(34px, 5vw, 58px);
@@ -1534,27 +1596,6 @@ small {
   font-weight: 700;
 }
 
-.contributor-progress {
-  padding-bottom: 16px;
-}
-
-.contributor-progress ol {
-  margin: 28px 0 0;
-  padding: 0;
-  border-top: 1px solid var(--line);
-  list-style: none;
-}
-
-.contributor-progress li {
-  display: grid;
-  grid-template-columns: minmax(100px, 0.3fr) minmax(0, 1fr);
-  gap: 24px;
-  padding: 18px 0;
-  border-bottom: 1px solid var(--line);
-  font-size: 13px;
-}
-
-.contributor-progress span,
 .profile-links > span {
   color: var(--muted);
 }
@@ -2131,10 +2172,23 @@ small {
 
   .profile-totals {
     grid-template-columns: repeat(2, 1fr);
+    column-gap: 18px;
   }
 
   .profile-totals div {
-    border-bottom: 1px solid var(--line);
+    padding: 16px 8px 16px 0;
+  }
+
+  .profile-section {
+    padding-block: 38px;
+  }
+
+  .profile-section-heading {
+    margin-bottom: 16px;
+  }
+
+  .profile-section-heading h2 {
+    font-size: clamp(32px, 10vw, 42px);
   }
 
   .install-panel {
@@ -2159,8 +2213,30 @@ small {
   }
 
   .profile-hero {
+    align-items: center;
+    gap: 14px;
+    padding-bottom: 24px;
+  }
+
+  .profile-hero .avatar-large {
+    width: 56px;
+    height: 56px;
+  }
+
+  .profile-identity {
+    min-width: 0;
+  }
+
+  .profile-hero h1 {
+    overflow-wrap: anywhere;
+    font-size: clamp(34px, 11.2vw, 52px);
+  }
+
+  .profile-links {
+    max-width: 100%;
     align-items: flex-start;
     flex-direction: column;
+    gap: 5px;
   }
 
   .agent-handoff {
@@ -2168,12 +2244,57 @@ small {
     flex-direction: column;
   }
 
-  .profile-projects {
-    overflow-x: auto;
+  .profile-page .profile-projects {
+    overflow: visible;
   }
 
-  .profile-projects > a {
-    min-width: 620px;
+  .profile-page .profile-projects > a,
+  .profile-page .profile-projects > .profile-project-block > a {
+    min-width: 0;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 8px 14px;
+    padding-block: 14px;
+  }
+
+  .profile-page .profile-projects > a > span:nth-child(2),
+  .profile-page .profile-projects > a > span:nth-child(3),
+  .profile-page
+    .profile-projects
+    > .profile-project-block
+    > a
+    > span:nth-child(2),
+  .profile-page
+    .profile-projects
+    > .profile-project-block
+    > a
+    > span:nth-child(3) {
+    grid-column: 1;
+  }
+
+  .profile-page .profile-projects > a > svg,
+  .profile-page .profile-projects > .profile-project-block > a > svg {
+    grid-column: 2;
+    grid-row: 1 / 4;
+  }
+
+  .profile-page .profile-project-stat {
+    align-items: baseline;
+    flex-direction: row;
+    gap: 8px;
+  }
+
+  .profile-project-stat small {
+    margin-top: 0;
+  }
+
+  .profile-page .event-list > a {
+    grid-template-columns: minmax(3.5rem, auto) minmax(0, 1fr) auto;
+    gap: 10px;
+    padding-block: 14px;
+  }
+
+  .profile-page .event-list strong {
+    font-size: 12px;
   }
 
   .cycle-number {
@@ -2189,7 +2310,6 @@ small {
     flex-direction: column;
   }
 
-  .contributor-progress li,
   .allocation-rows fieldset {
     grid-template-columns: 1fr;
   }

--- a/tests/app.test.tsx
+++ b/tests/app.test.tsx
@@ -493,13 +493,13 @@ describe("public records", () => {
     ).toBeInTheDocument();
     const totals = document.querySelector(".profile-totals");
     expect(totals).not.toBeNull();
-    expect(totals).toHaveTextContent("34recorded score");
+    expect(totals).toHaveTextContent("34all-time score");
     expect(
       screen.getByText("Harden the proximity manifest loader"),
     ).toBeVisible();
   });
 
-  it("shows a contributor's cross-project score, tokens, projections, and evidence", async () => {
+  it("shows a contributor's cross-project score, estimate, and accepted work", async () => {
     route("/contributors/finish-line");
     mockSnapshot();
     render(<App />);
@@ -524,8 +524,14 @@ describe("public records", () => {
         "Add verified screenshot, video, or log evidence before merge.",
       ),
     ).toBeInTheDocument();
-    expect(screen.getAllByText(/2026-07 scoring ·/).length).toBeGreaterThan(0);
+    expect(screen.queryAllByText(/2026-07 scoring ·/)).toHaveLength(0);
     expect(screen.getByText(/\+6 if it verifies/)).toBeInTheDocument();
+    expect(screen.getByText("all-time score")).toBeInTheDocument();
+    expect(screen.getByText("monthly estimate")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: "Progress" }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/retained permanently/u)).not.toBeInTheDocument();
   });
 
   it("shows opportunity-only contributors that have still-open guidance", async () => {
@@ -669,7 +675,7 @@ describe("public records", () => {
     render(<App />);
 
     const wallet = await screen.findByRole("link", {
-      name: /GitHub wallet claim · 11111111111111111111111111111111/i,
+      name: /Wallet · 11111111111111111111111111111111/i,
     });
     expect(wallet).toHaveAttribute("href", expect.stringContaining("/blob/"));
   });

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -434,7 +434,28 @@ test("renders contributor and cycle records from validated public data", async (
     waitUntil: "networkidle",
   });
   await expect(page.getByRole("heading", { name: actor.login })).toBeVisible();
-  await expect(page.getByText("total paid")).toBeVisible();
+  await expect(
+    page.locator(".profile-totals").getByText("paid", { exact: true }),
+  ).toBeVisible();
+  await expect(page.getByText("all-time score", { exact: true })).toBeVisible();
+  await expect(
+    page.getByText("monthly estimate", { exact: true }),
+  ).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Progress" })).toHaveCount(0);
+  const acceptedRecordCount = snapshot.ledger.filter(
+    (event) => event.actor.id === actor.id,
+  ).length;
+  if (acceptedRecordCount > 10) {
+    const acceptedSection = page
+      .locator(".profile-section")
+      .filter({ has: page.getByRole("heading", { name: "Accepted work" }) });
+    await expect(
+      acceptedSection.locator(":scope > .event-list > a"),
+    ).toHaveCount(10);
+    await expect(
+      acceptedSection.getByText(`View all ${acceptedRecordCount} records`),
+    ).toBeVisible();
+  }
 
   const archived = cycles.cycles.find((cycle) =>
     cycle.contributors.some((entry) => entry.actor.id === actor.id),


### PR DESCRIPTION
Closes #77.

## What changed

- Rebuilt contributor profiles around identity, score, project breakdown, and accepted work.
- Removed redundant explanatory copy and condensed the accepted-work ledger.
- Added a clear remaining-record disclosure after the first ten entries.
- Tightened desktop spacing and made the page fit cleanly at 320 px with two-column totals and no horizontal overflow.
- Added unit and four-viewport browser assertions for the new information contract.

## Why

The previous page made the most useful facts harder to scan and spent too much screen area explaining the interface. This keeps the underlying public data and score logic unchanged while making the profile useful at a glance.

## Verification

- `bun run test`: 35 Vitest files / 348 tests and 54 Bun skill tests passed.
- `bun run typecheck`: passed.
- `bun run lint:check`: passed.
- `bun run build`: passed, including skill packaging and the 149-file public manifest.
- Fresh live GitHub snapshot: 93 leaders, 2,420 score events, 100 GraphQL requests, canonical three-repository registry.
- Full Playwright suite against real `wrangler pages dev`: 36/36 across wide desktop, desktop, tablet, and 320 px mobile.
- Manual browser review: 1440 px, 390 px, and 320 px; no horizontal overflow, no console/page errors, and the 320 px totals remain two columns.
- Impeccable detector: no anti-pattern findings.

## Generated-data note

A first post-rebase browser run correctly failed closed because the ignored local `public/data/leaderboard.json` predated the Proximity registry migration. Regenerating the complete live snapshot resolved it; no validator weakening or source workaround was needed. The mistaken source-regression report #78 is closed with the corrected diagnosis.

## Safety

- Score calculation is unchanged.
- Payouts remain disabled.
- Diff is limited to `src/App.tsx`, `src/styles.css`, `tests/app.test.tsx`, and `tests/e2e/site.spec.ts`.