### PR TITLE
fix: verify Pages HTML at canonical routes

### DIFF
--- a/scripts/dist-manifest.mjs
+++ b/scripts/dist-manifest.mjs
@@ -308,9 +308,19 @@ function remoteUrl(origin, path, verificationToken, attempt) {
     .split("/")
     .map((part) => encodeURIComponent(part))
     .join("/");
-  // Pages canonically serves the entry document at the apex and redirects
-  // /index.html, so its bytes must be checked at the public route.
-  const publicPath = path === "index.html" ? "/" : `/${encodedPath}`;
+  // Cloudflare Pages redirects HTML filenames to its extensionless public
+  // routes. Verify the bytes at the canonical route while continuing to bind
+  // them to the exact file recorded in the local deployment manifest.
+  let publicPath;
+  if (encodedPath === "index.html") {
+    publicPath = "/";
+  } else if (encodedPath.endsWith("/index.html")) {
+    publicPath = `/${encodedPath.slice(0, -"index.html".length)}`;
+  } else if (encodedPath.endsWith(".html")) {
+    publicPath = `/${encodedPath.slice(0, -".html".length)}`;
+  } else {
+    publicPath = `/${encodedPath}`;
+  }
   const url = new URL(publicPath, origin);
   url.searchParams.set("verify", `${verificationToken}-${attempt}`);
   return url;

--- a/scripts/dist-manifest.test.mjs
+++ b/scripts/dist-manifest.test.mjs
@@ -35,6 +35,10 @@ async function fixture() {
     "<!doctype html><title>slop.cash</title>\n",
   );
   await writeFile(
+    join(root, "404.html"),
+    "<!doctype html><title>Not found</title>\n",
+  );
+  await writeFile(
     join(root, "skill-manifest.json"),
     '{"name":"contribute-to-eliza"}\n',
   );
@@ -79,6 +83,7 @@ describe("Cloudflare Pages deployment manifest", () => {
     expect(manifest.schemaVersion).toBe(1);
     expect(manifest.files.map((record) => record.path)).toEqual([
       ".well-known/agent-skills/index.json",
+      "404.html",
       "assets/index-test.js",
       "index.html",
       "skill-manifest.json",
@@ -118,7 +123,11 @@ describe("Cloudflare Pages deployment manifest", () => {
       const parsed = new URL(url);
       const publicPath = decodeURIComponent(parsed.pathname);
       const bundlePath =
-        publicPath === "/" ? "index.html" : publicPath.slice(1);
+        publicPath === "/"
+          ? "index.html"
+          : publicPath === "/404"
+            ? "404.html"
+            : publicPath.slice(1);
       requested.push({
         init,
         path: publicPath,
@@ -142,13 +151,19 @@ describe("Cloudflare Pages deployment manifest", () => {
       [
         `/${MANIFEST_FILENAME}`,
         ...manifest.files.map((record) =>
-          record.path === "index.html" ? "/" : `/${record.path}`,
+          record.path === "index.html"
+            ? "/"
+            : record.path.endsWith(".html")
+              ? `/${record.path.slice(0, -".html".length)}`
+              : `/${record.path}`,
         ),
       ].sort(),
     );
     expect(requested.map((request) => request.path)).not.toContain(
       "/index.html",
     );
+    expect(requested.map((request) => request.path)).toContain("/404");
+    expect(requested.map((request) => request.path)).not.toContain("/404.html");
     expect(requested.every((request) => request.token === "release-1-1")).toBe(
       true,
     );
@@ -166,7 +181,8 @@ describe("Cloudflare Pages deployment manifest", () => {
     const root = await fixture();
     await createDistManifest(root);
     const fetchImpl = async (url) => {
-      const path = decodeURIComponent(new URL(url).pathname.slice(1));
+      const publicPath = decodeURIComponent(new URL(url).pathname.slice(1));
+      const path = publicPath === "404" ? "404.html" : publicPath;
       const contents =
         path === "assets/index-test.js"
           ? Buffer.from("tampered")


### PR DESCRIPTION
Fixes the production release verifier discovered while validating #95.

Cloudflare Pages canonicalizes `/404.html` to `/404`; the exact verified bytes are served at `/404`. The manifest gate treated the expected 308 as a mismatch and could retry for over an hour even though the deployed artifact was correct.

This keeps redirect handling manual and byte verification fail-closed, but maps HTML artifacts to their canonical Pages routes before comparing the exact manifest length and SHA-256.

Evidence:
- `bun run test` (358 Vitest + 55 skill tests)
- `bun run typecheck`
- `bun run lint:check`
- `bun run format:check`
- exact production bundle verification: 152 files plus manifest passed against `https://slop.cash`

Related: #95 #93