### PR TITLE
fix: align deck with payout fee contract

### DIFF
--- a/src/Deck.tsx
+++ b/src/Deck.tsx
@@ -363,7 +363,7 @@ function Economics() {
         <div>
           <h2>Every payout makes the network stronger.</h2>
           <div className="deck-revenue-chips">
-            <span>Planned 3% payout fee</span>
+            <span>Planned 1% payout fee</span>
             <span>Collaborations</span>
             <span>Features</span>
             <span>Sponsors</span>
@@ -373,20 +373,20 @@ function Economics() {
           <strong>$100</strong>
           <span>payout</span>
           <b>→</b>
-          <strong>$3</strong>
+          <strong>$1</strong>
           <span>fee</span>
         </div>
         <div className="deck-token-split">
           <article>
-            <strong>$1</strong>
+            <strong>⅓</strong>
             <span>$SLOP buybacks</span>
           </article>
           <article>
-            <strong>$1</strong>
+            <strong>⅓</strong>
             <span>team</span>
           </article>
           <article>
-            <strong>$1</strong>
+            <strong>⅓</strong>
             <span>new incentives</span>
           </article>
         </div>

--- a/tests/deck.test.tsx
+++ b/tests/deck.test.tsx
@@ -58,7 +58,8 @@ describe("Slop fundraising deck", () => {
 
     window.history.replaceState({}, "", "/deck#8");
     rerender(<Deck key="economics" />);
-    expect(screen.getByText("Planned 3% payout fee")).toBeInTheDocument();
+    expect(screen.getByText("Planned 1% payout fee")).toBeInTheDocument();
+    expect(screen.getAllByText("⅓", { selector: "strong" })).toHaveLength(3);
     expect(screen.getByText("$SLOP buybacks")).toBeInTheDocument();
     expect(screen.getAllByText("$5M", { selector: "strong" })).toHaveLength(2);
 


### PR DESCRIPTION
## Summary
- correct the fundraising deck payout fee from 3% to the platform's 1% contract
- change the $100 example from a $3 fee to a $1 fee
- express the three fee destinations as equal thirds without inventing rounded dollar amounts

## Verification
- `bun run test -- tests/deck.test.tsx`
- `bun run lint:check`
- `bun run format:check`
- `bun run typecheck`
- `bun run build`
- `bun run test:e2e` with fresh validated live ledger (36/36 across 1440, 1024, 768, and 320px Chromium)

The accessibility failure from #96 was fixed by #100; this PR retains the payout-contract correction discovered during that validation.

Closes #96