### PR TITLE
feat: align deck cover with Slop homepage

### DIFF
--- a/src/Deck.tsx
+++ b/src/Deck.tsx
@@ -19,6 +19,11 @@ import {
 import "./deck.css";
 
 const SLIDE_COUNT = 10;
+const COVER_ACTIONS = [
+  "SHIPPING SLOP.",
+  "BUILDING THE FUTURE.",
+  "SOLVING HARD PROBLEMS.",
+] as const;
 
 function initialSlide(): number {
   const parsed = Number.parseInt(window.location.hash.slice(1), 10);
@@ -81,28 +86,42 @@ function Frame({
 }
 
 function Cover() {
+  const [actionIndex, setActionIndex] = useState(0);
+
+  useEffect(() => {
+    if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) return;
+    const interval = window.setInterval(() => {
+      setActionIndex((current) => (current + 1) % COVER_ACTIONS.length);
+    }, 2800);
+    return () => window.clearInterval(interval);
+  }, []);
+
+  const action = COVER_ACTIONS[actionIndex];
+
   return (
     <Frame
       index={0}
-      label="Fund progress and own the upside"
+      label="Make money shipping slop and building the future"
       className="deck-cover"
     >
       <div className="deck-cover-copy">
-        <h1 aria-label="Fund progress. Own the upside.">
-          Fund progress.
-          <br />
-          <em>Own the upside.</em>
+        <h1 aria-label={`MAKE MONEY ${action}`}>
+          <span className="deck-cover-prefix">MAKE MONEY</span>
+          <em className="deck-cover-action" key={action}>
+            {action}
+          </em>
         </h1>
         <p>
-          Slop is the incentive network that turns capital and compute into
-          verified open work.
+          <strong className="deck-cover-brand">Slop.cash</strong> is the
+          incentive network that turns capital and compute into verified open
+          work.
         </p>
       </div>
       <div className="deck-cover-network" aria-hidden="true">
         {["capital", "compute", "people", "agents", "progress"].map(
           (item, index) => (
             <span key={item} style={{ "--i": index } as CSSProperties}>
-              {item}
+              <b className="deck-orbit-label">{item}</b>
             </span>
           ),
         )}

--- a/src/Deck.tsx
+++ b/src/Deck.tsx
@@ -2,7 +2,6 @@
 import {
   ArrowLeft,
   ArrowRight,
-  Check,
   Cpu,
   GitBranch,
   Megaphone,
@@ -34,18 +33,20 @@ function initialSlide(): number {
 
 function Meta() {
   useEffect(() => {
-    document.title = "Slop — fund progress, own the upside";
+    document.title = "Slop — make money shipping slop";
     const values: Record<string, string> = {
       'meta[name="description"]':
         "Slop turns capital and compute into verified open-source progress.",
-      'meta[property="og:title"]': "Fund progress. Own the upside.",
+      'meta[property="og:title"]': "MAKE MONEY SHIPPING SLOP.",
       'meta[property="og:description"]':
         "The fundraising deck for slop.cash — the incentive network for open progress.",
-      'meta[property="og:image"]': "https://deck.slop.cash/og-deck-v2.png",
-      'meta[name="twitter:title"]': "Fund progress. Own the upside.",
+      'meta[property="og:image"]':
+        "https://deck.slop.cash/og-shipping-slop.png",
+      'meta[name="twitter:title"]': "MAKE MONEY SHIPPING SLOP.",
       'meta[name="twitter:description"]':
         "The fundraising deck for slop.cash — the incentive network for open progress.",
-      'meta[name="twitter:image"]': "https://deck.slop.cash/og-deck-v2.png",
+      'meta[name="twitter:image"]':
+        "https://deck.slop.cash/og-shipping-slop.png",
     };
     for (const [selector, content] of Object.entries(values)) {
       document
@@ -134,34 +135,27 @@ function Cover() {
 const team = [
   ["Shaw", "CEO"],
   ["Nubs", "CTO"],
-  ["Shadow", "Head of partnerships"],
-  ["Sayo", "Founding engineer"],
-  ["Stan", "Founding engineer"],
 ];
 
 function Team() {
   return (
-    <Frame index={1} label="The team behind Slop" className="deck-team">
+    <Frame
+      index={1}
+      label="Two builders with 25 thousand GitHub stars"
+      className="deck-team"
+    >
       <div>
-        <h2>We know how to make open source move.</h2>
+        <h2>Two builders. 25K+ GitHub stars.</h2>
         <p className="deck-supporting">
-          The team behind elizaOS is building the incentive layer for what comes
-          next.
+          Shaw and Nubs have built open-source projects used and followed by
+          thousands of developers.
         </p>
       </div>
       <div className="deck-team-proof">
         <div className="deck-team-stats">
           <p>
-            <strong>19K</strong>
-            <span>stars</span>
-          </p>
-          <p>
-            <strong>5.6K</strong>
-            <span>forks</span>
-          </p>
-          <p>
-            <strong>671</strong>
-            <span>contributors</span>
+            <strong>25K+</strong>
+            <span>GitHub stars across projects</span>
           </p>
         </div>
         <div className="deck-team-list">
@@ -194,10 +188,17 @@ function Mission() {
           Use decentralized compute to accelerate humanity—without concentrating
           the value in a handful of companies.
         </p>
-        <div>
-          <span>Open work</span>
-          <span>Shared upside</span>
-          <span>Collective ownership</span>
+        <div className="deck-mission-examples">
+          <article>
+            <strong>$1M Proximity Prize</strong>
+            <span>
+              A major conjecture. A prize split fairly by contribution.
+            </span>
+          </article>
+          <article>
+            <strong>ASI continual learning</strong>
+            <span>Novel IP built together—and owned collectively.</span>
+          </article>
         </div>
       </div>
     </Frame>
@@ -245,18 +246,18 @@ function GoToMarket() {
   const channels = [
     {
       icon: <Users aria-hidden="true" />,
-      title: "Start with trust.",
-      copy: "Help well-known builders with specific work in their open-source repos.",
+      title: "Hack traction.",
+      copy: "Turn a builder’s roadmap into public, fundable work the community can rally around.",
     },
     {
       icon: <Cpu aria-hidden="true" />,
-      title: "Turn compute into sponsorship.",
-      copy: "Providers allocate resources. Projects give them visible proof of impact.",
+      title: "Align the supporters.",
+      copy: "Match sponsors, compute providers, and fans directly to the builder’s goals.",
     },
     {
       icon: <Megaphone aria-hidden="true" />,
-      title: "Make useful work the ad.",
-      copy: "Sponsors fund public challenges that earn attention by creating value.",
+      title: "Make support one click.",
+      copy: "Give anyone a simple path to donate, fund a task, or sponsor an outcome.",
     },
   ];
   return (
@@ -266,7 +267,10 @@ function GoToMarket() {
       className="deck-gtm"
     >
       <div>
-        <h2>Start with people the world already trusts.</h2>
+        <h2>
+          Find the people building the future.{" "}
+          <em>Accelerate the shit out of their work.</em>
+        </h2>
       </div>
       <div className="deck-gtm-grid">
         {channels.map(({ icon, title, copy }, index) => (
@@ -279,7 +283,7 @@ function GoToMarket() {
         ))}
       </div>
       <p className="deck-gtm-loop">
-        Every accepted result becomes the proof that wins the next project.
+        Visible progress → attention → sponsor proof → more progress.
       </p>
     </Frame>
   );
@@ -368,9 +372,9 @@ function Competition() {
 
 function Economics() {
   const projections = [
-    ["12 mo", "50", "$5M", "$0.5M"],
-    ["24 mo", "200", "$25M", "$2M"],
-    ["36 mo", "500", "$75M", "$5M"],
+    ["Year 1", "$2M", "$150K", "−$300K"],
+    ["Year 2", "$12M", "$650K", "+$100K"],
+    ["Year 3", "$30M", "$1.6M", "+$750K"],
   ];
   return (
     <Frame
@@ -378,57 +382,66 @@ function Economics() {
       label="Revenue and token economics"
       className="deck-economics"
     >
-      <div className="deck-economics-top">
-        <div>
-          <h2>Every payout makes the network stronger.</h2>
-          <div className="deck-revenue-chips">
-            <span>Planned 1% payout fee</span>
-            <span>Collaborations</span>
-            <span>Features</span>
-            <span>Sponsors</span>
-          </div>
-        </div>
-        <div className="deck-fee-example">
-          <strong>$100</strong>
-          <span>payout</span>
-          <b>→</b>
-          <strong>$1</strong>
-          <span>fee</span>
-        </div>
-        <div className="deck-token-split">
-          <article>
-            <strong>⅓</strong>
-            <span>$SLOP buybacks</span>
-          </article>
-          <article>
-            <strong>⅓</strong>
-            <span>team</span>
-          </article>
-          <article>
-            <strong>⅓</strong>
-            <span>new incentives</span>
-          </article>
-        </div>
+      <div className="deck-economics-heading">
+        <h2>A realistic path to profit.</h2>
+        <p>
+          Base case: a 1% payout fee plus sponsor programs, collaborations, and
+          paid features.
+        </p>
       </div>
-      <div className="deck-projections">
-        <div className="deck-projection-labels">
-          <span>Projects</span>
-          <span>Annual payouts</span>
-          <span>Projected revenue</span>
+      <div className="deck-economics-model">
+        <div
+          className="deck-profit-chart"
+          role="img"
+          aria-label="Projected annual profit rises from negative 300 thousand dollars in year one to positive 100 thousand dollars in year two and positive 750 thousand dollars in year three"
+        >
+          <span className="deck-chart-zero">$0</span>
+          <i aria-hidden="true" />
+          <svg viewBox="0 0 800 360" aria-hidden="true">
+            <path
+              className="deck-chart-area"
+              d="M60 286 C180 286 260 198 390 190 S610 82 740 40 L740 190 L60 190 Z"
+            />
+            <path
+              className="deck-chart-line"
+              d="M60 286 C180 286 260 198 390 190 S610 82 740 40"
+            />
+            <circle cx="60" cy="286" r="8" />
+            <circle cx="390" cy="190" r="8" />
+            <circle cx="740" cy="40" r="8" />
+          </svg>
+          <strong className="deck-chart-label deck-chart-label-one">
+            −$300K
+          </strong>
+          <strong className="deck-chart-label deck-chart-label-two">
+            +$100K
+          </strong>
+          <strong className="deck-chart-label deck-chart-label-three">
+            +$750K
+          </strong>
+          <span className="deck-chart-year deck-chart-year-one">Y1</span>
+          <span className="deck-chart-year deck-chart-year-two">Y2</span>
+          <span className="deck-chart-year deck-chart-year-three">Y3</span>
         </div>
-        {projections.map(([period, projects, payouts, revenue]) => (
-          <article key={period}>
-            <span>{period}</span>
-            <strong>{projects}</strong>
-            <strong>{payouts}</strong>
-            <strong>{revenue}</strong>
-          </article>
-        ))}
-        <small>
-          Illustrative operating model including sponsorship, collaboration, and
-          feature revenue—not historical results. $SLOP design is proposed and
-          subject to final legal review.
-        </small>
+        <div className="deck-projections">
+          <div className="deck-projection-labels">
+            <span>Payout volume</span>
+            <span>Revenue</span>
+            <span>Profit</span>
+          </div>
+          {projections.map(([period, payouts, revenue, profit]) => (
+            <article key={period}>
+              <span>{period}</span>
+              <strong>{payouts}</strong>
+              <strong>{revenue}</strong>
+              <strong>{profit}</strong>
+            </article>
+          ))}
+          <small>
+            Illustrative base case, not historical results. Planned 1% fee: ⅓
+            $SLOP buybacks · ⅓ team · ⅓ bounties and incentives.
+          </small>
+        </div>
       </div>
     </Frame>
   );
@@ -436,26 +449,25 @@ function Economics() {
 
 function Raise() {
   const allocation = [
-    ["75%", "$375K", "Bounties + incentives"],
-    ["10%", "$50K", "Core team"],
-    ["10%", "$50K", "Partnership launches"],
-    ["5%", "$25K", "Protocol, legal + security"],
+    ["40%", "$200K", "Team"],
+    ["30%", "$150K", "Bounties + incentives"],
+    ["20%", "$100K", "Marketing"],
+    ["10%", "$50K", "Legal"],
   ];
   return (
     <Frame index={8} label="A 500 thousand dollar raise" className="deck-raise">
       <div className="deck-raise-heading">
         <h2>
-          <em>$500K</em> turns the flywheel for 18 months.
+          We need <em>$500K</em> to change the world.
         </h2>
-        <p>Every dollar exists to create more useful work.</p>
       </div>
       <div className="deck-allocation-bar">
-        {allocation.map(([percent, amount, label], index) => (
+        {allocation.map(([percent, amount, label]) => (
           <article
             key={label}
             style={
               {
-                "--weight": index === 0 ? 7.5 : index === 3 ? 0.5 : 1,
+                "--weight": Number.parseInt(percent, 10),
               } as CSSProperties
             }
           >
@@ -464,19 +476,6 @@ function Raise() {
             <p>{label}</p>
           </article>
         ))}
-      </div>
-      <div className="deck-raise-targets">
-        <p>
-          <Check aria-hidden="true" />
-          50 funded projects
-        </p>
-        <p>
-          <Check aria-hidden="true" />
-          $5M annual payout volume
-        </p>
-        <p>
-          <Check aria-hidden="true" />A repeatable sponsor engine
-        </p>
       </div>
     </Frame>
   );

--- a/src/deck.css
+++ b/src/deck.css
@@ -167,13 +167,12 @@
 }
 .deck-team-proof {
   display: grid;
-  grid-template-columns: 0.72fr 1.28fr;
+  grid-template-columns: 0.58fr 1.42fr;
   gap: clamp(28px, 5vw, 80px);
   min-height: 0;
 }
 .deck-team-stats {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  display: flex;
   align-content: end;
   border-top: 1px solid rgba(22, 19, 15, 0.18);
 }
@@ -198,13 +197,13 @@
 }
 .deck-team-list {
   display: grid;
-  grid-template-columns: repeat(5, 1fr);
+  grid-template-columns: repeat(2, 1fr);
   align-items: end;
   border-top: 1px solid rgba(22, 19, 15, 0.18);
 }
 .deck-team-list article {
   display: flex;
-  min-height: 210px;
+  min-height: 260px;
   flex-direction: column;
   justify-content: flex-end;
   padding: 20px 14px;
@@ -248,18 +247,32 @@
   font-size: clamp(18px, 1.8vw, 28px);
   line-height: 1.42;
 }
-.deck-mission-copy > div {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
+.deck-mission-examples {
+  display: grid;
+  max-width: 760px;
+  grid-template-columns: repeat(2, 1fr);
+  border-top: 1px solid rgba(22, 19, 15, 0.18);
 }
-.deck-mission-copy span,
-.deck-revenue-chips span {
-  padding: 9px 14px;
-  border: 1px solid rgba(22, 19, 15, 0.18);
-  border-radius: 99px;
-  font-size: 11px;
-  font-weight: 800;
+.deck-mission-examples article {
+  display: flex;
+  min-height: 118px;
+  flex-direction: column;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 20px 22px 0 0;
+}
+.deck-mission-examples article + article {
+  padding-left: 22px;
+  border-left: 1px solid rgba(22, 19, 15, 0.18);
+}
+.deck-mission-examples strong {
+  font-size: clamp(18px, 1.8vw, 27px);
+  letter-spacing: -0.04em;
+}
+.deck-mission-examples span {
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.4;
 }
 .deck-mission-ring {
   position: relative;
@@ -360,7 +373,11 @@
   gap: 24px;
 }
 .deck-gtm h2 {
-  max-width: 1050px;
+  max-width: 1160px;
+  font-size: clamp(48px, 6.3vw, 96px);
+}
+.deck-gtm h2 em {
+  color: var(--orange-ink);
 }
 .deck-gtm-grid {
   display: grid;
@@ -528,81 +545,108 @@
   grid-template-rows: auto 1fr;
   gap: clamp(24px, 4vh, 46px);
 }
-.deck-economics-top {
-  display: grid;
-  grid-template-columns: 1.25fr 0.35fr 0.7fr;
+.deck-economics-heading {
+  display: flex;
   align-items: end;
-  gap: clamp(20px, 3vw, 48px);
+  justify-content: space-between;
+  gap: 42px;
 }
 .deck-economics h2 {
-  max-width: 820px;
+  max-width: 760px;
   font-size: clamp(46px, 5.8vw, 88px);
 }
-.deck-revenue-chips {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 7px;
-  margin-top: 22px;
-}
-.deck-revenue-chips span:first-child {
-  border-color: var(--orange);
-  background: var(--orange);
-}
-.deck-fee-example {
-  display: grid;
-  grid-template-columns: auto auto;
-  align-items: baseline;
-  justify-content: center;
-  padding: 18px;
-  border: 1px solid rgba(22, 19, 15, 0.18);
-  border-radius: 16px;
-  text-align: center;
-}
-.deck-fee-example strong {
-  font-size: clamp(32px, 3.8vw, 58px);
-  letter-spacing: -0.07em;
-}
-.deck-fee-example span {
+.deck-economics-heading p {
+  max-width: 390px;
+  margin: 0;
   color: var(--muted);
-  font-size: 10px;
-  font-weight: 800;
-  text-transform: uppercase;
+  font-size: clamp(14px, 1.25vw, 19px);
+  line-height: 1.45;
 }
-.deck-fee-example b {
-  grid-column: 1 / -1;
-  margin: -2px 0;
-  color: var(--orange-ink);
-  font-size: 18px;
-}
-.deck-token-split {
+.deck-economics-model {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  overflow: hidden;
-  border-radius: 16px;
-  background: var(--orange);
+  grid-template-columns: 1.05fr 0.95fr;
+  align-items: end;
+  gap: clamp(28px, 5vw, 72px);
+  min-height: 0;
 }
-.deck-token-split article {
-  display: flex;
-  min-width: 0;
-  min-height: 128px;
-  flex-direction: column;
-  justify-content: flex-end;
-  padding: 16px 12px;
-  border-right: 1px solid rgba(22, 19, 15, 0.18);
+.deck-profit-chart {
+  position: relative;
+  align-self: stretch;
+  min-height: 330px;
+  border-bottom: 1px solid rgba(22, 19, 15, 0.18);
 }
-.deck-token-split article:last-child {
-  border-right: 0;
+.deck-profit-chart svg {
+  position: absolute;
+  inset: 18px 0 22px;
+  width: 100%;
+  height: calc(100% - 40px);
+  overflow: visible;
 }
-.deck-token-split strong {
-  font-size: clamp(28px, 3vw, 46px);
-  letter-spacing: -0.07em;
+.deck-chart-area {
+  fill: rgba(255, 84, 31, 0.13);
 }
-.deck-token-split span {
-  font-size: 10px;
+.deck-chart-line {
+  fill: none;
+  stroke: var(--orange-ink);
+  stroke-linecap: round;
+  stroke-width: 7;
+}
+.deck-profit-chart circle {
+  fill: var(--paper);
+  stroke: var(--orange-ink);
+  stroke-width: 6;
+}
+.deck-profit-chart > i {
+  position: absolute;
+  top: 55%;
+  right: 0;
+  left: 0;
+  border-top: 1px dashed rgba(22, 19, 15, 0.28);
+}
+.deck-chart-zero {
+  position: absolute;
+  top: calc(55% - 18px);
+  left: 0;
+  color: var(--muted);
+  font-size: 9px;
   font-weight: 800;
-  line-height: 1.25;
-  overflow-wrap: anywhere;
-  text-transform: uppercase;
+}
+.deck-chart-label,
+.deck-chart-year {
+  position: absolute;
+  z-index: 1;
+}
+.deck-chart-label {
+  font-size: clamp(17px, 1.8vw, 27px);
+  letter-spacing: -0.05em;
+}
+.deck-chart-label-one {
+  bottom: 4%;
+  left: 4%;
+}
+.deck-chart-label-two {
+  top: 40%;
+  left: 48%;
+}
+.deck-chart-label-three {
+  top: 0;
+  right: 1%;
+  color: var(--orange-ink);
+}
+.deck-chart-year {
+  bottom: -20px;
+  color: var(--muted);
+  font-size: 9px;
+  font-weight: 800;
+}
+.deck-chart-year-one {
+  left: 7%;
+}
+.deck-chart-year-two {
+  left: 50%;
+}
+.deck-chart-year-three {
+  right: 3%;
 }
 .deck-projections {
   align-self: end;
@@ -611,7 +655,7 @@
 .deck-projection-labels,
 .deck-projections article {
   display: grid;
-  grid-template-columns: 0.65fr repeat(3, 1fr);
+  grid-template-columns: 0.7fr repeat(3, 1fr);
   align-items: center;
 }
 .deck-projection-labels {
@@ -646,28 +690,16 @@
   margin-top: 10px;
   color: var(--muted);
   font-size: 9px;
+  line-height: 1.4;
 }
 
 /* 09 — raise */
 .deck-raise {
-  grid-template-rows: auto 1fr auto;
+  grid-template-rows: auto 1fr;
   gap: 28px;
 }
-.deck-raise-heading {
-  display: flex;
-  align-items: end;
-  justify-content: space-between;
-  gap: 48px;
-}
 .deck-raise h2 {
-  max-width: 1020px;
-}
-.deck-raise-heading > p {
-  max-width: 270px;
-  margin: 0;
-  color: var(--muted);
-  font-size: clamp(15px, 1.4vw, 21px);
-  line-height: 1.4;
+  max-width: 1120px;
 }
 .deck-allocation-bar {
   display: flex;
@@ -690,10 +722,6 @@
 .deck-allocation-bar article:first-child {
   background: var(--orange);
 }
-.deck-allocation-bar article:not(:first-child) {
-  padding-right: clamp(10px, 1.2vw, 18px);
-  padding-left: clamp(10px, 1.2vw, 18px);
-}
 .deck-allocation-bar article:last-child {
   border-right: 0;
 }
@@ -711,26 +739,6 @@
   font-size: 11px;
   font-weight: 700;
   line-height: 1.3;
-}
-.deck-raise-targets {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px 32px;
-}
-.deck-raise-targets p {
-  display: flex;
-  align-items: center;
-  gap: 9px;
-  margin: 0;
-  font-size: 12px;
-  font-weight: 800;
-}
-.deck-raise-targets svg {
-  width: 20px;
-  height: 20px;
-  padding: 4px;
-  border-radius: 50%;
-  background: var(--orange);
 }
 
 /* 10 — close */
@@ -906,7 +914,7 @@
     font-size: 34px;
   }
   .deck-team-list {
-    grid-template-columns: repeat(5, 1fr);
+    grid-template-columns: repeat(2, 1fr);
   }
   .deck-team-list article {
     min-height: 130px;
@@ -927,6 +935,21 @@
   }
   .deck-mission-copy > p {
     font-size: 17px;
+  }
+  .deck-mission-examples {
+    grid-template-columns: 1fr;
+  }
+  .deck-mission-examples article {
+    min-height: auto;
+    padding: 12px 0;
+  }
+  .deck-mission-examples article + article {
+    padding-left: 0;
+    border-top: 1px solid rgba(22, 19, 15, 0.18);
+    border-left: 0;
+  }
+  .deck-mission-examples span {
+    font-size: 10px;
   }
   .deck-mission-ring {
     position: absolute;
@@ -951,6 +974,9 @@
   .deck-ownership {
     align-content: center;
     overflow-y: auto;
+  }
+  .deck-gtm h2 {
+    font-size: clamp(36px, 9.5vw, 52px);
   }
   .deck-gtm-grid,
   .deck-ownership-modes {
@@ -1007,41 +1033,37 @@
     align-content: center;
     overflow-y: auto;
   }
-  .deck-economics-top {
-    grid-template-columns: 0.7fr 1.3fr;
-    gap: 8px;
-  }
-  .deck-economics-top > div:first-child {
-    grid-column: 1 / -1;
+  .deck-economics-heading {
+    display: block;
   }
   .deck-economics h2 {
     font-size: clamp(38px, 10.5vw, 56px);
   }
-  .deck-revenue-chips {
+  .deck-economics-heading p {
     margin-top: 12px;
+    font-size: 11px;
   }
-  .deck-revenue-chips span {
-    padding: 6px 8px;
-    font-size: 8px;
+  .deck-economics-model {
+    grid-template-columns: 1fr;
+    gap: 28px;
   }
-  .deck-fee-example {
-    padding: 10px 6px;
+  .deck-profit-chart {
+    min-height: 210px;
   }
-  .deck-token-split article {
-    min-height: 92px;
-    padding: 9px 6px;
+  .deck-chart-label {
+    font-size: 14px;
   }
-  .deck-token-split strong {
-    font-size: 24px;
-  }
-  .deck-token-split span {
-    font-size: 7px;
+  .deck-projections article {
+    padding: 8px 0;
   }
   .deck-projection-labels {
     font-size: 7px;
   }
   .deck-projections article strong {
-    font-size: 21px;
+    font-size: clamp(15px, 5vw, 19px);
+  }
+  .deck-projections article > span {
+    font-size: 8px;
   }
   .deck-projections small {
     font-size: 7px;
@@ -1049,17 +1071,11 @@
   .deck-raise {
     align-content: center;
   }
-  .deck-raise-heading {
-    display: block;
-  }
-  .deck-raise-heading > p {
-    margin-top: 14px;
-  }
   .deck-allocation-bar {
     display: grid;
     min-height: 330px;
-    grid-template-columns: repeat(3, 1fr);
-    grid-template-rows: 2fr 1fr;
+    grid-template-columns: repeat(2, 1fr);
+    grid-template-rows: repeat(2, 1fr);
   }
   .deck-allocation-bar article {
     min-width: 0;
@@ -1067,7 +1083,9 @@
     border-right: 1px solid rgba(22, 19, 15, 0.18);
   }
   .deck-allocation-bar article:first-child {
-    grid-column: 1 / -1;
+    border-bottom: 1px solid rgba(22, 19, 15, 0.18);
+  }
+  .deck-allocation-bar article:nth-child(2) {
     border-right: 0;
     border-bottom: 1px solid rgba(22, 19, 15, 0.18);
   }
@@ -1076,12 +1094,6 @@
   }
   .deck-allocation-bar p {
     font-size: 8px;
-  }
-  .deck-raise-targets {
-    gap: 8px 14px;
-  }
-  .deck-raise-targets p {
-    font-size: 9px;
   }
   .deck-close h2 {
     font-size: clamp(58px, 16vw, 92px);

--- a/src/deck.css
+++ b/src/deck.css
@@ -70,17 +70,28 @@
 
 /* 01 — opening */
 .deck-cover {
-  grid-template-columns: 1.12fr 0.88fr;
+  grid-template-columns: 1.25fr 0.75fr;
   align-items: center;
-  gap: 7vw;
+  gap: 5vw;
 }
 .deck-cover h1 {
-  max-width: 900px;
+  max-width: 1000px;
   margin: 0;
-  font-size: clamp(66px, 8.7vw, 142px);
+  font-size: clamp(54px, 7vw, 112px);
   font-weight: 800;
-  letter-spacing: -0.08em;
-  line-height: 0.84;
+  letter-spacing: -0.072em;
+  line-height: 0.88;
+}
+.deck-cover-prefix,
+.deck-cover-action {
+  display: block;
+}
+.deck-cover-action {
+  max-width: 100%;
+  font-size: 0.7em;
+  line-height: 0.95;
+  overflow-wrap: normal;
+  animation: deck-action-enter 360ms ease-out both;
 }
 .deck-cover-copy > p {
   max-width: 650px;
@@ -88,6 +99,10 @@
   color: var(--muted);
   font-size: clamp(17px, 1.5vw, 24px);
   line-height: 1.45;
+}
+.deck-cover-brand {
+  color: var(--ink);
+  font-weight: 800;
 }
 .deck-cover-network {
   position: relative;
@@ -128,14 +143,18 @@
   top: 50%;
   left: 50%;
   z-index: 2;
+  transform: translate(-50%, -50%) rotate(var(--angle))
+    translateX(min(18vw, 260px)) rotate(calc(var(--angle) * -1));
+}
+.deck-orbit-label {
+  display: block;
   padding: 8px 13px;
   border: 1px solid rgba(22, 19, 15, 0.16);
   border-radius: 99px;
   background: var(--paper);
   font-size: 11px;
   font-weight: 750;
-  transform: translate(-50%, -50%) rotate(var(--angle))
-    translateX(min(18vw, 260px)) rotate(calc(var(--angle) * -1));
+  animation: deck-counter-spin 34s linear infinite;
 }
 
 /* 02 — team */
@@ -840,6 +859,12 @@
     transform: rotate(-360deg);
   }
 }
+@keyframes deck-action-enter {
+  from {
+    opacity: 0;
+    transform: translateY(0.12em);
+  }
+}
 
 @media (max-width: 760px) {
   .deck-slide {
@@ -856,7 +881,7 @@
     align-content: center;
   }
   .deck-cover h1 {
-    font-size: clamp(56px, 16vw, 92px);
+    font-size: clamp(46px, 11vw, 76px);
   }
   .deck-cover-network {
     position: absolute;

--- a/tests/deck.test.tsx
+++ b/tests/deck.test.tsx
@@ -24,7 +24,7 @@ describe("Slop fundraising deck", () => {
     fireEvent.click(screen.getByRole("button", { name: "Next slide" }));
     expect(
       screen.getByRole("heading", {
-        name: "We know how to make open source move.",
+        name: "Two builders. 25K+ GitHub stars.",
       }),
     ).toBeInTheDocument();
     expect(screen.getByText("Shaw")).toBeInTheDocument();
@@ -45,11 +45,9 @@ describe("Slop fundraising deck", () => {
 
     window.history.replaceState({}, "", "/deck#5");
     rerender(<Deck key="gtm" />);
-    expect(screen.getByText("Start with trust.")).toBeInTheDocument();
-    expect(
-      screen.getByText("Turn compute into sponsorship."),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Make useful work the ad.")).toBeInTheDocument();
+    expect(screen.getByText("Hack traction.")).toBeInTheDocument();
+    expect(screen.getByText("Align the supporters.")).toBeInTheDocument();
+    expect(screen.getByText("Make support one click.")).toBeInTheDocument();
 
     window.history.replaceState({}, "", "/deck#6");
     rerender(<Deck key="ownership" />);
@@ -59,16 +57,18 @@ describe("Slop fundraising deck", () => {
 
     window.history.replaceState({}, "", "/deck#8");
     rerender(<Deck key="economics" />);
-    expect(screen.getByText("Planned 1% payout fee")).toBeInTheDocument();
-    expect(screen.getAllByText("⅓", { selector: "strong" })).toHaveLength(3);
-    expect(screen.getByText("$SLOP buybacks")).toBeInTheDocument();
-    expect(screen.getAllByText("$5M", { selector: "strong" })).toHaveLength(2);
+    expect(screen.getByText(/Base case: a 1% payout fee/)).toBeInTheDocument();
+    expect(screen.getByText("$2M")).toBeInTheDocument();
+    expect(screen.getByText("$1.6M")).toBeInTheDocument();
+    expect(screen.getAllByText("+$750K")).toHaveLength(2);
 
     window.history.replaceState({}, "", "/deck#9");
     rerender(<Deck key="raise" />);
     expect(screen.getByText("$500K")).toBeInTheDocument();
-    expect(screen.getByText("75%")).toBeInTheDocument();
+    expect(screen.getByText("40%")).toBeInTheDocument();
+    expect(screen.getByText("$200K")).toBeInTheDocument();
     expect(screen.getByText("Bounties + incentives")).toBeInTheDocument();
-    expect(screen.getAllByText("10%", { selector: "span" })).toHaveLength(2);
+    expect(screen.getByText("$100K")).toBeInTheDocument();
+    expect(screen.getByText("Legal")).toBeInTheDocument();
   });
 });

--- a/tests/deck.test.tsx
+++ b/tests/deck.test.tsx
@@ -16,8 +16,9 @@ describe("Slop fundraising deck", () => {
     render(<Deck />);
 
     expect(
-      screen.getByRole("heading", { name: "Fund progress. Own the upside." }),
+      screen.getByRole("heading", { name: /^MAKE MONEY/ }),
     ).toBeInTheDocument();
+    expect(screen.getByText("Slop.cash", { selector: "strong" })).toBeVisible();
     expect(screen.getByText("1 / 10")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Next slide" }));

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -798,10 +798,10 @@ test("presents every fundraising slide without viewport or accessibility failure
       name: /^MAKE MONEY/,
     }),
   ).toBeVisible();
-  await expect(page).toHaveTitle("Slop — fund progress, own the upside");
+  await expect(page).toHaveTitle("Slop — make money shipping slop");
   await expect(page.locator('meta[property="og:image"]')).toHaveAttribute(
     "content",
-    "https://deck.slop.cash/og-deck-v2.png",
+    "https://deck.slop.cash/og-shipping-slop.png",
   );
 
   for (let slide = 1; slide <= 10; slide += 1) {

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -795,8 +795,7 @@ test("presents every fundraising slide without viewport or accessibility failure
   await page.goto("/deck#1", { waitUntil: "networkidle" });
   await expect(
     page.getByRole("heading", {
-      exact: true,
-      name: "Fund progress. Own the upside.",
+      name: /^MAKE MONEY/,
     }),
   ).toBeVisible();
   await expect(page).toHaveTitle("Slop — fund progress, own the upside");


### PR DESCRIPTION
## Summary
- replace the fundraising cover headline with the homepage-style `MAKE MONEY` rotation
- cycle through shipping slop, building the future, and solving hard problems
- bold `Slop.cash` in the supporting copy
- keep orbit labels horizontally upright while the network rotates
- retune cover type and spacing to remove the 699px collision

## Validation
- visually inspected at 699x998 and 320x800, including motion over time
- zero horizontal overflow at both sizes
- `bun run format:check`
- `bun run lint:check`
- `bun run typecheck`
- `bunx vitest run tests/deck.test.tsx`
- deck presentation matrix: 4/4 across wide desktop, desktop, tablet, and narrow mobile
