### PR TITLE
fix: enforce project policy history in CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -89,8 +89,13 @@ jobs:
             --requirement "$RUNNER_TEMP/slop-python-requirements.txt"
 
       - name: Validate project registry and every skill
+        env:
+          PROJECT_POLICY_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
         run: |
           set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ] || [ "${{ github.event_name }}" = "push" ]; then
+            node scripts/check-project-transitions.mjs "$PROJECT_POLICY_BASE_SHA"
+          fi
           bun run projects:check
           bun run evaluations:check
           for skill in skills/*; do

--- a/scripts/check-project-transitions.d.mts
+++ b/scripts/check-project-transitions.d.mts
@@ -1,0 +1,10 @@
+export type ProjectManifestEntry = readonly [path: string, bytes: string];
+
+export declare function validateProjectTransitions(
+  previousEntries: readonly ProjectManifestEntry[],
+  currentEntries: readonly ProjectManifestEntry[],
+): { previous: number; current: number };
+
+export declare function checkProjectTransitions(
+  baseRevision: string,
+): Promise<{ previous: number; current: number }>;

--- a/scripts/check-project-transitions.mjs
+++ b/scripts/check-project-transitions.mjs
@@ -1,0 +1,129 @@
+/**
+ * Validates every project manifest transition against an immutable Git base.
+ * Schema validation alone cannot protect append-only policy history because a
+ * well-shaped manifest may still rewrite or delete an earlier binding.
+ */
+
+import { execFileSync } from "node:child_process";
+import { readdir, readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { assertProjectPolicyTransition } from "../src/lib/project-policy.mjs";
+import { assertProjectDefinition } from "../src/lib/project-schema.mjs";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const PROJECTS = resolve(ROOT, "projects");
+const REVISION = /^[0-9a-f]{40}$/u;
+const PROJECT_PATH =
+  /^projects\/([a-z0-9](?:[a-z0-9-]{0,46}[a-z0-9])?)\/project\.json$/u;
+const MAX_PROJECTS = 100;
+const MAX_MANIFEST_BYTES = 1024 * 1024;
+
+function parseManifest(bytes, path) {
+  if (Buffer.byteLength(bytes) > MAX_MANIFEST_BYTES) {
+    throw new TypeError(`${path} exceeds the manifest byte limit`);
+  }
+  let value;
+  try {
+    value = JSON.parse(bytes);
+  } catch (error) {
+    throw new TypeError(`${path} is invalid JSON`, { cause: error });
+  }
+  return assertProjectDefinition(value);
+}
+
+function boundedProjectMap(entries) {
+  if (entries.length > MAX_PROJECTS) {
+    throw new TypeError(`project inventory exceeds ${MAX_PROJECTS} entries`);
+  }
+  const projects = new Map();
+  for (const [path, bytes] of entries) {
+    const match = path.match(PROJECT_PATH);
+    if (!match) throw new TypeError(`project path is not canonical: ${path}`);
+    const project = parseManifest(bytes, path);
+    if (project.id !== match[1] || projects.has(project.id)) {
+      throw new TypeError(
+        `project identity is duplicated or misplaced: ${path}`,
+      );
+    }
+    projects.set(project.id, project);
+  }
+  return projects;
+}
+
+export function validateProjectTransitions(previousEntries, currentEntries) {
+  const previous = boundedProjectMap(previousEntries);
+  const current = boundedProjectMap(currentEntries);
+  for (const [projectId, prior] of previous) {
+    const next = current.get(projectId);
+    if (!next) {
+      throw new TypeError(
+        `project ${projectId} cannot be deleted; pause it and preserve its policy history`,
+      );
+    }
+    assertProjectPolicyTransition(prior, next);
+  }
+  return { previous: previous.size, current: current.size };
+}
+
+function git(args) {
+  return execFileSync("git", args, {
+    cwd: ROOT,
+    encoding: "utf8",
+    maxBuffer: 2 * 1024 * 1024,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function revisionEntries(revision) {
+  if (!REVISION.test(revision)) throw new TypeError("base revision is invalid");
+  git(["cat-file", "-e", `${revision}^{commit}`]);
+  const paths = git([
+    "ls-tree",
+    "-r",
+    "--name-only",
+    revision,
+    "--",
+    "projects",
+  ])
+    .split("\n")
+    .filter((path) => PROJECT_PATH.test(path));
+  return paths.map((path) => [path, git(["show", `${revision}:${path}`])]);
+}
+
+async function workingEntries() {
+  const directories = (await readdir(PROJECTS, { withFileTypes: true }))
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort();
+  return Promise.all(
+    directories.map(async (directory) => {
+      const path = `projects/${directory}/project.json`;
+      return [path, await readFile(resolve(ROOT, path), "utf8")];
+    }),
+  );
+}
+
+export async function checkProjectTransitions(baseRevision) {
+  return validateProjectTransitions(
+    revisionEntries(baseRevision),
+    await workingEntries(),
+  );
+}
+
+if (import.meta.main) {
+  try {
+    if (process.argv.length !== 3) {
+      throw new TypeError("Usage: check-project-transitions.mjs <base-sha>");
+    }
+    const result = await checkProjectTransitions(process.argv[2]);
+    process.stdout.write(
+      `[Slop] validated ${result.previous} existing project policy transitions across ${result.current} current projects\n`,
+    );
+  } catch (error) {
+    process.stderr.write(
+      `[Slop] project transition refused: ${error instanceof Error ? error.message : "unknown error"}\n`,
+    );
+    process.exitCode = 1;
+  }
+}

--- a/scripts/check-project-transitions.test.ts
+++ b/scripts/check-project-transitions.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import eliza from "../projects/eliza/project.json";
+import { validateProjectTransitions } from "./check-project-transitions.mjs";
+
+function entry(value: unknown): [string, string] {
+  return ["projects/eliza/project.json", JSON.stringify(value)];
+}
+
+describe("project transition gate", () => {
+  it("accepts unchanged policy and rejects silent terms history edits", () => {
+    expect(validateProjectTransitions([entry(eliza)], [entry(eliza)])).toEqual({
+      previous: 1,
+      current: 1,
+    });
+    const rewritten = structuredClone(eliza);
+    rewritten.terms.copyright.notice = "Rewritten without a new revision";
+    expect(() =>
+      validateProjectTransitions([entry(eliza)], [entry(rewritten)]),
+    ).toThrow(/new revision/u);
+  });
+
+  it("rejects project deletion and malformed inventory paths", () => {
+    expect(() => validateProjectTransitions([entry(eliza)], [])).toThrow(
+      /cannot be deleted/u,
+    );
+    expect(() =>
+      validateProjectTransitions(
+        [["projects/../eliza/project.json", JSON.stringify(eliza)]],
+        [entry(eliza)],
+      ),
+    ).toThrow(/not canonical/u);
+  });
+});

--- a/scripts/deployment-contract.test.mjs
+++ b/scripts/deployment-contract.test.mjs
@@ -234,6 +234,21 @@ describe("slop.cash deployment contract", () => {
     expect(deployJob).toContain("name: eliza-army-production");
   });
 
+  it("validates immutable project policy transitions before the registry", () => {
+    const transitionGate = qualityJob.indexOf(
+      'node scripts/check-project-transitions.mjs "$PROJECT_POLICY_BASE_SHA"',
+    );
+    const registryGate = qualityJob.indexOf("bun run projects:check");
+    expect(qualityJob).toContain(
+      `PROJECT_POLICY_BASE_SHA: ${"$"}{{ github.event.pull_request.base.sha || github.event.before }}`,
+    );
+    expect(qualityJob).toContain(
+      `if [ "${"$"}{{ github.event_name }}" = "pull_request" ] || [ "${"$"}{{ github.event_name }}" = "push" ]; then`,
+    );
+    expect(transitionGate).toBeGreaterThan(-1);
+    expect(registryGate).toBeGreaterThan(transitionGate);
+  });
+
   it("has no candidate-controlled production release path", () => {
     expect(workflow).toContain("workflow_dispatch:");
     expect(workflow).not.toContain("release_mode");


### PR DESCRIPTION
## Outcome

Repairs the production-enforcement gap identified after #133 merged.

- compares every existing project manifest against the immutable PR base or prior develop SHA
- runs the actual `assertProjectPolicyTransition` contract before registry validation on pull requests and develop pushes
- refuses project deletion, silent same-revision terms rewrites, repository/branch identity drift, receipt-policy rollback, and historical binding mutation
- bounds revision format, project count, manifest bytes, Git output, and canonical paths
- leaves new projects available for ordinary strict schema/registry review

This does not invent missing legal facts or activate paused projects. Private project-operator persistence and live remote drift polling remain issue #115 work; the merged helper is not represented as a deployed backend control.

## Verification

- transition, policy, and deployment contract tests: 14/14
- real gate against current develop: 4 existing transitions / 4 current projects
- typecheck, lint, format, diff check: pass

Advances #115.