### PR TITLE
fix: route private API through Pages Functions

### DIFF
--- a/public/_routes.json
+++ b/public/_routes.json
@@ -1,6 +1,12 @@
 {
   "version": 1,
-  "include": ["/", "/projects/*", "/contributors/*", "/cycles/*"],
+  "include": [
+    "/",
+    "/api/v1/*",
+    "/projects/*",
+    "/contributors/*",
+    "/cycles/*"
+  ],
   "exclude": [
     "/projects/*/*.md",
     "/projects/*/*.json",

--- a/scripts/deployment-contract.test.mjs
+++ b/scripts/deployment-contract.test.mjs
@@ -33,6 +33,9 @@ const pagesHeaders = readFileSync(
   join(packageRoot, "public", "_headers"),
   "utf8",
 );
+const pagesRoutes = JSON.parse(
+  readFileSync(join(packageRoot, "public", "_routes.json"), "utf8"),
+);
 const playwrightConfiguration = readFileSync(
   join(packageRoot, "playwright.config.ts"),
   "utf8",
@@ -228,6 +231,7 @@ describe("slop.cash deployment contract", () => {
     expect(pagesHeaders).toContain(
       "Cache-Control: public, max-age=31536000, immutable",
     );
+    expect(pagesRoutes.include).toContain("/api/v1/*");
   });
 
   it("binds the private trace and identity runtime through reviewed configuration", () => {

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -546,6 +546,15 @@ test("creates a valid GitHub-native project handoff", async ({ page }) => {
 test("serves byte-consistent install and read-only artifacts for every project", async ({
   request,
 }) => {
+  const privateApiResponse = await request.post("/api/v1/runs", {
+    data: {},
+  });
+  // The local Pages origin is intentionally plain HTTP, so reaching the
+  // Function must fail at its HTTPS boundary rather than Cloudflare's static
+  // file handler (405) or the SPA fallback (200).
+  expect(privateApiResponse.status()).toBe(400);
+  expect(await privateApiResponse.json()).toEqual({ error: "https_required" });
+
   const legacySkillResponse = await request.get("/skill.md", {
     maxRedirects: 0,
   });


### PR DESCRIPTION
Fixes the post-deploy 405 in run 31876690959. The Functions bundle was uploaded, but public/_routes.json omitted /api/v1/*, so Cloudflare sent API requests to its static handler/SPA fallback. This adds the API execution route and regression checks in both the deployment contract and the focused real-Wrangler browser test.\n\nValidation:\n- bunx vitest run scripts/deployment-contract.test.mjs functions/api/v1/trace-api.test.ts (16/16)\n- bun run build\n- focused Wrangler Pages browser contract (1/1)\n- formatting and diff checks