### PR TITLE
Focus pitch deck team slide on Shaw and Nubs

### DIFF
--- a/src/Deck.tsx
+++ b/src/Deck.tsx
@@ -113,67 +113,57 @@ function Cover() {
 }
 
 function Team() {
+  const leads = [
+    {
+      name: "Shaw",
+      role: "CEO",
+      x: "https://x.com/shawmakesmagic",
+      github: "https://github.com/lalalune",
+      portrait: "https://deck.eliza.app/team_shaw.jpg",
+      contributions: "https://deck.eliza.app/github_lalalune.svg",
+    },
+    {
+      name: "Nubs",
+      role: "CTO",
+      x: "https://x.com/nubsvault",
+      github: "https://github.com/NubsCarson",
+      portrait: "https://deck.eliza.app/team_nubs.jpg",
+      contributions: "https://deck.eliza.app/github_nubscarson.svg",
+    },
+  ];
   return (
-    <Frame index={1} label="Shaw leads Slop" className="deck-team">
-      <div className="deck-team-founder">
-        <div className="deck-team-copy">
-          <span className="deck-team-eyebrow">
-            <strong>Shaw</strong> · Founder / CEO
-          </span>
-          <h2>Shaw built a movement in open source.</h2>
-          <p className="deck-supporting">
-            Founder of elizaOS—one of the most followed open-source AI projects.
-            Now building the incentive layer for what comes next.
-          </p>
-          <div className="deck-founder-links">
+    <Frame index={1} label="The builders behind Slop" className="deck-team">
+      <h2>We built a movement in open source.</h2>
+      <div className="deck-team-leads">
+        {leads.map((lead) => (
+          <article className="deck-team-lead" key={lead.name}>
             <a
-              href="https://x.com/shawmakesmagic"
+              className="deck-team-avatar"
+              href={lead.x}
               target="_blank"
               rel="noreferrer"
+              aria-label={`${lead.name} on X`}
             >
-              @shawmakesmagic ↗
+              <img src={lead.portrait} alt={lead.name} />
             </a>
+            <div className="deck-team-identity">
+              <h3>{lead.name}</h3>
+              <span>{lead.role}</span>
+            </div>
             <a
-              href="https://github.com/lalalune"
+              className="deck-team-contributions"
+              href={lead.github}
               target="_blank"
               rel="noreferrer"
+              aria-label={`${lead.name} on GitHub`}
             >
-              github.com/lalalune ↗
+              <img
+                src={lead.contributions}
+                alt={`${lead.name} GitHub contributions`}
+              />
             </a>
-          </div>
-        </div>
-        <a
-          className="deck-founder-portrait"
-          href="https://x.com/shawmakesmagic"
-          target="_blank"
-          rel="noreferrer"
-          aria-label="Shaw on X"
-        >
-          <img src="https://deck.eliza.app/team_shaw.jpg" alt="Shaw" />
-        </a>
-      </div>
-      <div className="deck-team-proof">
-        <a
-          href="https://github.com/elizaOS/eliza"
-          target="_blank"
-          rel="noreferrer"
-        >
-          <strong>19K+</strong>
-          <span>stars · elizaOS/eliza</span>
-        </a>
-        <p>
-          <strong>5.6K</strong>
-          <span>forks</span>
-        </p>
-        <p>
-          <strong>671</strong>
-          <span>contributors</span>
-        </p>
-        <p className="deck-team-cto">
-          <span>CTO</span>
-          <strong>Nubs</strong>
-          <small>Open-source systems + protocol execution</small>
-        </p>
+          </article>
+        ))}
       </div>
     </Frame>
   );

--- a/src/deck.css
+++ b/src/deck.css
@@ -158,120 +158,74 @@
 
 /* 02 — team */
 .deck-team {
-  grid-template-rows: 1fr auto;
-  gap: clamp(24px, 4vh, 48px);
+  grid-template-rows: auto 1fr;
+  align-content: center;
+  gap: clamp(36px, 6vh, 72px);
 }
 .deck-team h2 {
-  max-width: 860px;
+  max-width: 980px;
 }
-.deck-team-founder {
+.deck-team-leads {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(220px, 0.42fr);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: clamp(20px, 3vw, 42px);
+}
+.deck-team-lead {
+  display: grid;
+  grid-template-columns: auto 1fr;
   align-items: center;
-  gap: clamp(32px, 7vw, 108px);
+  gap: clamp(16px, 2vw, 28px);
+  min-width: 0;
+  padding: clamp(22px, 2.5vw, 36px);
+  border: 1px solid rgba(22, 19, 15, 0.16);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.16);
 }
-.deck-team-copy {
-  align-self: center;
-}
-.deck-team-eyebrow {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-bottom: 18px;
-  color: var(--orange-ink);
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-.deck-team-eyebrow strong {
-  color: var(--ink);
-  font-size: 16px;
-  letter-spacing: -0.04em;
-  text-transform: none;
-}
-.deck-founder-links {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  margin-top: 28px;
-}
-.deck-founder-links a {
-  padding: 10px 14px;
-  border: 1px solid rgba(22, 19, 15, 0.18);
-  border-radius: 999px;
-  color: var(--ink);
-  font-size: 11px;
-  font-weight: 700;
-  text-decoration: none;
-}
-.deck-founder-links a:hover {
-  border-color: var(--orange);
-  background: var(--orange);
-}
-.deck-founder-portrait {
-  position: relative;
+.deck-team-avatar {
   display: block;
-  width: min(28vw, 360px);
+  width: clamp(92px, 10vw, 150px);
   aspect-ratio: 1;
-  justify-self: end;
   overflow: hidden;
-  border: 2px solid rgba(22, 19, 15, 0.14);
+  border: 2px solid var(--orange);
   border-radius: 50%;
   background: var(--orange);
 }
-.deck-founder-portrait::after {
-  position: absolute;
-  inset: 10px;
-  border: 1px solid rgba(245, 240, 231, 0.62);
-  border-radius: inherit;
-  content: "";
-}
-.deck-founder-portrait img {
+.deck-team-avatar img {
   width: 100%;
   height: 100%;
   object-fit: cover;
 }
-.deck-team-proof {
-  display: grid;
-  grid-template-columns: 1.15fr 0.7fr 0.7fr 1.15fr;
-  border-top: 1px solid rgba(22, 19, 15, 0.18);
-}
-.deck-team-proof > a,
-.deck-team-proof > p {
-  display: flex;
-  min-height: 116px;
-  flex-direction: column;
-  justify-content: flex-end;
-  gap: 5px;
+.deck-team-identity h3 {
   margin: 0;
-  padding: 18px clamp(14px, 2vw, 28px);
-  border-right: 1px solid rgba(22, 19, 15, 0.18);
-  color: inherit;
-  text-decoration: none;
-}
-.deck-team-proof > :first-child {
-  padding-left: 0;
-}
-.deck-team-proof > :last-child {
-  border-right: 0;
-}
-.deck-team-proof strong {
-  font-size: clamp(26px, 3vw, 48px);
-  letter-spacing: -0.07em;
-  line-height: 1;
-}
-.deck-team-proof span,
-.deck-team-proof small {
-  color: var(--muted);
-  font-size: 9px;
+  font-size: clamp(38px, 4.2vw, 64px);
   font-weight: 700;
-  letter-spacing: 0.08em;
-  line-height: 1.35;
+  letter-spacing: -0.065em;
+  line-height: 0.95;
+}
+.deck-team-identity span {
+  display: block;
+  margin-top: 9px;
+  color: var(--orange-ink);
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
 }
-.deck-team-cto strong {
-  color: var(--orange-ink);
+.deck-team-contributions {
+  grid-column: 1 / -1;
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid rgba(22, 19, 15, 0.14);
+  border-radius: 10px;
+  background: #0d1117;
+}
+.deck-team-contributions img {
+  display: block;
+  width: 100%;
+  height: 92px;
+  object-fit: cover;
+  object-position: right center;
 }
 
 /* 03 — mission */
@@ -953,52 +907,34 @@
       rotate(calc(var(--angle) * -1));
   }
   .deck-team {
-    align-content: center;
+    align-content: start;
+    gap: 24px;
     overflow-y: auto;
   }
-  .deck-team-founder {
-    grid-template-columns: 1fr 112px;
-    gap: 16px;
-  }
   .deck-team h2 {
-    font-size: clamp(39px, 10vw, 56px);
+    font-size: clamp(40px, 10.5vw, 58px);
   }
-  .deck-team .deck-supporting {
-    margin-top: 12px;
-    font-size: 12px;
+  .deck-team-leads {
+    grid-template-columns: 1fr;
+    gap: 12px;
   }
-  .deck-team-eyebrow {
-    margin-bottom: 10px;
-    font-size: 8px;
+  .deck-team-lead {
+    grid-template-columns: 78px 1fr;
+    gap: 14px;
+    padding: 14px;
   }
-  .deck-team-eyebrow strong {
-    font-size: 12px;
+  .deck-team-avatar {
+    width: 78px;
   }
-  .deck-founder-links {
-    gap: 5px;
-    margin-top: 12px;
+  .deck-team-identity h3 {
+    font-size: 35px;
   }
-  .deck-founder-links a {
-    padding: 5px 8px;
-    font-size: 7px;
+  .deck-team-identity span {
+    margin-top: 5px;
+    font-size: 9px;
   }
-  .deck-founder-portrait {
-    width: 112px;
-  }
-  .deck-team-proof {
-    grid-template-columns: repeat(4, 1fr);
-  }
-  .deck-team-proof > a,
-  .deck-team-proof > p {
-    min-height: 84px;
-    padding: 10px 6px;
-  }
-  .deck-team-proof strong {
-    font-size: 18px;
-  }
-  .deck-team-proof span,
-  .deck-team-proof small {
-    font-size: 5.5px;
+  .deck-team-contributions img {
+    height: 62px;
   }
   .deck-mission {
     grid-template-columns: 1fr;

--- a/tests/deck.test.tsx
+++ b/tests/deck.test.tsx
@@ -26,11 +26,15 @@ describe("Slop fundraising deck", () => {
     fireEvent.click(screen.getByRole("button", { name: "Next slide" }));
     expect(
       screen.getByRole("heading", {
-        name: "Shaw built a movement in open source.",
+        name: "We built a movement in open source.",
       }),
     ).toBeInTheDocument();
     expect(screen.getByText("Shaw")).toBeInTheDocument();
     expect(screen.getByText("Nubs")).toBeInTheDocument();
+    expect(screen.getByText("CEO")).toBeInTheDocument();
+    expect(screen.getByText("CTO")).toBeInTheDocument();
+    expect(screen.getByAltText("Shaw GitHub contributions")).toBeVisible();
+    expect(screen.getByAltText("Nubs GitHub contributions")).toBeVisible();
     expect(window.location.hash).toBe("#2");
 
     fireEvent.keyDown(window, { key: "End" });


### PR DESCRIPTION
## Summary
- change the team headline to “We built a movement in open source.”
- remove the founder eyebrow and repository-stat footer
- focus the slide on Shaw as CEO and Nubs as CTO
- show both leaders with their Eliza deck portraits and green GitHub contribution graphs

## Validation
- `bun run format:check`
- `bun run lint:check`
- `bun run typecheck`
- `bunx vitest run tests/deck.test.tsx`
- desktop and 699×998 browser review with no overflow or console warnings