### PR TITLE
test: require extended deployment verification

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -650,7 +650,9 @@ jobs:
             return 1
           }
           manifest_verified=false
-          for manifest_attempt in $(seq 1 24); do
+          # Custom-domain propagation has exceeded two minutes in production.
+          # Keep retrying the exact byte inventory rather than accepting stale content.
+          for manifest_attempt in $(seq 1 72); do
             if node scripts/dist-manifest.mjs verify \
               dist \
               https://slop.cash \

--- a/scripts/deployment-contract.test.mjs
+++ b/scripts/deployment-contract.test.mjs
@@ -219,7 +219,7 @@ describe("slop.cash deployment contract", () => {
     );
     expect(verificationStep).toContain("node scripts/dist-manifest.mjs verify");
     expect(verificationStep).toContain(
-      "for manifest_attempt in $(seq 1 24); do",
+      "for manifest_attempt in $(seq 1 72); do",
     );
     expect(verificationStep).toContain(
       '"$GITHUB_SHA-$GITHUB_RUN_ATTEMPT-$manifest_attempt"',


### PR DESCRIPTION
## Summary
- update the deployment contract test to require the new six-minute fail-closed manifest bound

## Verification
- `bun run test` (354 Vitest + 55 Bun tests passed)
- `bun run format:check`
- `git diff --check`