### PR TITLE
feat: replace issue wallet claims with authenticated registry

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -350,12 +350,14 @@ jobs:
             --remote \
             --json \
             --config workers/identity/wrangler.toml \
-            --command "SELECT type, name FROM sqlite_schema WHERE name IN ('identity_assertions','identity_oauth_flows','private_audit_events','run_progress_events','trace_objects','trace_read_grants','trace_runs','trace_upload_intents','trace_uploads','wallet_claims','wallet_claims_no_delete','wallet_claims_no_update') ORDER BY type, name" \
+            --command "SELECT type, name FROM sqlite_schema WHERE name IN ('identity_assertions','identity_oauth_flows','private_audit_events','run_progress_events','trace_objects','trace_read_grants','trace_runs','trace_upload_intents','trace_uploads','wallet_claims','wallet_claims_no_delete','wallet_claims_no_update','wallet_claims_one_root_per_actor','wallet_claims_one_successor') ORDER BY type, name" \
             > "$schema_response"
           node - "$schema_response" <<'NODE'
           const { readFileSync } = require("node:fs");
           const value = JSON.parse(readFileSync(process.argv[2], "utf8"));
           const expected = [
+            "index:wallet_claims_one_root_per_actor",
+            "index:wallet_claims_one_successor",
             "table:identity_assertions",
             "table:identity_oauth_flows",
             "table:private_audit_events",
@@ -380,11 +382,19 @@ jobs:
           }
           NODE
 
-          ./node_modules/.bin/wrangler deploy \
+          # Upload and promote a version without rewriting the existing custom
+          # domain or cron configuration. The production token intentionally
+          # has no zone-level Workers Routes permission.
+          ./node_modules/.bin/wrangler versions upload \
             --config workers/identity/wrangler.toml \
             --minify \
             --tag="$GITHUB_SHA" \
             --message="slop.cash release $GITHUB_SHA"
+          ./node_modules/.bin/wrangler versions deploy \
+            --name slop-identity \
+            --version-tag="$GITHUB_SHA@100%" \
+            --message="slop.cash release $GITHUB_SHA" \
+            --yes
 
           identity_versions="$RUNNER_TEMP/slop-identity-versions.json"
           identity_deployment="$RUNNER_TEMP/slop-identity-deployment.json"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,9 +179,10 @@ and safe metadata, never the trace body.
   reason. Wallet changes reset the review deadline. Missing wallets stay
   unclaimed; suspicious rows stay visible as held or excluded. Related-party
   money needs separate approval.
-- A wallet claim is one open issue authored by the contributor and bound to its
-  exact GitHub identity and body snapshot. An immutable profile README marker
-  or immutable, actor-bound D1 claim is a compatibility fallback. None proves
+- A wallet claim is an authenticated, actor-bound, append-only D1 record. An
+  address change creates an immutable successor and resets review; it never
+  edits or deletes prior records. Historical GitHub issue and immutable profile
+  README observations are migration-only compatibility inputs. None proves
   cryptographic wallet ownership.
 - Settlement tools create unsigned Solana mainnet USDC plans only. They never
   read keys, sign, broadcast, or claim success optimistically.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,9 +179,10 @@ and safe metadata, never the trace body.
   reason. Wallet changes reset the review deadline. Missing wallets stay
   unclaimed; suspicious rows stay visible as held or excluded. Related-party
   money needs separate approval.
-- A wallet claim is one open issue authored by the contributor and bound to its
-  exact GitHub identity and body snapshot. An immutable profile README marker
-  or immutable, actor-bound D1 claim is a compatibility fallback. None proves
+- A wallet claim is an authenticated, actor-bound, append-only D1 record. An
+  address change creates an immutable successor and resets review; it never
+  edits or deletes prior records. Historical GitHub issue and immutable profile
+  README observations are migration-only compatibility inputs. None proves
   cryptographic wallet ownership.
 - Settlement tools create unsigned Solana mainnet USDC plans only. They never
   read keys, sign, broadcast, or claim success optimistically.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -126,13 +126,14 @@ award PR.
 
 ### Get paid
 
-After a contribution, the same skill optionally registers a Solana public
-address in one open `Slop wallet claim` issue authored by the contributor in
-`elizaOS/slopdotcash`. At month close, the platform binds the issue author,
-node id, update time, and body digest into a 14-day proposal. Immutable GitHub
-profile README markers remain a compatibility fallback. After approval, the
-creator signs the exact transfer plan externally. Only finalized, reconciled
-USDC balance changes become “paid.”
+After a contribution, the same skill can optionally register a Solana public
+address through one-time GitHub OAuth. Slop stores an actor-bound, append-only
+claim in D1 and publishes only its safe metadata and digest. Address changes
+append a superseding record and restart the 14-day review; they never overwrite
+history. Historical GitHub issue claims and immutable profile README markers
+are migration-only compatibility inputs, not the live registry. After
+approval, the creator signs the exact transfer plan externally. Only finalized,
+reconciled USDC balance changes become “paid.”
 
 ## Creator journey
 

--- a/backend/trace/README.md
+++ b/backend/trace/README.md
@@ -72,15 +72,20 @@ atomically, and cannot be replayed. Grant creation and successful reads append
 audit records. Responses are attachments with `no-store`, `nosniff`, and a
 deny-all content security policy.
 
-## Wallet fallback
+## Wallet registry
 
-GitHub-authored wallet-claim issues remain sufficient primary evidence. A Slop
-operator can record a D1 fallback with `POST /api/v1/operator/wallet-claims`.
-Wallet claim records are append-only; SQLite triggers reject updates and
-deletes. The metadata-only URL `GET /api/v1/wallet-claims/{claimId}` is public
-so a reward manifest can bind the claim ID, GitHub actor ID, address,
-observation time, and canonical record digest. This endpoint never exposes a
-trace or credential.
+Contributors authenticate through the same one-time GitHub OAuth bridge and
+append their claim with `POST /api/v1/wallet-claims`. `GET
+/api/v1/wallet-claims/current` returns only the authenticated contributor's
+current safe metadata; `GET /api/v1/wallet-claims/actors/{numericId}/current`
+and `GET /api/v1/wallet-claims/{claimId}` are public metadata receipts used by
+reward preparation. Wallet records are append-only; changes must name the exact
+current predecessor, unique lineage indexes reject forks, and SQLite triggers
+reject updates and deletes.
+
+The operator endpoint remains only for bounded migration of historical GitHub
+issue/profile observations and disaster recovery. No endpoint exposes a trace,
+OAuth capability, assertion, bearer token, or credential.
 
 ## Cloudflare provisioning
 

--- a/backend/trace/cloudflare-persistence.ts
+++ b/backend/trace/cloudflare-persistence.ts
@@ -646,4 +646,21 @@ export class CloudflareTracePersistence implements TracePersistence {
       .first<WalletClaimRow>();
     return row === null ? null : mapWalletClaim(row);
   }
+
+  async getCurrentWalletClaim(githubId: string): Promise<WalletClaim | null> {
+    const row = await this.db
+      .prepare(
+        `SELECT claim.* FROM wallet_claims AS claim
+         WHERE claim.github_user_id = ?
+           AND NOT EXISTS (
+             SELECT 1 FROM wallet_claims AS successor
+             WHERE successor.supersedes_claim_id = claim.id
+           )
+         ORDER BY claim.observed_at DESC, claim.created_at DESC
+         LIMIT 1`,
+      )
+      .bind(githubId)
+      .first<WalletClaimRow>();
+    return row === null ? null : mapWalletClaim(row);
+  }
 }

--- a/backend/trace/contracts.ts
+++ b/backend/trace/contracts.ts
@@ -128,7 +128,7 @@ export type WalletClaim = {
   githubId: string;
   githubLogin: string;
   walletAddress: string;
-  source: "github_issue" | "profile_readme" | "d1_fallback";
+  source: "github_issue" | "profile_readme" | "d1_registry";
   issueRepository: string | null;
   issueNumber: number | null;
   sourceBodySha256: string;
@@ -179,4 +179,5 @@ export interface TracePersistence {
     claim: WalletClaim,
   ): Promise<PersistenceResult<WalletClaim>>;
   getWalletClaim(claimId: string): Promise<WalletClaim | null>;
+  getCurrentWalletClaim(githubId: string): Promise<WalletClaim | null>;
 }

--- a/backend/trace/handler.ts
+++ b/backend/trace/handler.ts
@@ -1,3 +1,4 @@
+import { isSolanaAddress } from "../../src/lib/wallets";
 import { signApiToken, verifyApiToken } from "./auth";
 import {
   type AuthenticatedActor,
@@ -142,8 +143,114 @@ async function readPublicWalletClaim(
   const claim = await deps.persistence.getWalletClaim(claimId);
   if (claim === null) fail(404, "not_found", "Wallet claim not found");
   const response = json(200, publicWalletClaim(claim));
-  response.headers.set("cache-control", "public, max-age=300, immutable");
+  response.headers.set("cache-control", "public, max-age=31536000, immutable");
   return response;
+}
+
+async function readCurrentWalletClaim(
+  deps: TraceApiDependencies,
+  githubId: string,
+): Promise<Response> {
+  if (!/^\d+$/u.test(githubId))
+    fail(400, "invalid_request", "Invalid GitHub actor id");
+  const claim = await deps.persistence.getCurrentWalletClaim(githubId);
+  if (claim === null) fail(404, "not_found", "Wallet claim not found");
+  const response = json(200, publicWalletClaim(claim));
+  response.headers.set("cache-control", "public, max-age=60, must-revalidate");
+  return response;
+}
+
+async function createContributorWalletClaim(
+  request: Request,
+  actor: AuthenticatedActor,
+  deps: TraceApiDependencies,
+): Promise<Response> {
+  assertWriter(actor);
+  const body = await readJsonObject(request);
+  const walletAddress = body.address;
+  if (!isSolanaAddress(walletAddress)) {
+    fail(400, "invalid_request", "Invalid Solana address");
+  }
+  const requestedPredecessor = optionalString(
+    body,
+    "supersedesClaimId",
+    validIdentifier,
+  );
+  const current = await deps.persistence.getCurrentWalletClaim(actor.githubId);
+  if (
+    (current === null && requestedPredecessor !== null) ||
+    (current !== null && requestedPredecessor !== current.id)
+  ) {
+    fail(
+      409,
+      "stale_wallet_claim",
+      "Wallet claim changed; reload the current claim before submitting",
+    );
+  }
+  if (current?.walletAddress === walletAddress) {
+    return json(200, publicWalletClaim(current));
+  }
+
+  const observedAt = deps.now().toISOString();
+  const declaration = JSON.stringify({
+    schemaVersion: 1,
+    githubActorId: actor.githubId,
+    address: walletAddress,
+    supersedesClaimId: requestedPredecessor,
+  });
+  const sourceBodySha256 = await sha256Hex(
+    new TextEncoder().encode(declaration),
+  );
+  const canonicalRecord = JSON.stringify({
+    schemaVersion: 1,
+    githubActorId: actor.githubId,
+    githubLogin: actor.githubLogin,
+    address: walletAddress,
+    source: "d1_registry",
+    issueRepository: null,
+    issueNumber: null,
+    sourceBodySha256,
+    observedAt,
+    supersedesClaimId: requestedPredecessor,
+  });
+  const claim: WalletClaim = {
+    id: deps.randomId(),
+    githubId: actor.githubId,
+    githubLogin: actor.githubLogin,
+    walletAddress,
+    source: "d1_registry",
+    issueRepository: null,
+    issueNumber: null,
+    sourceBodySha256,
+    observedAt,
+    recordSha256: await sha256Hex(new TextEncoder().encode(canonicalRecord)),
+    supersedesClaimId: requestedPredecessor,
+    createdAt: observedAt,
+  };
+  const result = await deps.persistence.createWalletClaim(claim);
+  if (result.status === "conflict") {
+    fail(
+      409,
+      "stale_wallet_claim",
+      "Wallet claim changed; reload the current claim before submitting",
+    );
+  }
+  await deps.persistence.writeAudit({
+    id: deps.randomId(),
+    actorGithubId: actor.githubId,
+    action: "wallet_claim.created",
+    target: `wallet-claim:${result.value.id}`,
+    requestId: deps.randomId(),
+    createdAt: observedAt,
+    details: {
+      recordDigest: result.value.recordSha256,
+      supersedesClaimId: result.value.supersedesClaimId,
+    },
+  });
+  return json(
+    result.status === "created" ? 201 : 200,
+    publicWalletClaim(result.value),
+  );
 }
 
 async function createFallbackWalletClaim(
@@ -165,10 +272,7 @@ async function createFallbackWalletClaim(
   ) {
     fail(400, "invalid_request", "Invalid githubLogin");
   }
-  if (
-    typeof walletAddress !== "string" ||
-    !/^[1-9A-HJ-NP-Za-km-z]{32,44}$/u.test(walletAddress)
-  ) {
+  if (typeof walletAddress !== "string" || !isSolanaAddress(walletAddress)) {
     fail(400, "invalid_request", "Invalid Solana address");
   }
   const observedAt = requiredString(body, "observedAt", validIsoTimestamp);
@@ -182,14 +286,39 @@ async function createFallbackWalletClaim(
     "supersedesClaimId",
     validIdentifier,
   );
+  if (
+    body.source !== undefined &&
+    body.source !== "github_issue" &&
+    body.source !== "d1_registry"
+  ) {
+    fail(400, "invalid_request", "Invalid wallet claim source");
+  }
+  const source =
+    body.source === "github_issue" ? "github_issue" : "d1_registry";
+  const issueRepository =
+    source === "github_issue" && body.issueRepository === "elizaOS/slopdotcash"
+      ? body.issueRepository
+      : null;
+  const issueNumber =
+    source === "github_issue" &&
+    Number.isSafeInteger(body.issueNumber) &&
+    Number(body.issueNumber) > 0
+      ? Number(body.issueNumber)
+      : null;
+  if (
+    source === "github_issue" &&
+    (issueRepository === null || issueNumber === null)
+  ) {
+    fail(400, "invalid_request", "Invalid GitHub issue source");
+  }
   const canonicalRecord = JSON.stringify({
     schemaVersion: 1,
     githubActorId: githubId,
     githubLogin,
     address: walletAddress,
-    source: "d1_fallback",
-    issueRepository: null,
-    issueNumber: null,
+    source,
+    issueRepository,
+    issueNumber,
     sourceBodySha256,
     observedAt,
     supersedesClaimId,
@@ -199,9 +328,9 @@ async function createFallbackWalletClaim(
     githubId,
     githubLogin,
     walletAddress,
-    source: "d1_fallback",
-    issueRepository: null,
-    issueNumber: null,
+    source,
+    issueRepository,
+    issueNumber,
     sourceBodySha256,
     observedAt,
     recordSha256: await sha256Hex(new TextEncoder().encode(canonicalRecord)),
@@ -214,7 +343,10 @@ async function createFallbackWalletClaim(
   await deps.persistence.writeAudit({
     id: deps.randomId(),
     actorGithubId: actor.githubId,
-    action: "wallet_claim.fallback_created",
+    action:
+      source === "github_issue"
+        ? "wallet_claim.historical_issue_migrated"
+        : "wallet_claim.operator_recovery_created",
     target: `wallet-claim:${result.value.id}`,
     requestId: deps.randomId(),
     createdAt: deps.now().toISOString(),
@@ -681,8 +813,18 @@ export async function handleTraceApi(
   try {
     if (
       request.method === "GET" &&
+      parts.length === 4 &&
+      parts[0] === "wallet-claims" &&
+      parts[1] === "actors" &&
+      parts[3] === "current"
+    ) {
+      return await readCurrentWalletClaim(deps, parts[2]);
+    }
+    if (
+      request.method === "GET" &&
       parts.length === 2 &&
-      parts[0] === "wallet-claims"
+      parts[0] === "wallet-claims" &&
+      parts[1] !== "current"
     ) {
       return await readPublicWalletClaim(deps, parts[1]);
     }
@@ -708,6 +850,26 @@ export async function handleTraceApi(
       nowSeconds: Math.floor(deps.now().getTime() / 1000),
     });
     if (actor === null) fail(401, "unauthorized", "Authentication failed");
+
+    if (
+      request.method === "GET" &&
+      parts.length === 2 &&
+      parts[0] === "wallet-claims" &&
+      parts[1] === "current"
+    ) {
+      const current = await deps.persistence.getCurrentWalletClaim(
+        actor.githubId,
+      );
+      if (current === null) fail(404, "not_found", "Wallet claim not found");
+      return json(200, publicWalletClaim(current));
+    }
+    if (
+      request.method === "POST" &&
+      parts.length === 1 &&
+      parts[0] === "wallet-claims"
+    ) {
+      return await createContributorWalletClaim(request, actor, deps);
+    }
 
     if (
       request.method === "POST" &&

--- a/functions/api/v1/trace-api.test.ts
+++ b/functions/api/v1/trace-api.test.ts
@@ -250,12 +250,37 @@ class MemoryPersistence implements TracePersistence {
       (item) => item.recordSha256 === claim.recordSha256,
     );
     if (existing !== undefined) return { status: "existing", value: existing };
+    const actorClaims = [...this.claims.values()].filter(
+      (item) => item.githubId === claim.githubId,
+    );
+    if (
+      (claim.supersedesClaimId === null &&
+        actorClaims.some((item) => item.supersedesClaimId === null)) ||
+      (claim.supersedesClaimId !== null &&
+        actorClaims.some(
+          (item) => item.supersedesClaimId === claim.supersedesClaimId,
+        ))
+    ) {
+      return { status: "conflict" };
+    }
     this.claims.set(claim.id, claim);
     return { status: "created", value: claim };
   }
 
   async getWalletClaim(claimId: string): Promise<WalletClaim | null> {
     return this.claims.get(claimId) ?? null;
+  }
+
+  async getCurrentWalletClaim(githubId: string): Promise<WalletClaim | null> {
+    const claims = [...this.claims.values()].filter(
+      (claim) => claim.githubId === githubId,
+    );
+    return (
+      claims.find(
+        (claim) =>
+          !claims.some((candidate) => candidate.supersedesClaimId === claim.id),
+      ) ?? null
+    );
   }
 }
 
@@ -679,8 +704,117 @@ describe("private trace API", () => {
     expect(await publicResponse.json()).toMatchObject({
       githubActorId: "42",
       address: "11111111111111111111111111111111",
-      source: "d1_fallback",
+      source: "d1_registry",
       recordDigest: claim.recordDigest,
     });
+  });
+
+  it("lets a GitHub-authenticated contributor create and supersede one wallet lineage", async () => {
+    const deps = dependencies();
+    const contributor = await token("42", "octocat", ["contributor"]);
+    const first = await handleTraceApi(
+      request(
+        "wallet-claims",
+        "POST",
+        contributor,
+        JSON.stringify({ address: "11111111111111111111111111111111" }),
+        { "content-type": "application/json" },
+      ),
+      deps,
+    );
+    expect(first.status).toBe(201);
+    const firstClaim = (await first.json()) as {
+      claimId: string;
+      githubActorId: string;
+      source: string;
+    };
+    expect(firstClaim).toMatchObject({
+      githubActorId: "42",
+      source: "d1_registry",
+    });
+
+    const unchanged = await handleTraceApi(
+      request(
+        "wallet-claims",
+        "POST",
+        contributor,
+        JSON.stringify({
+          address: "11111111111111111111111111111111",
+          supersedesClaimId: firstClaim.claimId,
+        }),
+        { "content-type": "application/json" },
+      ),
+      deps,
+    );
+    expect(unchanged.status).toBe(200);
+    expect((await unchanged.json()).claimId).toBe(firstClaim.claimId);
+
+    const changed = await handleTraceApi(
+      request(
+        "wallet-claims",
+        "POST",
+        contributor,
+        JSON.stringify({
+          address: "SysvarRent111111111111111111111111111111111",
+          supersedesClaimId: firstClaim.claimId,
+        }),
+        { "content-type": "application/json" },
+      ),
+      deps,
+    );
+    expect(changed.status).toBe(201);
+    const secondClaim = (await changed.json()) as {
+      claimId: string;
+      supersedesClaimId: string;
+    };
+    expect(secondClaim.supersedesClaimId).toBe(firstClaim.claimId);
+
+    const current = await handleTraceApi(
+      new Request(
+        "https://api.slop.cash/api/v1/wallet-claims/actors/42/current",
+      ),
+      deps,
+    );
+    expect(current.status).toBe(200);
+    expect((await current.json()).claimId).toBe(secondClaim.claimId);
+
+    const authenticatedCurrent = await handleTraceApi(
+      request("wallet-claims/current", "GET", contributor),
+      deps,
+    );
+    expect(authenticatedCurrent.status).toBe(200);
+    expect((await authenticatedCurrent.json()).claimId).toBe(
+      secondClaim.claimId,
+    );
+
+    const stale = await handleTraceApi(
+      request(
+        "wallet-claims",
+        "POST",
+        contributor,
+        JSON.stringify({
+          address: "Vote111111111111111111111111111111111111111",
+          supersedesClaimId: firstClaim.claimId,
+        }),
+        { "content-type": "application/json" },
+      ),
+      deps,
+    );
+    expect(stale.status).toBe(409);
+    expect(await stale.json()).toMatchObject({ error: "stale_wallet_claim" });
+  });
+
+  it("does not let an unauthenticated caller create a wallet claim", async () => {
+    const response = await handleTraceApi(
+      new Request("https://api.slop.cash/api/v1/wallet-claims", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          address: "11111111111111111111111111111111",
+        }),
+      }),
+      dependencies(),
+    );
+    expect(response.status).toBe(401);
   });
 });

--- a/migrations/0001_private_trace_backend.sql
+++ b/migrations/0001_private_trace_backend.sql
@@ -99,8 +99,8 @@ CREATE TABLE private_audit_events (
 
 CREATE INDEX private_audit_events_target ON private_audit_events(target, created_at);
 
--- A GitHub issue is the sufficient primary claim. This table also supports an
--- operator-recorded D1 fallback when GitHub is temporarily unavailable.
+-- Initial wallet observation table. Migration 0003 turns this into the
+-- authenticated append-only registry while preserving historical rows.
 CREATE TABLE wallet_claims (
   id TEXT PRIMARY KEY,
   github_user_id TEXT NOT NULL,

--- a/migrations/0003_wallet_claim_registry.sql
+++ b/migrations/0003_wallet_claim_registry.sql
@@ -1,0 +1,71 @@
+-- Make the authenticated append-only D1 registry the canonical wallet source.
+-- Historical issue and profile observations remain valid immutable records,
+-- but new contributor claims are written directly after GitHub OAuth.
+
+DROP TRIGGER wallet_claims_no_update;
+DROP TRIGGER wallet_claims_no_delete;
+DROP INDEX wallet_claims_actor;
+
+ALTER TABLE wallet_claims RENAME TO wallet_claims_legacy;
+
+CREATE TABLE wallet_claims (
+  id TEXT PRIMARY KEY,
+  github_user_id TEXT NOT NULL,
+  github_login TEXT NOT NULL,
+  wallet_address TEXT NOT NULL,
+  source TEXT NOT NULL CHECK (source IN ('github_issue', 'profile_readme', 'd1_registry')),
+  issue_repository TEXT,
+  issue_number INTEGER,
+  source_body_sha256 TEXT NOT NULL CHECK (length(source_body_sha256) = 64),
+  observed_at TEXT NOT NULL,
+  record_sha256 TEXT NOT NULL UNIQUE CHECK (length(record_sha256) = 64),
+  supersedes_claim_id TEXT REFERENCES wallet_claims(id),
+  created_at TEXT NOT NULL,
+  CHECK (
+    source != 'github_issue' OR
+    (issue_repository IS NOT NULL AND issue_number IS NOT NULL AND issue_number > 0)
+  ),
+  CHECK (
+    source = 'github_issue' OR
+    (issue_repository IS NULL AND issue_number IS NULL)
+  )
+) STRICT;
+
+INSERT INTO wallet_claims (
+  id, github_user_id, github_login, wallet_address, source,
+  issue_repository, issue_number, source_body_sha256, observed_at,
+  record_sha256, supersedes_claim_id, created_at
+)
+SELECT
+  id, github_user_id, github_login, wallet_address,
+  CASE source WHEN 'd1_fallback' THEN 'd1_registry' ELSE source END,
+  issue_repository, issue_number, source_body_sha256, observed_at,
+  record_sha256, supersedes_claim_id, created_at
+FROM wallet_claims_legacy;
+
+DROP TABLE wallet_claims_legacy;
+
+CREATE INDEX wallet_claims_actor
+ON wallet_claims(github_user_id, observed_at);
+
+-- A contributor has one claim lineage. Every change extends its current tip;
+-- forks and competing roots fail at the database boundary under concurrency.
+CREATE UNIQUE INDEX wallet_claims_one_root_per_actor
+ON wallet_claims(github_user_id)
+WHERE supersedes_claim_id IS NULL;
+
+CREATE UNIQUE INDEX wallet_claims_one_successor
+ON wallet_claims(supersedes_claim_id)
+WHERE supersedes_claim_id IS NOT NULL;
+
+CREATE TRIGGER wallet_claims_no_update
+BEFORE UPDATE ON wallet_claims
+BEGIN
+  SELECT RAISE(ABORT, 'wallet claims are immutable');
+END;
+
+CREATE TRIGGER wallet_claims_no_delete
+BEFORE DELETE ON wallet_claims
+BEGIN
+  SELECT RAISE(ABORT, 'wallet claims are permanent');
+END;

--- a/scripts/deployment-contract.test.mjs
+++ b/scripts/deployment-contract.test.mjs
@@ -58,7 +58,10 @@ describe("slop.cash deployment contract", () => {
     expect(deployJob).toContain(`node-version: ${"$"}{{ env.NODE_VERSION }}`);
     expect(deployJob).toContain("./node_modules/.bin/wrangler pages deploy \\");
     expect(deployJob).toContain(
-      "./node_modules/.bin/wrangler deploy \\\n            --config workers/identity/wrangler.toml \\",
+      "./node_modules/.bin/wrangler versions upload \\\n            --config workers/identity/wrangler.toml \\",
+    );
+    expect(deployJob).toContain(
+      "./node_modules/.bin/wrangler versions deploy \\\n            --name slop-identity \\",
     );
     expect(deployJob).toContain(
       "./node_modules/.bin/wrangler secret list \\\n            --config workers/identity/wrangler.toml",
@@ -73,15 +76,18 @@ describe("slop.cash deployment contract", () => {
       "./node_modules/.bin/wrangler d1 execute slop-private \\",
     );
     expect(deployJob).toContain('--tag="$GITHUB_SHA"');
+    expect(deployJob).toContain('--version-tag="$GITHUB_SHA@100%"');
     expect(deployJob).toContain('--message="slop.cash release $GITHUB_SHA"');
     expect(deployJob).toContain("wrangler versions list \\");
     expect(deployJob).toContain("wrangler deployments status \\");
     expect(deployJob).toContain("https://identity.slop.cash/v1/oauth/start");
     expect(deployJob).toContain("https://identity.slop.cash/v1/oauth/callback");
     expect(deployJob).toContain("https://api.slop.cash/api/v1/runs?verify=");
-    expect(deployJob.indexOf("wrangler deploy \\")).toBeLessThan(
+    expect(deployJob.indexOf("wrangler versions deploy \\")).toBeLessThan(
       deployJob.indexOf("wrangler pages deploy \\"),
     );
+    expect(deployJob).not.toContain("wrangler deploy \\");
+    expect(deployJob).toContain("has no zone-level Workers Routes permission");
     expect(deployJob).not.toContain("working-directory:");
     expect(deployJob).not.toContain("bunx wrangler");
     expect(deployJob).not.toContain("pages deploy dist");

--- a/scripts/github-wallets.test.ts
+++ b/scripts/github-wallets.test.ts
@@ -6,6 +6,8 @@ import { fetchPublishedGithubWallet } from "./github-wallets";
 
 const ADDRESS = "11111111111111111111111111111111";
 const COMMIT = "c".repeat(40);
+const ACTOR_ID = "U_finish_line";
+const IDENTITY = { id: 123456, login: "finish-line", node_id: ACTOR_ID };
 
 function jsonResponse(value: unknown, status = 200): Response {
   return new Response(JSON.stringify(value), {
@@ -19,7 +21,8 @@ describe("GitHub wallet observation", () => {
     const markdown = `# finish-line\n${formatPublishedWallet(ADDRESS)}\n`;
     const fetchMock = vi
       .fn()
-      .mockResolvedValueOnce(jsonResponse([]))
+      .mockResolvedValueOnce(jsonResponse(IDENTITY))
+      .mockResolvedValueOnce(jsonResponse({}, 404))
       .mockResolvedValueOnce(jsonResponse({ path: "README.md" }))
       .mockResolvedValueOnce(jsonResponse([{ sha: COMMIT }]))
       .mockResolvedValueOnce(
@@ -31,10 +34,12 @@ describe("GitHub wallet observation", () => {
         }),
       );
     await expect(
-      fetchPublishedGithubWallet("finish-line", "2026-08-02T00:00:00.000Z", {
-        fetch: fetchMock,
-        token: "test-token",
-      }),
+      fetchPublishedGithubWallet(
+        ACTOR_ID,
+        "finish-line",
+        "2026-08-02T00:00:00.000Z",
+        { fetch: fetchMock, token: "test-token" },
+      ),
     ).resolves.toEqual({
       address: ADDRESS,
       chain: "solana",
@@ -42,76 +47,86 @@ describe("GitHub wallet observation", () => {
       sourceCommit: COMMIT,
       sourceUrl: `https://github.com/finish-line/finish-line/blob/${COMMIT}/README.md`,
     });
-    expect(fetchMock).toHaveBeenCalledTimes(4);
-    expect(fetchMock.mock.calls[3][0]).toContain(`?ref=${COMMIT}`);
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+    expect(fetchMock.mock.calls[4][0]).toContain(`?ref=${COMMIT}`);
   });
 
-  it("prefers one canonical open Slop wallet claim issue", async () => {
-    const marker = formatPublishedWallet(ADDRESS);
-    const body = `# Wallet claim\n\n${marker}\n`;
-    const fetchMock = vi.fn().mockResolvedValueOnce(
-      jsonResponse([
-        {
-          number: 42,
-          node_id: "I_wallet_claim",
-          title: "Slop wallet claim",
-          body,
-          updated_at: "2026-08-01T12:00:00.000Z",
-          html_url: "https://github.com/elizaOS/slopdotcash/issues/42",
-          user: { login: "finish-line", node_id: "U_finish_line" },
-        },
-      ]),
-    );
+  it("prefers the authenticated actor's current D1 wallet claim", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(IDENTITY))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          schemaVersion: 1,
+          claimId: "wallet_claim_01",
+          githubActorId: "123456",
+          githubLogin: "finish-line",
+          address: ADDRESS,
+          source: "d1_registry",
+          issueRepository: null,
+          issueNumber: null,
+          sourceBodySha256: "a".repeat(64),
+          observedAt: "2026-08-01T12:00:00.000Z",
+          recordDigest: "b".repeat(64),
+          supersedesClaimId: null,
+        }),
+      );
     await expect(
-      fetchPublishedGithubWallet("finish-line", "2026-08-02T00:00:00.000Z", {
-        fetch: fetchMock,
-      }),
+      fetchPublishedGithubWallet(
+        ACTOR_ID,
+        "finish-line",
+        "2026-08-02T00:00:00.000Z",
+        { fetch: fetchMock },
+      ),
     ).resolves.toMatchObject({
       address: ADDRESS,
       chain: "solana",
-      sourceActorId: "U_finish_line",
-      sourceIssueId: "I_wallet_claim",
-      sourceIssueNumber: 42,
-      sourceUpdatedAt: "2026-08-01T12:00:00.000Z",
-      sourceUrl: "https://github.com/elizaOS/slopdotcash/issues/42",
+      observedAt: "2026-08-02T00:00:00.000Z",
+      sourceActorId: ACTOR_ID,
+      sourceClaimId: "wallet_claim_01",
+      sourceRecordSha256: "b".repeat(64),
+      sourceUrl: "https://api.slop.cash/api/v1/wallet-claims/wallet_claim_01",
     });
-    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
-  it("fails closed on duplicate open wallet claim issues", async () => {
-    const issue = {
-      number: 42,
-      node_id: "I_wallet_claim",
-      title: "Slop wallet claim",
-      body: formatPublishedWallet(ADDRESS),
-      updated_at: "2026-08-01T12:00:00.000Z",
-      html_url: "https://github.com/elizaOS/slopdotcash/issues/42",
-      user: { login: "finish-line", node_id: "U_finish_line" },
-    };
+  it("fails closed when the live GitHub actor identity changes", async () => {
     await expect(
-      fetchPublishedGithubWallet("finish-line", "2026-08-02T00:00:00.000Z", {
-        fetch: vi
-          .fn()
-          .mockResolvedValueOnce(
-            jsonResponse([issue, { ...issue, number: 43 }]),
-          ),
-      }),
-    ).rejects.toThrow(/multiple open wallet claim issues/u);
+      fetchPublishedGithubWallet(
+        ACTOR_ID,
+        "finish-line",
+        "2026-08-02T00:00:00.000Z",
+        {
+          fetch: vi
+            .fn()
+            .mockResolvedValueOnce(
+              jsonResponse({ ...IDENTITY, node_id: "U_attacker" }),
+            ),
+        },
+      ),
+    ).rejects.toThrow(/identity changed/u);
   });
 
   it("returns null for a missing profile repository or absent marker", async () => {
     await expect(
-      fetchPublishedGithubWallet("no-profile", "2026-08-02T00:00:00.000Z", {
-        fetch: vi
-          .fn()
-          .mockResolvedValueOnce(jsonResponse([]))
-          .mockResolvedValueOnce(jsonResponse({}, 404)),
-      }),
+      fetchPublishedGithubWallet(
+        "U_no_profile",
+        "no-profile",
+        "2026-08-02T00:00:00.000Z",
+        { fetch: vi.fn().mockResolvedValueOnce(jsonResponse({}, 404)) },
+      ),
     ).resolves.toBeNull();
 
     const fetchMock = vi
       .fn()
-      .mockResolvedValueOnce(jsonResponse([]))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          id: 234567,
+          login: "no-wallet",
+          node_id: "U_no_wallet",
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse({}, 404))
       .mockResolvedValueOnce(jsonResponse({ path: "README.md" }))
       .mockResolvedValueOnce(jsonResponse([{ sha: COMMIT }]))
       .mockResolvedValueOnce(
@@ -123,27 +138,35 @@ describe("GitHub wallet observation", () => {
         }),
       );
     await expect(
-      fetchPublishedGithubWallet("no-wallet", "2026-08-02T00:00:00.000Z", {
-        fetch: fetchMock,
-      }),
+      fetchPublishedGithubWallet(
+        "U_no_wallet",
+        "no-wallet",
+        "2026-08-02T00:00:00.000Z",
+        { fetch: fetchMock },
+      ),
     ).resolves.toBeNull();
   });
 
   it("fails closed on moving references and malformed immutable bytes", async () => {
     const mutable = vi
       .fn()
-      .mockResolvedValueOnce(jsonResponse([]))
+      .mockResolvedValueOnce(jsonResponse(IDENTITY))
+      .mockResolvedValueOnce(jsonResponse({}, 404))
       .mockResolvedValueOnce(jsonResponse({ path: "README.md" }))
       .mockResolvedValueOnce(jsonResponse([{ sha: "main" }]));
     await expect(
-      fetchPublishedGithubWallet("finish-line", "2026-08-02T00:00:00.000Z", {
-        fetch: mutable,
-      }),
+      fetchPublishedGithubWallet(
+        ACTOR_ID,
+        "finish-line",
+        "2026-08-02T00:00:00.000Z",
+        { fetch: mutable },
+      ),
     ).rejects.toThrow(/commit SHA/u);
 
     const malformed = vi
       .fn()
-      .mockResolvedValueOnce(jsonResponse([]))
+      .mockResolvedValueOnce(jsonResponse(IDENTITY))
+      .mockResolvedValueOnce(jsonResponse({}, 404))
       .mockResolvedValueOnce(jsonResponse({ path: "README.md" }))
       .mockResolvedValueOnce(jsonResponse([{ sha: COMMIT }]))
       .mockResolvedValueOnce(
@@ -155,9 +178,12 @@ describe("GitHub wallet observation", () => {
         }),
       );
     await expect(
-      fetchPublishedGithubWallet("finish-line", "2026-08-02T00:00:00.000Z", {
-        fetch: malformed,
-      }),
+      fetchPublishedGithubWallet(
+        ACTOR_ID,
+        "finish-line",
+        "2026-08-02T00:00:00.000Z",
+        { fetch: malformed },
+      ),
     ).rejects.toThrow(/encoding/u);
   });
 
@@ -169,9 +195,12 @@ describe("GitHub wallet observation", () => {
     );
 
     await expect(
-      fetchPublishedGithubWallet("finish-line", "2026-08-02T00:00:00.000Z", {
-        fetch: fetchMock,
-      }),
+      fetchPublishedGithubWallet(
+        ACTOR_ID,
+        "finish-line",
+        "2026-08-02T00:00:00.000Z",
+        { fetch: fetchMock },
+      ),
     ).rejects.toThrow("response is oversized");
     expect(fetchMock).toHaveBeenCalledOnce();
   });
@@ -184,14 +213,18 @@ describe("GitHub wallet observation", () => {
           code: "ConnectionRefused",
         }),
       )
-      .mockResolvedValueOnce(jsonResponse([]))
+      .mockResolvedValueOnce(jsonResponse(IDENTITY))
+      .mockResolvedValueOnce(jsonResponse({}, 404))
       .mockResolvedValueOnce(jsonResponse({}, 404));
 
     await expect(
-      fetchPublishedGithubWallet("finish-line", "2026-08-02T00:00:00.000Z", {
-        fetch: fetchMock,
-      }),
+      fetchPublishedGithubWallet(
+        ACTOR_ID,
+        "finish-line",
+        "2026-08-02T00:00:00.000Z",
+        { fetch: fetchMock },
+      ),
     ).resolves.toBeNull();
-    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
   });
 });

--- a/scripts/github-wallets.ts
+++ b/scripts/github-wallets.ts
@@ -4,15 +4,11 @@
  * are bounded and every source is rebound to the exact GitHub actor.
  */
 
-import { createHash } from "node:crypto";
 import type { WalletProof } from "../src/lib/rewards";
-import {
-  parsePublishedWallet,
-  WALLET_CLAIM_REPOSITORY,
-  WALLET_CLAIM_TITLE,
-} from "../src/lib/wallets";
+import { isSolanaAddress, parsePublishedWallet } from "../src/lib/wallets";
 
 const API_ORIGIN = "https://api.github.com";
+const WALLET_AUTHORITY = "https://api.slop.cash";
 const MAX_API_RESPONSE_BYTES = 2 * 1024 * 1024;
 const REQUEST_TIMEOUT_MS = 15_000;
 const MAX_API_ATTEMPTS = 4;
@@ -159,6 +155,64 @@ async function apiJson(
   throw new Error("GitHub wallet lookup exhausted its retry boundary");
 }
 
+async function registryJson(
+  path: string,
+  fetchImpl: FetchLike,
+): Promise<unknown | null> {
+  for (let attempt = 1; attempt <= MAX_API_ATTEMPTS; attempt += 1) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+    try {
+      let response: Response;
+      try {
+        response = await fetchImpl(`${WALLET_AUTHORITY}${path}`, {
+          headers: {
+            Accept: "application/json",
+            "User-Agent": "slop-wallet-observer/1",
+          },
+          redirect: "error",
+          signal: controller.signal,
+        });
+      } catch (error) {
+        const retryable =
+          controller.signal.aborted || transientNetworkError(error);
+        if (retryable && attempt < MAX_API_ATTEMPTS) {
+          await retryDelay(attempt);
+          continue;
+        }
+        throw new Error(
+          `Slop wallet registry network failed (${attempt}/${MAX_API_ATTEMPTS})`,
+          { cause: error },
+        );
+      }
+      if (
+        [502, 503, 504].includes(response.status) &&
+        attempt < MAX_API_ATTEMPTS
+      ) {
+        await retryDelay(attempt);
+        continue;
+      }
+      if (response.status === 404) return null;
+      if (!response.ok) {
+        throw new Error(
+          `Slop wallet registry failed with HTTP ${response.status}`,
+        );
+      }
+      const body = await boundedApiBody(response);
+      try {
+        return JSON.parse(body);
+      } catch (error) {
+        throw new Error("Slop wallet registry returned invalid JSON", {
+          cause: error,
+        });
+      }
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+  throw new Error("Slop wallet registry exhausted its retry boundary");
+}
+
 function object(value: unknown, context: string): Record<string, unknown> {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     throw new TypeError(`${context} is not an object`);
@@ -166,97 +220,90 @@ function object(value: unknown, context: string): Record<string, unknown> {
   return value as Record<string, unknown>;
 }
 
-async function fetchIssueWallet(
+async function fetchRegistryWallet(
+  githubNumericId: string,
+  sourceActorId: string,
   login: string,
   observedAt: string,
-  token: string | undefined,
   fetchImpl: FetchLike,
 ): Promise<WalletProof | null> {
-  const response = await apiJson(
-    `/repos/${WALLET_CLAIM_REPOSITORY}/issues?state=open&creator=${encodeURIComponent(login)}&sort=updated&direction=desc&per_page=100`,
-    token,
+  const response = await registryJson(
+    `/api/v1/wallet-claims/actors/${githubNumericId}/current`,
     fetchImpl,
   );
   if (response === null) return null;
-  if (!Array.isArray(response)) {
-    throw new TypeError("GitHub wallet claim lookup is not an array");
-  }
-  if (response.length === 100) {
-    throw new RangeError("GitHub wallet claim lookup reached its issue bound");
-  }
-  const claims = response.filter((value) => {
-    const issue = object(value, "GitHub wallet claim issue");
-    return issue.title === WALLET_CLAIM_TITLE && !("pull_request" in issue);
-  });
-  if (claims.length === 0) return null;
-  if (claims.length !== 1) {
-    throw new TypeError("GitHub account has multiple open wallet claim issues");
-  }
-  const issue = object(claims[0], "GitHub wallet claim issue");
-  const actor = object(issue.user, "GitHub wallet claim author");
+  const claim = object(response, "Slop wallet registry claim");
   if (
-    typeof actor.login !== "string" ||
-    actor.login.toLowerCase() !== login.toLowerCase() ||
-    typeof actor.node_id !== "string" ||
-    !/^[A-Za-z0-9_=-]+$/u.test(actor.node_id)
+    claim.schemaVersion !== 1 ||
+    typeof claim.claimId !== "string" ||
+    !/^[A-Za-z0-9_-]+$/u.test(claim.claimId) ||
+    claim.githubActorId !== githubNumericId ||
+    typeof claim.githubLogin !== "string" ||
+    claim.githubLogin.toLowerCase() !== login.toLowerCase() ||
+    !isSolanaAddress(claim.address) ||
+    !["d1_registry", "github_issue", "profile_readme"].includes(
+      String(claim.source),
+    ) ||
+    typeof claim.sourceBodySha256 !== "string" ||
+    !/^[0-9a-f]{64}$/u.test(claim.sourceBodySha256) ||
+    typeof claim.observedAt !== "string" ||
+    !Number.isFinite(Date.parse(claim.observedAt)) ||
+    Date.parse(claim.observedAt) > Date.parse(observedAt) ||
+    typeof claim.recordDigest !== "string" ||
+    !/^[0-9a-f]{64}$/u.test(claim.recordDigest)
   ) {
-    throw new TypeError(
-      "GitHub wallet claim author does not match the contributor",
-    );
-  }
-  if (typeof issue.body !== "string" || issue.body.length > 1_000_000) {
-    throw new TypeError("GitHub wallet claim body is invalid or too large");
-  }
-  const published = parsePublishedWallet(issue.body);
-  if (!published) {
-    throw new TypeError("GitHub wallet claim issue has no wallet marker");
-  }
-  if (
-    !Number.isSafeInteger(issue.number) ||
-    (issue.number as number) < 1 ||
-    typeof issue.node_id !== "string" ||
-    !/^[A-Za-z0-9_=-]+$/u.test(issue.node_id) ||
-    typeof issue.updated_at !== "string" ||
-    !Number.isFinite(Date.parse(issue.updated_at))
-  ) {
-    throw new TypeError("GitHub wallet claim identity is invalid");
-  }
-  const sourceIssueNumber = issue.number as number;
-  const sourceUrl = `https://github.com/${WALLET_CLAIM_REPOSITORY}/issues/${sourceIssueNumber}`;
-  if (issue.html_url !== sourceUrl) {
-    throw new TypeError("GitHub wallet claim URL is not canonical");
+    throw new TypeError("Slop wallet registry claim is invalid");
   }
   return {
-    address: published.address,
+    address: claim.address,
     chain: "solana",
     observedAt,
-    sourceActorId: actor.node_id,
-    sourceBodySha256: createHash("sha256").update(issue.body).digest("hex"),
-    sourceIssueId: issue.node_id,
-    sourceIssueNumber,
-    sourceUpdatedAt: issue.updated_at,
-    sourceUrl,
+    sourceActorId,
+    sourceClaimId: claim.claimId,
+    sourceRecordSha256: claim.recordDigest,
+    sourceUrl: `${WALLET_AUTHORITY}/api/v1/wallet-claims/${claim.claimId}`,
   };
 }
 
-/** Returns public wallet attribution, preferring one canonical open claim. */
+/** Returns an actor-bound D1 claim, with immutable profile bytes as fallback. */
 export async function fetchPublishedGithubWallet(
+  actorIdInput: string,
   loginInput: string,
   observedAt: string,
   options: { fetch?: FetchLike; token?: string } = {},
 ): Promise<WalletProof | null> {
+  if (!/^[A-Za-z0-9_=-]{4,128}$/u.test(actorIdInput)) {
+    throw new TypeError("GitHub actor id is invalid");
+  }
   const login = githubLogin(loginInput);
   if (!Number.isFinite(Date.parse(observedAt))) {
     throw new TypeError("Wallet observation time is invalid");
   }
   const fetchImpl = options.fetch ?? fetch;
-  const issueWallet = await fetchIssueWallet(
-    login,
-    observedAt,
+  const identityResponse = await apiJson(
+    `/users/${encodeURIComponent(login)}`,
     options.token,
     fetchImpl,
   );
-  if (issueWallet) return issueWallet;
+  if (identityResponse === null) return null;
+  const identity = object(identityResponse, "GitHub wallet actor identity");
+  if (
+    !Number.isSafeInteger(identity.id) ||
+    Number(identity.id) < 1 ||
+    identity.node_id !== actorIdInput ||
+    typeof identity.login !== "string" ||
+    identity.login.toLowerCase() !== login.toLowerCase()
+  ) {
+    throw new TypeError("GitHub wallet actor identity changed");
+  }
+  const registryWallet = await fetchRegistryWallet(
+    String(identity.id),
+    actorIdInput,
+    login,
+    observedAt,
+    fetchImpl,
+  );
+  if (registryWallet) return registryWallet;
   const repository = `${login}/${login}`;
   const readmeResponse = await apiJson(
     `/repos/${encodeURIComponent(login)}/${encodeURIComponent(login)}/readme`,

--- a/scripts/migrate-wallet-claim-issues.d.mts
+++ b/scripts/migrate-wallet-claim-issues.d.mts
@@ -1,0 +1,31 @@
+/** Types the one-time GitHub wallet-claim migration for focused tests. */
+
+export interface HistoricalWalletClaim {
+  address: string;
+  githubActorId: string;
+  githubLogin: string;
+  issueNumber: number;
+  observedAt: string;
+  sourceBodySha256: string;
+  sourceUrl: string;
+}
+
+export interface WalletMigrationOptions {
+  claims?: HistoricalWalletClaim[];
+  closeIssue?: boolean;
+  fetch?: WalletMigrationFetch;
+  refreshClaim?: (
+    issueNumber: number,
+  ) => HistoricalWalletClaim | Promise<HistoricalWalletClaim>;
+  tokenProvider?: (fetchImpl: WalletMigrationFetch) => Promise<string>;
+}
+
+export type WalletMigrationFetch = (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => Promise<Response>;
+
+export function main(
+  values?: string[],
+  options?: WalletMigrationOptions,
+): Promise<void>;

--- a/scripts/migrate-wallet-claim-issues.mjs
+++ b/scripts/migrate-wallet-claim-issues.mjs
@@ -1,0 +1,271 @@
+/**
+ * Imports historical open GitHub wallet-claim issues into the authenticated,
+ * append-only D1 registry. Planning is read-only. --execute performs the D1
+ * import after operator OAuth; --close closes only claims whose public D1
+ * receipt was fetched and byte-checked after creation.
+ */
+
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { slopIdentityAssertion } from "../skills/contribute-to-eliza/scripts/run-receipt.mjs";
+import { parsePublishedWallet } from "../src/lib/wallets.ts";
+
+const REPOSITORY = "elizaOS/slopdotcash";
+const API_ORIGIN = "https://api.slop.cash";
+const TITLE = "Slop wallet claim";
+const MAX_CLAIMS = 100;
+
+function argumentsFor(values) {
+  const unknown = values.filter(
+    (value) => !["--execute", "--close"].includes(value),
+  );
+  if (unknown.length > 0)
+    throw new TypeError(`Unknown argument: ${unknown[0]}`);
+  const execute = values.includes("--execute");
+  const close = values.includes("--close");
+  if (close && !execute) throw new TypeError("--close requires --execute");
+  return { close, execute };
+}
+
+function githubJson(path, fields = []) {
+  const source = execFileSync("gh", ["api", "-X", "GET", path, ...fields], {
+    encoding: "utf8",
+    maxBuffer: 2 * 1024 * 1024,
+  });
+  return JSON.parse(source);
+}
+
+function claimFromIssue(issue) {
+  const published = parsePublishedWallet(issue.body);
+  if (
+    issue.state !== "open" ||
+    issue.title !== TITLE ||
+    "pull_request" in issue ||
+    !published ||
+    !Number.isSafeInteger(issue.number) ||
+    issue.number < 1 ||
+    !Number.isSafeInteger(issue.user?.id) ||
+    issue.user.id < 1 ||
+    typeof issue.user.login !== "string" ||
+    typeof issue.updated_at !== "string" ||
+    !Number.isFinite(Date.parse(issue.updated_at)) ||
+    issue.html_url !== `https://github.com/${REPOSITORY}/issues/${issue.number}`
+  ) {
+    throw new TypeError(
+      `Wallet issue #${issue.number ?? "unknown"} is invalid`,
+    );
+  }
+  return {
+    address: published.address,
+    githubActorId: String(issue.user.id),
+    githubLogin: issue.user.login,
+    issueNumber: issue.number,
+    observedAt: issue.updated_at,
+    sourceBodySha256: createHash("sha256").update(issue.body).digest("hex"),
+    sourceUrl: issue.html_url,
+  };
+}
+
+function claimsFromGithub() {
+  const response = githubJson(`/repos/${REPOSITORY}/issues`, [
+    "-f",
+    "state=open",
+    "-f",
+    "per_page=100",
+  ]);
+  if (!Array.isArray(response) || response.length >= MAX_CLAIMS) {
+    throw new RangeError("Wallet migration reached its bounded issue limit");
+  }
+  return response
+    .filter((issue) => issue.title === TITLE && !("pull_request" in issue))
+    .map(claimFromIssue);
+}
+
+function currentClaimFromGithub(issueNumber) {
+  return claimFromIssue(
+    githubJson(`/repos/${REPOSITORY}/issues/${issueNumber}`),
+  );
+}
+
+function sameClaimSource(left, right) {
+  return (
+    left.address === right.address &&
+    left.githubActorId === right.githubActorId &&
+    left.githubLogin.toLowerCase() === right.githubLogin.toLowerCase() &&
+    left.issueNumber === right.issueNumber &&
+    left.observedAt === right.observedAt &&
+    left.sourceBodySha256 === right.sourceBodySha256 &&
+    left.sourceUrl === right.sourceUrl
+  );
+}
+
+async function responseJson(response, field) {
+  const source = await response.text();
+  if (new TextEncoder().encode(source).byteLength > 64 * 1024) {
+    throw new Error(`${field} response exceeded its bound`);
+  }
+  try {
+    return JSON.parse(source);
+  } catch {
+    throw new Error(`${field} response was not JSON`);
+  }
+}
+
+async function operatorToken(fetchImpl) {
+  let assertion = await slopIdentityAssertion(fetchImpl);
+  const response = await fetchImpl(`${API_ORIGIN}/api/v1/auth/session`, {
+    method: "POST",
+    headers: { "X-Slop-Identity-Assertion": assertion },
+    signal: AbortSignal.timeout(30_000),
+  });
+  assertion = "";
+  if (!response.ok)
+    throw new Error(`Operator authentication returned HTTP ${response.status}`);
+  const body = await responseJson(response, "Operator authentication");
+  if (
+    body.tokenType !== "Bearer" ||
+    typeof body.token !== "string" ||
+    body.token.length < 20 ||
+    body.token.length > 4096
+  ) {
+    throw new Error("Operator authentication returned invalid credentials");
+  }
+  return body.token;
+}
+
+function validateReceipt(value, source) {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    value.schemaVersion !== 1 ||
+    value.githubActorId !== source.githubActorId ||
+    typeof value.githubLogin !== "string" ||
+    value.githubLogin.toLowerCase() !== source.githubLogin.toLowerCase() ||
+    value.address !== source.address ||
+    value.source !== "github_issue" ||
+    value.issueRepository !== REPOSITORY ||
+    value.issueNumber !== source.issueNumber ||
+    value.sourceBodySha256 !== source.sourceBodySha256 ||
+    value.observedAt !== source.observedAt ||
+    typeof value.claimId !== "string" ||
+    !/^[A-Za-z0-9_-]+$/u.test(value.claimId) ||
+    typeof value.recordDigest !== "string" ||
+    !/^[0-9a-f]{64}$/u.test(value.recordDigest)
+  ) {
+    throw new Error(
+      `D1 receipt for issue #${source.issueNumber} did not match`,
+    );
+  }
+  return value;
+}
+
+async function migrate(source, token, fetchImpl) {
+  const response = await fetchImpl(
+    `${API_ORIGIN}/api/v1/operator/wallet-claims`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        address: source.address,
+        githubActorId: source.githubActorId,
+        githubLogin: source.githubLogin,
+        issueNumber: source.issueNumber,
+        issueRepository: REPOSITORY,
+        observedAt: source.observedAt,
+        source: "github_issue",
+        sourceBodySha256: source.sourceBodySha256,
+      }),
+      signal: AbortSignal.timeout(30_000),
+    },
+  );
+  if (!response.ok) {
+    throw new Error(
+      `D1 import for issue #${source.issueNumber} returned HTTP ${response.status}`,
+    );
+  }
+  const created = validateReceipt(
+    await responseJson(response, `D1 import #${source.issueNumber}`),
+    source,
+  );
+  const receipt = await fetchImpl(
+    `${API_ORIGIN}/api/v1/wallet-claims/${created.claimId}`,
+    { signal: AbortSignal.timeout(30_000) },
+  );
+  if (!receipt.ok) {
+    throw new Error(
+      `Public receipt for issue #${source.issueNumber} returned HTTP ${receipt.status}`,
+    );
+  }
+  return validateReceipt(
+    await responseJson(receipt, `Public receipt #${source.issueNumber}`),
+    source,
+  );
+}
+
+export async function main(values = process.argv.slice(2), options = {}) {
+  const parsed = argumentsFor(values);
+  const sources = (options.claims ?? claimsFromGithub()).sort(
+    (left, right) => left.issueNumber - right.issueNumber,
+  );
+  if (!parsed.execute) {
+    process.stdout.write(
+      `${JSON.stringify({ execute: false, claims: sources }, null, 2)}\n`,
+    );
+    return;
+  }
+  const fetchImpl = options.fetch ?? globalThis.fetch;
+  let token = await (options.tokenProvider ?? operatorToken)(fetchImpl);
+  const migrated = [];
+  for (const source of sources) {
+    const receipt = await migrate(source, token, fetchImpl);
+    migrated.push({
+      address: receipt.address,
+      claimId: receipt.claimId,
+      issueNumber: source.issueNumber,
+      recordDigest: receipt.recordDigest,
+    });
+    if (parsed.close && options.closeIssue !== false) {
+      const refreshed = await (options.refreshClaim ?? currentClaimFromGithub)(
+        source.issueNumber,
+      );
+      if (!sameClaimSource(source, refreshed)) {
+        throw new Error(
+          `Wallet issue #${source.issueNumber} changed after migration; refusing closure`,
+        );
+      }
+      execFileSync(
+        "gh",
+        [
+          "issue",
+          "close",
+          String(source.issueNumber),
+          "--repo",
+          REPOSITORY,
+          "--reason",
+          "completed",
+          "--comment",
+          `Migrated to Slop's authenticated append-only wallet registry.\n\n- Claim: ${API_ORIGIN}/api/v1/wallet-claims/${receipt.claimId}\n- Record digest: \`${receipt.recordDigest}\`\n\nThis issue is no longer a live payout authority. Future address changes append a superseding D1 record after one-time GitHub OAuth.`,
+        ],
+        { stdio: "inherit" },
+      );
+    }
+  }
+  token = "";
+  process.stdout.write(
+    `${JSON.stringify({ execute: true, migrated }, null, 2)}\n`,
+  );
+}
+
+if (import.meta.main) {
+  try {
+    await main();
+  } catch (error) {
+    process.stderr.write(
+      `[Slop] wallet issue migration refused: ${error instanceof Error ? error.message : "unknown error"}\n`,
+    );
+    process.exitCode = 1;
+  }
+}

--- a/scripts/migrate-wallet-claim-issues.test.ts
+++ b/scripts/migrate-wallet-claim-issues.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from "vitest";
+import { main } from "./migrate-wallet-claim-issues.mjs";
+
+const source = {
+  address: "11111111111111111111111111111111",
+  githubActorId: "123456",
+  githubLogin: "octocat",
+  issueNumber: 50,
+  observedAt: "2026-08-15T00:00:00.000Z",
+  sourceBodySha256: "a".repeat(64),
+  sourceUrl: "https://github.com/elizaOS/slopdotcash/issues/50",
+};
+
+const receipt = {
+  schemaVersion: 1,
+  claimId: "wallet_claim_01",
+  githubActorId: source.githubActorId,
+  githubLogin: source.githubLogin,
+  address: source.address,
+  source: "github_issue",
+  issueRepository: "elizaOS/slopdotcash",
+  issueNumber: source.issueNumber,
+  sourceBodySha256: source.sourceBodySha256,
+  observedAt: source.observedAt,
+  recordDigest: "b".repeat(64),
+  supersedesClaimId: null,
+};
+
+describe("wallet issue migration", () => {
+  it("imports and refetches an exact public receipt before closure", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(Response.json(receipt, { status: 201 }))
+      .mockResolvedValueOnce(Response.json(receipt));
+    await main(["--execute", "--close"], {
+      claims: [source],
+      closeIssue: false,
+      fetch: fetchMock,
+      tokenProvider: async () => "operator_test_bearer_token_value",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "https://api.slop.cash/api/v1/operator/wallet-claims",
+    );
+    expect(fetchMock.mock.calls[1][0]).toBe(
+      "https://api.slop.cash/api/v1/wallet-claims/wallet_claim_01",
+    );
+    const request = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    expect(request).toMatchObject({
+      source: "github_issue",
+      issueNumber: 50,
+      sourceBodySha256: source.sourceBodySha256,
+    });
+  });
+
+  it("refuses to close without executing migration", async () => {
+    await expect(main(["--close"], { claims: [source] })).rejects.toThrow(
+      /requires --execute/u,
+    );
+  });
+
+  it("fails closed when the public receipt changes", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(Response.json(receipt, { status: 201 }))
+      .mockResolvedValueOnce(
+        Response.json({
+          ...receipt,
+          address: "SysvarRent111111111111111111111111111111111",
+        }),
+      );
+    await expect(
+      main(["--execute"], {
+        claims: [source],
+        fetch: fetchMock,
+        tokenProvider: async () => "operator_test_bearer_token_value",
+      }),
+    ).rejects.toThrow(/did not match/u);
+  });
+
+  it("refuses closure if the issue changes after its D1 receipt is verified", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(Response.json(receipt, { status: 201 }))
+      .mockResolvedValueOnce(Response.json(receipt));
+    await expect(
+      main(["--execute", "--close"], {
+        claims: [source],
+        fetch: fetchMock,
+        refreshClaim: async () => ({ ...source, address: "changed" }),
+        tokenProvider: async () => "operator_test_bearer_token_value",
+      }),
+    ).rejects.toThrow(/changed after migration/u);
+  });
+});

--- a/scripts/prepare-reward-cycle.ts
+++ b/scripts/prepare-reward-cycle.ts
@@ -163,6 +163,7 @@ export async function prepareRewardCycle(
     generatedAt?: string;
     githubToken?: string;
     observeWallet?: (
+      actorId: string,
       login: string,
       observedAt: string,
     ) => Promise<WalletProof | null>;
@@ -224,8 +225,8 @@ export async function prepareRewardCycle(
     }
     const observe =
       options.observeWallet ??
-      ((login: string, observedAt: string) =>
-        fetchPublishedGithubWallet(login, observedAt, {
+      ((actorId: string, login: string, observedAt: string) =>
+        fetchPublishedGithubWallet(actorId, login, observedAt, {
           token: options.githubToken,
         }));
     const observations = await mapWithConcurrency(
@@ -233,7 +234,7 @@ export async function prepareRewardCycle(
       WALLET_LOOKUP_CONCURRENCY,
       async (leader) => ({
         actorId: leader.actor.id,
-        wallet: await observe(leader.actor.login, generatedAt),
+        wallet: await observe(leader.actor.id, leader.actor.login, generatedAt),
       }),
     );
     for (const observation of observations) {

--- a/skill-tests/project-skills.test.ts
+++ b/skill-tests/project-skills.test.ts
@@ -32,6 +32,7 @@ import {
   uploadPrivateTrace,
   usageDelta,
 } from "../skills/contribute-to-eliza/scripts/run-receipt.mjs";
+import { registerWalletClaim } from "../skills/contribute-to-eliza/scripts/wallet-claim.mjs";
 import { assessModelAttribution } from "../src/lib/leaderboard";
 import { PROJECTS } from "../src/lib/projects.mjs";
 
@@ -63,7 +64,9 @@ describe("project skill contracts", () => {
       assert.match(source, /gh api user --jq '\.login'/u);
       assert.match(source, /upstream\s+permission/is);
       assert.match(source, /stars are\s+optional/u);
-      assert.match(source, /explicit authorization before\s+creating one/is);
+      if (project.reward.kind === "monthly-pool") {
+        assert.match(source, /explicit approval before registration/is);
+      }
       assert.match(source, /live-report\.mjs --repo/u);
       assert.match(source, /token.*never earns|receipt cannot create score/is);
       assert.match(source, /untrusted/u);
@@ -173,19 +176,19 @@ describe("project skill contracts", () => {
       );
       assert.strictEqual(result.status, 0, result.stderr);
       const plan = JSON.parse(result.stdout);
-      assert.strictEqual(plan.repository, "elizaOS/slopdotcash");
-      assert.strictEqual(plan.title, "Slop wallet claim");
+      assert.deepStrictEqual(plan, {
+        action: "register-wallet",
+        address: "11111111111111111111111111111111",
+        authority: "https://api.slop.cash/api/v1/wallet-claims",
+        authentication: "one-time-github-oauth",
+        storage: "append-only-d1",
+        writes: false,
+      });
+      const authority = new URL(plan.authority);
       assert.strictEqual(
-        plan.body,
-        '<!-- slop-wallet:v1 {"chain":"solana","address":"11111111111111111111111111111111"} -->',
+        `${authority.origin}${authority.pathname}`,
+        "https://api.slop.cash/api/v1/wallet-claims",
       );
-      const issueUrl = new URL(plan.newIssueUrl);
-      assert.strictEqual(
-        `${issueUrl.origin}${issueUrl.pathname}`,
-        "https://github.com/elizaOS/slopdotcash/issues/new",
-      );
-      assert.strictEqual(issueUrl.searchParams.get("title"), plan.title);
-      assert.strictEqual(issueUrl.searchParams.get("body"), plan.body);
     }
     const invalid = spawnSync(
       process.execPath,
@@ -198,6 +201,61 @@ describe("project skill contracts", () => {
     );
     assert.notStrictEqual(invalid.status, 0);
     assert.match(invalid.stderr, /refused.*canonical 32-byte Solana/u);
+  });
+
+  it("registers a wallet only after one-time identity authentication", async () => {
+    const calls: Array<{ input: string; init?: RequestInit }> = [];
+    const responses = [
+      Response.json({
+        expiresAt: "2026-08-15T00:10:00.000Z",
+        token: "private_test_bearer_token_value",
+        tokenType: "Bearer",
+      }),
+      Response.json({ error: "not_found" }, { status: 404 }),
+      Response.json(
+        {
+          schemaVersion: 1,
+          claimId: "wallet_claim_01",
+          githubActorId: "123456",
+          githubLogin: "octocat",
+          address: "11111111111111111111111111111111",
+          source: "d1_registry",
+          issueRepository: null,
+          issueNumber: null,
+          sourceBodySha256: "a".repeat(64),
+          observedAt: "2026-08-15T00:00:00.000Z",
+          recordDigest: "b".repeat(64),
+          supersedesClaimId: null,
+        },
+        { status: 201 },
+      ),
+    ];
+    const fetchMock = async (input: RequestInfo | URL, init?: RequestInit) => {
+      calls.push({ input: String(input), init });
+      const response = responses.shift();
+      assert.ok(response);
+      return response;
+    };
+    const registered = await registerWalletClaim(
+      "11111111111111111111111111111111",
+      {
+        fetch: fetchMock,
+        assertionProvider: async () => "one_time_identity_assertion_value",
+      },
+    );
+    assert.strictEqual(registered.claimId, "wallet_claim_01");
+    assert.deepStrictEqual(
+      calls.map(({ input }) => input),
+      [
+        "https://api.slop.cash/api/v1/auth/session",
+        "https://api.slop.cash/api/v1/wallet-claims/current",
+        "https://api.slop.cash/api/v1/wallet-claims",
+      ],
+    );
+    assert.match(
+      String(calls[1].init?.headers && Object.values(calls[1].init.headers)[0]),
+      /^Bearer private_test_/u,
+    );
   });
 
   it("keeps every registered review skill hostile-input aware and non-punitive", () => {

--- a/skills/contribute-to-asi/SKILL.md
+++ b/skills/contribute-to-asi/SKILL.md
@@ -393,30 +393,32 @@ Compute spent is not progress made.
 After the public contribution artifact is ready, offer this optional step once.
 It never blocks contribution, review, or receipt completion.
 
-1. Read the currently authenticated GitHub identity with `gh api user`. Query
-   open issues authored by that identity in `elizaOS/slopdotcash` whose exact
-   title is `Slop wallet claim`. Ignore pull requests. If one valid claim
-   exists, report its public address and do nothing unless the operator asks to
-   change it. If multiple claims exist, stop payout setup and ask the operator
-   to close the extras; never choose between conflicting claims.
-2. If no claim exists, ask whether the operator wants to register a payout
-   address. If they decline, continue without one. Ask only for a **public
-   Solana address**; never request, read, create, or handle a seed phrase,
-   private key, wallet connection, signature, or transaction.
-3. Validate and render the claim locally:
+1. Ask whether the operator wants to register a payout address. If they
+   decline, continue without one. Ask only for a **public Solana address**;
+   never request, read, create, or handle a seed phrase, private key, wallet
+   connection, signature, or transaction.
+2. Validate and render the no-write plan locally:
 
 ```bash
 node <skill-directory>/scripts/wallet-claim.mjs --address <public-address>
 ```
 
-4. Show the exact GitHub repository, issue title, marker body, and whether the
-   action creates or edits an issue. Wait for explicit approval before any
-   GitHub write. The prefilled URL lets the operator review and submit in the
-   browser. Using `gh issue create` or `gh issue edit` is allowed only after the
-   same approval.
-5. Keep exactly one open claim issue. Slop binds its GitHub author, node id,
-   update time, and body digest into a reward proposal. Editing the address is a
-   material change and restarts that allocation's 14-day review.
+3. Show the exact public address, fixed Slop API authority, one-time GitHub OAuth
+   authentication, append-only D1 storage, and the fact that the plan performs
+   no write. Wait for explicit approval before registration.
+4. After approval, register through the authenticated Slop authority:
+
+```bash
+node <skill-directory>/scripts/wallet-claim.mjs register --address <public-address>
+```
+
+   Show the printed `identity.slop.cash` authorization URL to the operator and
+   wait for completion. The script keeps the OAuth capability, assertion, and
+   Slop bearer token only in process memory. It prints the immutable claim ID,
+   record digest, and public metadata URL—never a credential.
+5. An address change appends a new claim linked to the current claim; it never
+   edits or deletes history. The change is material and restarts that
+   allocation's 14-day review.
 
 A claim identifies where a reviewed payout may go. It does not prove custody,
 guarantee payment, approve an allocation, connect a wallet, or move funds.

--- a/skills/contribute-to-asi/scripts/wallet-claim.mjs
+++ b/skills/contribute-to-asi/scripts/wallet-claim.mjs
@@ -1,16 +1,20 @@
 /**
- * Validates a public Solana address and renders the canonical Slop wallet claim
- * issue without touching GitHub, local credentials, or private key material.
+ * Validates a public Solana address and registers it in Slop's authenticated,
+ * append-only D1 wallet registry. Planning is local; only the explicit
+ * `register` command performs GitHub OAuth and a network write.
  */
 
+import { existsSync, realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { slopIdentityAssertion } from "./run-receipt.mjs";
+
+const API_ORIGIN = "https://api.slop.cash";
 const BASE58_ALPHABET =
   "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
 const BASE58_INDEX = new Map(
   [...BASE58_ALPHABET].map((character, index) => [character, index]),
 );
-const CLAIM_REPOSITORY = "elizaOS/slopdotcash";
-const CLAIM_TITLE = "Slop wallet claim";
-const MARKER_PREFIX = "slop-wallet:v1";
+const MAX_RESPONSE_BYTES = 64 * 1024;
 
 function decodeBase58(value) {
   if (!value || value.length > 44) return null;
@@ -33,8 +37,8 @@ function decodeBase58(value) {
   while (leadingZeroes < value.length && value[leadingZeroes] === "1") {
     leadingZeroes += 1;
   }
-  const significantBytes = bytes.length === 1 && bytes[0] === 0 ? [] : bytes;
-  return leadingZeroes + significantBytes.length;
+  const significant = bytes.length === 1 && bytes[0] === 0 ? 0 : bytes.length;
+  return leadingZeroes + significant;
 }
 
 function isSolanaAddress(value) {
@@ -50,47 +54,198 @@ function isSolanaAddress(value) {
 function usage() {
   return `Usage:
   node wallet-claim.mjs --address <public-solana-address>
+  node wallet-claim.mjs register --address <public-solana-address>
 
-Prints a JSON plan and prefilled GitHub issue URL. It performs no network or
-GitHub write and never accepts a seed phrase or private key.`;
+The first command prints a no-write plan. The register command opens Slop's
+one-time GitHub authorization flow and appends an immutable D1 claim. Neither
+command accepts a seed phrase, private key, wallet connection, or signature.`;
 }
 
-function addressArgument(values) {
-  if (values.includes("--help")) return null;
-  if (values.length !== 2 || values[0] !== "--address") {
-    throw new TypeError("Expected only --address <public-solana-address>");
+function argumentsFor(values) {
+  if (values.includes("--help")) return { action: "help", address: null };
+  const action = values[0] === "register" ? "register" : "plan";
+  const offset = action === "register" ? 1 : 0;
+  if (
+    values.length !== offset + 2 ||
+    values[offset] !== "--address" ||
+    !isSolanaAddress(values[offset + 1]?.trim())
+  ) {
+    throw new TypeError(
+      "Expected --address with a canonical 32-byte Solana public key",
+    );
   }
-  const address = values[1]?.trim();
-  if (!isSolanaAddress(address)) {
-    throw new TypeError("Address is not a canonical 32-byte Solana public key");
-  }
-  return address;
+  return { action, address: values[offset + 1].trim() };
 }
 
-try {
-  const address = addressArgument(process.argv.slice(2));
-  if (address === null) {
+async function responseJson(response, field) {
+  const source = await response.text();
+  if (Buffer.byteLength(source) > MAX_RESPONSE_BYTES) {
+    throw new Error(`${field} response exceeded its bound`);
+  }
+  try {
+    return JSON.parse(source);
+  } catch {
+    throw new Error(`${field} response was not JSON`);
+  }
+}
+
+function claim(value, field) {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    value.schemaVersion !== 1 ||
+    typeof value.claimId !== "string" ||
+    !/^[A-Za-z0-9_-]+$/u.test(value.claimId) ||
+    !isSolanaAddress(value.address) ||
+    typeof value.githubActorId !== "string" ||
+    !/^\d+$/u.test(value.githubActorId) ||
+    typeof value.githubLogin !== "string" ||
+    typeof value.observedAt !== "string" ||
+    !Number.isFinite(Date.parse(value.observedAt)) ||
+    typeof value.recordDigest !== "string" ||
+    !/^[0-9a-f]{64}$/u.test(value.recordDigest) ||
+    !(
+      value.supersedesClaimId === null ||
+      (typeof value.supersedesClaimId === "string" &&
+        /^[A-Za-z0-9_-]+$/u.test(value.supersedesClaimId))
+    )
+  ) {
+    throw new Error(`${field} returned an invalid wallet claim`);
+  }
+  return value;
+}
+
+async function authenticate(fetchImpl, assertionProvider) {
+  let assertion = await assertionProvider(fetchImpl);
+  const response = await fetchImpl(`${API_ORIGIN}/api/v1/auth/session`, {
+    method: "POST",
+    headers: { "X-Slop-Identity-Assertion": assertion },
+    signal: AbortSignal.timeout(30_000),
+  });
+  assertion = "";
+  if (!response.ok) {
+    throw new Error(
+      `Slop wallet authentication returned HTTP ${response.status}`,
+    );
+  }
+  const result = await responseJson(response, "Slop wallet authentication");
+  if (
+    typeof result !== "object" ||
+    result === null ||
+    result.tokenType !== "Bearer" ||
+    typeof result.token !== "string" ||
+    result.token.length < 20 ||
+    result.token.length > 4096
+  ) {
+    throw new Error("Slop wallet authentication returned invalid credentials");
+  }
+  return result.token;
+}
+
+export async function registerWalletClaim(
+  address,
+  {
+    fetch: fetchImpl = globalThis.fetch,
+    assertionProvider = slopIdentityAssertion,
+  } = {},
+) {
+  if (typeof fetchImpl !== "function") {
+    throw new Error("Slop wallet registry transport is unavailable");
+  }
+  let token = await authenticate(fetchImpl, assertionProvider);
+  const headers = { Authorization: `Bearer ${token}` };
+  const currentResponse = await fetchImpl(
+    `${API_ORIGIN}/api/v1/wallet-claims/current`,
+    { headers, signal: AbortSignal.timeout(30_000) },
+  );
+  let current = null;
+  if (currentResponse.status !== 404) {
+    if (!currentResponse.ok) {
+      token = "";
+      throw new Error(
+        `Current wallet claim returned HTTP ${currentResponse.status}`,
+      );
+    }
+    current = claim(
+      await responseJson(currentResponse, "Current wallet claim"),
+      "Current wallet claim",
+    );
+  }
+  if (current?.address === address) {
+    token = "";
+    return current;
+  }
+  const created = await fetchImpl(`${API_ORIGIN}/api/v1/wallet-claims`, {
+    method: "POST",
+    headers: { ...headers, "Content-Type": "application/json" },
+    body: JSON.stringify({
+      address,
+      supersedesClaimId: current?.claimId ?? null,
+    }),
+    signal: AbortSignal.timeout(30_000),
+  });
+  token = "";
+  if (!created.ok) {
+    throw new Error(`Wallet registration returned HTTP ${created.status}`);
+  }
+  return claim(
+    await responseJson(created, "Wallet registration"),
+    "Wallet registration",
+  );
+}
+
+export async function main(values = process.argv.slice(2), options = {}) {
+  const parsed = argumentsFor(values);
+  if (parsed.action === "help") {
     process.stdout.write(`${usage()}\n`);
-  } else {
-    const marker = `<!-- ${MARKER_PREFIX} ${JSON.stringify({ chain: "solana", address })} -->`;
-    const query = new URLSearchParams({ title: CLAIM_TITLE, body: marker });
+    return;
+  }
+  if (parsed.action === "plan") {
     process.stdout.write(
       `${JSON.stringify(
         {
-          address,
-          body: marker,
-          newIssueUrl: `https://github.com/${CLAIM_REPOSITORY}/issues/new?${query}`,
-          repository: CLAIM_REPOSITORY,
-          title: CLAIM_TITLE,
+          action: "register-wallet",
+          address: parsed.address,
+          authority: `${API_ORIGIN}/api/v1/wallet-claims`,
+          authentication: "one-time-github-oauth",
+          storage: "append-only-d1",
+          writes: false,
         },
         null,
         2,
       )}\n`,
     );
+    return;
   }
-} catch (error) {
-  process.stderr.write(
-    `[Slop] wallet claim refused: ${error instanceof Error ? error.message : "unknown error"}\n`,
+  const registered = await registerWalletClaim(parsed.address, options);
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        address: registered.address,
+        claimId: registered.claimId,
+        githubLogin: registered.githubLogin,
+        observedAt: registered.observedAt,
+        recordDigest: registered.recordDigest,
+        sourceUrl: `${API_ORIGIN}/api/v1/wallet-claims/${registered.claimId}`,
+      },
+      null,
+      2,
+    )}\n`,
   );
-  process.exitCode = 1;
+}
+
+const invokedDirectly =
+  typeof process.argv[1] === "string" &&
+  existsSync(process.argv[1]) &&
+  realpathSync(fileURLToPath(import.meta.url)) ===
+    realpathSync(process.argv[1]);
+if (invokedDirectly) {
+  try {
+    await main();
+  } catch (error) {
+    process.stderr.write(
+      `[Slop] wallet registration refused: ${error instanceof Error ? error.message : "unknown error"}\n`,
+    );
+    process.exitCode = 1;
+  }
 }

--- a/skills/contribute-to-eliza/SKILL.md
+++ b/skills/contribute-to-eliza/SKILL.md
@@ -246,30 +246,32 @@ The device signature is evidence integrity, not an oracle of truth.
 After the public contribution artifact is ready, offer this optional step once.
 It never blocks contribution, review, or receipt completion.
 
-1. Read the currently authenticated GitHub identity with `gh api user`. Query
-   open issues authored by that identity in `elizaOS/slopdotcash` whose exact
-   title is `Slop wallet claim`. Ignore pull requests. If one valid claim
-   exists, report its public address and do nothing unless the operator asks to
-   change it. If multiple claims exist, stop payout setup and ask the operator
-   to close the extras; never choose between conflicting claims.
-2. If no claim exists, ask whether the operator wants to register a payout
-   address. If they decline, continue without one. Ask only for a **public
-   Solana address**; never request, read, create, or handle a seed phrase,
-   private key, wallet connection, signature, or transaction.
-3. Validate and render the claim locally:
+1. Ask whether the operator wants to register a payout address. If they
+   decline, continue without one. Ask only for a **public Solana address**;
+   never request, read, create, or handle a seed phrase, private key, wallet
+   connection, signature, or transaction.
+2. Validate and render the no-write plan locally:
 
 ```bash
 node <skill-directory>/scripts/wallet-claim.mjs --address <public-address>
 ```
 
-4. Show the exact GitHub repository, issue title, marker body, and whether the
-   action creates or edits an issue. Wait for explicit approval before any
-   GitHub write. The prefilled URL lets the operator review and submit in the
-   browser. Using `gh issue create` or `gh issue edit` is allowed only after the
-   same approval.
-5. Keep exactly one open claim issue. Slop binds its GitHub author, node id,
-   update time, and body digest into a reward proposal. Editing the address is a
-   material change and restarts that allocation's 14-day review.
+3. Show the exact public address, fixed Slop API authority, one-time GitHub OAuth
+   authentication, append-only D1 storage, and the fact that the plan performs
+   no write. Wait for explicit approval before registration.
+4. After approval, register through the authenticated Slop authority:
+
+```bash
+node <skill-directory>/scripts/wallet-claim.mjs register --address <public-address>
+```
+
+   Show the printed `identity.slop.cash` authorization URL to the operator and
+   wait for completion. The script keeps the OAuth capability, assertion, and
+   Slop bearer token only in process memory. It prints the immutable claim ID,
+   record digest, and public metadata URL—never a credential.
+5. An address change appends a new claim linked to the current claim; it never
+   edits or deletes history. The change is material and restarts that
+   allocation's 14-day review.
 
 A claim identifies where a reviewed payout may go. It does not prove custody,
 guarantee payment, approve an allocation, connect a wallet, or move funds.

--- a/skills/contribute-to-eliza/scripts/wallet-claim.mjs
+++ b/skills/contribute-to-eliza/scripts/wallet-claim.mjs
@@ -1,16 +1,20 @@
 /**
- * Validates a public Solana address and renders the canonical Slop wallet claim
- * issue without touching GitHub, local credentials, or private key material.
+ * Validates a public Solana address and registers it in Slop's authenticated,
+ * append-only D1 wallet registry. Planning is local; only the explicit
+ * `register` command performs GitHub OAuth and a network write.
  */
 
+import { existsSync, realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { slopIdentityAssertion } from "./run-receipt.mjs";
+
+const API_ORIGIN = "https://api.slop.cash";
 const BASE58_ALPHABET =
   "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
 const BASE58_INDEX = new Map(
   [...BASE58_ALPHABET].map((character, index) => [character, index]),
 );
-const CLAIM_REPOSITORY = "elizaOS/slopdotcash";
-const CLAIM_TITLE = "Slop wallet claim";
-const MARKER_PREFIX = "slop-wallet:v1";
+const MAX_RESPONSE_BYTES = 64 * 1024;
 
 function decodeBase58(value) {
   if (!value || value.length > 44) return null;
@@ -33,8 +37,8 @@ function decodeBase58(value) {
   while (leadingZeroes < value.length && value[leadingZeroes] === "1") {
     leadingZeroes += 1;
   }
-  const significantBytes = bytes.length === 1 && bytes[0] === 0 ? [] : bytes;
-  return leadingZeroes + significantBytes.length;
+  const significant = bytes.length === 1 && bytes[0] === 0 ? 0 : bytes.length;
+  return leadingZeroes + significant;
 }
 
 function isSolanaAddress(value) {
@@ -50,47 +54,198 @@ function isSolanaAddress(value) {
 function usage() {
   return `Usage:
   node wallet-claim.mjs --address <public-solana-address>
+  node wallet-claim.mjs register --address <public-solana-address>
 
-Prints a JSON plan and prefilled GitHub issue URL. It performs no network or
-GitHub write and never accepts a seed phrase or private key.`;
+The first command prints a no-write plan. The register command opens Slop's
+one-time GitHub authorization flow and appends an immutable D1 claim. Neither
+command accepts a seed phrase, private key, wallet connection, or signature.`;
 }
 
-function addressArgument(values) {
-  if (values.includes("--help")) return null;
-  if (values.length !== 2 || values[0] !== "--address") {
-    throw new TypeError("Expected only --address <public-solana-address>");
+function argumentsFor(values) {
+  if (values.includes("--help")) return { action: "help", address: null };
+  const action = values[0] === "register" ? "register" : "plan";
+  const offset = action === "register" ? 1 : 0;
+  if (
+    values.length !== offset + 2 ||
+    values[offset] !== "--address" ||
+    !isSolanaAddress(values[offset + 1]?.trim())
+  ) {
+    throw new TypeError(
+      "Expected --address with a canonical 32-byte Solana public key",
+    );
   }
-  const address = values[1]?.trim();
-  if (!isSolanaAddress(address)) {
-    throw new TypeError("Address is not a canonical 32-byte Solana public key");
-  }
-  return address;
+  return { action, address: values[offset + 1].trim() };
 }
 
-try {
-  const address = addressArgument(process.argv.slice(2));
-  if (address === null) {
+async function responseJson(response, field) {
+  const source = await response.text();
+  if (Buffer.byteLength(source) > MAX_RESPONSE_BYTES) {
+    throw new Error(`${field} response exceeded its bound`);
+  }
+  try {
+    return JSON.parse(source);
+  } catch {
+    throw new Error(`${field} response was not JSON`);
+  }
+}
+
+function claim(value, field) {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    value.schemaVersion !== 1 ||
+    typeof value.claimId !== "string" ||
+    !/^[A-Za-z0-9_-]+$/u.test(value.claimId) ||
+    !isSolanaAddress(value.address) ||
+    typeof value.githubActorId !== "string" ||
+    !/^\d+$/u.test(value.githubActorId) ||
+    typeof value.githubLogin !== "string" ||
+    typeof value.observedAt !== "string" ||
+    !Number.isFinite(Date.parse(value.observedAt)) ||
+    typeof value.recordDigest !== "string" ||
+    !/^[0-9a-f]{64}$/u.test(value.recordDigest) ||
+    !(
+      value.supersedesClaimId === null ||
+      (typeof value.supersedesClaimId === "string" &&
+        /^[A-Za-z0-9_-]+$/u.test(value.supersedesClaimId))
+    )
+  ) {
+    throw new Error(`${field} returned an invalid wallet claim`);
+  }
+  return value;
+}
+
+async function authenticate(fetchImpl, assertionProvider) {
+  let assertion = await assertionProvider(fetchImpl);
+  const response = await fetchImpl(`${API_ORIGIN}/api/v1/auth/session`, {
+    method: "POST",
+    headers: { "X-Slop-Identity-Assertion": assertion },
+    signal: AbortSignal.timeout(30_000),
+  });
+  assertion = "";
+  if (!response.ok) {
+    throw new Error(
+      `Slop wallet authentication returned HTTP ${response.status}`,
+    );
+  }
+  const result = await responseJson(response, "Slop wallet authentication");
+  if (
+    typeof result !== "object" ||
+    result === null ||
+    result.tokenType !== "Bearer" ||
+    typeof result.token !== "string" ||
+    result.token.length < 20 ||
+    result.token.length > 4096
+  ) {
+    throw new Error("Slop wallet authentication returned invalid credentials");
+  }
+  return result.token;
+}
+
+export async function registerWalletClaim(
+  address,
+  {
+    fetch: fetchImpl = globalThis.fetch,
+    assertionProvider = slopIdentityAssertion,
+  } = {},
+) {
+  if (typeof fetchImpl !== "function") {
+    throw new Error("Slop wallet registry transport is unavailable");
+  }
+  let token = await authenticate(fetchImpl, assertionProvider);
+  const headers = { Authorization: `Bearer ${token}` };
+  const currentResponse = await fetchImpl(
+    `${API_ORIGIN}/api/v1/wallet-claims/current`,
+    { headers, signal: AbortSignal.timeout(30_000) },
+  );
+  let current = null;
+  if (currentResponse.status !== 404) {
+    if (!currentResponse.ok) {
+      token = "";
+      throw new Error(
+        `Current wallet claim returned HTTP ${currentResponse.status}`,
+      );
+    }
+    current = claim(
+      await responseJson(currentResponse, "Current wallet claim"),
+      "Current wallet claim",
+    );
+  }
+  if (current?.address === address) {
+    token = "";
+    return current;
+  }
+  const created = await fetchImpl(`${API_ORIGIN}/api/v1/wallet-claims`, {
+    method: "POST",
+    headers: { ...headers, "Content-Type": "application/json" },
+    body: JSON.stringify({
+      address,
+      supersedesClaimId: current?.claimId ?? null,
+    }),
+    signal: AbortSignal.timeout(30_000),
+  });
+  token = "";
+  if (!created.ok) {
+    throw new Error(`Wallet registration returned HTTP ${created.status}`);
+  }
+  return claim(
+    await responseJson(created, "Wallet registration"),
+    "Wallet registration",
+  );
+}
+
+export async function main(values = process.argv.slice(2), options = {}) {
+  const parsed = argumentsFor(values);
+  if (parsed.action === "help") {
     process.stdout.write(`${usage()}\n`);
-  } else {
-    const marker = `<!-- ${MARKER_PREFIX} ${JSON.stringify({ chain: "solana", address })} -->`;
-    const query = new URLSearchParams({ title: CLAIM_TITLE, body: marker });
+    return;
+  }
+  if (parsed.action === "plan") {
     process.stdout.write(
       `${JSON.stringify(
         {
-          address,
-          body: marker,
-          newIssueUrl: `https://github.com/${CLAIM_REPOSITORY}/issues/new?${query}`,
-          repository: CLAIM_REPOSITORY,
-          title: CLAIM_TITLE,
+          action: "register-wallet",
+          address: parsed.address,
+          authority: `${API_ORIGIN}/api/v1/wallet-claims`,
+          authentication: "one-time-github-oauth",
+          storage: "append-only-d1",
+          writes: false,
         },
         null,
         2,
       )}\n`,
     );
+    return;
   }
-} catch (error) {
-  process.stderr.write(
-    `[Slop] wallet claim refused: ${error instanceof Error ? error.message : "unknown error"}\n`,
+  const registered = await registerWalletClaim(parsed.address, options);
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        address: registered.address,
+        claimId: registered.claimId,
+        githubLogin: registered.githubLogin,
+        observedAt: registered.observedAt,
+        recordDigest: registered.recordDigest,
+        sourceUrl: `${API_ORIGIN}/api/v1/wallet-claims/${registered.claimId}`,
+      },
+      null,
+      2,
+    )}\n`,
   );
-  process.exitCode = 1;
+}
+
+const invokedDirectly =
+  typeof process.argv[1] === "string" &&
+  existsSync(process.argv[1]) &&
+  realpathSync(fileURLToPath(import.meta.url)) ===
+    realpathSync(process.argv[1]);
+if (invokedDirectly) {
+  try {
+    await main();
+  } catch (error) {
+    process.stderr.write(
+      `[Slop] wallet registration refused: ${error instanceof Error ? error.message : "unknown error"}\n`,
+    );
+    process.exitCode = 1;
+  }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -898,8 +898,8 @@ function InstallPanel({ project }: { project: ProjectDefinition }) {
       <p className="install-note">
         Any model can join. The skill publishes the exact provider, model, and
         client. Every agent run uploads a permanent private trace; only Slop
-        operators can access its contents. Payout setup uses a GitHub wallet
-        claim, with database recovery when needed.
+        operators can access its contents. Payout setup uses an authenticated,
+        append-only Slop wallet registry.
       </p>
       <details className="install-advanced">
         <summary>Advanced options</summary>
@@ -1320,11 +1320,11 @@ function ProfilePage({
             </ExternalLinkAnchor>
             {wallet ? (
               <ExternalLinkAnchor href={wallet.sourceUrl}>
-                Wallet · {wallet.address}{" "}
+                Payout wallet · {wallet.address}{" "}
                 <ExternalLink aria-hidden="true" size={15} />
               </ExternalLinkAnchor>
             ) : (
-              <span>Wallet not linked</span>
+              <span>No payout wallet registered</span>
             )}
           </div>
         </div>

--- a/tests/app.test.tsx
+++ b/tests/app.test.tsx
@@ -413,7 +413,7 @@ describe("project routes", () => {
       screen.queryByText(/One prompt handles the contribution/u),
     ).not.toBeInTheDocument();
     expect(
-      screen.getByText(/Payout setup uses a GitHub wallet claim/u),
+      screen.getByText(/Payout setup uses an authenticated/u),
     ).toBeInTheDocument();
     expect(
       screen.queryByLabelText("Solana public address"),
@@ -675,7 +675,7 @@ describe("public records", () => {
     render(<App />);
 
     const wallet = await screen.findByRole("link", {
-      name: /Wallet · 11111111111111111111111111111111/i,
+      name: /Payout wallet · 11111111111111111111111111111111/i,
     });
     expect(wallet).toHaveAttribute("href", expect.stringContaining("/blob/"));
   });

--- a/workers/identity/README.md
+++ b/workers/identity/README.md
@@ -153,6 +153,13 @@ bunx wrangler deploy --config workers/identity/wrangler.toml
 `SLOP_IDENTITY`. Keep `workers_dev = false`; only the custom OAuth domain and
 service binding should invoke it.
 
+The final `wrangler deploy` above is a one-time provisioning operation because
+it creates the custom domain and cron trigger. Normal production releases use
+the protected workflow's `wrangler versions upload` followed by
+`wrangler versions deploy`; that updates the active code and bindings without
+requesting zone-level Workers Routes authority or rewriting the established
+domain.
+
 Before enabling clients, verify the custom domain's DNS and TLS separately and
 prove rate limiting, assertion replay, and CSRF rejection in production. Zone
 WAF rules remain defense in depth and must not replace the route-specific


### PR DESCRIPTION
## Outcome

Wallet issues are no longer a live payout authority. Contributors now authenticate once with GitHub OAuth and append an actor-bound wallet record directly to the immutable D1 registry. Address changes append a successor; they never mutate history.

## What changed

- add authenticated contributor `GET/POST /api/v1/wallet-claims/current`
- add public actor-current and immutable claim receipt endpoints
- enforce one root and one successor per actor at the D1 boundary
- resolve reward wallets from D1 first, with immutable profile README retained only as a legacy fallback
- remove GitHub issue reads from reward preparation and both payout skills
- add a bounded, receipt-verified migration for historical issues #50 and #53–#58
- re-read each issue immediately before closure and abort on any source drift
- label historical issue/profile proofs as migrated/legacy in public UI
- switch identity Worker releases to tagged version upload + 100% promotion, avoiding the zone-route mutation that failed Actions job 94979003714

## Verification

- `bun install --frozen-lockfile`
- `bun run projects:check`
- `bun run evaluations:check`
- `bun run cycles:check`
- `bun run protocol:check`
- `bun run typecheck`
- `bun run lint:check`
- `bun run format:check`
- `bun run audit:dependencies` (no vulnerabilities)
- `bun run test` (353 Vitest + 55 Bun tests)
- `bun run build`
- `bun run test:e2e` (36/36 across wide desktop, desktop, tablet, narrow mobile)
- Wrangler local D1 migrations 0001–0003 and exact schema inventory
- Wrangler identity `versions upload --dry-run`
- live leaderboard refresh: 93 leaders, 2,445 score events, all bounded GitHub reads complete
- read-only wallet migration preview: exactly #50, #53, #54, #55, #56, #57, #58

## Post-deploy transaction

After the protected `develop` release applies migration 0003 and deploys the API, run the migration with operator OAuth. Close a historical issue only after its immutable public D1 receipt matches and a fresh GitHub re-read confirms the source did not change.
