### PR TITLE
fix: wait for Pages custom-domain propagation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -650,7 +650,7 @@ jobs:
             return 1
           }
           manifest_verified=false
-          for manifest_attempt in 1 2 3; do
+          for manifest_attempt in $(seq 1 24); do
             if node scripts/dist-manifest.mjs verify \
               dist \
               https://slop.cash \

--- a/scripts/deployment-contract.test.mjs
+++ b/scripts/deployment-contract.test.mjs
@@ -218,7 +218,9 @@ describe("slop.cash deployment contract", () => {
       `"https://slop.cash${"$"}{remote_path}?verify=`,
     );
     expect(verificationStep).toContain("node scripts/dist-manifest.mjs verify");
-    expect(verificationStep).toContain("for manifest_attempt in 1 2 3; do");
+    expect(verificationStep).toContain(
+      "for manifest_attempt in $(seq 1 24); do",
+    );
     expect(verificationStep).toContain(
       '"$GITHUB_SHA-$GITHUB_RUN_ATTEMPT-$manifest_attempt"',
     );


### PR DESCRIPTION
The exact release in run 31878185033 passed upload, exact Worker version-ID promotion, deployment metadata, and the private API 401 boundary, but the custom-domain deployment manifest remained stale for longer than 15 seconds. This extends only that fail-closed manifest propagation loop to a bounded two minutes. It does not weaken byte verification or accept stale content.\n\nValidation: bunx vitest run scripts/deployment-contract.test.mjs (7/7), formatting and diff checks.