### PR TITLE
fix: close funding lifecycle gaps

### DIFF
--- a/scripts/verify-funding-solana.test.ts
+++ b/scripts/verify-funding-solana.test.ts
@@ -77,4 +77,20 @@ describe("Solana funding verifier", () => {
       }),
     ).rejects.toThrow(/absent at finalized/u);
   });
+
+  it("rejects an unbounded amount before querying an RPC", async () => {
+    let queried = false;
+    await expect(
+      verifyFundingSolana({
+        signature: SIGNATURE,
+        recipient: RECIPIENT,
+        amountMinor: "1".repeat(41),
+        fetchImpl: async () => {
+          queried = true;
+          return new Response();
+        },
+      }),
+    ).rejects.toThrow(/invalid/u);
+    expect(queried).toBe(false);
+  });
 });

--- a/scripts/verify-funding-solana.ts
+++ b/scripts/verify-funding-solana.ts
@@ -30,6 +30,7 @@ export async function verifyFundingSolana(input: {
   if (
     !isSolanaTransactionId(input.signature) ||
     !isSolanaAddress(input.recipient) ||
+    input.amountMinor.length > 40 ||
     !/^[1-9]\d*$/u.test(input.amountMinor)
   ) {
     throw new TypeError("signature, recipient, or amount is invalid");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1199,7 +1199,13 @@ function FundingQr({
 
 export function ProjectFunding({ project }: { project: ProjectDefinition }) {
   const [copied, setCopied] = useState<string | null>(null);
-  if (project.funding.addresses.length === 0) return null;
+  const now = Date.now();
+  const activeRoutes = project.funding.addresses.filter(
+    (route) =>
+      Date.parse(route.effectiveAt) <= now &&
+      (route.replacedAt === null || now < Date.parse(route.replacedAt)),
+  );
+  if (activeRoutes.length === 0) return null;
   return (
     <section className="section project-funding">
       <details>
@@ -1211,8 +1217,8 @@ export function ProjectFunding({ project }: { project: ProjectDefinition }) {
           wallet ownership.
         </p>
         <div className="funding-routes">
-          {project.funding.addresses.map((route) => {
-            const key = `${route.network}:${route.asset}`;
+          {activeRoutes.map((route) => {
+            const key = `${route.network}:${route.asset}:${route.address}:${route.effectiveAt}`;
             return (
               <div className="funding-route" key={key}>
                 <strong>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,7 @@ import {
 } from "./lib/cycle-index";
 import {
   assertProjectFundingIndex,
+  currentProjectFundingRecords,
   isFundingAddress,
   type ProjectFundingIndex,
   type ProjectFundingRecord,
@@ -1306,8 +1307,10 @@ function ProjectFundingPage({ project }: { project: ProjectDefinition }) {
   const funding = useFundingIndex();
   const records =
     funding.status === "ready"
-      ? funding.index.records.filter(
-          (record) => record.projectId === project.id,
+      ? currentProjectFundingRecords(
+          funding.index.records.filter(
+            (record) => record.projectId === project.id,
+          ),
         )
       : [];
   const totals = projectFundingTotals(records);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,7 +37,7 @@ import {
   projectFundingTotals,
   publicFundingRecordsForDonor,
 } from "./lib/funding";
-import { settlementReminder } from "./lib/funding-reminders";
+import { cycleSettlementReminder } from "./lib/funding-reminders";
 import { createGlobalLeaders } from "./lib/global-leaderboard";
 import { createInstallCommand } from "./lib/install-command";
 import {
@@ -2046,11 +2046,17 @@ function CyclePage({
   if (!from || !to) return <NotFound title="Cycle unavailable" />;
   const lifecycle =
     record?.state ?? (view?.cycle.status === "live" ? "live" : "closed");
-  const reminder = settlementReminder(
-    to,
-    new Date().toISOString(),
-    record?.settledAt ?? null,
-  );
+  const reminder = cycleSettlementReminder({
+    closesAt: to,
+    kind:
+      record?.kind ??
+      (view?.reward.kind === "external-prize-share"
+        ? "external-prize-share"
+        : "monthly-pool"),
+    now: new Date().toISOString(),
+    settledAt: record?.settledAt ?? null,
+    state: record?.state ?? (view?.cycle.status === "live" ? "live" : "review"),
+  });
   const headlineAmount = record
     ? record.kind === "external-prize-share"
       ? `${(record.reward.sharePartsPerMillion ?? 0) / 10_000}%`

--- a/src/lib/funding-address.d.mts
+++ b/src/lib/funding-address.d.mts
@@ -3,6 +3,21 @@
 export type FundingNetwork = "base" | "bitcoin" | "ethereum" | "solana";
 export type FundingAsset = "BTC" | "USDC";
 
+export interface FundingAddressRoute {
+  readonly network: FundingNetwork;
+  readonly asset: FundingAsset;
+  readonly address: string;
+  readonly effectiveAt: string;
+  readonly replacedAt: string | null;
+}
+
+export declare const MAX_FUNDING_ROUTES: 32;
+
+export declare function assertFundingAddresses(
+  value: unknown,
+  field?: string,
+): readonly FundingAddressRoute[];
+
 export declare function fundingAssetForNetwork(
   network: unknown,
 ): FundingAsset | null;

--- a/src/lib/funding-address.mjs
+++ b/src/lib/funding-address.mjs
@@ -1,6 +1,32 @@
 /** Validates canonical public receiving addresses for each funding network. */
 
 const BASE58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+export const MAX_FUNDING_ROUTES = 32;
+
+function fundingTimestamp(value, field) {
+  if (
+    typeof value !== "string" ||
+    !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value) ||
+    !Number.isFinite(Date.parse(value)) ||
+    new Date(value).toISOString() !== value
+  ) {
+    throw new TypeError(`${field} is invalid`);
+  }
+  return value;
+}
+
+function fundingRecord(value, field) {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new TypeError(`${field} must be an object`);
+  }
+  return value;
+}
+
+function exactFundingKeys(value, keys, field) {
+  if (Object.keys(value).sort().join("\0") !== [...keys].sort().join("\0")) {
+    throw new TypeError(`${field} has unexpected or missing fields`);
+  }
+}
 
 function decodedBase58Length(value, minimumLength, maximumLength) {
   if (
@@ -105,4 +131,82 @@ export function isFundingAddress(network, value) {
 
 export function isSolanaTransactionId(value) {
   return decodedBase58Length(value, 64, 88) === 64;
+}
+
+/**
+ * Validates the complete bounded receiving-address history. A project keeps
+ * replaced routes so old transaction records remain independently verifiable,
+ * while intervals for the same network and asset may never overlap.
+ */
+export function assertFundingAddresses(
+  value,
+  field = "project funding addresses",
+) {
+  if (!Array.isArray(value) || value.length > MAX_FUNDING_ROUTES) {
+    throw new TypeError(
+      `${field} must be an array of at most ${MAX_FUNDING_ROUTES} routes`,
+    );
+  }
+  const seenAddresses = new Set();
+  const histories = new Map();
+  const routes = value.map((candidate, index) => {
+    const routeField = `${field}[${index}]`;
+    const route = fundingRecord(candidate, routeField);
+    exactFundingKeys(
+      route,
+      ["address", "asset", "effectiveAt", "network", "replacedAt"],
+      routeField,
+    );
+    const asset = fundingAssetForNetwork(route.network);
+    if (asset === null || route.asset !== asset) {
+      throw new TypeError(`${routeField} network or asset is unsupported`);
+    }
+    if (!isFundingAddress(route.network, route.address)) {
+      throw new TypeError(`${routeField}.address is invalid`);
+    }
+    const effectiveAt = fundingTimestamp(
+      route.effectiveAt,
+      `${routeField}.effectiveAt`,
+    );
+    const replacedAt =
+      route.replacedAt === null
+        ? null
+        : fundingTimestamp(route.replacedAt, `${routeField}.replacedAt`);
+    if (
+      replacedAt !== null &&
+      Date.parse(replacedAt) <= Date.parse(effectiveAt)
+    ) {
+      throw new TypeError(`${routeField}.replacedAt must follow effectiveAt`);
+    }
+    const addressKey = `${route.network}:${route.asset}:${route.address}`;
+    if (seenAddresses.has(addressKey)) {
+      throw new TypeError(`${field} contain a duplicate receiving address`);
+    }
+    seenAddresses.add(addressKey);
+    const result = {
+      network: route.network,
+      asset: route.asset,
+      address: route.address,
+      effectiveAt,
+      replacedAt,
+    };
+    const historyKey = `${route.network}:${route.asset}`;
+    const history = histories.get(historyKey) ?? [];
+    history.push(result);
+    histories.set(historyKey, history);
+    return result;
+  });
+  for (const history of histories.values()) {
+    history.sort((left, right) =>
+      left.effectiveAt.localeCompare(right.effectiveAt),
+    );
+    for (let index = 1; index < history.length; index += 1) {
+      const prior = history[index - 1];
+      const current = history[index];
+      if (prior.replacedAt === null || prior.replacedAt > current.effectiveAt) {
+        throw new TypeError(`${field} contain overlapping active routes`);
+      }
+    }
+  }
+  return routes;
 }

--- a/src/lib/funding-reminders.test.ts
+++ b/src/lib/funding-reminders.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { settlementReminder } from "./funding-reminders";
+import {
+  cycleSettlementReminder,
+  settlementReminder,
+} from "./funding-reminders";
 
 const close = "2026-08-01T00:00:00.000Z";
 
@@ -28,5 +31,31 @@ describe("funding cycle reminders", () => {
         "2026-08-03T00:00:00.000Z",
       ),
     ).toBeNull();
+  });
+
+  it("never emits settlement instructions for non-settlement lifecycles", () => {
+    const reminder = (
+      kind: "external-prize-share" | "monthly-pool",
+      state: "closed-no-awards" | "external-provisional" | "paid",
+    ) =>
+      cycleSettlementReminder({
+        closesAt: close,
+        kind,
+        now: "2026-08-05T00:00:00.000Z",
+        settledAt: null,
+        state,
+      });
+    expect(reminder("monthly-pool", "closed-no-awards")).toBeNull();
+    expect(reminder("external-prize-share", "external-provisional")).toBeNull();
+    expect(reminder("monthly-pool", "paid")).toBeNull();
+    expect(
+      cycleSettlementReminder({
+        closesAt: close,
+        kind: "monthly-pool",
+        now: "2026-08-05T00:00:00.000Z",
+        settledAt: null,
+        state: "payment-ready",
+      })?.kind,
+    ).toBe("overdue");
   });
 });

--- a/src/lib/funding-reminders.test.ts
+++ b/src/lib/funding-reminders.test.ts
@@ -5,9 +5,7 @@ const close = "2026-08-01T00:00:00.000Z";
 
 describe("funding cycle reminders", () => {
   it("publishes the UTC warning and seven-day settler reminder", () => {
-    expect(settlementReminder(close, "2026-07-20T00:00:00.000Z")?.kind).toBe(
-      "cycle-close",
-    );
+    expect(settlementReminder(close, "2026-07-20T00:00:00.000Z")).toBeNull();
     expect(settlementReminder(close, "2026-07-25T00:00:00.000Z")?.kind).toBe(
       "settler-seven-day",
     );

--- a/src/lib/funding-reminders.ts
+++ b/src/lib/funding-reminders.ts
@@ -29,10 +29,7 @@ export function settlementReminder(
   if (settledAt !== null) return null;
   const elapsed = current - close;
   if (elapsed < -7 * DAY_MS) {
-    return {
-      kind: "cycle-close",
-      message: `UTC cycle-close warning: this cycle closes ${utc(closesAt)} UTC.`,
-    };
+    return null;
   }
   if (elapsed < 0) {
     return {

--- a/src/lib/funding-reminders.ts
+++ b/src/lib/funding-reminders.ts
@@ -6,6 +6,15 @@ export type SettlementReminder =
   | { kind: "ready-to-sign"; message: string }
   | { kind: "settler-seven-day"; message: string };
 
+export type SettlementReminderLifecycle =
+  | "closed-no-awards"
+  | "external-provisional"
+  | "live"
+  | "paid"
+  | "payment-ready"
+  | "review"
+  | "settlement-planned";
+
 const DAY_MS = 24 * 60 * 60 * 1_000;
 
 function utc(value: string): string {
@@ -55,4 +64,23 @@ export function settlementReminder(
     message:
       "Overdue settlement reminder: more than 72 hours have passed since UTC cycle close without reconciled settlement evidence.",
   };
+}
+
+/** Suppresses signing language for cycles that never enter platform settlement. */
+export function cycleSettlementReminder(input: {
+  closesAt: string;
+  kind: "external-prize-share" | "monthly-pool";
+  now: string;
+  settledAt: string | null;
+  state: SettlementReminderLifecycle;
+}): SettlementReminder | null {
+  if (
+    input.kind !== "monthly-pool" ||
+    input.state === "closed-no-awards" ||
+    input.state === "external-provisional" ||
+    input.state === "paid"
+  ) {
+    return null;
+  }
+  return settlementReminder(input.closesAt, input.now, input.settledAt);
 }

--- a/src/lib/funding.test.ts
+++ b/src/lib/funding.test.ts
@@ -228,6 +228,61 @@ describe("project funding records", () => {
     ).toThrow(/not later/u);
   });
 
+  it("allows a later correction after rotation without permitting recipient mutation", () => {
+    const rotatedRoutes = assertProjectFundingAddresses([
+      {
+        network: "ethereum",
+        asset: "USDC",
+        address: ADDRESS,
+        effectiveAt: "2026-08-01T00:00:00.000Z",
+        replacedAt: "2026-08-03T00:00:00.000Z",
+      },
+      {
+        network: "ethereum",
+        asset: "USDC",
+        address: `0x${"2".repeat(40)}`,
+        effectiveAt: "2026-08-03T00:00:00.000Z",
+        replacedAt: null,
+      },
+    ]);
+    const original = record();
+    const correction = record({
+      recordId: "fund_rotated_correction",
+      observedAt: "2026-08-04T00:00:00.000Z",
+      state: "disputed",
+      finality: { kind: "confirmations", confirmations: 64 },
+      verifier: {
+        version: "funding-ethereum-v1",
+        checkedAt: "2026-08-04T00:00:00.000Z",
+        evidenceUrl: `https://etherscan.io/tx/${TRANSACTION}`,
+        reason: "A later reorg invalidated the original evidence.",
+      },
+      supersedes: original.recordId,
+    });
+    expect(
+      assertProjectFundingLedger([original, correction], rotatedRoutes).map(
+        ({ recordId }) => recordId,
+      ),
+    ).toEqual(["fund_fixture_01", "fund_rotated_correction"]);
+
+    expect(() =>
+      assertProjectFundingLedger(
+        [
+          original,
+          {
+            ...correction,
+            recipient: `0x${"2".repeat(40)}`,
+          },
+        ],
+        rotatedRoutes,
+      ),
+    ).toThrow(/changes transaction identity/u);
+
+    expect(() =>
+      assertProjectFundingRecord(correction, [rotatedRoutes[1]]),
+    ).toThrow(/absent from.*route history/u);
+  });
+
   it("never combines self-reported and verified totals", () => {
     const secondTransaction = `0x${"c".repeat(64)}`;
     const verified = record({

--- a/src/lib/funding.test.ts
+++ b/src/lib/funding.test.ts
@@ -123,6 +123,7 @@ describe("project funding records", () => {
           donor: {
             attribution: "github",
             actorId: "1".repeat(21),
+            actorNodeId: "MDQ6VXNlcjE4NjMzMjY0",
             login: "lalalune",
           },
         }),

--- a/src/lib/funding.test.ts
+++ b/src/lib/funding.test.ts
@@ -5,6 +5,7 @@ import {
   assertProjectFundingAddresses,
   assertProjectFundingLedger,
   assertProjectFundingRecord,
+  currentProjectFundingRecords,
   projectFundingTotals,
   publicFundingRecordsForDonor,
 } from "./funding";
@@ -206,6 +207,9 @@ describe("project funding records", () => {
       supersedes: original.recordId,
     });
     const ledger = assertProjectFundingLedger([original, correction], routes);
+    expect(
+      currentProjectFundingRecords(ledger).map(({ recordId }) => recordId),
+    ).toEqual(["fund_fixture_02"]);
     expect(projectFundingTotals(ledger)).toEqual([
       { asset: "USDC", selfReportedMinor: "0", verifiedMinor: "0" },
     ]);

--- a/src/lib/funding.test.ts
+++ b/src/lib/funding.test.ts
@@ -49,6 +49,47 @@ function record(overrides: Record<string, unknown> = {}) {
 }
 
 describe("project funding records", () => {
+  it("retains non-overlapping receiving history and rejects ambiguous time", () => {
+    expect(
+      assertProjectFundingAddresses([
+        {
+          network: "ethereum",
+          asset: "USDC",
+          address: ADDRESS,
+          effectiveAt: "2026-08-01T00:00:00.000Z",
+          replacedAt: "2026-08-02T00:00:00.000Z",
+        },
+        {
+          network: "ethereum",
+          asset: "USDC",
+          address: `0x${"2".repeat(40)}`,
+          effectiveAt: "2026-08-02T00:00:00.000Z",
+          replacedAt: null,
+        },
+      ]),
+    ).toHaveLength(2);
+    expect(() =>
+      assertProjectFundingAddresses([
+        ...routes.map((route) => ({
+          ...route,
+          replacedAt: "2026-08-03T00:00:00.000Z",
+        })),
+        {
+          network: "ethereum",
+          asset: "USDC",
+          address: `0x${"2".repeat(40)}`,
+          effectiveAt: "2026-08-02T00:00:00.000Z",
+          replacedAt: null,
+        },
+      ]),
+    ).toThrow(/overlapping active routes/u);
+    expect(() =>
+      assertProjectFundingAddresses([
+        { ...routes[0], effectiveAt: "2026-02-30T00:00:00.000Z" },
+      ]),
+    ).toThrow(/invalid/u);
+  });
+
   it("binds a self-report to the exact active manifest address", () => {
     expect(assertProjectFundingRecord(record(), routes)).toMatchObject({
       state: "self-reported",
@@ -63,6 +104,30 @@ describe("project funding records", () => {
     expect(() =>
       assertProjectFundingRecord(record({ amountMinor: "1.0" }), routes),
     ).toThrow(/integer minor units/u);
+    expect(() =>
+      assertProjectFundingRecord(
+        record({ amountMinor: "1".repeat(41) }),
+        routes,
+      ),
+    ).toThrow(/integer minor units/u);
+    expect(() =>
+      assertProjectFundingRecord(
+        record({ observedAt: "2026-02-30T00:00:00.000Z" }),
+        routes,
+      ),
+    ).toThrow(/invalid/u);
+    expect(() =>
+      assertProjectFundingRecord(
+        record({
+          donor: {
+            attribution: "github",
+            actorId: "1".repeat(21),
+            login: "lalalune",
+          },
+        }),
+        routes,
+      ),
+    ).toThrow(/donor identity/u);
     expect(() =>
       assertProjectFundingRecord(
         record({

--- a/src/lib/funding.ts
+++ b/src/lib/funding.ts
@@ -249,19 +249,29 @@ export function assertProjectFundingRecord(
   ) {
     throw new TypeError("funding record recipient is invalid");
   }
+  if (
+    record.supersedes !== null &&
+    (typeof record.supersedes !== "string" ||
+      !RECORD_ID_PATTERN.test(record.supersedes))
+  ) {
+    throw new TypeError("funding record supersedes id is invalid");
+  }
   const observedAt = timestamp(record.observedAt, "funding record observedAt");
   const route = addresses.find(
     (candidate) =>
       candidate.network === network &&
       candidate.asset === record.asset &&
       candidate.address === record.recipient &&
-      Date.parse(candidate.effectiveAt) <= Date.parse(observedAt) &&
-      (candidate.replacedAt === null ||
-        Date.parse(observedAt) < Date.parse(candidate.replacedAt)),
+      (record.supersedes !== null ||
+        (Date.parse(candidate.effectiveAt) <= Date.parse(observedAt) &&
+          (candidate.replacedAt === null ||
+            Date.parse(observedAt) < Date.parse(candidate.replacedAt)))),
   );
   if (!route) {
     throw new TypeError(
-      "funding record recipient was not active at the manifest-bound observation time",
+      record.supersedes === null
+        ? "funding record recipient was not active at the manifest-bound observation time"
+        : "funding correction recipient is absent from the manifest-bound route history",
     );
   }
   canonicalMinor(record.amountMinor, "funding record amountMinor");
@@ -335,13 +345,6 @@ export function assertProjectFundingRecord(
     ) {
       throw new TypeError("funding record dispute reason is inconsistent");
     }
-  }
-  if (
-    record.supersedes !== null &&
-    (typeof record.supersedes !== "string" ||
-      !RECORD_ID_PATTERN.test(record.supersedes))
-  ) {
-    throw new TypeError("funding record supersedes id is invalid");
   }
   return value as ProjectFundingRecord;
 }

--- a/src/lib/funding.ts
+++ b/src/lib/funding.ts
@@ -387,16 +387,26 @@ export function assertProjectFundingLedger(
   return records;
 }
 
-export function projectFundingTotals(records: readonly ProjectFundingRecord[]) {
+export function currentProjectFundingRecords(
+  records: readonly ProjectFundingRecord[],
+): readonly ProjectFundingRecord[] {
   const latest = new Map<string, ProjectFundingRecord>();
   for (const record of records) {
     latest.set(`${record.network}:${record.transactionId}`, record);
   }
+  return [...latest.values()].sort(
+    (left, right) =>
+      Date.parse(right.observedAt) - Date.parse(left.observedAt) ||
+      left.recordId.localeCompare(right.recordId),
+  );
+}
+
+export function projectFundingTotals(records: readonly ProjectFundingRecord[]) {
   const byAsset = new Map<
     FundingAsset,
     { selfReportedMinor: bigint; verifiedMinor: bigint }
   >();
-  for (const record of latest.values()) {
+  for (const record of currentProjectFundingRecords(records)) {
     const totals = byAsset.get(record.asset) ?? {
       selfReportedMinor: 0n,
       verifiedMinor: 0n,
@@ -427,11 +437,7 @@ export function publicFundingRecordsForDonor(
   records: readonly ProjectFundingRecord[],
   actorNodeId: string,
 ): readonly ProjectFundingRecord[] {
-  const latest = new Map<string, ProjectFundingRecord>();
-  for (const record of records) {
-    latest.set(`${record.network}:${record.transactionId}`, record);
-  }
-  return [...latest.values()]
+  return currentProjectFundingRecords(records)
     .filter((record) => {
       if (record.donor.attribution !== "github") return false;
       return record.donor.actorNodeId === actorNodeId;

--- a/src/lib/funding.ts
+++ b/src/lib/funding.ts
@@ -1,6 +1,7 @@
 /** Strict, non-custodial project-funding records and deterministic totals. */
 
 import {
+  assertFundingAddresses,
   fundingAssetForNetwork,
   isFundingAddress,
   isSolanaTransactionId,
@@ -86,7 +87,8 @@ function timestamp(value: unknown, field: string): string {
   if (
     typeof value !== "string" ||
     !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value) ||
-    !Number.isFinite(Date.parse(value))
+    !Number.isFinite(Date.parse(value)) ||
+    new Date(value).toISOString() !== value
   ) {
     throw new TypeError(`${field} is invalid`);
   }
@@ -94,7 +96,11 @@ function timestamp(value: unknown, field: string): string {
 }
 
 function canonicalMinor(value: unknown, field: string): string {
-  if (typeof value !== "string" || !/^(?:0|[1-9]\d*)$/u.test(value)) {
+  if (
+    typeof value !== "string" ||
+    value.length > 40 ||
+    !/^(?:0|[1-9]\d*)$/u.test(value)
+  ) {
     throw new TypeError(`${field} must be canonical integer minor units`);
   }
   if (BigInt(value) === 0n) throw new TypeError(`${field} must be positive`);
@@ -130,62 +136,7 @@ function canonicalEvidenceUrl(
 export function assertProjectFundingAddresses(
   value: unknown,
 ): readonly ProjectFundingAddress[] {
-  if (!Array.isArray(value) || value.length > 4) {
-    throw new TypeError(
-      "project funding addresses must be an array of at most four routes",
-    );
-  }
-  const seen = new Set<string>();
-  return value.map((candidate, index) => {
-    const field = `project funding address ${index}`;
-    const route = object(candidate, field);
-    exactKeys(
-      route,
-      ["address", "asset", "effectiveAt", "network", "replacedAt"],
-      field,
-    );
-    if (
-      typeof route.network !== "string" ||
-      fundingAssetForNetwork(route.network) === null
-    ) {
-      throw new TypeError(`${field} network is unsupported`);
-    }
-    const network = route.network as FundingNetwork;
-    if (route.asset !== fundingAssetForNetwork(network)) {
-      throw new TypeError(`${field} asset is unsupported for its network`);
-    }
-    if (
-      typeof route.address !== "string" ||
-      !isFundingAddress(network, route.address)
-    ) {
-      throw new TypeError(`${field} address is invalid`);
-    }
-    const effectiveAt = timestamp(route.effectiveAt, `${field}.effectiveAt`);
-    const replacedAt =
-      route.replacedAt === null
-        ? null
-        : timestamp(route.replacedAt, `${field}.replacedAt`);
-    if (
-      replacedAt !== null &&
-      Date.parse(replacedAt) <= Date.parse(effectiveAt)
-    ) {
-      throw new TypeError(`${field} replacement must follow activation`);
-    }
-    const key = `${network}:${route.asset}`;
-    if (seen.has(key)) {
-      throw new TypeError(
-        "project funding addresses contain a duplicate network and asset",
-      );
-    }
-    seen.add(key);
-    return {
-      network,
-      asset: route.asset,
-      address: route.address,
-      effectiveAt,
-      replacedAt,
-    } as ProjectFundingAddress;
-  });
+  return assertFundingAddresses(value) as readonly ProjectFundingAddress[];
 }
 
 function assertFinality(
@@ -334,7 +285,7 @@ export function assertProjectFundingRecord(
     if (
       donor.attribution !== "github" ||
       typeof donor.actorId !== "string" ||
-      !/^[1-9]\d*$/u.test(donor.actorId) ||
+      !/^[1-9]\d{0,19}$/u.test(donor.actorId) ||
       typeof donor.actorNodeId !== "string" ||
       !/^[A-Za-z0-9_=-]{4,128}$/u.test(donor.actorNodeId) ||
       typeof donor.login !== "string" ||

--- a/src/lib/project-schema.mjs
+++ b/src/lib/project-schema.mjs
@@ -4,10 +4,7 @@
  * request cannot smuggle executable configuration or ambiguous reward terms.
  */
 
-import {
-  fundingAssetForNetwork,
-  isFundingAddress,
-} from "./funding-address.mjs";
+import { assertFundingAddresses } from "./funding-address.mjs";
 
 const PROJECT_KEYS = [
   "authority",
@@ -764,46 +761,7 @@ function validateFunding(value, projectId) {
   ) {
     throw new TypeError("project.funding non-custodial policy is invalid");
   }
-  if (!Array.isArray(funding.addresses) || funding.addresses.length > 4) {
-    throw new TypeError(
-      "project.funding addresses must contain at most four routes",
-    );
-  }
-  const seen = new Set();
-  for (const [index, value] of funding.addresses.entries()) {
-    const field = `project.funding.addresses[${index}]`;
-    const route = record(value, field);
-    exactKeys(
-      route,
-      ["address", "asset", "effectiveAt", "network", "replacedAt"],
-      field,
-    );
-    const expectedAsset = fundingAssetForNetwork(route.network);
-    if (!expectedAsset || route.asset !== expectedAsset) {
-      throw new TypeError(`${field} network or asset is unsupported`);
-    }
-    if (!isFundingAddress(route.network, route.address)) {
-      throw new TypeError(`${field}.address is invalid`);
-    }
-    const effectiveAt = timestamp(route.effectiveAt, `${field}.effectiveAt`);
-    const replacedAt =
-      route.replacedAt === null
-        ? null
-        : timestamp(route.replacedAt, `${field}.replacedAt`);
-    if (
-      replacedAt !== null &&
-      Date.parse(replacedAt) <= Date.parse(effectiveAt)
-    ) {
-      throw new TypeError(`${field}.replacedAt must follow effectiveAt`);
-    }
-    const key = `${route.network}:${route.asset}`;
-    if (seen.has(key)) {
-      throw new TypeError(
-        "project.funding addresses contain a duplicate route",
-      );
-    }
-    seen.add(key);
-  }
+  assertFundingAddresses(funding.addresses, "project.funding.addresses");
   return funding;
 }
 

--- a/src/lib/project-schema.test.ts
+++ b/src/lib/project-schema.test.ts
@@ -100,14 +100,14 @@ describe("project proposal schema", () => {
       /non-custodial/u,
     );
 
-    const duplicate = structuredClone(eliza);
-    duplicate.funding.addresses = [
+    const rotation = structuredClone(eliza);
+    rotation.funding.addresses = [
       {
         network: "solana",
         asset: "USDC",
         address: "11111111111111111111111111111111",
         effectiveAt: "2026-08-16T00:00:00.000Z",
-        replacedAt: null,
+        replacedAt: "2026-08-17T00:00:00.000Z",
       },
       {
         network: "solana",
@@ -117,8 +117,15 @@ describe("project proposal schema", () => {
         replacedAt: null,
       },
     ] as never;
-    expect(() => assertProjectDefinition(duplicate)).toThrow(
-      /duplicate route/u,
+    expect(assertProjectDefinition(rotation).funding.addresses).toHaveLength(2);
+    const overlap = structuredClone(rotation);
+    (
+      overlap.funding.addresses[0] as unknown as {
+        replacedAt: string | null;
+      }
+    ).replacedAt = "2026-08-18T00:00:00.000Z";
+    expect(() => assertProjectDefinition(overlap)).toThrow(
+      /overlapping active routes/u,
     );
 
     const invalidSolana = structuredClone(eliza);

--- a/src/lib/solana-settlement.ts
+++ b/src/lib/solana-settlement.ts
@@ -92,6 +92,7 @@ function tokenBalances(
     if (
       ui.decimals !== USDC_DECIMALS ||
       typeof ui.amount !== "string" ||
+      ui.amount.length > 40 ||
       !/^(?:0|[1-9]\d*)$/u.test(ui.amount)
     ) {
       throw new TypeError(`${field}[${index}] has invalid raw token amount`);
@@ -210,7 +211,11 @@ export function assertFinalizedUsdcFundingTransfer(
   amountMinor: string,
 ): VerifiedSolanaTransaction {
   signature(expectedSignature, "expected signature");
-  if (!isSolanaAddress(recipientOwner) || !/^[1-9]\d*$/u.test(amountMinor)) {
+  if (
+    !isSolanaAddress(recipientOwner) ||
+    amountMinor.length > 40 ||
+    !/^[1-9]\d*$/u.test(amountMinor)
+  ) {
     throw new TypeError("funding transfer expectation is invalid");
   }
   const transaction = record(transactionValue, "Solana transaction");

--- a/tests/app.test.tsx
+++ b/tests/app.test.tsx
@@ -964,6 +964,13 @@ describe("direct project funding", () => {
           {
             network: "solana" as const,
             asset: "USDC" as const,
+            address: "Vote111111111111111111111111111111111111111",
+            effectiveAt: "2026-08-14T00:00:00.000Z",
+            replacedAt: "2026-08-15T00:00:00.000Z",
+          },
+          {
+            network: "solana" as const,
+            asset: "USDC" as const,
             address: "11111111111111111111111111111111",
             effectiveAt: "2026-08-16T00:00:00.000Z",
             replacedAt: null,
@@ -975,6 +982,9 @@ describe("direct project funding", () => {
     render(<ProjectFunding project={fundedProject} />);
     fireEvent.click(screen.getByText("Fund this project"));
     expect(screen.getByText(fundedProject.funding.disclosure)).toBeVisible();
+    expect(
+      screen.queryByText("Vote111111111111111111111111111111111111111"),
+    ).not.toBeInTheDocument();
     expect(screen.getByText("11111111111111111111111111111111")).toBeVisible();
     expect(
       await screen.findByRole("img", {

--- a/tests/app.test.tsx
+++ b/tests/app.test.tsx
@@ -760,6 +760,7 @@ describe("public records", () => {
     expect(
       screen.getByText("This cycle closed with no accepted awards."),
     ).toBeInTheDocument();
+    expect(screen.queryByText(/settlement reminder/u)).not.toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Outcome

Repairs the safety and UX gaps left after #130 merged while its review was still in progress.

- preserves bounded, non-overlapping historical receiving routes so old donations remain verifiable after rotation
- shows only routes active at the current time
- rejects malformed canonical timestamps, oversized amounts and token balances, duplicate addresses, and overlapping route intervals
- keeps immutable GitHub actor/node binding on attributed donor records
- shows only the latest correction for a funding transaction in totals and profiles while retaining the full immutable history
- allows a later append-only correction or dispute after receiving-address rotation, while binding network/asset/recipient/transaction identity to the validated original chain
- emits payout reminders only during the final seven days of a cycle and suppresses signing/overdue language for external-prize, zero-award, and already-paid lifecycles

This remains direct non-custodial honor-system funding. Slop does not hold funds, sign transactions, or claim Base/Ethereum/Bitcoin verification.

## Verification

Exact head: `8960bad05367b72b72fd26fdddf8885285a838ae`, based on `develop` `e15debf7742925fd9ef74236a88669ea3a9e3d68`.

- rebase range-diff: all five PR commits are patch-identical to the independently audited prior head; no unrelated PR changes
- exact-head rotated-correction and lifecycle-reminder domain regressions: 2 files / 10 tests passed
- exact-head closed-no-awards UI regression: 1/1 passed
- exact-head AGENTS.md and CLAUDE.md: byte-identical
- GitHub exact-head unit suite: 46 files / 441 tests passed, plus 72 bundled skill tests across 5 files
- GitHub exact-head browser suite: 36/36 desktop/mobile tests passed; Pages artifact contract 1/1 passed
- GitHub exact-head typecheck, lint, format, project/skill registry validation, live contribution generation, reward/Solana validation, build, and Pages bundle upload: passed
- production build manifest: 176 public files

The earlier broader local app-file run had one unrelated five-second discovery-test timeout under heavy host contention; its assertions did not fail. The isolated lifecycle UI regression passed, and GitHub CI is the clean exact-head full-suite authority.

Advances #114. Keep it open for Base/Ethereum/Bitcoin verifiers, declared-settler authority proof, and a reviewed mainnet funding route/canary.
