### PR TITLE
fix: preserve hidden Pages artifacts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -134,6 +134,7 @@ jobs:
         with:
           name: slop-pages-${{ github.run_id }}
           path: dist
+          include-hidden-files: true
           if-no-files-found: error
           retention-days: 7
 
@@ -216,6 +217,9 @@ jobs:
         with:
           name: slop-pages-${{ github.run_id }}
           path: dist
+
+      - name: Verify downloaded Pages bundle
+        run: node scripts/dist-manifest.mjs verify-local dist
 
       - name: Require live release-input equivalence
         run: |

--- a/scripts/deployment-contract.test.mjs
+++ b/scripts/deployment-contract.test.mjs
@@ -145,6 +145,13 @@ describe("slop.cash deployment contract", () => {
     expect(packageManifest.scripts.build).toContain(
       "node scripts/dist-manifest.mjs create dist",
     );
+    expect(qualityJob).toContain("include-hidden-files: true");
+    expect(deployJob).toContain(
+      "- name: Verify downloaded Pages bundle\n        run: node scripts/dist-manifest.mjs verify-local dist",
+    );
+    expect(deployJob.indexOf("Verify downloaded Pages bundle")).toBeLessThan(
+      deployJob.indexOf("Require scoped Cloudflare credentials"),
+    );
     expect(playwrightConfiguration).toContain("workers: 1");
     expect(packageManifest.scripts["test:e2e"]).toBe(
       "node scripts/run-e2e.mjs",

--- a/scripts/dist-manifest.mjs
+++ b/scripts/dist-manifest.mjs
@@ -279,6 +279,12 @@ async function loadLocalManifest(root) {
   return { manifest, manifestBytes };
 }
 
+/** Verifies that an artifact download still contains every inventoried byte. */
+export async function verifyLocalBundle(distRoot) {
+  const { manifest } = await loadLocalManifest(resolve(distRoot));
+  return manifest.files.length;
+}
+
 export async function createDistManifest(distRoot) {
   const root = resolve(distRoot);
   const files = await inventory(root);
@@ -494,6 +500,17 @@ async function main(arguments_) {
     return;
   }
   if (
+    command === "verify-local" &&
+    distRoot !== undefined &&
+    origin === undefined
+  ) {
+    const count = await verifyLocalBundle(distRoot);
+    process.stdout.write(
+      `[DistManifest] Verified ${count} local public files against the manifest.\n`,
+    );
+    return;
+  }
+  if (
     command === "verify" &&
     distRoot !== undefined &&
     origin === CANONICAL_ORIGIN &&
@@ -511,7 +528,7 @@ async function main(arguments_) {
     return;
   }
   throw new TypeError(
-    `Usage: ${basename(process.argv[1])} create <dist> | verify <dist> ${CANONICAL_ORIGIN} <token>`,
+    `Usage: ${basename(process.argv[1])} create <dist> | verify-local <dist> | verify <dist> ${CANONICAL_ORIGIN} <token>`,
   );
 }
 

--- a/scripts/dist-manifest.test.mjs
+++ b/scripts/dist-manifest.test.mjs
@@ -19,6 +19,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   createDistManifest,
   MANIFEST_FILENAME,
+  verifyLocalBundle,
   verifyPublishedBundle,
 } from "./dist-manifest.mjs";
 
@@ -28,6 +29,7 @@ async function fixture() {
   const root = await mkdtemp(join(tmpdir(), "gitarmy-dist-manifest-"));
   temporaryDirectories.push(root);
   await mkdir(join(root, "assets"));
+  await mkdir(join(root, ".well-known", "agent-skills"), { recursive: true });
   await writeFile(
     join(root, "index.html"),
     "<!doctype html><title>slop.cash</title>\n",
@@ -39,6 +41,10 @@ async function fixture() {
   await writeFile(
     join(root, "assets", "index-test.js"),
     "export const ready = true;\n",
+  );
+  await writeFile(
+    join(root, ".well-known", "agent-skills", "index.json"),
+    '{"skills":["slop"]}\n',
   );
   await writeFile(
     join(root, "_headers"),
@@ -72,6 +78,7 @@ describe("Cloudflare Pages deployment manifest", () => {
 
     expect(manifest.schemaVersion).toBe(1);
     expect(manifest.files.map((record) => record.path)).toEqual([
+      ".well-known/agent-skills/index.json",
       "assets/index-test.js",
       "index.html",
       "skill-manifest.json",
@@ -189,6 +196,17 @@ describe("Cloudflare Pages deployment manifest", () => {
         retryDelayMs: 0,
       }),
     ).rejects.toThrow(/does not match the local Pages bundle/u);
+  });
+
+  it("fails local artifact verification when a hidden endpoint is omitted", async () => {
+    const root = await fixture();
+    const manifest = await createDistManifest(root);
+
+    await expect(verifyLocalBundle(root)).resolves.toBe(manifest.files.length);
+    await rm(join(root, ".well-known", "agent-skills", "index.json"));
+    await expect(verifyLocalBundle(root)).rejects.toThrow(
+      /does not match the local Pages bundle/u,
+    );
   });
 
   it("rejects verification settings that exceed the production time bound", async () => {


### PR DESCRIPTION
Closes the production artifact gap that omitted `.well-known` endpoints from the trusted Pages bundle.

- include hidden files in the exact tested artifact
- verify the downloaded artifact against its manifest before any Cloudflare mutation
- fail closed when a hidden endpoint is missing
- pin the workflow contract and ordering

Validation: 357 Vitest tests; 69 skill tests; typecheck; lint; format; diff check.