### PR TITLE
fix: make deck slides keyboard focusable

### DIFF
--- a/src/Deck.tsx
+++ b/src/Deck.tsx
@@ -68,6 +68,7 @@ function Frame({
     <section
       className={`deck-slide ${className}`}
       aria-label={`${index + 1} of ${SLIDE_COUNT}: ${label}`}
+      tabIndex={0}
     >
       <div className="deck-kicker">
         <img src="/slop-mark.svg" alt="" />

--- a/src/Deck.tsx
+++ b/src/Deck.tsx
@@ -1,3 +1,4 @@
+/* biome-ignore-all lint/a11y/noNoninteractiveTabindex: Narrow slides can scroll and must remain keyboard-accessible. */
 import {
   ArrowLeft,
   ArrowRight,


### PR DESCRIPTION
## Summary
- make each fundraising slide keyboard-focusable
- satisfies `scrollable-region-focusable` when narrow mobile font metrics make a slide vertically scrollable

## Validation
- `bun run format:check`
- `bun run typecheck`
- `bun run build`
- narrow-mobile 320x800 fundraising presentation/accessibility test passes

Follow-up to #99.