### PR TITLE
fix: serialize Pages browser verification

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -14,6 +14,10 @@ export default defineConfig({
   timeout: 45_000,
   expect: { timeout: 10_000 },
   fullyParallel: true,
+  // Wrangler's Pages proxy can terminate while serving concurrent browser
+  // workers. Keep one browser worker so the production-like server remains
+  // available for the complete desktop/mobile matrix.
+  workers: 1,
   retries: process.env.CI ? 2 : 0,
   reporter: process.env.CI ? [["html", { open: "never" }], ["list"]] : "list",
   use: {

--- a/scripts/deployment-contract.test.mjs
+++ b/scripts/deployment-contract.test.mjs
@@ -33,6 +33,10 @@ const pagesHeaders = readFileSync(
   join(packageRoot, "public", "_headers"),
   "utf8",
 );
+const playwrightConfiguration = readFileSync(
+  join(packageRoot, "playwright.config.ts"),
+  "utf8",
+);
 const qualityJob = workflow.slice(
   workflow.indexOf("\n  quality:"),
   workflow.indexOf("\n  deploy:"),
@@ -109,6 +113,8 @@ describe("slop.cash deployment contract", () => {
     expect(packageManifest.scripts.build).toContain(
       "node scripts/dist-manifest.mjs create dist",
     );
+    expect(playwrightConfiguration).toContain("workers: 1");
+    expect(qualityJob).toContain("run: bun run test:e2e");
   });
 
   it("keeps every release path restricted to develop", () => {


### PR DESCRIPTION
## Summary
- keep the Wrangler Pages proxy behind one Playwright worker
- lock serial browser execution into the deployment contract

## Evidence
- production run #31868629322 passed all quality steps through build, then the Pages proxy exited under two browser workers after 2 passing cases
- the same 36-case matrix passes with one worker locally
- focused deployment contract, typecheck, lint, and format checks pass

Production deploy remains fail-closed until this fix passes on a fresh trusted develop run.