### PR TITLE
fix: verify Cloudflare clean 404 route

### DIFF
--- a/scripts/dist-manifest.mjs
+++ b/scripts/dist-manifest.mjs
@@ -308,9 +308,15 @@ function remoteUrl(origin, path, verificationToken, attempt) {
     .split("/")
     .map((part) => encodeURIComponent(part))
     .join("/");
-  // Pages canonically serves the entry document at the apex and redirects
-  // /index.html, so its bytes must be checked at the public route.
-  const publicPath = path === "index.html" ? "/" : `/${encodedPath}`;
+  // Pages canonically serves HTML documents with clean URLs. Verify the exact
+  // bytes at the public route instead of treating the expected redirect from
+  // the source filename as a deployment mismatch.
+  const publicPath =
+    path === "index.html"
+      ? "/"
+      : path === "404.html"
+        ? "/404"
+        : `/${encodedPath}`;
   const url = new URL(publicPath, origin);
   url.searchParams.set("verify", `${verificationToken}-${attempt}`);
   return url;

--- a/scripts/dist-manifest.test.mjs
+++ b/scripts/dist-manifest.test.mjs
@@ -35,6 +35,10 @@ async function fixture() {
     "<!doctype html><title>slop.cash</title>\n",
   );
   await writeFile(
+    join(root, "404.html"),
+    "<!doctype html><title>Not found</title>\n",
+  );
+  await writeFile(
     join(root, "skill-manifest.json"),
     '{"name":"contribute-to-eliza"}\n',
   );
@@ -79,6 +83,7 @@ describe("Cloudflare Pages deployment manifest", () => {
     expect(manifest.schemaVersion).toBe(1);
     expect(manifest.files.map((record) => record.path)).toEqual([
       ".well-known/agent-skills/index.json",
+      "404.html",
       "assets/index-test.js",
       "index.html",
       "skill-manifest.json",
@@ -118,7 +123,11 @@ describe("Cloudflare Pages deployment manifest", () => {
       const parsed = new URL(url);
       const publicPath = decodeURIComponent(parsed.pathname);
       const bundlePath =
-        publicPath === "/" ? "index.html" : publicPath.slice(1);
+        publicPath === "/"
+          ? "index.html"
+          : publicPath === "/404"
+            ? "404.html"
+            : publicPath.slice(1);
       requested.push({
         init,
         path: publicPath,
@@ -142,13 +151,18 @@ describe("Cloudflare Pages deployment manifest", () => {
       [
         `/${MANIFEST_FILENAME}`,
         ...manifest.files.map((record) =>
-          record.path === "index.html" ? "/" : `/${record.path}`,
+          record.path === "index.html"
+            ? "/"
+            : record.path === "404.html"
+              ? "/404"
+              : `/${record.path}`,
         ),
       ].sort(),
     );
     expect(requested.map((request) => request.path)).not.toContain(
       "/index.html",
     );
+    expect(requested.map((request) => request.path)).not.toContain("/404.html");
     expect(requested.every((request) => request.token === "release-1-1")).toBe(
       true,
     );
@@ -166,7 +180,8 @@ describe("Cloudflare Pages deployment manifest", () => {
     const root = await fixture();
     await createDistManifest(root);
     const fetchImpl = async (url) => {
-      const path = decodeURIComponent(new URL(url).pathname.slice(1));
+      const publicPath = decodeURIComponent(new URL(url).pathname);
+      const path = publicPath === "/404" ? "404.html" : publicPath.slice(1);
       const contents =
         path === "assets/index-test.js"
           ? Buffer.from("tampered")


### PR DESCRIPTION
## Summary
- verify the generated `404.html` bytes at Cloudflare Pages’ canonical `/404` route
- retain manual redirect handling for every other deployment artifact
- cover the clean-route mapping in the deterministic manifest tests

## Production evidence
The deployed exact artifact for run 31912241747 fails only because `/404.html` returns Cloudflare’s expected 308 to `/404`. With this change, the same downloaded artifact verifies all 152 public files and the manifest byte-for-byte at `https://slop.cash`.

## Verification
- `bunx vitest run scripts/dist-manifest.test.mjs scripts/deployment-contract.test.mjs` (14/14)
- `bun run typecheck`
- `bun run lint:check`
- `bun run format:check`
- `git diff --check`
- live exact-artifact verification: 152 files + manifest