### PR TITLE
fix: respect reduced motion on deck cover

### DIFF
--- a/src/Deck.tsx
+++ b/src/Deck.tsx
@@ -18,12 +18,6 @@ import {
 import "./deck.css";
 
 const SLIDE_COUNT = 10;
-const COVER_ACTIONS = [
-  "SHIPPING SLOP.",
-  "BUILDING THE FUTURE.",
-  "SOLVING HARD PROBLEMS.",
-] as const;
-
 function initialSlide(): number {
   const parsed = Number.parseInt(window.location.hash.slice(1), 10);
   return Number.isInteger(parsed) && parsed >= 1 && parsed <= SLIDE_COUNT
@@ -87,18 +81,6 @@ function Frame({
 }
 
 function Cover() {
-  const [actionIndex, setActionIndex] = useState(0);
-
-  useEffect(() => {
-    if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) return;
-    const interval = window.setInterval(() => {
-      setActionIndex((current) => (current + 1) % COVER_ACTIONS.length);
-    }, 2800);
-    return () => window.clearInterval(interval);
-  }, []);
-
-  const action = COVER_ACTIONS[actionIndex];
-
   return (
     <Frame
       index={0}
@@ -106,11 +88,9 @@ function Cover() {
       className="deck-cover"
     >
       <div className="deck-cover-copy">
-        <h1 aria-label={`MAKE MONEY ${action}`}>
+        <h1 aria-label="MAKE MONEY SHIPPING SLOP.">
           <span className="deck-cover-prefix">MAKE MONEY</span>
-          <em className="deck-cover-action" key={action}>
-            {action}
-          </em>
+          <em className="deck-cover-action">SHIPPING SLOP.</em>
         </h1>
         <p>
           <strong className="deck-cover-brand">Slop.cash</strong> is the

--- a/src/deck.css
+++ b/src/deck.css
@@ -91,7 +91,6 @@
   font-size: 0.7em;
   line-height: 0.95;
   overflow-wrap: normal;
-  animation: deck-action-enter 360ms ease-out both;
 }
 .deck-cover-copy > p {
   max-width: 650px;
@@ -867,13 +866,6 @@
     transform: rotate(-360deg);
   }
 }
-@keyframes deck-action-enter {
-  from {
-    opacity: 0;
-    transform: translateY(0.12em);
-  }
-}
-
 @media (max-width: 760px) {
   .deck-slide {
     padding: 76px 22px 74px;
@@ -1144,6 +1136,7 @@
   .deck-stage,
   .deck-cover-network,
   .deck-cover-network > strong,
+  .deck-orbit-label,
   .deck-mission-ring::before,
   .deck-flywheel,
   .deck-flywheel > strong {

--- a/tests/deck.test.tsx
+++ b/tests/deck.test.tsx
@@ -16,7 +16,9 @@ describe("Slop fundraising deck", () => {
     render(<Deck />);
 
     expect(
-      screen.getByRole("heading", { name: /^MAKE MONEY/ }),
+      screen.getByRole("heading", {
+        name: "MAKE MONEY SHIPPING SLOP.",
+      }),
     ).toBeInTheDocument();
     expect(screen.getByText("Slop.cash", { selector: "strong" })).toBeVisible();
     expect(screen.getByText("1 / 10")).toBeInTheDocument();

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -795,9 +795,15 @@ test("presents every fundraising slide without viewport or accessibility failure
   await page.goto("/deck#1", { waitUntil: "networkidle" });
   await expect(
     page.getByRole("heading", {
-      name: /^MAKE MONEY/,
+      exact: true,
+      name: "MAKE MONEY SHIPPING SLOP.",
     }),
   ).toBeVisible();
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await expect(page.locator(".deck-orbit-label").first()).toHaveCSS(
+    "animation-name",
+    "none",
+  );
   await expect(page).toHaveTitle("Slop — make money shipping slop");
   await expect(page.locator('meta[property="og:image"]')).toHaveAttribute(
     "content",


### PR DESCRIPTION
## Summary
- keep the deck cover headline static so moving content does not run indefinitely
- disable the orbit-label counter-animation for reduced-motion users
- pin the exact accessible heading and reduced-motion behavior in unit/browser coverage

## Verification
- `bunx vitest run tests/deck.test.tsx`
- `bun run typecheck`
- `bun run lint:check`
- `bun run format:check`
- `bunx playwright test tests/e2e/site.spec.ts --grep "presents every fundraising slide" --workers=1` (4/4 viewports)
- `git diff --check`