### PR TITLE
fix: isolate Pages browser contract

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "audit:dependencies": "bun audit --production",
     "typecheck": "tsc -b",
     "test": "vitest run && bun test skill-tests/*.test.ts",
-    "test:e2e": "playwright test",
+    "test:e2e": "node scripts/run-e2e.mjs",
     "test:e2e:record": "node scripts/record-evidence.mjs --local",
     "test:e2e:record:production": "node scripts/record-evidence.mjs --production",
     "lint": "bunx @biomejs/biome check --write --unsafe .",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,6 +8,16 @@ const externalBaseUrl =
   process.env.SLOP_BASE_URL ??
   process.env.GITARMY_BASE_URL ??
   process.env.ELIZA_ARMY_BASE_URL;
+const prebuiltSite = process.env.SLOP_E2E_PREBUILT === "1";
+const localServer = process.env.SLOP_E2E_SERVER ?? "pages";
+if (!new Set(["pages", "preview"]).has(localServer)) {
+  throw new TypeError(`Unsupported SLOP_E2E_SERVER: ${localServer}`);
+}
+
+const localServerCommand =
+  localServer === "preview"
+    ? "bun --bun vite preview --host 127.0.0.1 --port 4466 --strictPort"
+    : "bunx wrangler pages dev dist --ip 127.0.0.1 --port 4466 --log-level warn --show-interactive-dev-session=false";
 
 export default defineConfig({
   testDir: "./tests/e2e",
@@ -30,8 +40,7 @@ export default defineConfig({
   webServer: externalBaseUrl
     ? undefined
     : {
-        command:
-          "bun run build && bunx wrangler pages dev dist --ip 127.0.0.1 --port 4466 --log-level warn --show-interactive-dev-session=false",
+        command: `${prebuiltSite ? "" : "bun run build && "}${localServerCommand}`,
         url: "http://127.0.0.1:4466",
         reuseExistingServer: !process.env.CI,
         timeout: 120_000,

--- a/scripts/deployment-contract.test.mjs
+++ b/scripts/deployment-contract.test.mjs
@@ -37,6 +37,10 @@ const playwrightConfiguration = readFileSync(
   join(packageRoot, "playwright.config.ts"),
   "utf8",
 );
+const e2eRunner = readFileSync(
+  join(packageRoot, "scripts", "run-e2e.mjs"),
+  "utf8",
+);
 const qualityJob = workflow.slice(
   workflow.indexOf("\n  quality:"),
   workflow.indexOf("\n  deploy:"),
@@ -120,6 +124,29 @@ describe("slop.cash deployment contract", () => {
       "node scripts/dist-manifest.mjs create dist",
     );
     expect(playwrightConfiguration).toContain("workers: 1");
+    expect(packageManifest.scripts["test:e2e"]).toBe(
+      "node scripts/run-e2e.mjs",
+    );
+    expect(playwrightConfiguration).toContain(
+      'process.env.SLOP_E2E_PREBUILT === "1"',
+    );
+    expect(playwrightConfiguration).toContain(
+      'process.env.SLOP_E2E_SERVER ?? "pages"',
+    );
+    expect(playwrightConfiguration).toContain("vite preview");
+    expect(playwrightConfiguration).toContain("wrangler pages dev dist");
+    for (const project of [
+      "wide-desktop-chromium",
+      "desktop-chromium",
+      "tablet-chromium",
+      "narrow-mobile-chromium",
+    ]) {
+      expect(playwrightConfiguration).toContain(`name: "${project}"`);
+    }
+    expect(e2eRunner).toContain('SLOP_E2E_SERVER: "preview"');
+    expect(e2eRunner).toContain('SLOP_E2E_SERVER: "pages"');
+    expect(e2eRunner).toContain('"--grep-invert", artifactContract');
+    expect(e2eRunner).toContain('"--grep",\n    artifactContract');
     expect(qualityJob).toContain("run: bun run test:e2e");
   });
 

--- a/scripts/run-e2e.mjs
+++ b/scripts/run-e2e.mjs
@@ -1,0 +1,54 @@
+/**
+ * Runs the complete browser matrix against the stable built-site preview, then
+ * gives the one redirect/header/artifact contract a focused Pages-emulator run.
+ * Wrangler can terminate during long browser sessions on constrained hosted
+ * runners, while that focused check still exercises the behavior only Pages
+ * supplies instead of replacing it with a generic static-server assertion.
+ */
+
+import { spawnSync } from "node:child_process";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const playwright = join(packageRoot, "node_modules", ".bin", "playwright");
+const artifactContract =
+  "serves byte-consistent install and read-only artifacts for every project";
+
+function run(command, args, env = process.env) {
+  const result = spawnSync(command, args, {
+    cwd: packageRoot,
+    env,
+    stdio: "inherit",
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) process.exit(result.status ?? 1);
+}
+
+run("bun", ["run", "build"]);
+
+run(
+  playwright,
+  ["test", "--grep-invert", artifactContract, ...process.argv.slice(2)],
+  {
+    ...process.env,
+    SLOP_E2E_PREBUILT: "1",
+    SLOP_E2E_SERVER: "preview",
+  },
+);
+
+run(
+  playwright,
+  [
+    "test",
+    "--project=wide-desktop-chromium",
+    "--grep",
+    artifactContract,
+    ...process.argv.slice(2),
+  ],
+  {
+    ...process.env,
+    SLOP_E2E_PREBUILT: "1",
+    SLOP_E2E_SERVER: "pages",
+  },
+);


### PR DESCRIPTION
Supersedes the prematurely merged #82 after run 31875824981 proved that even a fresh long-lived Wrangler session can terminate on the hosted Linux runner.\n\nThe full desktop/tablet/mobile UI matrix now runs against the exact built production files on Vite's stable preview. A separate focused Wrangler Pages check still proves the Pages-only redirect, response-header, and byte-consistent artifact contract. No assertion is removed; the request-only Pages contract is simply run once rather than redundantly once per viewport.\n\nValidation:\n- CI=true bun run test:e2e (32 UI viewport checks + focused Pages artifact contract)\n- bunx vitest run scripts/deployment-contract.test.mjs\n- bunx vitest run scripts/prepare-site.test.ts src/lib/install-command.test.ts\n- bun run typecheck\n- bun run lint:check\n- bun run format:check\n- bun run build