### PR TITLE
Fix evaluated trace contribution comment ingestion

### DIFF
--- a/evaluations/delta-star/award-region-middle-counterexample-23.json
+++ b/evaluations/delta-star/award-region-middle-counterexample-23.json
@@ -1,0 +1,29 @@
+{
+  "schemaVersion": "1",
+  "kind": "evaluated-contribution",
+  "id": "award_region_middle_counterexample_23",
+  "projectId": "delta-star",
+  "repository": "elizaOS/proximityprize",
+  "actor": {
+    "id": "MDQ6VXNlcjEyNDcxNTI=",
+    "login": "leo-guinan",
+    "avatarUrl": "https://avatars.githubusercontent.com/u/1247152?v=4",
+    "url": "https://github.com/leo-guinan",
+    "kind": "User"
+  },
+  "occurredAt": "2026-08-16T12:45:11.000Z",
+  "points": 8,
+  "source": {
+    "id": "IC_kwDOT48hJc8AAAABPFoBmA",
+    "kind": "comment",
+    "number": 1,
+    "title": "Counterexample: RegionMiddleExclusion (ZMod 23) is false",
+    "url": "https://github.com/elizaOS/proximityprize/issues/1#issuecomment-5307498904"
+  },
+  "reason": "The contribution supplies two disjoint exact ZMod 23 witnesses that refute the stronger RegionMiddleExclusion conjecture at the first advertised test-family member. Both dependency-free verifiers independently reproduce the claimed vanishing polynomials, nonzero linear-cofactor syzygies, determinant obstructions to constant cofactors, and arithmetic profile, while explicitly limiting the conclusion so it does not claim genuine F1 or the open delta-star result.",
+  "review": {
+    "reviewer": "lalalune",
+    "reviewedAt": "2026-08-16T16:23:05.000Z",
+    "decisionUrl": "https://github.com/elizaOS/slopdotcash/pull/129"
+  }
+}

--- a/evaluations/delta-star/award-region-middle-counterexample-23.json
+++ b/evaluations/delta-star/award-region-middle-counterexample-23.json
@@ -7,7 +7,7 @@
   "actor": {
     "id": "MDQ6VXNlcjEyNDcxNTI=",
     "login": "leo-guinan",
-    "avatarUrl": "https://avatars.githubusercontent.com/u/1247152?v=4",
+    "avatarUrl": "https://avatars.githubusercontent.com/u/1247152?u=e5e94e91a2ed4e0b7be8f83ce4c3d389f25524b8&v=4",
     "url": "https://github.com/leo-guinan",
     "kind": "User"
   },

--- a/src/lib/evaluator-awards.test.ts
+++ b/src/lib/evaluator-awards.test.ts
@@ -142,6 +142,30 @@ describe("evaluator award protocol", () => {
     ).toThrow("not the expected canonical GitHub URL");
   });
 
+  it("binds comment awards to one immutable issue comment", () => {
+    const source = {
+      id: "IC_useful_comment_17",
+      kind: "comment",
+      number: 17,
+      title: "Useful campaign contribution",
+      url: "https://github.com/elizaOS/eliza/issues/17#issuecomment-170",
+    };
+
+    expect(assertEvaluatorAwardManifest(award({ source })).source).toEqual(
+      source,
+    );
+
+    for (const url of [
+      "https://github.com/elizaOS/eliza/issues/17",
+      "https://github.com/elizaOS/eliza/issues/17#pullrequestreview-170",
+      "https://github.com/elizaOS/eliza/issues/17?notification=1#issuecomment-170",
+    ]) {
+      expect(() =>
+        assertEvaluatorAwardManifest(award({ source: { ...source, url } })),
+      ).toThrow("not the expected canonical GitHub URL");
+    }
+  });
+
   it("rejects duplicate source credit even when award ids differ", () => {
     const root = fixtureRoot();
     writeFileSync(

--- a/src/lib/evaluator-awards.ts
+++ b/src/lib/evaluator-awards.ts
@@ -242,7 +242,11 @@ export function assertEvaluatorAwardManifest(
     ["id", "kind", "number", "title", "url"],
     "evaluator award.source",
   );
-  if (!["issue", "pull-request", "review"].includes(String(source.kind))) {
+  if (
+    !["comment", "issue", "pull-request", "review"].includes(
+      String(source.kind),
+    )
+  ) {
     throw new TypeError("evaluator award.source.kind is invalid");
   }
   if (!Number.isSafeInteger(source.number) || Number(source.number) <= 0) {
@@ -250,7 +254,8 @@ export function assertEvaluatorAwardManifest(
   }
   const number = Number(source.number);
   const sourceKind = source.kind as ScoreEvent["source"]["kind"];
-  const pathKind = sourceKind === "issue" ? "issues" : "pull";
+  const pathKind =
+    sourceKind === "issue" || sourceKind === "comment" ? "issues" : "pull";
   const normalizedRepository = repository.split("/");
   const sourceUrl = githubUrl(
     source.url,
@@ -258,7 +263,9 @@ export function assertEvaluatorAwardManifest(
     `/${normalizedRepository[0]}/${normalizedRepository[1]}/${pathKind}/${number}`,
     sourceKind === "review"
       ? /^#(?:pullrequestreview-|discussion_r)\d+$/iu
-      : undefined,
+      : sourceKind === "comment"
+        ? /^#issuecomment-\d+$/iu
+        : undefined,
   );
   const occurredAt = iso(manifest.occurredAt, "evaluator award.occurredAt");
   const approval = review(manifest.review, "evaluator award.review");

--- a/src/lib/leaderboard.test.ts
+++ b/src/lib/leaderboard.test.ts
@@ -1518,6 +1518,15 @@ describe("scoring and limits", () => {
       }),
     );
 
+    const replayedReceipt = structuredClone(snapshot);
+    replayedReceipt.attributions.push({
+      ...replayedReceipt.attributions[0],
+      id: "attribution_replayed_receipt",
+    });
+    expect(() => assertLeaderboardSnapshot(replayedReceipt)).toThrow(
+      /reuses client run/u,
+    );
+
     for (const mismatchedActor of [
       actor("different-author"),
       { ...contributor, id: "ACTOR_same-login-impostor" },

--- a/src/lib/leaderboard.test.ts
+++ b/src/lib/leaderboard.test.ts
@@ -1458,6 +1458,87 @@ describe("scoring and limits", () => {
     ).toHaveLength(3);
   });
 
+  it("joins an evaluated issue comment to its signed finalized run", () => {
+    const contributor = actor("campaign-author");
+    const source: GitHubTextSource = {
+      ...textSource(
+        "IC_campaign_17",
+        reviewAttribution({
+          provider: "openai",
+          model: "gpt-5.6-sol",
+          client: "hermes-agent",
+        }).replace(/^Findings: none\.\n\n```slop-review\n[^\n]+\n```\n\n/u, ""),
+        contributor,
+      ),
+      artifactId: "ISSUE_CAMPAIGN_17",
+      url: "https://github.com/elizaOS/eliza/issues/17#issuecomment-170",
+    };
+    const evaluated = {
+      ...evaluatedContribution(0, contributor),
+      occurredAt: source.createdAt,
+      source: {
+        id: source.id,
+        kind: "comment" as const,
+        number: 17,
+        title: "Useful campaign contribution",
+        url: source.url,
+      },
+    };
+
+    const snapshot = createLeaderboardSnapshot(
+      input({
+        openIssues: [
+          issue({
+            id: "ISSUE_CAMPAIGN_17",
+            number: 17,
+            url: "https://github.com/elizaOS/eliza/issues/17",
+            closedAt: null,
+            stateReason: null,
+            comments: [source],
+          }),
+        ],
+        evaluatedContributions: [evaluated],
+      }),
+    );
+
+    expect(snapshot.invalidAttributionMarkers).toEqual([]);
+    expect(snapshot.attributions).toEqual([
+      expect.objectContaining({
+        sourceId: source.id,
+        actor: contributor,
+        run: expect.objectContaining({
+          traceUpload: expect.objectContaining({ sha256: "b".repeat(64) }),
+        }),
+      }),
+    ]);
+    expect(snapshot.ledger).toContainEqual(
+      expect.objectContaining({
+        id: evaluated.id,
+        source: expect.objectContaining({ kind: "comment", id: source.id }),
+      }),
+    );
+
+    expect(() =>
+      createLeaderboardSnapshot(
+        input({
+          openIssues: [
+            issue({
+              id: "ISSUE_CAMPAIGN_17",
+              number: 17,
+              url: "https://github.com/elizaOS/eliza/issues/17",
+              closedAt: null,
+              stateReason: null,
+              comments: [source],
+            }),
+          ],
+          evaluatedContributions: [
+            { ...evaluated, actor: actor("different-author") },
+          ],
+        }),
+      ),
+    ).toThrow("does not match its exact GitHub comment");
+  });
+
   it("rejects an evaluator award for a source already scored by GitHub", () => {
     const merged = pullRequest();
     const duplicate = {

--- a/src/lib/leaderboard.test.ts
+++ b/src/lib/leaderboard.test.ts
@@ -1518,25 +1518,28 @@ describe("scoring and limits", () => {
       }),
     );
 
-    expect(() =>
-      createLeaderboardSnapshot(
-        input({
-          openIssues: [
-            issue({
-              id: "ISSUE_CAMPAIGN_17",
-              number: 17,
-              url: "https://github.com/elizaOS/eliza/issues/17",
-              closedAt: null,
-              stateReason: null,
-              comments: [source],
-            }),
-          ],
-          evaluatedContributions: [
-            { ...evaluated, actor: actor("different-author") },
-          ],
-        }),
-      ),
-    ).toThrow("does not match its exact GitHub comment");
+    for (const mismatchedActor of [
+      actor("different-author"),
+      { ...contributor, id: "ACTOR_same-login-impostor" },
+    ]) {
+      expect(() =>
+        createLeaderboardSnapshot(
+          input({
+            openIssues: [
+              issue({
+                id: "ISSUE_CAMPAIGN_17",
+                number: 17,
+                url: "https://github.com/elizaOS/eliza/issues/17",
+                closedAt: null,
+                stateReason: null,
+                comments: [source],
+              }),
+            ],
+            evaluatedContributions: [{ ...evaluated, actor: mismatchedActor }],
+          }),
+        ),
+      ).toThrow("does not match its exact GitHub comment");
+    }
   });
 
   it("rejects an evaluator award for a source already scored by GitHub", () => {

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -294,7 +294,7 @@ export interface ScoreEvent {
   repository: RepositoryId;
   source: {
     id: string;
-    kind: "issue" | "pull-request" | "review";
+    kind: "comment" | "issue" | "pull-request" | "review";
     number: number;
     title: string;
     url: string;
@@ -2874,6 +2874,26 @@ export function createLeaderboardSnapshot(
   }
 
   const evaluatedSourceKeys = new Set<string>();
+  const evaluatedTextSources = new Map<string, GitHubTextSource>();
+  for (const source of [
+    ...mergedPullRequests.flatMap(pullRequestTextSources),
+    ...openPullRequests.flatMap(pullRequestTextSources),
+    ...resolvedIssues.flatMap(issueTextSources),
+    ...openIssues.flatMap(issueTextSources),
+  ]) {
+    const existing = evaluatedTextSources.get(source.id);
+    if (
+      existing &&
+      (existing.url !== source.url ||
+        existing.body !== source.body ||
+        !sameActor(existing.author, source.author))
+    ) {
+      throw new TypeError(
+        `Evaluated source ${source.id} has conflicting GitHub records`,
+      );
+    }
+    evaluatedTextSources.set(source.id, source);
+  }
   const evaluatedContributions = [...(input.evaluatedContributions ?? [])].sort(
     (left, right) =>
       parseIsoTime(right.occurredAt) - parseIsoTime(left.occurredAt) ||
@@ -2908,6 +2928,20 @@ export function createLeaderboardSnapshot(
     }
     evaluatedSourceKeys.add(sourceKey);
     addScore(entries, ledger, event);
+    if (event.source.kind === "comment") {
+      const source = evaluatedTextSources.get(event.source.id);
+      if (
+        source?.kind !== "comment" ||
+        source.url !== event.source.url ||
+        !sameActor(source.author, event.actor) ||
+        parseIsoTime(source.createdAt) !== occurredAt
+      ) {
+        throw new TypeError(
+          `Evaluated contribution ${event.id} does not match its exact GitHub comment`,
+        );
+      }
+      recordScoredSources([source]);
+    }
   }
 
   const issueQueue = openIssues.map((record) =>
@@ -3090,7 +3124,7 @@ function secureUrl(value: unknown, path: string): URL {
 function assertRepositoryUrl(
   value: unknown,
   path: string,
-  expectedKind?: "issue" | "pull-request" | "review",
+  expectedKind?: "comment" | "issue" | "pull-request" | "review",
   expectedNumber?: number,
   expectedRepository?: RepositoryId,
 ): RepositoryId {
@@ -3117,6 +3151,7 @@ function assertRepositoryUrl(
     match[3].toLowerCase() === "issues" ? "issue" : "pull-request";
   if (
     expectedKind &&
+    expectedKind !== "comment" &&
     (expectedKind === "issue"
       ? actualKind !== "issue"
       : actualKind !== "pull-request")
@@ -3126,7 +3161,13 @@ function assertRepositoryUrl(
   if (expectedNumber !== undefined && Number(match[4]) !== expectedNumber) {
     throw new Error(`${path} number does not match its repository URL`);
   }
-  if (expectedKind === "review") {
+  if (expectedKind === "comment") {
+    if (!/^#issuecomment-\d+$/i.test(parsed.hash)) {
+      throw new Error(
+        `${path} comment URL must identify an exact GitHub issue or pull-request comment`,
+      );
+    }
+  } else if (expectedKind === "review") {
     if (!/^#(?:pullrequestreview-|discussion_r)\d+$/i.test(parsed.hash)) {
       throw new Error(
         `${path} review URL must identify a GitHub review or inline discussion`,
@@ -3985,7 +4026,7 @@ function assertLedgerValue(
   assertString(source.id, `${path}.source.id`);
   assertEnum(
     source.kind,
-    ["issue", "pull-request", "review"],
+    ["comment", "issue", "pull-request", "review"],
     `${path}.source.kind`,
   );
   assertPositiveInteger(source.number, `${path}.source.number`);
@@ -4570,6 +4611,13 @@ export function assertLeaderboardSnapshot(
       if (
         event.category === "substantive-review" &&
         event.source.kind === "review" &&
+        event.source.id === attribution.sourceId
+      ) {
+        return true;
+      }
+      if (
+        event.category === "evaluated-contribution" &&
+        event.source.kind === "comment" &&
         event.source.id === attribution.sourceId
       ) {
         return true;

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -2886,7 +2886,7 @@ export function createLeaderboardSnapshot(
       existing &&
       (existing.url !== source.url ||
         existing.body !== source.body ||
-        !sameActor(existing.author, source.author))
+        existing.author?.id !== source.author?.id)
     ) {
       throw new TypeError(
         `Evaluated source ${source.id} has conflicting GitHub records`,
@@ -2933,7 +2933,7 @@ export function createLeaderboardSnapshot(
       if (
         source?.kind !== "comment" ||
         source.url !== event.source.url ||
-        !sameActor(source.author, event.actor) ||
+        source.author?.id !== event.actor.id ||
         parseIsoTime(source.createdAt) !== occurredAt
       ) {
         throw new TypeError(

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -4597,6 +4597,24 @@ export function assertLeaderboardSnapshot(
   ) {
     throw new Error("snapshot.attributions must contain unique IDs");
   }
+  const receiptClaims = new Map<string, string>();
+  for (const attribution of validatedAttributions) {
+    if (!attribution.run?.traceUpload) continue;
+    for (const [kind, value] of [
+      ["client run", attribution.run.runId],
+      ["server run", attribution.run.traceUpload.serverRunId],
+      ["trace object", attribution.run.traceUpload.objectId],
+    ] as const) {
+      const key = `${kind}:${value}`;
+      const prior = receiptClaims.get(key);
+      if (prior !== undefined) {
+        throw new Error(
+          `snapshot attribution ${attribution.id} reuses ${kind} already claimed by ${prior}`,
+        );
+      }
+      receiptClaims.set(key, attribution.id);
+    }
+  }
   for (const attribution of validatedAttributions) {
     const hasCausalLedgerEvent = validatedLedger.some((event) => {
       if (!sameActor(event.actor, attribution.actor)) {


### PR DESCRIPTION
## Summary

- add a strict evaluated-contribution source kind for one immutable GitHub issue comment
- require the exact `#issuecomment-<database-id>` receipt and reject root URLs, review anchors, queries, actor drift, timestamp drift, missing comments, and conflicting GitHub records
- join the exact comment's signed terminal run receipt into public attribution only after a maintainer-reviewed evaluation makes that otherwise-unscored work score-bearing
- award 8 points to the exact Delta Star counterexample comment after independently reproducing both published `ZMod 23` witnesses in a network-denied Python sandbox

Advances #90. Keep it open until protected deployment proves the exact public-ledger join and the remaining denied replay/state-mismatch cases are recorded.

## Validation

- `bunx vitest run src/lib/evaluator-awards.test.ts src/lib/leaderboard.test.ts --coverage.enabled=false` — 84/84 passed
- `bun run evaluations:check` — both checked-in awards validated
- independent witness verification — both exact partitions, vanishing polynomials, cofactor syzygies, determinant obstructions, and arithmetic bounds passed in a network-denied sandbox
- prior exact-head checks on the ingestion commit: typecheck, lint, format, and live full GitHub regeneration passed
- production negative probes already captured on #90: denied callback 400, expired flow 410, tampered state 410, and invalid poll capability 400/410 depending on whether the flow remained live

## Acceptance boundary

- The contributor's authenticated production trace upload, digest-checked finalize, signed terminal marker, GitHub publication, and exact byte readback are documented on #90.
- This PR is the public maintainer decision for the immutable evaluation manifest. The reason is factual and narrowly scoped: it recognizes the refutation of `RegionMiddleExclusion`, not genuine F1 or the open delta-star theorem.
- After merge, the protected workflow must regenerate and deploy the ledger. Closure requires byte-checking the public snapshot for the exact comment ID, run ID, server-run ID, and trajectory digest.

## Safety

- no private trace bytes, OAuth state, assertion, credential, or local path is committed or posted
- no identity, trace, scoring, or payout fail-closed check is relaxed
- no automated approval, exclusion, signing, broadcasting, or money movement is added

