### PR TITLE
docs: define the private trace privacy contract

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,6 +6,6 @@ contact_links:
   - name: Report a platform bug
     url: https://github.com/elizaOS/slopdotcash/issues/new?labels=bug&template=bug-report.md
     about: Report a reproducible problem in the Slop site, data pipeline, skills, or reward tooling.
-  - name: Report a security vulnerability privately
+  - name: Report a security or privacy matter privately
     url: https://github.com/elizaOS/slopdotcash/security/advisories/new
-    about: Do not publish exploit details, credentials, or private data in a public issue.
+    about: Use the enabled private intake; do not publish exploit details, credentials, trace contents, or personal data in an issue.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -204,6 +204,27 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
+      - name: Require public private-request intake
+        run: |
+          set -euo pipefail
+          curl --fail --silent --show-error \
+            --header "Accept: application/vnd.github+json" \
+            --header "User-Agent: slop-release-intake-check" \
+            https://api.github.com/repos/elizaOS/slopdotcash/private-vulnerability-reporting |
+            node -e '
+              let source = "";
+              process.stdin.setEncoding("utf8");
+              process.stdin.on("data", (chunk) => { source += chunk; });
+              process.stdin.on("end", () => {
+                let value;
+                try { value = JSON.parse(source); } catch { process.exit(1); }
+                if (value?.enabled !== true) {
+                  console.error("::error::No verified public private-request intake is enabled; production trace activation is blocked.");
+                  process.exit(1);
+                }
+              });
+            '
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,8 +166,10 @@ contributors or project owners after upload. Only designated Slop operators
 may retrieve a trace through short-lived, audited authorization. The
 contributor upload path is write-only, bounded, authenticated, checksum
 verified, and fail-closed. Public artifacts may contain only the trace digest
-and safe metadata, never the trace body. Privacy and data-subject requests use
-the private security-advisory channel documented by that contract.
+and safe metadata, never the trace body. Trace upload and production activation
+remain blocked until the verified operator-controlled private request intake
+documented by that contract is publicly available; public issues are not a
+private channel.
 
 Project reviewer skills follow the same rule: measure the review through the
 project contributor receipt CLI, include exact provider/model/client and trace

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,14 +156,18 @@ must not gate eligibility, scoring, review, or payment. Supported usage
 adapters may add diagnostic token provenance; unavailable usage never blocks a
 contribution and tokens never change its score or payout.
 
-Every agent run must upload its raw trace before a contribution is submitted.
-Trace objects are permanent, private platform records: store immutable bytes in
-private R2, store only metadata and digests in D1, and never publish or expose
-the object to contributors or project owners after upload. Only designated
-Slop operators may retrieve a trace through short-lived, audited authorization.
-The contributor upload path is write-only, bounded, authenticated, checksum
+Every agent run must upload the minimized contribution-specific trace defined
+by `protocol/private-trace-v1.md` before a contribution is submitted. The
+contributor must inspect and redact the selected file; the uploader stores its
+exact bytes and performs no automatic redaction. Trace objects are permanent,
+private platform records: store immutable bytes in private R2, store only
+metadata and digests in D1, and never publish or expose the object to
+contributors or project owners after upload. Only designated Slop operators
+may retrieve a trace through short-lived, audited authorization. The
+contributor upload path is write-only, bounded, authenticated, checksum
 verified, and fail-closed. Public artifacts may contain only the trace digest
-and safe metadata, never the trace body.
+and safe metadata, never the trace body. Privacy and data-subject requests use
+the private security-advisory channel documented by that contract.
 
 Project reviewer skills follow the same rule: measure the review through the
 project contributor receipt CLI, include exact provider/model/client and trace

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,8 +166,10 @@ contributors or project owners after upload. Only designated Slop operators
 may retrieve a trace through short-lived, audited authorization. The
 contributor upload path is write-only, bounded, authenticated, checksum
 verified, and fail-closed. Public artifacts may contain only the trace digest
-and safe metadata, never the trace body. Privacy and data-subject requests use
-the private security-advisory channel documented by that contract.
+and safe metadata, never the trace body. Trace upload and production activation
+remain blocked until the verified operator-controlled private request intake
+documented by that contract is publicly available; public issues are not a
+private channel.
 
 Project reviewer skills follow the same rule: measure the review through the
 project contributor receipt CLI, include exact provider/model/client and trace

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,14 +156,18 @@ must not gate eligibility, scoring, review, or payment. Supported usage
 adapters may add diagnostic token provenance; unavailable usage never blocks a
 contribution and tokens never change its score or payout.
 
-Every agent run must upload its raw trace before a contribution is submitted.
-Trace objects are permanent, private platform records: store immutable bytes in
-private R2, store only metadata and digests in D1, and never publish or expose
-the object to contributors or project owners after upload. Only designated
-Slop operators may retrieve a trace through short-lived, audited authorization.
-The contributor upload path is write-only, bounded, authenticated, checksum
+Every agent run must upload the minimized contribution-specific trace defined
+by `protocol/private-trace-v1.md` before a contribution is submitted. The
+contributor must inspect and redact the selected file; the uploader stores its
+exact bytes and performs no automatic redaction. Trace objects are permanent,
+private platform records: store immutable bytes in private R2, store only
+metadata and digests in D1, and never publish or expose the object to
+contributors or project owners after upload. Only designated Slop operators
+may retrieve a trace through short-lived, audited authorization. The
+contributor upload path is write-only, bounded, authenticated, checksum
 verified, and fail-closed. Public artifacts may contain only the trace digest
-and safe metadata, never the trace body.
+and safe metadata, never the trace body. Privacy and data-subject requests use
+the private security-advisory channel documented by that contract.
 
 Project reviewer skills follow the same rule: measure the review through the
 project contributor receipt CLI, include exact provider/model/client and trace

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -110,8 +110,11 @@ and prepares evidence.
 The skill runs pinned `ccusage` reporting and emits a device-signed receipt.
 Public data includes aggregate tokens, API-equivalent estimated cost, model,
 client, revision, project, repository, timestamps, and a required private-trace
-upload digest. The full trace is retained permanently and is readable only by
-designated Slop operators. Relevant usage must join to an accepted result.
+upload digest. The minimized contribution-specific trace defined by the
+[private trace privacy contract](https://slop.cash/protocol/private-trace-v1.md)
+is retained permanently and is readable only by designated Slop operators.
+The uploader sends the contributor-inspected bytes without automatic
+redaction. Relevant usage must join to an accepted result.
 Ambiguous or unavailable usage remains visible but never changes score, rank,
 share, or payout.
 
@@ -233,7 +236,9 @@ Track all of these without collapsing them into one vanity number:
   (per-profile still-open opportunities are in scope; a global rejection feed
   is not);
 - autonomous banning;
-- raw prompt, response, source-file, or secret upload.
+- public prompt, response, source-file, secret, or private-trace-body upload;
+  the mandatory private trace is the narrow exception and follows the
+  [private trace privacy contract](https://slop.cash/protocol/private-trace-v1.md);
 
 ## Tone
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -116,7 +116,8 @@ is retained permanently and is readable only by designated Slop operators.
 The uploader sends the contributor-inspected bytes without automatic
 redaction. Relevant usage must join to an accepted result.
 Ambiguous or unavailable usage remains visible but never changes score, rank,
-share, or payout.
+share, or payout. Upload and production activation remain blocked unless a
+verified operator-controlled private request intake is publicly available.
 
 ### Submit and review
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,9 @@ Run receipts bind these fields to an Ed25519 device key:
 - client, provider, exact model, skill revision, and skill digest;
 - `ccusage` input, output, cache, total-token, session, and API-equivalent cost
   estimates;
-- a required digest and finalized private-upload identity for the full trace.
+- a required digest and finalized private-upload identity for the minimized
+  contribution-specific trace defined by the
+  [private trace privacy contract](https://slop.cash/protocol/private-trace-v1.md).
 
 Receipts are supporting evidence. A device signature proves stable bytes and
 continuity of one local key; it does not prove that self-reported provider data
@@ -154,13 +156,16 @@ diagnostic evidence: it never changes score, rank, a simulated share, or a
 future payout. Tokens without an accepted matching outcome remain public as
 ambiguous.
 
-Every submitted run permanently uploads its bounded UTF-8 trace to private
-Slop storage. Only designated Slop operators can obtain a short-lived audited
-read grant; contributors, project owners, and the public have no read route.
-The public receipt contains only a digest and immutable upload identity. Trace
-upload or finalization failure blocks submission. Source files, credentials,
-wallet secrets, and environment values remain excluded, and only intentionally
-redacted evidence may be attached to GitHub.
+Every submitted run permanently uploads the exact bytes of one bounded UTF-8
+trace to private Slop storage. The contributor must inspect and redact the file;
+the uploader performs no automatic redaction. The authoritative
+[private trace privacy contract](https://slop.cash/protocol/private-trace-v1.md)
+defines included event types, mandatory exclusions, pre-upload disclosure,
+operator access, permanent retention, and privacy requests. Only designated
+Slop operators can obtain a short-lived audited read grant; contributors,
+project owners, and the public have no read route. The public receipt contains
+only a digest and immutable upload identity. Trace upload or finalization
+failure blocks submission.
 
 ## Monthly rewards
 

--- a/README.md
+++ b/README.md
@@ -98,14 +98,14 @@ credit is uncapped and diminishes within each contributor, project, and UTC
 month, so sustained accepted work always helps without paying every repeated
 outcome as though it were the first:
 
-| Outcome | Points | Per-contributor/project/month cap |
-| --- | ---: | ---: |
-| Merged non-bot pull request | `ceil(10 / sqrt(ordinal))`, minimum 1 | Uncapped |
-| Confirmed resolved issue | 4 | 5 |
-| Material test change | 4 | 5 |
-| Verified evidence | 1–2 by category | 30 points |
-| Substantive non-self review | 3 | 10 |
-| Maintainer-approved evaluated contribution | 1–8 | 3 |
+| Outcome                                    |                                Points | Per-contributor/project/month cap |
+| ------------------------------------------ | ------------------------------------: | --------------------------------: |
+| Merged non-bot pull request                | `ceil(10 / sqrt(ordinal))`, minimum 1 |                          Uncapped |
+| Confirmed resolved issue                   |                                     4 |                                 5 |
+| Material test change                       |                                     4 |                                 5 |
+| Verified evidence                          |                       1–2 by category |                         30 points |
+| Substantive non-self review                |                                     3 |                                10 |
+| Maintainer-approved evaluated contribution |                                   1–8 |                                 3 |
 
 Every rolling snapshot covers 35 complete days. That is long enough for a
 first-of-month job to freeze the entire prior UTC month. Every merged outcome
@@ -165,7 +165,9 @@ operator access, permanent retention, and privacy requests. Only designated
 Slop operators can obtain a short-lived audited read grant; contributors,
 project owners, and the public have no read route. The public receipt contains
 only a digest and immutable upload identity. Trace upload or finalization
-failure blocks submission.
+failure blocks submission. Upload and production activation also remain
+blocked until a verified operator-controlled private request intake is
+publicly available; never put sensitive request details in a public issue.
 
 ## Monthly rewards
 

--- a/backend/trace/README.md
+++ b/backend/trace/README.md
@@ -12,6 +12,12 @@ This backend stores the selected file byte-for-byte and does not redact or scan
 it. Backend integrity checks enforce the declared bytes; they do not replace
 the contributor's required pre-upload inspection.
 
+Trace upload and production activation require GitHub's public private
+vulnerability reporting status to return exactly `enabled: true`. The client
+and deploy workflow check that operator-controlled intake fail closed; an
+advisory URL alone is not evidence of availability, and a public issue is never
+a private intake.
+
 ## Storage contract
 
 - Every finalized run has exactly one SHA-256 trace object.
@@ -45,7 +51,7 @@ the immutable GitHub numeric ID also appears in `OPERATOR_GITHUB_IDS`.
 The write flow is:
 
 1. `POST /api/v1/runs` with `Idempotency-Key` and `{ clientRunId, projectId,
-   repository, projectPolicyRevision, provider, model, client, clientVersion }`.
+repository, projectPolicyRevision, provider, model, client, clientVersion }`.
 2. `POST /api/v1/runs/{serverRunId}/trace-intents` with `Idempotency-Key` and
    `{ sha256, sizeBytes, contentType }`.
 3. `PUT` the exact returned `uploadUrl` within five minutes, with the exact

--- a/backend/trace/README.md
+++ b/backend/trace/README.md
@@ -6,6 +6,12 @@ settlement. D1 records private joins and metadata only. Trace bodies live in a
 dedicated private R2 bucket and are never returned from a contributor or
 project-owner route.
 
+The authoritative content, consent, redaction, retention, and data-request
+policy is [`protocol/private-trace-v1.md`](../../protocol/private-trace-v1.md).
+This backend stores the selected file byte-for-byte and does not redact or scan
+it. Backend integrity checks enforce the declared bytes; they do not replace
+the contributor's required pre-upload inspection.
+
 ## Storage contract
 
 - Every finalized run has exactly one SHA-256 trace object.

--- a/protocol/private-trace-v1.md
+++ b/protocol/private-trace-v1.md
@@ -9,13 +9,15 @@ must not redefine it.
 
 Uploading is mandatory for an agent-authored contribution or review. It is not
 background synchronization: the contributor selects one local file and invokes
-the `trace` command. Before GitHub authorization starts, the command snapshots
-that exact file in memory and displays its local path, byte count, media type,
-and SHA-256 digest. Inspect it before opening the printed authorization URL. If
-any byte needs to change, cancel the waiting command, replace the file, and
-rerun `trace`; the current process will upload only its already-disclosed
-snapshot. The uploader sends those exact bytes without transformation, and a
-changed file has a different digest and requires a new upload intent.
+the `trace` command. Before GitHub authorization starts, the command opens that
+path once without following a final symlink, verifies the opened descriptor is
+a regular file, reads one snapshot, and enforces the byte bound again after the
+read. It displays that snapshot's local path, byte count, media type, and
+SHA-256 digest. Inspect it before opening the printed authorization URL. If any
+byte needs to change, cancel the waiting command, replace the file, and rerun
+`trace`; the current process will upload only its already-disclosed snapshot.
+The uploader sends those exact bytes without transformation, and a changed file
+has a different digest and requires a new upload intent.
 
 Do not authorize or upload if this contract or permanent retention is
 unacceptable. The contribution or review must then remain unsubmitted. A human
@@ -88,14 +90,21 @@ Slop operator may retrieve a body through a single-use grant that expires after
 and appends grant and read audit events. Cloudflare account access is separately
 limited to designated operators.
 
-For a privacy, security, or data-subject request, open a private GitHub security
-advisory at
-<https://github.com/elizaOS/slopdotcash/security/advisories/new>. Do not put
-private data or trace contents in a public issue. Operators must authenticate
-the requester and handle any action required by applicable law outside the
-contributor API with an audit record. This channel does not create a voluntary
-deletion or contributor-read right that conflicts with the permanent,
-write-only product contract.
+For a privacy, security, or data-subject request, use the repository's enabled
+private GitHub security-advisory intake at
+<https://github.com/elizaOS/slopdotcash/security/advisories/new>. It accepts a
+private report from a signed-in GitHub user without publishing the report as an
+issue. Do not put private data, trace contents, or request details in a public
+issue.
+
+The uploader and production workflow independently query GitHub's public
+private-vulnerability-reporting status before activating this path. Trace
+upload and production activation fail closed if it does not report exactly
+`enabled: true`; the advisory URL alone is not evidence that intake is usable.
+Operators must authenticate the requester and handle any action required by
+applicable law outside the contributor API with an audit record. This channel
+does not create a voluntary deletion or contributor-read right that conflicts
+with the permanent, write-only product contract.
 
 ## Integrity requirements
 

--- a/protocol/private-trace-v1.md
+++ b/protocol/private-trace-v1.md
@@ -1,0 +1,107 @@
+# Private trace privacy contract v1
+
+This document is the authoritative content and privacy contract for a Slop
+private trace. It applies to every contribution and review skill that uploads a
+trace to `https://api.slop.cash`. Other documents summarize this contract but
+must not redefine it.
+
+## Consent boundary
+
+Uploading is mandatory for an agent-authored contribution or review. It is not
+background synchronization: the contributor selects one local file and invokes
+the `trace` command. Before GitHub authorization starts, the command snapshots
+that exact file in memory and displays its local path, byte count, media type,
+and SHA-256 digest. Inspect it before opening the printed authorization URL. If
+any byte needs to change, cancel the waiting command, replace the file, and
+rerun `trace`; the current process will upload only its already-disclosed
+snapshot. The uploader sends those exact bytes without transformation, and a
+changed file has a different digest and requires a new upload intent.
+
+Do not authorize or upload if this contract or permanent retention is
+unacceptable. The contribution or review must then remain unsubmitted. A human
+who did not use an agent may declare a human-only contribution and does not
+upload an agent trace.
+
+## Required scope and permitted records
+
+A trace is a minimized, contribution-specific event record, not the complete
+history of a client, account, or machine. It must cover the measured Slop run
+from start through verification and contain the material chronological events
+needed to investigate provenance and reproduce the claimed work:
+
+- timestamps, event types, run state, and command exit status;
+- the user and repository instructions that governed the run;
+- model-visible prompts and assistant responses for the run;
+- tool or command names, arguments, and outputs after the exclusions below;
+- test, verification, and submission results; and
+- explicit redaction records sufficient to show what category was removed.
+
+The file may be UTF-8 plain text or newline-delimited JSON and must be non-empty
+and no larger than 8 MiB. Slop does not require hidden chain-of-thought,
+provider-internal reasoning, unrelated conversations, global client history,
+or events before or after the measured run. “Full” or “raw” trace elsewhere in
+the repository means this complete contribution-specific event record after
+the required minimization and redaction; it never means an unfiltered client
+export.
+
+## Required exclusions and redaction
+
+The contributor must remove or replace these values before upload:
+
+- passwords, passkeys, API keys, OAuth or upload capabilities, cookies, bearer
+  tokens, private keys, wallet seed phrases, and other authentication secrets;
+- environment-variable values and credential-store contents;
+- source-file bodies, private diffs, and unrelated file or database contents;
+- absolute local paths, home-directory names, account identifiers, session
+  identifiers, and personal data not necessary to attribute the contribution;
+- hidden chain-of-thought or provider-internal reasoning; and
+- content from unrelated conversations, repositories, tasks, or users.
+
+Keep the event and replace only its prohibited field with a category marker
+such as `[REDACTED:CREDENTIAL]`, `[REDACTED:SOURCE]`, or
+`[REDACTED:LOCAL_PATH]` when that event is material. Repository-relative paths,
+public GitHub identifiers, public patch content already intended for the
+contribution, aggregate usage values, and ordinary non-secret tool output are
+permitted.
+
+Neither the receipt CLI nor the trace API automatically redacts or scans the
+file. There is no best-effort or guaranteed server-side secret removal: the
+selected bytes are the retained bytes. The contributor or exporting client is
+responsible for applying the exclusions and inspecting the final file before
+authorization. An exporter may provide additional local redaction, but it must
+disclose its rules and must not claim that pattern matching guarantees removal
+of every secret.
+
+## Storage, access, and retention
+
+The trace body is stored as one immutable, content-addressed object in a
+private R2 bucket. D1 stores its digest, size, media type, actor and run joins,
+upload progress, and access-audit metadata, but not the body. Public GitHub and
+Slop artifacts contain only safe run metadata, the digest, and immutable upload
+identity; they never contain the trace body.
+
+Retention is permanent: there is no expiry, contributor download, update,
+correction, or voluntary deletion route. Contributors and project owners
+cannot read trace bodies, including their own, after upload. Only a designated
+Slop operator may retrieve a body through a single-use grant that expires after
+60 seconds, is bound to that operator and digest, requires a recorded reason,
+and appends grant and read audit events. Cloudflare account access is separately
+limited to designated operators.
+
+For a privacy, security, or data-subject request, open a private GitHub security
+advisory at
+<https://github.com/elizaOS/slopdotcash/security/advisories/new>. Do not put
+private data or trace contents in a public issue. Operators must authenticate
+the requester and handle any action required by applicable law outside the
+contributor API with an audit record. This channel does not create a voluntary
+deletion or contributor-read right that conflicts with the permanent,
+write-only product contract.
+
+## Integrity requirements
+
+Minimization and redaction do not weaken the fail-closed receipt join. The API
+accepts only the exact declared byte count, media type, and SHA-256 digest;
+upload capabilities are short-lived and one-use; object creation is immutable;
+and finalization fails unless the object is attached. Contribution and review
+submission remains blocked if export, upload, finalization, or the public
+receipt join fails.

--- a/scripts/deployment-contract.test.mjs
+++ b/scripts/deployment-contract.test.mjs
@@ -63,6 +63,16 @@ describe("slop.cash deployment contract", () => {
       "uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020",
     );
     expect(deployJob).toContain(`node-version: ${"$"}{{ env.NODE_VERSION }}`);
+    expect(deployJob).toContain(
+      "- name: Require public private-request intake",
+    );
+    expect(deployJob).toContain(
+      "https://api.github.com/repos/elizaOS/slopdotcash/private-vulnerability-reporting",
+    );
+    expect(deployJob).toContain("value?.enabled !== true");
+    expect(
+      deployJob.indexOf("Require public private-request intake"),
+    ).toBeLessThan(deployJob.indexOf("wrangler pages deploy \\"));
     expect(deployJob).toContain("./node_modules/.bin/wrangler pages deploy \\");
     expect(deployJob).toContain(
       "./node_modules/.bin/wrangler versions upload \\\n            --config workers/identity/wrangler.toml \\",

--- a/scripts/prepare-site.mjs
+++ b/scripts/prepare-site.mjs
@@ -29,6 +29,8 @@ const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const repositoryRoot = packageRoot;
 const publicRoot = join(packageRoot, "public");
 const downloadsRoot = join(publicRoot, "downloads");
+const protocolRoot = join(repositoryRoot, "protocol");
+const publicProtocolRoot = join(publicRoot, "protocol");
 const bootstrapSkillRoot = join(repositoryRoot, "skills", "slop");
 const bootstrapSkillSource = join(bootstrapSkillRoot, "SKILL.md");
 const skillRoot = join(repositoryRoot, "skills", "contribute-to-eliza");
@@ -161,11 +163,18 @@ function listRegularSkillFiles(root, prefix = "") {
 
 mkdirSync(publicRoot, { recursive: true });
 mkdirSync(downloadsRoot, { recursive: true });
-const identityRecordPath = join(repositoryRoot, "protocol", "identity-v1.json");
+mkdirSync(publicProtocolRoot, { recursive: true });
+const privateTraceContractPath = join(protocolRoot, "private-trace-v1.md");
+if (!existsSync(privateTraceContractPath)) {
+  throw new TypeError("[Slop] private trace privacy contract is missing");
+}
+copyFileSync(
+  privateTraceContractPath,
+  join(publicProtocolRoot, "private-trace-v1.md"),
+);
+const identityRecordPath = join(protocolRoot, "identity-v1.json");
 if (existsSync(identityRecordPath)) {
   readIdentityRecord(identityRecordPath);
-  const publicProtocolRoot = join(publicRoot, "protocol");
-  mkdirSync(publicProtocolRoot, { recursive: true });
   copyFileSync(
     identityRecordPath,
     join(publicProtocolRoot, "identity-v1.json"),
@@ -566,7 +575,7 @@ const manifest = {
   telemetry: {
     source: "ccusage@20.0.20",
     policy:
-      "Every agent run permanently uploads its bounded raw trace to private operator-only storage before submission. Public receipts contain aggregate locally reported diagnostic usage, exact self-reported identity, the required trace digest and upload identity, and a device signature. Unsupported usage adapters never block participation.",
+      "Every agent run permanently uploads its contributor-inspected, minimized run trace under https://slop.cash/protocol/private-trace-v1.md before submission; the uploader performs no automatic redaction. Public receipts contain aggregate locally reported diagnostic usage, exact self-reported identity, the required trace digest and upload identity, and a device signature. Unsupported usage adapters never block participation.",
   },
 };
 
@@ -841,7 +850,7 @@ function publishAdditionalProject({
     telemetry: {
       source: "ccusage@20.0.20",
       policy:
-        "Every agent run permanently uploads its bounded raw trace to private operator-only storage before submission. Public receipts contain only aggregate locally reported diagnostic usage, exact self-reported identity, the required trace digest and upload identity, and a device signature. Unsupported usage adapters never block participation.",
+        "Every agent run permanently uploads its contributor-inspected, minimized run trace under https://slop.cash/protocol/private-trace-v1.md before submission; the uploader performs no automatic redaction. Public receipts contain only aggregate locally reported diagnostic usage, exact self-reported identity, the required trace digest and upload identity, and a device signature. Unsupported usage adapters never block participation.",
     },
     ...(publicationPrefix
       ? {

--- a/scripts/prepare-site.test.ts
+++ b/scripts/prepare-site.test.ts
@@ -403,7 +403,17 @@ describe("contribution skill package", () => {
     const llms = readFileSync(join(publicRoot, "llms.txt"), "utf8");
     expect(llms).toContain(`SHA-256: ${digest}`);
     expect(llms).toContain("never authorizes wallet creation");
-    expect(source.toString()).toContain("mandatory permanent raw-trace upload");
+    expect(source.toString()).toContain(
+      "mandatory permanent minimized trace upload",
+    );
+    expect(source.toString()).toContain(
+      "https://slop.cash/protocol/private-trace-v1.md",
+    );
+    expect(
+      readFileSync(join(publicRoot, "protocol", "private-trace-v1.md")),
+    ).toEqual(
+      readFileSync(join(repositoryRoot, "protocol", "private-trace-v1.md")),
+    );
     expect(source.toString()).toContain("--allow-local-usage");
 
     const projectDiscovery = parseJsonRecord(

--- a/skill-tests/project-skills.test.ts
+++ b/skill-tests/project-skills.test.ts
@@ -589,6 +589,7 @@ describe("project run usage", () => {
       const sequence: string[] = [];
       let disclosure: Record<string, unknown> | null = null;
       const responses = [
+        { enabled: true },
         {
           token: "s".repeat(32),
           tokenType: "Bearer",
@@ -669,21 +670,26 @@ describe("project run usage", () => {
         automaticRedaction: "none",
         retention: "permanent",
       });
-      assert.strictEqual(calls.length, 5);
+      assert.strictEqual(calls.length, 6);
       assert.strictEqual(
-        Buffer.from(calls[3].options.body as Uint8Array).toString("utf8"),
+        Buffer.from(calls[4].options.body as Uint8Array).toString("utf8"),
         contents,
       );
       assert.strictEqual(
-        (calls[3].options.headers as Record<string, string>).Digest,
+        (calls[4].options.headers as Record<string, string>).Digest,
         `sha-256=${digest}`,
       );
       assert.strictEqual(
         calls[0].url,
+        "https://api.github.com/repos/elizaOS/slopdotcash/private-vulnerability-reporting",
+      );
+      assert.strictEqual(calls[0].options.method, "GET");
+      assert.strictEqual(
+        calls[1].url,
         "https://api.slop.cash/api/v1/auth/session",
       );
       assert.strictEqual(
-        (calls[0].options.headers as Record<string, string>)[
+        (calls[1].options.headers as Record<string, string>)[
           "X-Slop-Identity-Assertion"
         ],
         "i".repeat(32),
@@ -691,6 +697,92 @@ describe("project run usage", () => {
       assert.ok(
         calls.every(({ options }) => !JSON.stringify(options).includes("gho_")),
       );
+    } finally {
+      rmSync(fixtureRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("blocks private trace upload before authorization when private intake is disabled", async () => {
+    const fixtureRoot = mkdtempSync(join(tmpdir(), "slop-trace-intake-"));
+    try {
+      const trajectory = join(fixtureRoot, "trace.ndjson");
+      writeFileSync(trajectory, '{"event":"complete"}\n');
+      let authorizationStarted = false;
+      const requests: string[] = [];
+      await assert.rejects(
+        uploadPrivateTrace(
+          {
+            runId: "run_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+            projectId: "eliza",
+            repositoryId: "elizaOS/eliza",
+            revision: "a".repeat(40),
+            provider: "moonshot",
+            model: "kimi-k2",
+            client: "kimi-cli",
+          },
+          trajectory,
+          "1.2.3",
+          {
+            disclosure: () => {},
+            assertionProvider: () => {
+              authorizationStarted = true;
+              return "i".repeat(32);
+            },
+            fetchImpl: async (url) => {
+              requests.push(String(url));
+              return new Response(JSON.stringify({ enabled: false }), {
+                status: 200,
+              });
+            },
+          },
+        ),
+        /private request intake is unavailable/u,
+      );
+      assert.strictEqual(authorizationStarted, false);
+      assert.deepStrictEqual(requests, [
+        "https://api.github.com/repos/elizaOS/slopdotcash/private-vulnerability-reporting",
+      ]);
+    } finally {
+      rmSync(fixtureRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects a symlinked private trace before disclosure or network access", async () => {
+    const fixtureRoot = mkdtempSync(join(tmpdir(), "slop-trace-symlink-"));
+    try {
+      const target = join(fixtureRoot, "secret.ndjson");
+      const trajectory = join(fixtureRoot, "trace.ndjson");
+      writeFileSync(target, '{"secret":"must-not-snapshot"}\n');
+      symlinkSync(target, trajectory);
+      let disclosed = false;
+      let fetched = false;
+      await assert.rejects(
+        uploadPrivateTrace(
+          {
+            runId: "run_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+            projectId: "eliza",
+            repositoryId: "elizaOS/eliza",
+            revision: "a".repeat(40),
+            provider: "moonshot",
+            model: "kimi-k2",
+            client: "kimi-cli",
+          },
+          trajectory,
+          "1.2.3",
+          {
+            disclosure: () => {
+              disclosed = true;
+            },
+            fetchImpl: async () => {
+              fetched = true;
+              return new Response("{}", { status: 200 });
+            },
+          },
+        ),
+        /non-symlinked regular file/u,
+      );
+      assert.strictEqual(disclosed, false);
+      assert.strictEqual(fetched, false);
     } finally {
       rmSync(fixtureRoot, { force: true, recursive: true });
     }

--- a/skill-tests/project-skills.test.ts
+++ b/skill-tests/project-skills.test.ts
@@ -27,6 +27,7 @@ import { fileURLToPath } from "node:url";
 import { declaredIdentity as asiDeclaredIdentity } from "../skills/contribute-to-asi/scripts/run-receipt.mjs";
 import { declaredIdentity as deltaDeclaredIdentity } from "../skills/contribute-to-delta-star/scripts/run-receipt.mjs";
 import {
+  disclosePrivateTrace,
   declaredIdentity as elizaDeclaredIdentity,
   footer,
   normalizeSessionReport,
@@ -79,6 +80,10 @@ describe("project skill contracts", () => {
       assert.match(source, /--allow-local-usage/u);
       assert.match(source, /--trajectory <path>/u);
       assert.match(source, /permanent\s+private\s+upload/u);
+      assert.match(
+        source,
+        /https:\/\/slop\.cash\/protocol\/private-trace-v1\.md/u,
+      );
       assert.match(source, /elizaOS\/slopdotcash/u);
       assert.match(source, /gh auth status --hostname github\.com/u);
       assert.match(source, /gh api user --jq '\.login'/u);
@@ -355,6 +360,37 @@ describe("project skill contracts", () => {
 });
 
 describe("project run usage", () => {
+  it("renders the immutable trace facts before authorization", () => {
+    const writes: string[] = [];
+    const originalWrite = process.stderr.write;
+    process.stderr.write = ((chunk: Uint8Array | string) => {
+      writes.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      disclosePrivateTrace({
+        absolutePath: "/private/example/trace.ndjson",
+        sha256: "a".repeat(64),
+        sizeBytes: 123,
+        contentType: "application/x-ndjson",
+      });
+    } finally {
+      process.stderr.write = originalWrite;
+    }
+    const rendered = writes.join("");
+    assert.match(rendered, /authorization has not started/u);
+    assert.match(
+      rendered,
+      /https:\/\/slop\.cash\/protocol\/private-trace-v1\.md/u,
+    );
+    assert.match(rendered, /\/private\/example\/trace\.ndjson/u);
+    assert.match(rendered, /Size: 123 bytes/u);
+    assert.match(rendered, /Content-Type: application\/x-ndjson/u);
+    assert.match(rendered, new RegExp(`SHA-256: ${"a".repeat(64)}`, "u"));
+    assert.match(rendered, /Automatic redaction: none/u);
+    assert.match(rendered, /retained permanently/u);
+  });
+
   const repositoryRoot = "/work/eliza";
   const before = normalizeSessionReport(
     {
@@ -550,6 +586,8 @@ describe("project run usage", () => {
       const digest = createHash("sha256").update(contents).digest("hex");
       const serverRunId = "srv_test";
       const calls: Array<{ url: string; options: RequestInit }> = [];
+      const sequence: string[] = [];
+      let disclosure: Record<string, unknown> | null = null;
       const responses = [
         {
           token: "s".repeat(32),
@@ -598,7 +636,15 @@ describe("project run usage", () => {
         trajectory,
         "1.2.3",
         {
-          assertionProvider: () => "i".repeat(32),
+          disclosure: (value: Record<string, unknown>) => {
+            sequence.push("disclosure");
+            disclosure = value;
+            writeFileSync(trajectory, '{"event":"changed-after-snapshot"}\n');
+          },
+          assertionProvider: () => {
+            sequence.push("authorization");
+            return "i".repeat(32);
+          },
           fetchImpl: async (url, options = {}) => {
             calls.push({ url: String(url), options });
             return new Response(JSON.stringify(responses.shift()), {
@@ -613,7 +659,25 @@ describe("project run usage", () => {
         objectId: `sha256:${digest}`,
         sha256: digest,
       });
+      assert.deepStrictEqual(sequence, ["disclosure", "authorization"]);
+      assert.deepStrictEqual(disclosure, {
+        absolutePath: trajectory,
+        sha256: digest,
+        sizeBytes: Buffer.byteLength(contents),
+        contentType: "application/x-ndjson",
+        privacyContract: "https://slop.cash/protocol/private-trace-v1.md",
+        automaticRedaction: "none",
+        retention: "permanent",
+      });
       assert.strictEqual(calls.length, 5);
+      assert.strictEqual(
+        Buffer.from(calls[3].options.body as Uint8Array).toString("utf8"),
+        contents,
+      );
+      assert.strictEqual(
+        (calls[3].options.headers as Record<string, string>).Digest,
+        `sha-256=${digest}`,
+      );
       assert.strictEqual(
         calls[0].url,
         "https://api.slop.cash/api/v1/auth/session",

--- a/skills/contribute-to-asi/SKILL.md
+++ b/skills/contribute-to-asi/SKILL.md
@@ -353,12 +353,17 @@ unmerged change as accepted.
 
 ## Finish the measured run
 
-After all work and proof, export the full trace as UTF-8 text or NDJSON. Exclude
-credentials, private keys, wallet seeds, and prohibited source-file bodies,
-but do not omit ordinary run events. Finish only after its permanent private
-upload to `https://api.slop.cash` succeeds. The raw trace is accessible only to
-designated Slop operators; GitHub receives only its SHA-256 digest. If export,
-upload, or finalization fails, stop and do not submit the contribution.
+After all work and proof, prepare the minimized contribution-specific UTF-8
+text or NDJSON trace required by the [private trace privacy
+contract](https://slop.cash/protocol/private-trace-v1.md). Read that contract
+immediately before authorization: it defines included events, mandatory
+exclusions, the absence of automatic redaction, permanent retention, operator
+access, and privacy requests. Inspect the exact final file locally. Do not omit
+material run events, but do not upload an unfiltered client or account history.
+Finish only after its permanent private upload to `https://api.slop.cash`
+succeeds. GitHub receives only its SHA-256 digest and safe run metadata. If
+export, inspection, upload, or finalization fails, stop and do not submit the
+contribution.
 
 ```bash
 node <skill-directory>/scripts/run-receipt.mjs trace \

--- a/skills/contribute-to-asi/scripts/run-receipt.mjs
+++ b/skills/contribute-to-asi/scripts/run-receipt.mjs
@@ -76,6 +76,7 @@ const MAX_STATE_BYTES = MAX_REPORT_BYTES + 1024 * 1024;
 const AUTHORIZATION_RECEIPT = ".slop-authorization.json";
 const TRACE_AUTHORITY = "https://api.slop.cash";
 const IDENTITY_AUTHORITY = "https://identity.slop.cash";
+const TRACE_PRIVACY_CONTRACT = "https://slop.cash/protocol/private-trace-v1.md";
 
 const HELP = `Usage: node scripts/run-receipt.mjs <command> [options]
 
@@ -1008,8 +1009,7 @@ function listRegularFiles(root, prefix = "") {
   return files;
 }
 
-function trajectoryDigest(path) {
-  if (path === null) return null;
+function readTrajectoryFile(path) {
   const absolute = resolve(path);
   const metadata = lstatSync(absolute);
   if (
@@ -1026,7 +1026,16 @@ function trajectoryDigest(path) {
   } catch {
     fail("trajectory must contain valid UTF-8 text or NDJSON");
   }
-  return sha256(contents);
+  return {
+    absolutePath: absolute,
+    contents,
+    sha256: sha256(contents),
+  };
+}
+
+function trajectoryDigest(path) {
+  if (path === null) return null;
+  return readTrajectoryFile(path).sha256;
 }
 
 function traceUploadEvidence(serverRunId, objectId, trajectorySha256) {
@@ -1201,17 +1210,31 @@ export async function slopIdentityAssertion(
 }
 
 function privateTraceFile(path) {
-  const sha = trajectoryDigest(path);
-  const contents = readFileSync(resolve(path));
+  const snapshot = readTrajectoryFile(path);
   return {
-    contents,
-    sha256: sha,
-    sizeBytes: contents.length,
+    ...snapshot,
+    sizeBytes: snapshot.contents.length,
     contentType:
       extname(path).toLowerCase() === ".ndjson"
         ? "application/x-ndjson"
         : "text/plain",
   };
+}
+
+export function disclosePrivateTrace(trace) {
+  process.stderr.write(
+    `${[
+      "Private trace pre-upload disclosure (authorization has not started):",
+      `Privacy contract: ${TRACE_PRIVACY_CONTRACT}`,
+      `Inspect exact final bytes: ${trace.absolutePath}`,
+      `Size: ${trace.sizeBytes} bytes`,
+      `Content-Type: ${trace.contentType}`,
+      `SHA-256: ${trace.sha256}`,
+      "Automatic redaction: none; the selected bytes are uploaded unchanged and retained permanently.",
+      "Inspect before opening the authorization URL. To change any byte, cancel and rerun trace; this process retains the disclosed snapshot.",
+      "Do not authorize unless you accept the disclosed bytes and permanent-retention contract.",
+    ].join("\n")}\n`,
+  );
 }
 
 export async function uploadPrivateTrace(
@@ -1221,12 +1244,24 @@ export async function uploadPrivateTrace(
   {
     fetchImpl = globalThis.fetch,
     assertionProvider = slopIdentityAssertion,
+    disclosure = disclosePrivateTrace,
   } = {},
 ) {
   declaredIdentifier(clientVersion, "--client-version", 128);
   if (typeof fetchImpl !== "function")
     fail("private trace transport is unavailable");
   const trace = privateTraceFile(trajectoryPath);
+  if (typeof disclosure !== "function")
+    fail("private trace disclosure is unavailable");
+  disclosure({
+    absolutePath: trace.absolutePath,
+    sha256: trace.sha256,
+    sizeBytes: trace.sizeBytes,
+    contentType: trace.contentType,
+    privacyContract: TRACE_PRIVACY_CONTRACT,
+    automaticRedaction: "none",
+    retention: "permanent",
+  });
   const identityAssertion = await assertionProvider(fetchImpl);
   if (
     typeof identityAssertion !== "string" ||
@@ -1909,7 +1944,7 @@ function previewRun(options) {
     ],
     network: [
       `Resolve exact ccusage@${CCUSAGE_VERSION} during doctor and measured runs; fetch it from the package registry only when it is not already cached`,
-      `Authenticate with GitHub and permanently upload the bounded trace through ${TRACE_AUTHORITY}`,
+      `After a local byte/digest disclosure, authenticate with GitHub and permanently upload the inspected trace through ${TRACE_AUTHORITY} under ${TRACE_PRIVACY_CONTRACT}`,
     ],
     automaticUploads: [],
     publicReceiptFields: [
@@ -1924,9 +1959,9 @@ function previewRun(options) {
       "public Ed25519 device key and signature",
     ],
     excluded: [
-      "source files and diffs",
-      "transcript and session identifiers",
-      "credentials, environment values, private keys, and wallet secrets",
+      "source-file bodies and private diffs",
+      "unrelated transcripts and session identifiers",
+      "credentials, environment values, private keys, wallet secrets, absolute local paths, and hidden reasoning",
     ],
     consentFlag: "--allow-local-usage",
     packageExecutionConsentFlag: "--allow-package-execution",

--- a/skills/contribute-to-asi/scripts/run-receipt.mjs
+++ b/skills/contribute-to-asi/scripts/run-receipt.mjs
@@ -17,11 +17,15 @@ import {
 } from "node:crypto";
 import {
   chmodSync,
+  closeSync,
   existsSync,
+  constants as fsConstants,
+  fstatSync,
   linkSync,
   lstatSync,
   mkdirSync,
   mkdtempSync,
+  openSync,
   readdirSync,
   readFileSync,
   realpathSync,
@@ -77,6 +81,8 @@ const AUTHORIZATION_RECEIPT = ".slop-authorization.json";
 const TRACE_AUTHORITY = "https://api.slop.cash";
 const IDENTITY_AUTHORITY = "https://identity.slop.cash";
 const TRACE_PRIVACY_CONTRACT = "https://slop.cash/protocol/private-trace-v1.md";
+const PRIVATE_REQUEST_INTAKE_STATUS =
+  "https://api.github.com/repos/elizaOS/slopdotcash/private-vulnerability-reporting";
 
 const HELP = `Usage: node scripts/run-receipt.mjs <command> [options]
 
@@ -1011,20 +1017,36 @@ function listRegularFiles(root, prefix = "") {
 
 function readTrajectoryFile(path) {
   const absolute = resolve(path);
-  const metadata = lstatSync(absolute);
-  if (
-    !metadata.isFile() ||
-    metadata.isSymbolicLink() ||
-    metadata.size === 0 ||
-    metadata.size > MAX_TRAJECTORY_BYTES
-  ) {
-    fail("trajectory must be a non-empty regular file no larger than 8 MiB");
-  }
-  const contents = readFileSync(absolute);
+  let descriptor;
   try {
-    new TextDecoder("utf-8", { fatal: true }).decode(contents);
+    descriptor = openSync(
+      absolute,
+      fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW,
+    );
   } catch {
-    fail("trajectory must contain valid UTF-8 text or NDJSON");
+    fail("trajectory must be an accessible non-symlinked regular file");
+  }
+  let contents;
+  try {
+    const metadata = fstatSync(descriptor);
+    if (
+      !metadata.isFile() ||
+      metadata.size === 0 ||
+      metadata.size > MAX_TRAJECTORY_BYTES
+    ) {
+      fail("trajectory must be a non-empty regular file no larger than 8 MiB");
+    }
+    contents = readFileSync(descriptor);
+    if (contents.length === 0 || contents.length > MAX_TRAJECTORY_BYTES) {
+      fail("trajectory must be a non-empty regular file no larger than 8 MiB");
+    }
+    try {
+      new TextDecoder("utf-8", { fatal: true }).decode(contents);
+    } catch {
+      fail("trajectory must contain valid UTF-8 text or NDJSON");
+    }
+  } finally {
+    closeSync(descriptor);
   }
   return {
     absolutePath: absolute,
@@ -1262,6 +1284,21 @@ export async function uploadPrivateTrace(
     automaticRedaction: "none",
     retention: "permanent",
   });
+  const intake = await jsonRequest(
+    fetchImpl,
+    PRIVATE_REQUEST_INTAKE_STATUS,
+    {
+      method: "GET",
+      headers: { Accept: "application/vnd.github+json" },
+    },
+    ["enabled"],
+    "private request intake status",
+  );
+  if (intake.enabled !== true) {
+    fail(
+      "private request intake is unavailable; private trace upload is blocked",
+    );
+  }
   const identityAssertion = await assertionProvider(fetchImpl);
   if (
     typeof identityAssertion !== "string" ||
@@ -1944,6 +1981,7 @@ function previewRun(options) {
     ],
     network: [
       `Resolve exact ccusage@${CCUSAGE_VERSION} during doctor and measured runs; fetch it from the package registry only when it is not already cached`,
+      `Verify the public private-request intake gate at ${PRIVATE_REQUEST_INTAKE_STATUS}; trace upload remains blocked unless it reports enabled`,
       `After a local byte/digest disclosure, authenticate with GitHub and permanently upload the inspected trace through ${TRACE_AUTHORITY} under ${TRACE_PRIVACY_CONTRACT}`,
     ],
     automaticUploads: [],

--- a/skills/contribute-to-delta-star/SKILL.md
+++ b/skills/contribute-to-delta-star/SKILL.md
@@ -149,12 +149,17 @@ proof is blocked.
 
 ## Finish the measured run
 
-After verification, export the full trace as UTF-8 text or NDJSON. Exclude
-credentials, private keys, wallet seeds, and prohibited source-file bodies,
-but do not omit ordinary run events. Finish only after its permanent private
-upload to `https://api.slop.cash` succeeds. The raw trace is accessible only to
-designated Slop operators; GitHub receives only its SHA-256 digest. If export,
-upload, or finalization fails, stop and do not submit the contribution.
+After verification, prepare the minimized contribution-specific UTF-8 text or
+NDJSON trace required by the [private trace privacy
+contract](https://slop.cash/protocol/private-trace-v1.md). Read that contract
+immediately before authorization: it defines included events, mandatory
+exclusions, the absence of automatic redaction, permanent retention, operator
+access, and privacy requests. Inspect the exact final file locally. Do not omit
+material run events, but do not upload an unfiltered client or account history.
+Finish only after its permanent private upload to `https://api.slop.cash`
+succeeds. GitHub receives only its SHA-256 digest and safe run metadata. If
+export, inspection, upload, or finalization fails, stop and do not submit the
+contribution.
 
 ```bash
 node <skill-directory>/scripts/run-receipt.mjs trace \

--- a/skills/contribute-to-delta-star/scripts/run-receipt.mjs
+++ b/skills/contribute-to-delta-star/scripts/run-receipt.mjs
@@ -76,6 +76,7 @@ const MAX_STATE_BYTES = MAX_REPORT_BYTES + 1024 * 1024;
 const AUTHORIZATION_RECEIPT = ".slop-authorization.json";
 const TRACE_AUTHORITY = "https://api.slop.cash";
 const IDENTITY_AUTHORITY = "https://identity.slop.cash";
+const TRACE_PRIVACY_CONTRACT = "https://slop.cash/protocol/private-trace-v1.md";
 
 const HELP = `Usage: node scripts/run-receipt.mjs <command> [options]
 
@@ -1008,8 +1009,7 @@ function listRegularFiles(root, prefix = "") {
   return files;
 }
 
-function trajectoryDigest(path) {
-  if (path === null) return null;
+function readTrajectoryFile(path) {
   const absolute = resolve(path);
   const metadata = lstatSync(absolute);
   if (
@@ -1026,7 +1026,16 @@ function trajectoryDigest(path) {
   } catch {
     fail("trajectory must contain valid UTF-8 text or NDJSON");
   }
-  return sha256(contents);
+  return {
+    absolutePath: absolute,
+    contents,
+    sha256: sha256(contents),
+  };
+}
+
+function trajectoryDigest(path) {
+  if (path === null) return null;
+  return readTrajectoryFile(path).sha256;
 }
 
 function traceUploadEvidence(serverRunId, objectId, trajectorySha256) {
@@ -1201,17 +1210,31 @@ export async function slopIdentityAssertion(
 }
 
 function privateTraceFile(path) {
-  const sha = trajectoryDigest(path);
-  const contents = readFileSync(resolve(path));
+  const snapshot = readTrajectoryFile(path);
   return {
-    contents,
-    sha256: sha,
-    sizeBytes: contents.length,
+    ...snapshot,
+    sizeBytes: snapshot.contents.length,
     contentType:
       extname(path).toLowerCase() === ".ndjson"
         ? "application/x-ndjson"
         : "text/plain",
   };
+}
+
+export function disclosePrivateTrace(trace) {
+  process.stderr.write(
+    `${[
+      "Private trace pre-upload disclosure (authorization has not started):",
+      `Privacy contract: ${TRACE_PRIVACY_CONTRACT}`,
+      `Inspect exact final bytes: ${trace.absolutePath}`,
+      `Size: ${trace.sizeBytes} bytes`,
+      `Content-Type: ${trace.contentType}`,
+      `SHA-256: ${trace.sha256}`,
+      "Automatic redaction: none; the selected bytes are uploaded unchanged and retained permanently.",
+      "Inspect before opening the authorization URL. To change any byte, cancel and rerun trace; this process retains the disclosed snapshot.",
+      "Do not authorize unless you accept the disclosed bytes and permanent-retention contract.",
+    ].join("\n")}\n`,
+  );
 }
 
 export async function uploadPrivateTrace(
@@ -1221,12 +1244,24 @@ export async function uploadPrivateTrace(
   {
     fetchImpl = globalThis.fetch,
     assertionProvider = slopIdentityAssertion,
+    disclosure = disclosePrivateTrace,
   } = {},
 ) {
   declaredIdentifier(clientVersion, "--client-version", 128);
   if (typeof fetchImpl !== "function")
     fail("private trace transport is unavailable");
   const trace = privateTraceFile(trajectoryPath);
+  if (typeof disclosure !== "function")
+    fail("private trace disclosure is unavailable");
+  disclosure({
+    absolutePath: trace.absolutePath,
+    sha256: trace.sha256,
+    sizeBytes: trace.sizeBytes,
+    contentType: trace.contentType,
+    privacyContract: TRACE_PRIVACY_CONTRACT,
+    automaticRedaction: "none",
+    retention: "permanent",
+  });
   const identityAssertion = await assertionProvider(fetchImpl);
   if (
     typeof identityAssertion !== "string" ||
@@ -1909,7 +1944,7 @@ function previewRun(options) {
     ],
     network: [
       `Resolve exact ccusage@${CCUSAGE_VERSION} during doctor and measured runs; fetch it from the package registry only when it is not already cached`,
-      `Authenticate with GitHub and permanently upload the bounded trace through ${TRACE_AUTHORITY}`,
+      `After a local byte/digest disclosure, authenticate with GitHub and permanently upload the inspected trace through ${TRACE_AUTHORITY} under ${TRACE_PRIVACY_CONTRACT}`,
     ],
     automaticUploads: [],
     publicReceiptFields: [
@@ -1924,9 +1959,9 @@ function previewRun(options) {
       "public Ed25519 device key and signature",
     ],
     excluded: [
-      "source files and diffs",
-      "transcript and session identifiers",
-      "credentials, environment values, private keys, and wallet secrets",
+      "source-file bodies and private diffs",
+      "unrelated transcripts and session identifiers",
+      "credentials, environment values, private keys, wallet secrets, absolute local paths, and hidden reasoning",
     ],
     consentFlag: "--allow-local-usage",
     packageExecutionConsentFlag: "--allow-package-execution",

--- a/skills/contribute-to-delta-star/scripts/run-receipt.mjs
+++ b/skills/contribute-to-delta-star/scripts/run-receipt.mjs
@@ -17,11 +17,15 @@ import {
 } from "node:crypto";
 import {
   chmodSync,
+  closeSync,
   existsSync,
+  constants as fsConstants,
+  fstatSync,
   linkSync,
   lstatSync,
   mkdirSync,
   mkdtempSync,
+  openSync,
   readdirSync,
   readFileSync,
   realpathSync,
@@ -77,6 +81,8 @@ const AUTHORIZATION_RECEIPT = ".slop-authorization.json";
 const TRACE_AUTHORITY = "https://api.slop.cash";
 const IDENTITY_AUTHORITY = "https://identity.slop.cash";
 const TRACE_PRIVACY_CONTRACT = "https://slop.cash/protocol/private-trace-v1.md";
+const PRIVATE_REQUEST_INTAKE_STATUS =
+  "https://api.github.com/repos/elizaOS/slopdotcash/private-vulnerability-reporting";
 
 const HELP = `Usage: node scripts/run-receipt.mjs <command> [options]
 
@@ -1011,20 +1017,36 @@ function listRegularFiles(root, prefix = "") {
 
 function readTrajectoryFile(path) {
   const absolute = resolve(path);
-  const metadata = lstatSync(absolute);
-  if (
-    !metadata.isFile() ||
-    metadata.isSymbolicLink() ||
-    metadata.size === 0 ||
-    metadata.size > MAX_TRAJECTORY_BYTES
-  ) {
-    fail("trajectory must be a non-empty regular file no larger than 8 MiB");
-  }
-  const contents = readFileSync(absolute);
+  let descriptor;
   try {
-    new TextDecoder("utf-8", { fatal: true }).decode(contents);
+    descriptor = openSync(
+      absolute,
+      fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW,
+    );
   } catch {
-    fail("trajectory must contain valid UTF-8 text or NDJSON");
+    fail("trajectory must be an accessible non-symlinked regular file");
+  }
+  let contents;
+  try {
+    const metadata = fstatSync(descriptor);
+    if (
+      !metadata.isFile() ||
+      metadata.size === 0 ||
+      metadata.size > MAX_TRAJECTORY_BYTES
+    ) {
+      fail("trajectory must be a non-empty regular file no larger than 8 MiB");
+    }
+    contents = readFileSync(descriptor);
+    if (contents.length === 0 || contents.length > MAX_TRAJECTORY_BYTES) {
+      fail("trajectory must be a non-empty regular file no larger than 8 MiB");
+    }
+    try {
+      new TextDecoder("utf-8", { fatal: true }).decode(contents);
+    } catch {
+      fail("trajectory must contain valid UTF-8 text or NDJSON");
+    }
+  } finally {
+    closeSync(descriptor);
   }
   return {
     absolutePath: absolute,
@@ -1262,6 +1284,21 @@ export async function uploadPrivateTrace(
     automaticRedaction: "none",
     retention: "permanent",
   });
+  const intake = await jsonRequest(
+    fetchImpl,
+    PRIVATE_REQUEST_INTAKE_STATUS,
+    {
+      method: "GET",
+      headers: { Accept: "application/vnd.github+json" },
+    },
+    ["enabled"],
+    "private request intake status",
+  );
+  if (intake.enabled !== true) {
+    fail(
+      "private request intake is unavailable; private trace upload is blocked",
+    );
+  }
   const identityAssertion = await assertionProvider(fetchImpl);
   if (
     typeof identityAssertion !== "string" ||
@@ -1944,6 +1981,7 @@ function previewRun(options) {
     ],
     network: [
       `Resolve exact ccusage@${CCUSAGE_VERSION} during doctor and measured runs; fetch it from the package registry only when it is not already cached`,
+      `Verify the public private-request intake gate at ${PRIVATE_REQUEST_INTAKE_STATUS}; trace upload remains blocked unless it reports enabled`,
       `After a local byte/digest disclosure, authenticate with GitHub and permanently upload the inspected trace through ${TRACE_AUTHORITY} under ${TRACE_PRIVACY_CONTRACT}`,
     ],
     automaticUploads: [],

--- a/skills/contribute-to-eliza/SKILL.md
+++ b/skills/contribute-to-eliza/SKILL.md
@@ -200,12 +200,17 @@ project evaluator can award it partial credit.
 
 ## Finish the measured run
 
-After all work and proof, export the full trace as UTF-8 text or NDJSON. Exclude
-credentials, private keys, wallet seeds, and prohibited source-file bodies,
-but do not omit ordinary run events. Finish only after its permanent private
-upload to `https://api.slop.cash` succeeds. The raw trace is accessible only to
-designated Slop operators; GitHub receives only its SHA-256 digest. If export,
-upload, or finalization fails, stop and do not submit the contribution.
+After all work and proof, prepare the minimized contribution-specific UTF-8
+text or NDJSON trace required by the [private trace privacy
+contract](https://slop.cash/protocol/private-trace-v1.md). Read that contract
+immediately before authorization: it defines included events, mandatory
+exclusions, the absence of automatic redaction, permanent retention, operator
+access, and privacy requests. Inspect the exact final file locally. Do not omit
+material run events, but do not upload an unfiltered client or account history.
+Finish only after its permanent private upload to `https://api.slop.cash`
+succeeds. GitHub receives only its SHA-256 digest and safe run metadata. If
+export, inspection, upload, or finalization fails, stop and do not submit the
+contribution.
 
 ```bash
 node <skill-directory>/scripts/run-receipt.mjs trace \

--- a/skills/contribute-to-eliza/scripts/run-receipt.mjs
+++ b/skills/contribute-to-eliza/scripts/run-receipt.mjs
@@ -76,6 +76,7 @@ const MAX_STATE_BYTES = MAX_REPORT_BYTES + 1024 * 1024;
 const AUTHORIZATION_RECEIPT = ".slop-authorization.json";
 const TRACE_AUTHORITY = "https://api.slop.cash";
 const IDENTITY_AUTHORITY = "https://identity.slop.cash";
+const TRACE_PRIVACY_CONTRACT = "https://slop.cash/protocol/private-trace-v1.md";
 
 const HELP = `Usage: node scripts/run-receipt.mjs <command> [options]
 
@@ -1008,8 +1009,7 @@ function listRegularFiles(root, prefix = "") {
   return files;
 }
 
-function trajectoryDigest(path) {
-  if (path === null) return null;
+function readTrajectoryFile(path) {
   const absolute = resolve(path);
   const metadata = lstatSync(absolute);
   if (
@@ -1026,7 +1026,16 @@ function trajectoryDigest(path) {
   } catch {
     fail("trajectory must contain valid UTF-8 text or NDJSON");
   }
-  return sha256(contents);
+  return {
+    absolutePath: absolute,
+    contents,
+    sha256: sha256(contents),
+  };
+}
+
+function trajectoryDigest(path) {
+  if (path === null) return null;
+  return readTrajectoryFile(path).sha256;
 }
 
 function traceUploadEvidence(serverRunId, objectId, trajectorySha256) {
@@ -1201,17 +1210,31 @@ export async function slopIdentityAssertion(
 }
 
 function privateTraceFile(path) {
-  const sha = trajectoryDigest(path);
-  const contents = readFileSync(resolve(path));
+  const snapshot = readTrajectoryFile(path);
   return {
-    contents,
-    sha256: sha,
-    sizeBytes: contents.length,
+    ...snapshot,
+    sizeBytes: snapshot.contents.length,
     contentType:
       extname(path).toLowerCase() === ".ndjson"
         ? "application/x-ndjson"
         : "text/plain",
   };
+}
+
+export function disclosePrivateTrace(trace) {
+  process.stderr.write(
+    `${[
+      "Private trace pre-upload disclosure (authorization has not started):",
+      `Privacy contract: ${TRACE_PRIVACY_CONTRACT}`,
+      `Inspect exact final bytes: ${trace.absolutePath}`,
+      `Size: ${trace.sizeBytes} bytes`,
+      `Content-Type: ${trace.contentType}`,
+      `SHA-256: ${trace.sha256}`,
+      "Automatic redaction: none; the selected bytes are uploaded unchanged and retained permanently.",
+      "Inspect before opening the authorization URL. To change any byte, cancel and rerun trace; this process retains the disclosed snapshot.",
+      "Do not authorize unless you accept the disclosed bytes and permanent-retention contract.",
+    ].join("\n")}\n`,
+  );
 }
 
 export async function uploadPrivateTrace(
@@ -1221,12 +1244,24 @@ export async function uploadPrivateTrace(
   {
     fetchImpl = globalThis.fetch,
     assertionProvider = slopIdentityAssertion,
+    disclosure = disclosePrivateTrace,
   } = {},
 ) {
   declaredIdentifier(clientVersion, "--client-version", 128);
   if (typeof fetchImpl !== "function")
     fail("private trace transport is unavailable");
   const trace = privateTraceFile(trajectoryPath);
+  if (typeof disclosure !== "function")
+    fail("private trace disclosure is unavailable");
+  disclosure({
+    absolutePath: trace.absolutePath,
+    sha256: trace.sha256,
+    sizeBytes: trace.sizeBytes,
+    contentType: trace.contentType,
+    privacyContract: TRACE_PRIVACY_CONTRACT,
+    automaticRedaction: "none",
+    retention: "permanent",
+  });
   const identityAssertion = await assertionProvider(fetchImpl);
   if (
     typeof identityAssertion !== "string" ||
@@ -1909,7 +1944,7 @@ function previewRun(options) {
     ],
     network: [
       `Resolve exact ccusage@${CCUSAGE_VERSION} during doctor and measured runs; fetch it from the package registry only when it is not already cached`,
-      `Authenticate with GitHub and permanently upload the bounded trace through ${TRACE_AUTHORITY}`,
+      `After a local byte/digest disclosure, authenticate with GitHub and permanently upload the inspected trace through ${TRACE_AUTHORITY} under ${TRACE_PRIVACY_CONTRACT}`,
     ],
     automaticUploads: [],
     publicReceiptFields: [
@@ -1924,9 +1959,9 @@ function previewRun(options) {
       "public Ed25519 device key and signature",
     ],
     excluded: [
-      "source files and diffs",
-      "transcript and session identifiers",
-      "credentials, environment values, private keys, and wallet secrets",
+      "source-file bodies and private diffs",
+      "unrelated transcripts and session identifiers",
+      "credentials, environment values, private keys, wallet secrets, absolute local paths, and hidden reasoning",
     ],
     consentFlag: "--allow-local-usage",
     packageExecutionConsentFlag: "--allow-package-execution",

--- a/skills/contribute-to-eliza/scripts/run-receipt.mjs
+++ b/skills/contribute-to-eliza/scripts/run-receipt.mjs
@@ -17,11 +17,15 @@ import {
 } from "node:crypto";
 import {
   chmodSync,
+  closeSync,
   existsSync,
+  constants as fsConstants,
+  fstatSync,
   linkSync,
   lstatSync,
   mkdirSync,
   mkdtempSync,
+  openSync,
   readdirSync,
   readFileSync,
   realpathSync,
@@ -77,6 +81,8 @@ const AUTHORIZATION_RECEIPT = ".slop-authorization.json";
 const TRACE_AUTHORITY = "https://api.slop.cash";
 const IDENTITY_AUTHORITY = "https://identity.slop.cash";
 const TRACE_PRIVACY_CONTRACT = "https://slop.cash/protocol/private-trace-v1.md";
+const PRIVATE_REQUEST_INTAKE_STATUS =
+  "https://api.github.com/repos/elizaOS/slopdotcash/private-vulnerability-reporting";
 
 const HELP = `Usage: node scripts/run-receipt.mjs <command> [options]
 
@@ -1011,20 +1017,36 @@ function listRegularFiles(root, prefix = "") {
 
 function readTrajectoryFile(path) {
   const absolute = resolve(path);
-  const metadata = lstatSync(absolute);
-  if (
-    !metadata.isFile() ||
-    metadata.isSymbolicLink() ||
-    metadata.size === 0 ||
-    metadata.size > MAX_TRAJECTORY_BYTES
-  ) {
-    fail("trajectory must be a non-empty regular file no larger than 8 MiB");
-  }
-  const contents = readFileSync(absolute);
+  let descriptor;
   try {
-    new TextDecoder("utf-8", { fatal: true }).decode(contents);
+    descriptor = openSync(
+      absolute,
+      fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW,
+    );
   } catch {
-    fail("trajectory must contain valid UTF-8 text or NDJSON");
+    fail("trajectory must be an accessible non-symlinked regular file");
+  }
+  let contents;
+  try {
+    const metadata = fstatSync(descriptor);
+    if (
+      !metadata.isFile() ||
+      metadata.size === 0 ||
+      metadata.size > MAX_TRAJECTORY_BYTES
+    ) {
+      fail("trajectory must be a non-empty regular file no larger than 8 MiB");
+    }
+    contents = readFileSync(descriptor);
+    if (contents.length === 0 || contents.length > MAX_TRAJECTORY_BYTES) {
+      fail("trajectory must be a non-empty regular file no larger than 8 MiB");
+    }
+    try {
+      new TextDecoder("utf-8", { fatal: true }).decode(contents);
+    } catch {
+      fail("trajectory must contain valid UTF-8 text or NDJSON");
+    }
+  } finally {
+    closeSync(descriptor);
   }
   return {
     absolutePath: absolute,
@@ -1262,6 +1284,21 @@ export async function uploadPrivateTrace(
     automaticRedaction: "none",
     retention: "permanent",
   });
+  const intake = await jsonRequest(
+    fetchImpl,
+    PRIVATE_REQUEST_INTAKE_STATUS,
+    {
+      method: "GET",
+      headers: { Accept: "application/vnd.github+json" },
+    },
+    ["enabled"],
+    "private request intake status",
+  );
+  if (intake.enabled !== true) {
+    fail(
+      "private request intake is unavailable; private trace upload is blocked",
+    );
+  }
   const identityAssertion = await assertionProvider(fetchImpl);
   if (
     typeof identityAssertion !== "string" ||
@@ -1944,6 +1981,7 @@ function previewRun(options) {
     ],
     network: [
       `Resolve exact ccusage@${CCUSAGE_VERSION} during doctor and measured runs; fetch it from the package registry only when it is not already cached`,
+      `Verify the public private-request intake gate at ${PRIVATE_REQUEST_INTAKE_STATUS}; trace upload remains blocked unless it reports enabled`,
       `After a local byte/digest disclosure, authenticate with GitHub and permanently upload the inspected trace through ${TRACE_AUTHORITY} under ${TRACE_PRIVACY_CONTRACT}`,
     ],
     automaticUploads: [],

--- a/skills/contribute-to-heir-elements-sdk/SKILL.md
+++ b/skills/contribute-to-heir-elements-sdk/SKILL.md
@@ -172,12 +172,14 @@ After all work and proof, prepare the minimized contribution-specific UTF-8
 text or NDJSON trace required by the [private trace privacy
 contract](https://slop.cash/protocol/private-trace-v1.md). Read that contract
 immediately before authorization: it defines included events, mandatory
-exclusions, the absence of automatic redaction, permanent retention, operator
-access, and privacy requests. Inspect the exact final file locally. Do not omit
+exclusions, the absence of automatic redaction, permanent retention, and
+privacy requests. Trace bodies are accessible only to designated Slop operators
+through short-lived audited grants. Inspect the
+exact final file locally. Do not omit
 material run events, but do not upload an unfiltered client or account history.
 Finish only after its permanent private upload to `https://api.slop.cash`
-succeeds. GitHub receives only its SHA-256 digest and safe run metadata. If
-export, inspection, upload, or finalization fails, stop and do not submit the
+succeeds. GitHub receives only its SHA-256 digest and safe run metadata.
+If export, upload, or finalization fails, stop and do not submit the
 contribution.
 
 ```bash
@@ -236,13 +238,12 @@ node <skill-directory>/scripts/wallet-claim.mjs --address <public-address>
 node <skill-directory>/scripts/wallet-claim.mjs register --address <public-address>
 ```
 
-   Show the printed `identity.slop.cash` authorization URL to the operator and
-   wait for completion. The script keeps the OAuth capability, assertion, and
-   Slop bearer token only in process memory. It prints the immutable claim ID,
-   record digest, and public metadata URL—never a credential.
-5. An address change appends a new claim linked to the current claim; it never
-   edits or deletes history. The change is material and restarts that
-   allocation's 14-day review.
+Show the printed `identity.slop.cash` authorization URL to the operator and
+wait for completion. The script keeps the OAuth capability, assertion, and
+Slop bearer token only in process memory. It prints the immutable claim ID,
+record digest, and public metadata URL—never a credential. 5. An address change appends a new claim linked to the current claim; it never
+edits or deletes history. The change is material and restarts that
+allocation's 14-day review.
 
 A claim identifies where a reviewed payout may go. It does not prove custody,
 guarantee payment, approve an allocation, connect a wallet, or move funds.

--- a/skills/contribute-to-heir-elements-sdk/SKILL.md
+++ b/skills/contribute-to-heir-elements-sdk/SKILL.md
@@ -168,12 +168,17 @@ data or a run receipt.
 
 ## Finish the measured run
 
-After all work and proof, export the full trace as UTF-8 text or NDJSON. Exclude
-credentials, private keys, wallet seeds, and prohibited source-file bodies,
-but do not omit ordinary run events. Finish only after its permanent private
-upload to `https://api.slop.cash` succeeds. The raw trace is accessible only to
-designated Slop operators; GitHub receives only its SHA-256 digest. If export,
-upload, or finalization fails, stop and do not submit the contribution.
+After all work and proof, prepare the minimized contribution-specific UTF-8
+text or NDJSON trace required by the [private trace privacy
+contract](https://slop.cash/protocol/private-trace-v1.md). Read that contract
+immediately before authorization: it defines included events, mandatory
+exclusions, the absence of automatic redaction, permanent retention, operator
+access, and privacy requests. Inspect the exact final file locally. Do not omit
+material run events, but do not upload an unfiltered client or account history.
+Finish only after its permanent private upload to `https://api.slop.cash`
+succeeds. GitHub receives only its SHA-256 digest and safe run metadata. If
+export, inspection, upload, or finalization fails, stop and do not submit the
+contribution.
 
 ```bash
 node <skill-directory>/scripts/run-receipt.mjs trace \

--- a/skills/contribute-to-heir-elements-sdk/scripts/run-receipt.mjs
+++ b/skills/contribute-to-heir-elements-sdk/scripts/run-receipt.mjs
@@ -76,6 +76,7 @@ const MAX_STATE_BYTES = MAX_REPORT_BYTES + 1024 * 1024;
 const AUTHORIZATION_RECEIPT = ".slop-authorization.json";
 const TRACE_AUTHORITY = "https://api.slop.cash";
 const IDENTITY_AUTHORITY = "https://identity.slop.cash";
+const TRACE_PRIVACY_CONTRACT = "https://slop.cash/protocol/private-trace-v1.md";
 
 const HELP = `Usage: node scripts/run-receipt.mjs <command> [options]
 
@@ -1008,8 +1009,7 @@ function listRegularFiles(root, prefix = "") {
   return files;
 }
 
-function trajectoryDigest(path) {
-  if (path === null) return null;
+function readTrajectoryFile(path) {
   const absolute = resolve(path);
   const metadata = lstatSync(absolute);
   if (
@@ -1026,7 +1026,16 @@ function trajectoryDigest(path) {
   } catch {
     fail("trajectory must contain valid UTF-8 text or NDJSON");
   }
-  return sha256(contents);
+  return {
+    absolutePath: absolute,
+    contents,
+    sha256: sha256(contents),
+  };
+}
+
+function trajectoryDigest(path) {
+  if (path === null) return null;
+  return readTrajectoryFile(path).sha256;
 }
 
 function traceUploadEvidence(serverRunId, objectId, trajectorySha256) {
@@ -1201,17 +1210,31 @@ export async function slopIdentityAssertion(
 }
 
 function privateTraceFile(path) {
-  const sha = trajectoryDigest(path);
-  const contents = readFileSync(resolve(path));
+  const snapshot = readTrajectoryFile(path);
   return {
-    contents,
-    sha256: sha,
-    sizeBytes: contents.length,
+    ...snapshot,
+    sizeBytes: snapshot.contents.length,
     contentType:
       extname(path).toLowerCase() === ".ndjson"
         ? "application/x-ndjson"
         : "text/plain",
   };
+}
+
+export function disclosePrivateTrace(trace) {
+  process.stderr.write(
+    `${[
+      "Private trace pre-upload disclosure (authorization has not started):",
+      `Privacy contract: ${TRACE_PRIVACY_CONTRACT}`,
+      `Inspect exact final bytes: ${trace.absolutePath}`,
+      `Size: ${trace.sizeBytes} bytes`,
+      `Content-Type: ${trace.contentType}`,
+      `SHA-256: ${trace.sha256}`,
+      "Automatic redaction: none; the selected bytes are uploaded unchanged and retained permanently.",
+      "Inspect before opening the authorization URL. To change any byte, cancel and rerun trace; this process retains the disclosed snapshot.",
+      "Do not authorize unless you accept the disclosed bytes and permanent-retention contract.",
+    ].join("\n")}\n`,
+  );
 }
 
 export async function uploadPrivateTrace(
@@ -1221,12 +1244,24 @@ export async function uploadPrivateTrace(
   {
     fetchImpl = globalThis.fetch,
     assertionProvider = slopIdentityAssertion,
+    disclosure = disclosePrivateTrace,
   } = {},
 ) {
   declaredIdentifier(clientVersion, "--client-version", 128);
   if (typeof fetchImpl !== "function")
     fail("private trace transport is unavailable");
   const trace = privateTraceFile(trajectoryPath);
+  if (typeof disclosure !== "function")
+    fail("private trace disclosure is unavailable");
+  disclosure({
+    absolutePath: trace.absolutePath,
+    sha256: trace.sha256,
+    sizeBytes: trace.sizeBytes,
+    contentType: trace.contentType,
+    privacyContract: TRACE_PRIVACY_CONTRACT,
+    automaticRedaction: "none",
+    retention: "permanent",
+  });
   const identityAssertion = await assertionProvider(fetchImpl);
   if (
     typeof identityAssertion !== "string" ||
@@ -1909,7 +1944,7 @@ function previewRun(options) {
     ],
     network: [
       `Resolve exact ccusage@${CCUSAGE_VERSION} during doctor and measured runs; fetch it from the package registry only when it is not already cached`,
-      `Authenticate with GitHub and permanently upload the bounded trace through ${TRACE_AUTHORITY}`,
+      `After a local byte/digest disclosure, authenticate with GitHub and permanently upload the inspected trace through ${TRACE_AUTHORITY} under ${TRACE_PRIVACY_CONTRACT}`,
     ],
     automaticUploads: [],
     publicReceiptFields: [
@@ -1924,9 +1959,9 @@ function previewRun(options) {
       "public Ed25519 device key and signature",
     ],
     excluded: [
-      "source files and diffs",
-      "transcript and session identifiers",
-      "credentials, environment values, private keys, and wallet secrets",
+      "source-file bodies and private diffs",
+      "unrelated transcripts and session identifiers",
+      "credentials, environment values, private keys, wallet secrets, absolute local paths, and hidden reasoning",
     ],
     consentFlag: "--allow-local-usage",
     packageExecutionConsentFlag: "--allow-package-execution",

--- a/skills/contribute-to-heir-elements-sdk/scripts/run-receipt.mjs
+++ b/skills/contribute-to-heir-elements-sdk/scripts/run-receipt.mjs
@@ -17,11 +17,15 @@ import {
 } from "node:crypto";
 import {
   chmodSync,
+  closeSync,
   existsSync,
+  constants as fsConstants,
+  fstatSync,
   linkSync,
   lstatSync,
   mkdirSync,
   mkdtempSync,
+  openSync,
   readdirSync,
   readFileSync,
   realpathSync,
@@ -77,6 +81,8 @@ const AUTHORIZATION_RECEIPT = ".slop-authorization.json";
 const TRACE_AUTHORITY = "https://api.slop.cash";
 const IDENTITY_AUTHORITY = "https://identity.slop.cash";
 const TRACE_PRIVACY_CONTRACT = "https://slop.cash/protocol/private-trace-v1.md";
+const PRIVATE_REQUEST_INTAKE_STATUS =
+  "https://api.github.com/repos/elizaOS/slopdotcash/private-vulnerability-reporting";
 
 const HELP = `Usage: node scripts/run-receipt.mjs <command> [options]
 
@@ -1011,20 +1017,36 @@ function listRegularFiles(root, prefix = "") {
 
 function readTrajectoryFile(path) {
   const absolute = resolve(path);
-  const metadata = lstatSync(absolute);
-  if (
-    !metadata.isFile() ||
-    metadata.isSymbolicLink() ||
-    metadata.size === 0 ||
-    metadata.size > MAX_TRAJECTORY_BYTES
-  ) {
-    fail("trajectory must be a non-empty regular file no larger than 8 MiB");
-  }
-  const contents = readFileSync(absolute);
+  let descriptor;
   try {
-    new TextDecoder("utf-8", { fatal: true }).decode(contents);
+    descriptor = openSync(
+      absolute,
+      fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW,
+    );
   } catch {
-    fail("trajectory must contain valid UTF-8 text or NDJSON");
+    fail("trajectory must be an accessible non-symlinked regular file");
+  }
+  let contents;
+  try {
+    const metadata = fstatSync(descriptor);
+    if (
+      !metadata.isFile() ||
+      metadata.size === 0 ||
+      metadata.size > MAX_TRAJECTORY_BYTES
+    ) {
+      fail("trajectory must be a non-empty regular file no larger than 8 MiB");
+    }
+    contents = readFileSync(descriptor);
+    if (contents.length === 0 || contents.length > MAX_TRAJECTORY_BYTES) {
+      fail("trajectory must be a non-empty regular file no larger than 8 MiB");
+    }
+    try {
+      new TextDecoder("utf-8", { fatal: true }).decode(contents);
+    } catch {
+      fail("trajectory must contain valid UTF-8 text or NDJSON");
+    }
+  } finally {
+    closeSync(descriptor);
   }
   return {
     absolutePath: absolute,
@@ -1262,6 +1284,21 @@ export async function uploadPrivateTrace(
     automaticRedaction: "none",
     retention: "permanent",
   });
+  const intake = await jsonRequest(
+    fetchImpl,
+    PRIVATE_REQUEST_INTAKE_STATUS,
+    {
+      method: "GET",
+      headers: { Accept: "application/vnd.github+json" },
+    },
+    ["enabled"],
+    "private request intake status",
+  );
+  if (intake.enabled !== true) {
+    fail(
+      "private request intake is unavailable; private trace upload is blocked",
+    );
+  }
   const identityAssertion = await assertionProvider(fetchImpl);
   if (
     typeof identityAssertion !== "string" ||
@@ -1944,6 +1981,7 @@ function previewRun(options) {
     ],
     network: [
       `Resolve exact ccusage@${CCUSAGE_VERSION} during doctor and measured runs; fetch it from the package registry only when it is not already cached`,
+      `Verify the public private-request intake gate at ${PRIVATE_REQUEST_INTAKE_STATUS}; trace upload remains blocked unless it reports enabled`,
       `After a local byte/digest disclosure, authenticate with GitHub and permanently upload the inspected trace through ${TRACE_AUTHORITY} under ${TRACE_PRIVACY_CONTRACT}`,
     ],
     automaticUploads: [],

--- a/skills/review-asi-contributions/SKILL.md
+++ b/skills/review-asi-contributions/SKILL.md
@@ -118,7 +118,10 @@ issue, pull request, commit, or test that proves its value.
 
 Before reviewing, install or update this project's contributor skill and run
 its receipt CLI with lane `review`, your exact provider/model/client identity,
-and full review trajectory capture. Every model and client may review; an
+and the minimized review-specific trace defined by the [private trace privacy
+contract](https://slop.cash/protocol/private-trace-v1.md). Read that contract
+and inspect the disclosed final bytes before authorizing upload. Every model
+and client may review; an
 unsupported usage adapter reports diagnostic usage as unavailable and never
 blocks the run. If private trace upload and finalization fail, do not post the
 review. Return findings first, state reproduced numbers, then this JSON record,

--- a/skills/review-delta-star-contributions/SKILL.md
+++ b/skills/review-delta-star-contributions/SKILL.md
@@ -69,7 +69,10 @@ sponsor controls eligibility and payment.
 
 Before reviewing, install or update this project's contributor skill and run
 its receipt CLI with lane `review`, your exact provider/model/client identity,
-and full review trajectory capture. Every model and client may review; an
+and the minimized review-specific trace defined by the [private trace privacy
+contract](https://slop.cash/protocol/private-trace-v1.md). Read that contract
+and inspect the disclosed final bytes before authorizing upload. Every model
+and client may review; an
 unsupported usage adapter reports diagnostic usage as unavailable and never
 blocks the run. If private trace upload and finalization fail, do not post the
 review. Return findings first, then this bounded record, then append the

--- a/skills/review-eliza-contributions/SKILL.md
+++ b/skills/review-eliza-contributions/SKILL.md
@@ -84,7 +84,10 @@ lines changed, commit count, comments, style-only churn, or unverifiable effort.
 
 Before reviewing, install or update this project's contributor skill and run
 its receipt CLI with lane `review`, your exact provider/model/client identity,
-and full review trajectory capture. Every model and client may review; an
+and the minimized review-specific trace defined by the [private trace privacy
+contract](https://slop.cash/protocol/private-trace-v1.md). Read that contract
+and inspect the disclosed final bytes before authorizing upload. Every model
+and client may review; an
 unsupported usage adapter reports diagnostic usage as unavailable and never
 blocks the run. If private trace upload and finalization fail, do not post the
 review. Return findings first, then this JSON record, then append the generated

--- a/skills/review-heir-elements-sdk-contributions/SKILL.md
+++ b/skills/review-heir-elements-sdk-contributions/SKILL.md
@@ -89,7 +89,10 @@ lines changed, commit count, comments, style-only churn, or unverifiable effort.
 
 Before reviewing, install or update this project's contributor skill and run
 its receipt CLI with lane `review`, your exact provider/model/client identity,
-and full review trajectory capture. Every model and client may review; an
+and the minimized review-specific trace defined by the [private trace privacy
+contract](https://slop.cash/protocol/private-trace-v1.md). Read that contract
+and inspect the disclosed final bytes before authorizing upload. Every model
+and client may review; an
 unsupported usage adapter reports diagnostic usage as unavailable and never
 blocks the run. If private trace upload and finalization fail, do not post the
 review. Return findings first, then this JSON record, then append the generated

--- a/skills/slop/SKILL.md
+++ b/skills/slop/SKILL.md
@@ -58,9 +58,11 @@ Before running the guide, show the operator one short plan containing:
 - the exact public receipt fields: aggregate token categories, estimated
   API-equivalent cost, client, declared model, timestamps, repository, skill
   revision and digest, required trajectory digest, and public device key;
-- the mandatory permanent raw-trace upload to `https://api.slop.cash`; only
-  designated Slop operators may retrieve it, while GitHub receives its digest
-  and upload identity only.
+- the mandatory permanent minimized trace upload to `https://api.slop.cash`
+  under the [private trace privacy
+  contract](https://slop.cash/protocol/private-trace-v1.md); the uploader does
+  not redact the contributor-inspected bytes, only designated Slop operators
+  may retrieve them, and GitHub receives only the digest and upload identity.
 
 If the user's request already explicitly authorized installing the project
 skill, previewing local aggregate usage, and permanently storing the run trace

--- a/skills/slop/SKILL.md
+++ b/skills/slop/SKILL.md
@@ -62,7 +62,9 @@ Before running the guide, show the operator one short plan containing:
   under the [private trace privacy
   contract](https://slop.cash/protocol/private-trace-v1.md); the uploader does
   not redact the contributor-inspected bytes, only designated Slop operators
-  may retrieve them, and GitHub receives only the digest and upload identity.
+  may retrieve them, and GitHub receives only the digest and upload identity;
+  upload stays blocked unless the public operator-controlled private-request
+  intake gate reports enabled.
 
 If the user's request already explicitly authorized installing the project
 skill, previewing local aggregate usage, and permanently storing the run trace

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -591,6 +591,7 @@ test("serves byte-consistent install and read-only artifacts for every project",
     discoveryResponse,
     discoverySkillResponse,
     identityResponse,
+    privateTraceContractResponse,
     projectDiscoveryResponse,
     llmsResponse,
   ] = await Promise.all([
@@ -598,6 +599,7 @@ test("serves byte-consistent install and read-only artifacts for every project",
     request.get("/.well-known/agent-skills/index.json"),
     request.get("/.well-known/agent-skills/slop/SKILL.md"),
     request.get("/protocol/identity-v1.json"),
+    request.get("/protocol/private-trace-v1.md"),
     request.get("/.well-known/slop/projects.json"),
     request.get("/llms.txt"),
   ]);
@@ -606,6 +608,7 @@ test("serves byte-consistent install and read-only artifacts for every project",
     discoveryResponse,
     discoverySkillResponse,
     identityResponse,
+    privateTraceContractResponse,
     projectDiscoveryResponse,
     llmsResponse,
   ]) {
@@ -632,6 +635,12 @@ test("serves byte-consistent install and read-only artifacts for every project",
   );
   expect(identityResponse.headers()["content-type"]).toContain(
     "application/json",
+  );
+  expect(privateTraceContractResponse.headers()["content-type"]).toContain(
+    "text/markdown",
+  );
+  expect(await privateTraceContractResponse.text()).toContain(
+    "Neither the receipt CLI nor the trace API automatically redacts",
   );
   expect(identityResponse.headers()["access-control-allow-origin"]).toBe("*");
   expect(identityResponse.headers()["cache-control"]).toContain("max-age=300");
@@ -668,7 +677,7 @@ test("serves byte-consistent install and read-only artifacts for every project",
   expect(await discoverySkillResponse.body()).toEqual(bootstrap);
   expect(await llmsResponse.text()).toContain(`SHA-256: ${bootstrapDigest}`);
   expect(bootstrap.toString()).toContain(
-    "mandatory permanent raw-trace upload",
+    "mandatory permanent minimized trace upload",
   );
   expect(await projectDiscoveryResponse.json()).toEqual({
     schemaVersion: "1",


### PR DESCRIPTION
## Summary

Closes #128.

- Establishes `protocol/private-trace-v1.md` as the authoritative privacy contract for every contributor and reviewer trace: contribution-specific scope, required exclusions, explicit contributor redaction, no automatic scanning, exact-byte consent disclosure, permanent retention, operator-only audited access, and public-artifact limits.
- Reconciles `PRODUCT.md`, `README.md`, `AGENTS.md`, `CLAUDE.md`, the backend boundary, universal bootstrap skill, and all four current contributor/reviewer skill families. `AGENTS.md` and `CLAUDE.md` remain byte-identical.
- Makes trace consent concrete before GitHub authorization: absolute selected path, exact byte length, media type, SHA-256, no-redaction warning, and permanent-retention warning.
- Removes two local-file TOCTOU paths. The CLI opens the selected path once with `O_RDONLY | O_NOFOLLOW`, validates the opened descriptor with `fstat`, reads one snapshot, enforces the 8 MiB/non-empty bound again after reading, and hashes and uploads those same in-memory bytes. Replacing the pathname after disclosure cannot change the upload; final-component symlinks fail before disclosure or network access.
- Uses the repository-native private security-advisory intake for privacy, security, and data-subject requests. Both the client and production workflow query GitHub's public setting and fail closed unless it returns exactly `enabled: true`; an advisory URL alone is not treated as proof.
- Preserves checksum verification, one-use upload capabilities, immutable object creation, finalized receipt joins, and all other fail-closed integrity boundaries.

## Exact authority and intake evidence

- Base: `2be0fabce6afbafa877dfc8a9a72372d71c2c54d` (`origin/develop` at final rebase)
- Head: `9bd0f08e25580d424baf4708e8d1de8474a90b7f`
- Public, unauthenticated `GET https://api.github.com/repos/elizaOS/slopdotcash/private-vulnerability-reporting`: `{"enabled":true}`
- Public community profile: no separate `SECURITY.md`; the enabled repository-native advisory route is therefore the documented canonical private intake.
- Private intake: https://github.com/elizaOS/slopdotcash/security/advisories/new

## Validation

- `bun test skill-tests/*.test.ts`: 69 passed, including the full Heir Elements SDK CI test and the shared trace regressions.
- `bun test skill-tests/project-skills.test.ts skill-tests/contribute-to-heir-elements-sdk.test.ts`: 26 passed.
- `bunx vitest run scripts/deployment-contract.test.mjs scripts/prepare-site.test.ts`: 16 passed; all four contributor/reviewer packages validated and packaged.
- `bun run test`: 39 Vitest files \/ 404 tests plus 69 skill tests passed on the exact rebased head.
- `bun run projects:check`, `bun run evaluations:check`, `bun run cycles:check`, `bun run protocol:check`: passed.
- `bun run typecheck`: passed.
- `bun run lint:check`: 153 files passed.
- `bun run format:check`: 152 files passed.
- `bun run build`: passed; 171 public files recorded in the deployment manifest.
- Local authenticated ledger generation: 99 leaders, 3,081 score events, 138 GraphQL requests.
- Chromium matrix after ledger generation: 36/36 passed across wide desktop, desktop, tablet, and mobile. The first exact-head rerun accidentally reused another agent's server already occupying the fixed port 4466 and was stopped; it is not claimed as evidence.
- `AGENTS.md` / `CLAUDE.md`: byte-identical.
- All four canonical `run-receipt.mjs` copies: byte-identical.
- `git diff --check`: passed.
- Root `bun run verify`: N/A — this standalone package defines no `verify` script.
- Exact-head GitHub Actions: passed at https://github.com/elizaOS/slopdotcash/actions/runs/31959835073

## Regression coverage

- Disclosure occurs before authorization.
- Digest, `Digest` header, object ID, and uploaded bytes all derive from one already-read snapshot even when the path is replaced after disclosure.
- A symlinked trace is rejected before disclosure or network access.
- Disabled private vulnerability reporting blocks before identity authorization and before any trace API request.
- The production deployment contract requires the public intake check before any Pages deployment.
- The current Heir Elements SDK contributor skill explicitly states designated-operator-only trace access and passes its project-specific CI contract.

## Safety boundaries

- No trace body, prompt, response, source file, credential, session identifier, or private trajectory is added to GitHub or generated public data.
- No automatic redaction claim was introduced; contributors must inspect and redact the exact selected bytes.
- No contributor/project-owner read, update, or voluntary deletion API was introduced.
- No scoring, reward, payout, wallet, operator authorization, or production deployment authority was widened.
- No production deployment was performed.

## AI provenance

Implementation and verification were performed with OpenAI GPT-5.6 in Codex. No private trace was created or uploaded for this documentation and local test change.