### PR TITLE
fix: require public identity OAuth app

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -541,7 +541,7 @@ jobs:
             echo "::error::Identity authorization returned HTTP $authorization_status; expected 302."
             exit 1
           fi
-          node - "$authorization_headers" <<'NODE'
+          github_client_id="$(node - "$authorization_headers" <<'NODE'
           const { readFileSync } = require("node:fs");
           const headers = readFileSync(process.argv[2], "utf8");
           const match = headers.match(/^location:\s*(\S+)\s*$/imu);
@@ -559,6 +559,42 @@ jobs:
           const clientId = location.searchParams.get("client_id") ?? "";
           if (clientId.length === 0 || clientId.length > 128 || !/^[A-Za-z0-9._-]+$/u.test(clientId)) {
             throw new TypeError("identity authorization omitted the GitHub App client id");
+          }
+          process.stdout.write(clientId);
+          NODE
+          )"
+
+          # Query without GitHub credentials. A private App is visible to this
+          # repository's organization token but returns 404 to contributors,
+          # which makes every external OAuth authorization fail before consent.
+          github_app_response="$RUNNER_TEMP/slop-identity-github-app.json"
+          github_app_status="$(
+            curl --silent --show-error \
+              --connect-timeout 10 \
+              --max-time 30 \
+              --output "$github_app_response" \
+              --write-out "%{http_code}" \
+              --header "Accept: application/vnd.github+json" \
+              --header "X-GitHub-Api-Version: 2022-11-28" \
+              https://api.github.com/apps/slop-identity
+          )"
+          if [ "$github_app_status" != "200" ]; then
+            echo "::error::The Slop Identity GitHub App is not publicly discoverable (HTTP $github_app_status)."
+            exit 1
+          fi
+          node - "$github_app_response" "$github_client_id" <<'NODE'
+          const { readFileSync } = require("node:fs");
+          const value = JSON.parse(readFileSync(process.argv[2], "utf8"));
+          const clientId = process.argv[3];
+          if (
+            value?.slug !== "slop-identity" ||
+            value?.name !== "Slop Identity" ||
+            value?.client_id !== clientId ||
+            value?.owner?.login !== "elizaOS" ||
+            JSON.stringify(value?.permissions) !== "{}" ||
+            JSON.stringify(value?.events) !== "[]"
+          ) {
+            throw new TypeError("the public Slop Identity GitHub App contract drifted");
           }
           NODE
 

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex" />
+    <title>Not found — slop.cash</title>
+  </head>
+  <body>
+    <main>
+      <h1>Page not found</h1>
+      <p>The requested Slop page or artifact does not exist.</p>
+      <a href="/">See open projects</a>
+    </main>
+  </body>
+</html>

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,1 +1,8 @@
 /skill.md /projects/eliza/skill.md 301
+/deck / 200
+/deck/* / 200
+/projects/new / 200
+/projects/:project/manage / 200
+/projects/:project / 200
+/contributors/:login / 200
+/cycles/:project/:cycle / 200

--- a/scripts/deployment-contract.test.mjs
+++ b/scripts/deployment-contract.test.mjs
@@ -92,6 +92,13 @@ describe("slop.cash deployment contract", () => {
     expect(deployJob).toContain("wrangler deployments status \\");
     expect(deployJob).toContain("https://identity.slop.cash/v1/oauth/start");
     expect(deployJob).toContain("https://identity.slop.cash/v1/oauth/callback");
+    expect(deployJob).toContain("https://api.github.com/apps/slop-identity");
+    expect(deployJob).toContain(
+      "The Slop Identity GitHub App is not publicly discoverable",
+    );
+    expect(deployJob).toContain('value?.owner?.login !== "elizaOS"');
+    expect(deployJob).toContain('JSON.stringify(value?.permissions) !== "{}"');
+    expect(deployJob).toContain('JSON.stringify(value?.events) !== "[]"');
     expect(deployJob).toContain("https://api.slop.cash/api/v1/runs?verify=");
     expect(deployJob).toContain("timeout-minutes: 30");
     expect(deployJob).toContain("- name: Ensure deck Pages custom domain");

--- a/scripts/prepare-site.test.ts
+++ b/scripts/prepare-site.test.ts
@@ -451,6 +451,11 @@ describe("contribution skill package", () => {
       "/projects/:project/downloads/:archive\n  Content-Type: application/octet-stream",
     );
     expect(redirects).toContain("/skill.md /projects/eliza/skill.md 301");
+    expect(redirects).toContain("/projects/:project / 200");
+    expect(redirects).toContain("/cycles/:project/:cycle / 200");
+    expect(readFileSync(join(publicRoot, "404.html"), "utf8")).toContain(
+      "The requested Slop page or artifact does not exist.",
+    );
     expect(readFileSync(join(publicRoot, "SKILL.md"), "utf8")).toContain(
       "name: slop",
     );

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -586,6 +586,14 @@ test("serves byte-consistent install and read-only artifacts for every project",
   ]) {
     expect(response.status()).toBe(200);
   }
+  const [missingDiscovery, missingProjectArtifact] = await Promise.all([
+    request.get("/.well-known/slop/missing.json"),
+    request.get("/projects/not-a-project/skill-manifest.json"),
+  ]);
+  for (const response of [missingDiscovery, missingProjectArtifact]) {
+    expect(response.status()).toBe(404);
+    expect(await response.text()).not.toContain('<div id="root"></div>');
+  }
   expect(bootstrapResponse.headers()["content-type"]).toContain(
     "text/markdown",
   );


### PR DESCRIPTION
Closes the configuration hole behind #90 and #93.

The production Worker currently emits the valid `slop-identity` client ID, but the GitHub App is private. GitHub permits only members of the owning organization to authorize a private App, so external contributors receive GitHub 404 before consent.

This release guard now queries `https://api.github.com/apps/slop-identity` without GitHub credentials and fails closed unless the App is publicly discoverable, owned by `elizaOS`, named and slugged exactly, permissionless, eventless, and byte-matched to the client ID emitted by the just-deployed Worker. A private App returns HTTP 404 to this unauthenticated check.

Validation:
- project, evaluation, and cycle checks
- typecheck, format, lint
- 358 Vitest + 55 skill tests
- production build / 151-file manifest
- 36/36 Chromium product cases across 1440px, desktop, tablet, and 320px mobile
- 1/1 Wrangler Pages artifact contract
- workflow YAML parse

The external App visibility change and full live OAuth/trace proof remain required before #90/#93 close. This PR does not weaken OAuth, request scopes, repository permissions, trace privacy, or payout controls.