### PR TITLE
test: align private API production contract

### DIFF
--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -542,16 +542,24 @@ test("creates a valid GitHub-native project handoff", async ({ page }) => {
 });
 
 test("serves byte-consistent install and read-only artifacts for every project", async ({
+  baseURL,
   request,
 }) => {
   const privateApiResponse = await request.post("/api/v1/runs", {
     data: {},
   });
-  // The local Pages origin is intentionally plain HTTP, so reaching the
-  // Function must fail at its HTTPS boundary rather than Cloudflare's static
-  // file handler (405) or the SPA fallback (200).
-  expect(privateApiResponse.status()).toBe(400);
-  expect(await privateApiResponse.json()).toEqual({ error: "https_required" });
+  const originProtocol = new URL(baseURL ?? "http://127.0.0.1:4466").protocol;
+  if (originProtocol !== "http:" && originProtocol !== "https:") {
+    throw new Error(`unsupported test origin protocol: ${originProtocol}`);
+  }
+  const privateApiExpectation =
+    originProtocol === "https:"
+      ? { status: 401, error: "unauthorized" }
+      : { status: 400, error: "https_required" };
+  expect(privateApiResponse.status()).toBe(privateApiExpectation.status);
+  expect(await privateApiResponse.json()).toMatchObject({
+    error: privateApiExpectation.error,
+  });
 
   const legacySkillResponse = await request.get("/skill.md", {
     maxRedirects: 0,


### PR DESCRIPTION
## Summary

- derive the private API expectation from the configured Playwright origin protocol
- require local HTTP to fail at the HTTPS boundary with `400 https_required`
- require production HTTPS to reach authentication and fail with `401 unauthorized`
- reject unsupported origin protocols

No runtime API behavior changes.

## Verification

- `bun run test` (358 Vitest + 55 skill tests)
- `bun run typecheck`
- `bun run lint:check`
- `bun run format:check`
- focused local Pages test: 1 passed (`400 https_required`)
- focused `https://slop.cash` test: 1 passed (`401 unauthorized`)
- `bun run test:e2e`: 36 preview tests + 1 Pages contract test passed across the complete viewport matrix

The full browser suite used a freshly generated authenticated live leaderboard, as required by the repository contract.