### PR TITLE
fix: make public project drafting unmistakable

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1062,7 +1062,7 @@ function ProjectPaymentHistory({
     <section className="section payment-history">
       <div className="simple-heading">
         <h2>Payment history</h2>
-        <Link href={`/projects/${project.slug}/manage`}>Manage project</Link>
+        <Link href={`/projects/${project.slug}/manage`}>Draft an update</Link>
       </div>
       <p className="money-summary">
         <strong>{formatMicroUsdc(paid.toString())} paid</strong>
@@ -1773,7 +1773,7 @@ interface AllocationDraftRow {
   reason: string;
 }
 
-function ProjectManagePage({
+export function ProjectManagePage({
   project,
   state,
 }: {
@@ -1838,6 +1838,9 @@ function ProjectManagePage({
     changedRowsHaveReasons;
   const feeMinor = feeForPrincipal(parsedTotal ?? "0", 100);
   const cycleId = latestRecord?.cycleId ?? view?.cycle.id ?? "next-cycle";
+  const payoutDraftingEnabled =
+    project.reward.kind === "monthly-pool" &&
+    project.reward.paymentMode === "enabled";
   const allocationDraft = JSON.stringify(
     {
       projectId: project.id,
@@ -1864,17 +1867,19 @@ function ProjectManagePage({
     <main className="shell route-main manage-page">
       <p className="breadcrumb">
         <Link href={`/projects/${project.slug}`}>{project.name}</Link>
-        <span>/</span>Manage
+        <span>/</span>Draft update
       </p>
       <div className="manage-intro">
-        <h1>Run {project.name}.</h1>
+        <h1>Propose changes to {project.name}.</h1>
         <p>
-          Draft changes here. GitHub review remains the publishing boundary.
+          This public tool does not save or publish changes. Copy a proposal and
+          open a reviewed GitHub pull request; the repository remains the source
+          of truth.
         </p>
       </div>
 
       <section className="owner-section">
-        <h2>Project</h2>
+        <h2>Project brief</h2>
         <div className="owner-form">
           <label>
             Headline
@@ -1902,133 +1907,168 @@ function ProjectManagePage({
             onClick={() => void copy("project", projectBrief)}
             type="button"
           >
-            {copied === "project" ? "Copied" : "Copy project update"}
+            {copied === "project" ? "Copied" : "Copy GitHub brief"}
           </button>
         </div>
       </section>
 
-      <section className="owner-section allocation-editor">
-        <h2>{cycleId} payout</h2>
-        <p>
-          Set any nonnegative amount, including zero. Changed amounts need a
-          public reason. The 1% fee is charged only when principal is paid.
-        </p>
-        <label className="total-field">
-          Total payout, USDC
-          <input
-            inputMode="decimal"
-            min="0"
-            step="0.000001"
-            type="number"
-            value={total}
-            onChange={(event) => setTotal(event.target.value)}
-          />
-        </label>
-        {rows.length > 20 ? (
-          <label className="allocation-search">
-            Find contributor
-            <input
-              onChange={(event) => setAllocationQuery(event.target.value)}
-              placeholder="GitHub login"
-              type="search"
-              value={allocationQuery}
-            />
-          </label>
-        ) : null}
-        {rows.length === 0 ? (
-          <EmptyState text="No contributors are available for this cycle." />
-        ) : visibleRows.length === 0 ? (
-          <EmptyState text="No contributor matches that login." />
-        ) : (
-          <div className="allocation-rows">
-            {visibleRows.map((row) => (
-              <fieldset key={row.login}>
-                <legend>{row.login}</legend>
-                <label>
-                  Amount, USDC
+      {payoutDraftingEnabled ? (
+        <section className="owner-section allocation-editor">
+          <h2>{cycleId} allocation</h2>
+          <div className="owner-section-body">
+            <p>
+              Draft only. This page cannot save, approve, sign, or send USDC.
+              Changed amounts need a public reason; the 1% fee applies only if a
+              reviewed cycle is later paid.
+            </p>
+            <label className="total-field">
+              Draft total, USDC
+              <input
+                inputMode="decimal"
+                min="0"
+                step="0.000001"
+                type="number"
+                value={total}
+                onChange={(event) => setTotal(event.target.value)}
+              />
+            </label>
+            <details className="allocation-details">
+              <summary>
+                Edit {rows.length} contributor allocation
+                {rows.length === 1 ? "" : "s"}
+              </summary>
+              {rows.length > 20 ? (
+                <label className="allocation-search">
+                  Find contributor
                   <input
-                    aria-label={`${row.login} amount in USDC`}
-                    inputMode="decimal"
-                    min="0"
-                    step="0.000001"
-                    type="number"
-                    value={row.amount}
-                    onChange={(event) =>
-                      setRows((current) =>
-                        current.map((candidate) =>
-                          candidate.login === row.login
-                            ? { ...candidate, amount: event.target.value }
-                            : candidate,
-                        ),
-                      )
-                    }
+                    onChange={(event) => setAllocationQuery(event.target.value)}
+                    placeholder="GitHub login"
+                    type="search"
+                    value={allocationQuery}
                   />
                 </label>
-                <label>
-                  Reason
-                  <input
-                    aria-label={`${row.login} reason`}
-                    value={row.reason}
-                    onChange={(event) =>
-                      setRows((current) =>
-                        current.map((candidate) =>
-                          candidate.login === row.login
-                            ? { ...candidate, reason: event.target.value }
-                            : candidate,
-                        ),
-                      )
-                    }
-                  />
-                </label>
-              </fieldset>
-            ))}
+              ) : null}
+              {rows.length === 0 ? (
+                <EmptyState text="No contributors are available for this cycle." />
+              ) : visibleRows.length === 0 ? (
+                <EmptyState text="No contributor matches that login." />
+              ) : (
+                <div className="allocation-rows">
+                  {visibleRows.map((row) => (
+                    <fieldset key={row.login}>
+                      <legend>{row.login}</legend>
+                      <label>
+                        Amount, USDC
+                        <input
+                          aria-label={`${row.login} amount in USDC`}
+                          inputMode="decimal"
+                          min="0"
+                          step="0.000001"
+                          type="number"
+                          value={row.amount}
+                          onChange={(event) =>
+                            setRows((current) =>
+                              current.map((candidate) =>
+                                candidate.login === row.login
+                                  ? {
+                                      ...candidate,
+                                      amount: event.target.value,
+                                    }
+                                  : candidate,
+                              ),
+                            )
+                          }
+                        />
+                      </label>
+                      <label>
+                        Reason
+                        <input
+                          aria-label={`${row.login} reason`}
+                          value={row.reason}
+                          onChange={(event) =>
+                            setRows((current) =>
+                              current.map((candidate) =>
+                                candidate.login === row.login
+                                  ? {
+                                      ...candidate,
+                                      reason: event.target.value,
+                                    }
+                                  : candidate,
+                              ),
+                            )
+                          }
+                        />
+                      </label>
+                    </fieldset>
+                  ))}
+                </div>
+              )}
+              {matchingRows.length > visibleRows.length ? (
+                <p className="allocation-count">
+                  Showing the first 10 contributors. Search by GitHub login to
+                  edit another.
+                </p>
+              ) : null}
+            </details>
+            <div className="payout-totals" aria-live="polite">
+              <span>{formatMicroUsdc(allocated.toString())} allocated</span>
+              <span>{formatMicroUsdc(feeMinor)} fee</span>
+              <strong>
+                {formatMicroUsdc(
+                  (BigInt(parsedTotal ?? "0") + BigInt(feeMinor)).toString(),
+                )}{" "}
+                total debit
+              </strong>
+            </div>
+            {!validAllocation && rows.length > 0 ? (
+              <p className="form-error" role="alert">
+                Allocations must equal the total. Add a reason for every changed
+                amount.
+              </p>
+            ) : null}
+            <button
+              className="button primary-button"
+              disabled={!validAllocation || rows.length === 0}
+              onClick={() => void copy("allocation", allocationDraft)}
+              type="button"
+            >
+              {copied === "allocation"
+                ? "Allocation copied"
+                : "Copy unsigned allocation"}
+            </button>
+            <div className="payout-action">
+              {latestRecord?.files.executionPlan ? (
+                <ExternalLinkAnchor href={latestRecord.files.executionPlan.url}>
+                  View unsigned plan{" "}
+                  <ExternalLink aria-hidden="true" size={14} />
+                </ExternalLinkAnchor>
+              ) : (
+                <span>No reviewed execution plan exists for this cycle.</span>
+              )}
+              <p>
+                Settlement happens outside this page and counts as paid only
+                after finalized USDC balance changes pass verification.
+              </p>
+            </div>
           </div>
-        )}
-        {matchingRows.length > visibleRows.length ? (
-          <p className="allocation-count">
-            Showing 10 contributors. Search by GitHub login to edit another.
-          </p>
-        ) : null}
-        <div className="payout-totals" aria-live="polite">
-          <span>{formatMicroUsdc(allocated.toString())} allocated</span>
-          <span>{formatMicroUsdc(feeMinor)} fee</span>
-          <strong>
-            {formatMicroUsdc(
-              (BigInt(parsedTotal ?? "0") + BigInt(feeMinor)).toString(),
-            )}{" "}
-            total debit
-          </strong>
-        </div>
-        {!validAllocation && rows.length > 0 ? (
-          <p className="form-error" role="alert">
-            Allocations must equal the total. Add a reason for every changed
-            amount.
-          </p>
-        ) : null}
-        <button
-          className="button primary-button"
-          disabled={!validAllocation || rows.length === 0}
-          onClick={() => void copy("allocation", allocationDraft)}
-          type="button"
-        >
-          {copied === "allocation"
-            ? "Allocation copied"
-            : "Copy allocation draft"}
-        </button>
-        <div className="payout-action">
-          {latestRecord?.files.executionPlan ? (
-            <ExternalLinkAnchor href={latestRecord.files.executionPlan.url}>
-              View unsigned plan <ExternalLink aria-hidden="true" size={14} />
-            </ExternalLinkAnchor>
-          ) : (
-            <span>Generate an immutable unsigned plan before signing.</span>
-          )}
-          <p>
-            Sign the exact mainnet USDC transfers in your wallet. A cycle is
-            paid only after finalized USDC deltas pass verification.
-          </p>
-        </div>
-      </section>
+        </section>
+      ) : (
+        <section className="owner-section">
+          <h2>Payouts</h2>
+          <div className="owner-section-body payout-status">
+            <strong>
+              {project.reward.kind === "external-prize-share"
+                ? "External award"
+                : "Payouts disabled"}
+            </strong>
+            <p>
+              {project.reward.kind === "external-prize-share"
+                ? "This project publishes contribution shares only. Slop cannot draft, approve, sign, or pay the external award."
+                : "Slop cannot draft, approve, sign, or pay allocations while the public project manifest keeps payouts disabled."}
+            </p>
+          </div>
+        </section>
+      )}
     </main>
   );
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1641,22 +1641,23 @@ small {
 }
 
 .manage-intro {
-  max-width: 920px;
-  padding-bottom: 70px;
+  max-width: 860px;
+  padding-bottom: 56px;
 }
 
 .manage-intro h1 {
-  margin-bottom: 20px;
-  font-size: clamp(52px, 8vw, 104px);
-  letter-spacing: -0.065em;
-  line-height: 0.92;
+  max-width: 14ch;
+  margin-bottom: 18px;
+  font-size: clamp(46px, 6.5vw, 86px);
+  letter-spacing: -0.035em;
+  line-height: 0.96;
 }
 
 .manage-intro p,
-.owner-section > p {
+.owner-section-body > p {
   max-width: 68ch;
   color: var(--muted);
-  font-size: 14px;
+  font-size: 15px;
   line-height: 1.65;
 }
 
@@ -1668,18 +1669,12 @@ small {
   border-top: 1px solid var(--line);
 }
 
-:where(.owner-section)
-  > :where(
-    p,
-    .total-field,
-    .allocation-rows,
-    .payout-totals,
-    .form-error,
-    .button,
-    .payout-action,
-    .empty-state
-  ) {
-  grid-column: 2;
+.owner-section-body {
+  min-width: 0;
+}
+
+.owner-section-body > :first-child {
+  margin-top: 0;
 }
 
 .owner-form {
@@ -1726,13 +1721,46 @@ small {
 
 .total-field {
   max-width: 360px;
-  margin-top: 16px;
+  margin-top: 24px;
+}
+
+.allocation-details {
+  margin-top: 32px;
+  border-block: 1px solid var(--line);
+}
+
+.allocation-details > summary {
+  min-height: 52px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  color: var(--ink);
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 750;
+  list-style: none;
+}
+
+.allocation-details > summary::-webkit-details-marker {
+  display: none;
+}
+
+.allocation-details > summary::after {
+  content: "+";
+  color: var(--orange-dark);
+  font-size: 20px;
+  font-weight: 700;
+}
+
+.allocation-details[open] > summary::after {
+  content: "−";
 }
 
 .allocation-search {
   display: block;
   max-width: 360px;
-  margin-block: 24px;
+  margin-block: 16px 24px;
 }
 
 .allocation-count {
@@ -1756,9 +1784,10 @@ small {
 }
 
 .allocation-rows legend {
-  float: left;
+  grid-column: 1 / -1;
+  float: none;
   width: 100%;
-  margin-bottom: 10px;
+  padding: 0;
   font-size: 16px;
   font-weight: 750;
 }
@@ -1782,13 +1811,34 @@ small {
   font-size: 12px;
 }
 
-.owner-section > .button {
+.owner-section-body > .button {
   width: fit-content;
+  margin-top: 24px;
 }
 
-.owner-section > .button:disabled {
+.owner-section-body > .button:disabled {
   opacity: 0.4;
   cursor: not-allowed;
+}
+
+.payout-status {
+  max-width: 680px;
+}
+
+.payout-status strong {
+  display: block;
+  margin-bottom: 8px;
+  color: var(--orange-dark);
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.payout-status p {
+  max-width: 64ch;
+  margin: 0;
+  color: var(--muted);
+  font-size: 15px;
+  line-height: 1.65;
 }
 
 .payout-action {
@@ -1887,20 +1937,6 @@ small {
 
   .proposal-grid {
     gap: 18px;
-  }
-
-  :where(.owner-section)
-    > :where(
-      p,
-      .total-field,
-      .allocation-rows,
-      .payout-totals,
-      .form-error,
-      .button,
-      .payout-action,
-      .empty-state
-    ) {
-    grid-column: 1;
   }
 
   .project-card-content {
@@ -2312,6 +2348,10 @@ small {
 
   .allocation-rows fieldset {
     grid-template-columns: 1fr;
+  }
+
+  .allocation-rows legend {
+    grid-column: 1;
   }
 
   .payout-totals {

--- a/tests/app.test.tsx
+++ b/tests/app.test.tsx
@@ -15,7 +15,11 @@ import {
   within,
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { App, publicFooterDomain } from "../src/App";
+import { App, ProjectManagePage, publicFooterDomain } from "../src/App";
+import { assertCycleIndex } from "../src/lib/cycle-index";
+import { assertLeaderboardSnapshot } from "../src/lib/leaderboard";
+import { createProjectView } from "../src/lib/project-view";
+import { PROJECTS } from "../src/lib/projects.mjs";
 import { cycleIndexFixture, snapshotFixture } from "./fixtures";
 
 function route(path: string): void {
@@ -819,8 +823,8 @@ describe("project proposals", () => {
   });
 });
 
-describe("project owner workspace", () => {
-  it("lets an owner set zero or larger allocations and calculates the exact payout fee", async () => {
+describe("public project draft workspace", () => {
+  it("makes the public boundary explicit and hides disabled payout controls", async () => {
     route("/projects/eliza/manage");
     const index = archivedPaidCycleIndex();
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input) =>
@@ -831,26 +835,87 @@ describe("project owner workspace", () => {
     render(<App />);
 
     expect(
-      await screen.findByRole("heading", { name: "Run Eliza." }),
+      await screen.findByRole("heading", {
+        name: "Propose changes to Eliza.",
+      }),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/Sign the exact mainnet USDC transfers/u),
+      screen.getByText(/does not save or publish changes/u),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Payouts disabled")).toBeInTheDocument();
+    expect(
+      screen.getByText(/cannot draft, approve, sign, or pay allocations/u),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByLabelText(/Draft total, USDC/u),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /allocation/u }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/mainnet USDC transfers/u),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy GitHub brief" }));
+    await act(async () => Promise.resolve());
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      expect.stringContaining("Update eliza through a reviewed Slop PR"),
+    );
+  });
+
+  it("keeps an enabled allocation unsigned, bounded, and exact", async () => {
+    const project = PROJECTS.find((candidate) => candidate.id === "eliza");
+    if (!project) throw new TypeError("The Eliza project fixture is missing");
+    const snapshot = snapshotFixture();
+    assertLeaderboardSnapshot(snapshot);
+    const cycleIndex = archivedPaidCycleIndex();
+    assertCycleIndex(cycleIndex);
+    const enabledProject = {
+      ...project,
+      reward: {
+        ...project.reward,
+        committedMinor: project.reward.monthlyCapMinor,
+        fundingState: "committed" as const,
+        paymentMode: "enabled" as const,
+      },
+    };
+    render(
+      <ProjectManagePage
+        project={enabledProject}
+        state={{
+          status: "ready",
+          snapshot,
+          cycleIndex,
+          views: [createProjectView(snapshot, "eliza")],
+        }}
+      />,
+    );
+
+    expect(
+      await screen.findByRole("heading", { name: "2026-06 allocation" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/cannot save, approve, sign, or send USDC/u),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("link", { name: /View unsigned plan/u }),
     ).toHaveAttribute("href", expect.stringContaining("execution-plan.json"));
     expect(
-      screen.getByText(/paid only after finalized USDC deltas/u),
-    ).toBeInTheDocument();
+      screen.queryByText(/Sign the exact mainnet USDC transfers/u),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByText("Edit 1 contributor allocation", { exact: true }),
+    );
     const amount = screen.getByLabelText("archive-only amount in USDC");
-    const total = screen.getByLabelText("Total payout, USDC");
+    const total = screen.getByLabelText("Draft total, USDC");
     const reason = screen.getByLabelText("archive-only reason");
 
     fireEvent.change(amount, { target: { value: "0" } });
     fireEvent.change(total, { target: { value: "0" } });
     fireEvent.change(reason, { target: { value: "Creator decision" } });
     expect(
-      screen.getByRole("button", { name: "Copy allocation draft" }),
+      screen.getByRole("button", { name: "Copy unsigned allocation" }),
     ).toBeEnabled();
 
     fireEvent.change(amount, { target: { value: "12.345678" } });
@@ -858,7 +923,7 @@ describe("project owner workspace", () => {
     expect(screen.getByText("$0.12 fee")).toBeInTheDocument();
     expect(screen.getByText("$12.47 total debit")).toBeInTheDocument();
     fireEvent.click(
-      screen.getByRole("button", { name: "Copy allocation draft" }),
+      screen.getByRole("button", { name: "Copy unsigned allocation" }),
     );
     await act(async () => Promise.resolve());
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -486,30 +486,22 @@ test("renders contributor and cycle records from validated public data", async (
   }
 });
 
-test("keeps a large payout editor searchable and bounded", async ({
+test("makes the public project draft boundary unmistakable", async ({
   page,
-  request,
 }) => {
-  const snapshot = await loadSnapshot(request);
-  const leaders = createProjectView(snapshot, "eliza").leaders;
-  if (leaders.length <= 10) {
-    test.skip(true, "The live Eliza ledger has ten or fewer contributors.");
-    return;
-  }
-  const target = leaders.at(-1);
-  if (!target) return;
   await page.goto("/projects/eliza/manage", { waitUntil: "networkidle" });
   await expect(
-    page.getByRole("searchbox", { name: "Find contributor" }),
+    page.getByRole("heading", { name: "Propose changes to Eliza." }),
   ).toBeVisible();
-  await expect(page.locator(".allocation-rows fieldset")).toHaveCount(10);
-  await page
-    .getByRole("searchbox", { name: "Find contributor" })
-    .fill(target.actor.login);
   await expect(
-    page.getByRole("group", { name: target.actor.login }),
+    page.getByText(/does not save or publish changes/u),
   ).toBeVisible();
-  await expect(page.locator(".allocation-rows fieldset")).toHaveCount(1);
+  await expect(
+    page.getByText("Payouts disabled", { exact: true }),
+  ).toBeVisible();
+  await expect(page.getByLabel("Draft total, USDC")).toHaveCount(0);
+  await expect(page.locator(".allocation-rows")).toHaveCount(0);
+  await expect(page.getByText(/mainnet USDC transfers/u)).toHaveCount(0);
 });
 
 test("creates a valid GitHub-native project handoff", async ({ page }) => {
@@ -760,6 +752,7 @@ test("keeps primary routes accessible and inside the viewport", async ({
   for (const path of [
     "/",
     ...PROJECTS.map((project) => `/projects/${project.id}`),
+    "/projects/eliza/manage",
     "/projects/new",
   ]) {
     await page.goto(path, { waitUntil: "networkidle" });


### PR DESCRIPTION
Closes #91.

## What changed

- Renamed the public `/projects/:id/manage` workflow around drafting a reviewed GitHub proposal rather than managing live state.
- Made the non-mutation boundary explicit: the page cannot save, publish, approve, sign, or pay.
- Removed allocation, signing, and wallet copy unless a monthly-pool manifest explicitly enables payments.
- Kept the enabled-path allocation as a collapsed, unsigned JSON draft with exact fee math and dedicated regression coverage.
- Preserved the merged `deck.slop.cash` host routing and browser cases while rebasing onto current `develop`.

## Why

The route is intentionally a public, client-only GitHub drafting tool. It has no save, publish, payment, or operator API. The live wording nevertheless looks like an authenticated admin console and displays payout/signing controls while Eliza's manifest says `paymentMode: disabled`. This preserves the useful handoff while making its authority and payment boundary unmistakable.

## Verification

- Exact source: `f1de3ed31d8ce6d50d533ac3dcf8321b0edac43d` on `develop@cd56f799db4ebd79d5af76023c6e6af7b6b1920f`.
- Scope remains exactly `src/App.tsx`, `src/styles.css`, `tests/app.test.tsx`, and `tests/e2e/site.spec.ts`.
- `bun install --frozen-lockfile --ignore-scripts`: passed.
- `bun run test`: 37 Vitest files / 357 tests and 55 Bun skill tests passed.
- `bun run typecheck`, `format:check`, and `lint:check`: passed.
- `projects:check`, `evaluations:check`, and `cycles:check`: passed; payouts remain disabled and zero reward cycles changed.
- Fresh authenticated GitHub snapshot: 96 leaders, 2,739 score events, 3 repositories, generated 2026-08-15T20:20:47Z.
- `bun run build`: passed; 1,803 modules and a 150-file deployment manifest.
- `bun run test:e2e`: 36/36 browser cases across 1440, 1024, 768, and 320 px plus 1/1 real Wrangler Pages artifact contract passed.
- `bun run test:e2e:record`: passed; exact-head desktop/mobile captures and 10.2 s MP4 produced with zero console errors, page errors, failed first-party requests, or failed first-party responses.
- Manual exact-head review: desktop and 320 px `/projects/eliza/manage` renders are unclipped and explicitly say the tool does not save/publish and that payouts are disabled.
- Hosted exact-head check is required before merge.

## Evidence

The earlier comment retains the equivalent-patch before/after captures. A fresh exact-head capture was also manually reviewed after the rebase; the new browser/build receipts are recorded in the exact-head verification comment.

## Safety

- The current Eliza project still has payouts disabled.
- No API, Worker, project manifest, reward cycle, wallet, settlement, credential, production, or deployment path changed.
- GitHub review remains the sole publishing authority.
- This PR must not merge without an independent approval and successful exact-head hosted check.
