### PR TITLE
fix: allow bounded Pages domain propagation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -650,7 +650,9 @@ jobs:
             return 1
           }
           manifest_verified=false
-          for manifest_attempt in $(seq 1 24); do
+          # Custom-domain propagation has exceeded two minutes in production.
+          # Keep retrying the exact byte inventory rather than accepting stale content.
+          for manifest_attempt in $(seq 1 72); do
             if node scripts/dist-manifest.mjs verify \
               dist \
               https://slop.cash \


### PR DESCRIPTION
## Summary
- extend the fail-closed slop.cash manifest verification window from two to six minutes
- retain exact byte comparison on every retry; no fallback success

## Evidence
- production deployments b69af9f9 and d1b10680 were healthy immediately at immutable Pages URLs
- slop.cash converged to the exact build after the original two-minute bound
- `bun run format:check`
- `git diff --check`