### PR TITLE
Fix operator session role issuance

### DIFF
--- a/backend/trace/handler.ts
+++ b/backend/trace/handler.ts
@@ -1,6 +1,7 @@
 import { isSolanaAddress } from "../../src/lib/wallets";
 import { signApiToken, verifyApiToken } from "./auth";
 import {
+  type ApiRole,
   type AuthenticatedActor,
   MAX_TRACE_BYTES,
   OPERATOR_GRANT_TTL_SECONDS,
@@ -373,7 +374,11 @@ async function exchangeIdentityAssertion(
   if (identity === null)
     fail(401, "unauthorized", "Identity authentication failed");
   const issuedAt = Math.floor(deps.now().getTime() / 1000);
-  const expiresAt = issuedAt + 10 * 60;
+  const isOperator = deps.operatorGithubIds.has(identity.githubId);
+  const expiresAt = issuedAt + (isOperator ? 5 : 10) * 60;
+  const roles: ApiRole[] = isOperator
+    ? ["contributor", "operator"]
+    : ["contributor"];
   const token = await signApiToken(
     {
       iss: "slop.cash",
@@ -381,7 +386,7 @@ async function exchangeIdentityAssertion(
       sub: `github:${identity.githubId}`,
       githubId: identity.githubId,
       githubLogin: identity.githubLogin,
-      roles: ["contributor"],
+      roles,
       iat: issuedAt,
       exp: expiresAt,
       jti: deps.randomId(),

--- a/functions/api/v1/trace-api.test.ts
+++ b/functions/api/v1/trace-api.test.ts
@@ -445,6 +445,34 @@ describe("private trace API", () => {
     expect(denied.status).toBe(403);
   });
 
+  it("grants operator access only to an asserted actor in the configured set", async () => {
+    const deps = dependencies();
+    deps.operatorGithubIds = new Set(["42"]);
+    const response = await handleTraceApi(
+      new Request("https://api.slop.cash/api/v1/auth/session", {
+        method: "POST",
+        headers: {
+          "x-slop-identity-assertion": "valid_slop_identity_assertion_value",
+        },
+      }),
+      deps,
+    );
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { token: string };
+    const granted = await handleTraceApi(
+      request(
+        `operator/traces/${"a".repeat(64)}/grant`,
+        "POST",
+        body.token,
+        JSON.stringify({ reason: "support investigation" }),
+        { "content-type": "application/json" },
+      ),
+      deps,
+    );
+    expect(granted.status).toBe(404);
+    expect(await granted.json()).toMatchObject({ error: "not_found" });
+  });
+
   it("requires a valid trace before finalization and is write-only for contributors", async () => {
     const store = new MemoryPersistence();
     const deps = dependencies(store);


### PR DESCRIPTION
Fixes the production authorization gap that made the audited wallet-claim migration endpoint unreachable.

- grants `operator` only when the asserted immutable GitHub actor ID is configured
- keeps contributor-only identity exchanges unchanged
- bounds operator sessions to the existing five-minute maximum
- proves configured and unconfigured actor behavior

Validation: full unit + skill suite (359 + 55), typecheck, lint, format, and production build.