### PR TITLE
fix: cover observed Pages propagation bound

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -650,9 +650,9 @@ jobs:
             return 1
           }
           manifest_verified=false
-          # Custom-domain propagation has exceeded two minutes in production.
+          # Custom-domain propagation has exceeded six minutes in production.
           # Keep retrying the exact byte inventory rather than accepting stale content.
-          for manifest_attempt in $(seq 1 72); do
+          for manifest_attempt in $(seq 1 96); do
             if node scripts/dist-manifest.mjs verify \
               dist \
               https://slop.cash \

--- a/scripts/deployment-contract.test.mjs
+++ b/scripts/deployment-contract.test.mjs
@@ -219,7 +219,7 @@ describe("slop.cash deployment contract", () => {
     );
     expect(verificationStep).toContain("node scripts/dist-manifest.mjs verify");
     expect(verificationStep).toContain(
-      "for manifest_attempt in $(seq 1 72); do",
+      "for manifest_attempt in $(seq 1 96); do",
     );
     expect(verificationStep).toContain(
       '"$GITHUB_SHA-$GITHUB_RUN_ATTEMPT-$manifest_attempt"',


### PR DESCRIPTION
## Summary
- extend exact-byte custom-domain verification from six to eight minutes
- update the pinned deployment contract assertion in the same commit

## Production evidence
- run 31879904446 remained stale through the six-minute bound
- the live manifest matched the exact verified artifact immediately after the bound
- the check remains fail-closed and never accepts stale bytes

## Verification
- `bunx vitest run scripts/deployment-contract.test.mjs`
- `bun run format:check`
- `git diff --check`