### PR TITLE
fix: make protected release retries idempotent

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -385,14 +385,26 @@ jobs:
           # Upload and promote a version without rewriting the existing custom
           # domain or cron configuration. The production token intentionally
           # has no zone-level Workers Routes permission.
+          identity_upload="$RUNNER_TEMP/slop-identity-upload.log"
           ./node_modules/.bin/wrangler versions upload \
             --config workers/identity/wrangler.toml \
             --minify \
             --tag="$GITHUB_SHA" \
-            --message="slop.cash release $GITHUB_SHA"
+            --message="slop.cash release $GITHUB_SHA" 2>&1 | tee "$identity_upload"
+          identity_version_id="$(node - "$identity_upload" <<'NODE'
+          const { readFileSync } = require("node:fs");
+          const contents = readFileSync(process.argv[2], "utf8");
+          const matches = [...contents.matchAll(/^Worker Version ID:\s*([0-9a-f-]+)\s*$/gmu)];
+          if (matches.length !== 1 || !/^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$/u.test(matches[0][1])) {
+            throw new TypeError("identity upload did not return exactly one Worker version id");
+          }
+          process.stdout.write(matches[0][1]);
+          NODE
+          )"
           ./node_modules/.bin/wrangler versions deploy \
             --name slop-identity \
-            --version-tag="$GITHUB_SHA@100%" \
+            --version-id="$identity_version_id" \
+            --percentage=100 \
             --message="slop.cash release $GITHUB_SHA" \
             --yes
 
@@ -637,10 +649,22 @@ jobs:
             echo "::error::Published $artifact did not match the verified build."
             return 1
           }
-          node scripts/dist-manifest.mjs verify \
-            dist \
-            https://slop.cash \
-            "$GITHUB_SHA-$GITHUB_RUN_ATTEMPT"
+          manifest_verified=false
+          for manifest_attempt in 1 2 3; do
+            if node scripts/dist-manifest.mjs verify \
+              dist \
+              https://slop.cash \
+              "$GITHUB_SHA-$GITHUB_RUN_ATTEMPT-$manifest_attempt"; then
+              manifest_verified=true
+              break
+            fi
+            echo "::warning::Deployment manifest verification attempt $manifest_attempt did not match the verified build."
+            sleep 5
+          done
+          if [ "$manifest_verified" != true ]; then
+            echo "::error::Published deployment manifest did not match the verified build."
+            exit 1
+          fi
           # The inventory checks /index.html; this additional request proves the
           # public root route resolves to those same tested bytes.
           verify_download / dist/index.html index.html

--- a/scripts/deployment-contract.test.mjs
+++ b/scripts/deployment-contract.test.mjs
@@ -83,7 +83,10 @@ describe("slop.cash deployment contract", () => {
       "./node_modules/.bin/wrangler d1 execute slop-private \\",
     );
     expect(deployJob).toContain('--tag="$GITHUB_SHA"');
-    expect(deployJob).toContain('--version-tag="$GITHUB_SHA@100%"');
+    expect(deployJob).toContain('--version-id="$identity_version_id"');
+    expect(deployJob).toContain("--percentage=100");
+    expect(deployJob).not.toContain('--version-tag="$GITHUB_SHA@100%"');
+    expect(deployJob).toContain("Worker Version ID:");
     expect(deployJob).toContain('--message="slop.cash release $GITHUB_SHA"');
     expect(deployJob).toContain("wrangler versions list \\");
     expect(deployJob).toContain("wrangler deployments status \\");
@@ -215,10 +218,13 @@ describe("slop.cash deployment contract", () => {
       `"https://slop.cash${"$"}{remote_path}?verify=`,
     );
     expect(verificationStep).toContain("node scripts/dist-manifest.mjs verify");
+    expect(verificationStep).toContain("for manifest_attempt in 1 2 3; do");
+    expect(verificationStep).toContain(
+      '"$GITHUB_SHA-$GITHUB_RUN_ATTEMPT-$manifest_attempt"',
+    );
     expect(verificationStep.match(/verify_download \//g)).toHaveLength(1);
     expect(verificationStep).toContain('while [ "$attempt" -le 3 ]');
     expect(verificationStep).toContain("https://slop.cash \\");
-    expect(verificationStep).toContain('"$GITHUB_SHA-$GITHUB_RUN_ATTEMPT"');
   });
 
   it("serves HTTPS policy and immutable hashed assets", () => {


### PR DESCRIPTION
Fixes the exact retry failure in run 31877449943 attempt 2. A repeated identity upload legitimately creates another Worker version with the same audited commit tag, so tag-based promotion becomes ambiguous. The workflow now parses and validates the exact version ID returned by this upload and promotes that ID at 100%, while retaining the commit tag/message for post-deploy provenance verification. It also retries the deployment-manifest propagation boundary before failing.\n\nValidation:\n- bunx vitest run scripts/deployment-contract.test.mjs (7/7)\n- wrangler versions upload --dry-run\n- Biome and diff checks