### PR TITLE
fix: trust project transition enforcement

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -90,11 +90,12 @@ jobs:
 
       - name: Validate project registry and every skill
         env:
-          PROJECT_POLICY_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          PROJECT_POLICY_BASE_SHA: ${{ github.event.before }}
+          PROJECT_POLICY_HEAD_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "pull_request" ] || [ "${{ github.event_name }}" = "push" ]; then
-            node scripts/check-project-transitions.mjs "$PROJECT_POLICY_BASE_SHA"
+          if [ "${{ github.event_name }}" = "push" ]; then
+            node scripts/check-project-transitions.mjs "$PROJECT_POLICY_BASE_SHA" "$PROJECT_POLICY_HEAD_SHA"
           fi
           bun run projects:check
           bun run evaluations:check

--- a/.github/workflows/project-transitions.yml
+++ b/.github/workflows/project-transitions.yml
@@ -1,0 +1,44 @@
+name: Trusted project transition gate
+
+on:
+  pull_request_target:
+    branches: [develop]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: trusted-project-transition-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  project-transitions:
+    name: Trusted project transition gate
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      # Execute only the checker committed at the immutable base SHA. The PR
+      # head is fetched as Git object data and is never checked out or run.
+      - name: Checkout immutable trusted base
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+          submodules: false
+
+      - name: Validate immutable base and head manifests
+        env:
+          PROJECT_POLICY_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PROJECT_POLICY_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PROJECT_POLICY_PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$PROJECT_POLICY_BASE_SHA"
+          git fetch --no-tags --depth=1 origin \
+            "+refs/pull/$PROJECT_POLICY_PR_NUMBER/head:refs/remotes/origin/slop-transition-head"
+          fetched_head="$(git rev-parse refs/remotes/origin/slop-transition-head)"
+          test "$fetched_head" = "$PROJECT_POLICY_HEAD_SHA"
+          node scripts/check-project-transitions.mjs \
+            "$PROJECT_POLICY_BASE_SHA" "$PROJECT_POLICY_HEAD_SHA"

--- a/scripts/check-project-transitions.mjs
+++ b/scripts/check-project-transitions.mjs
@@ -75,8 +75,8 @@ function git(args) {
   });
 }
 
-function revisionEntries(revision) {
-  if (!REVISION.test(revision)) throw new TypeError("base revision is invalid");
+function revisionEntries(revision, label = "revision") {
+  if (!REVISION.test(revision)) throw new TypeError(`${label} is invalid`);
   git(["cat-file", "-e", `${revision}^{commit}`]);
   const paths = git([
     "ls-tree",
@@ -104,19 +104,26 @@ async function workingEntries() {
   );
 }
 
-export async function checkProjectTransitions(baseRevision) {
+export async function checkProjectTransitions(baseRevision, currentRevision) {
   return validateProjectTransitions(
-    revisionEntries(baseRevision),
-    await workingEntries(),
+    revisionEntries(baseRevision, "base revision"),
+    currentRevision === undefined
+      ? await workingEntries()
+      : revisionEntries(currentRevision, "current revision"),
   );
 }
 
 if (import.meta.main) {
   try {
-    if (process.argv.length !== 3) {
-      throw new TypeError("Usage: check-project-transitions.mjs <base-sha>");
+    if (process.argv.length < 3 || process.argv.length > 4) {
+      throw new TypeError(
+        "Usage: check-project-transitions.mjs <base-sha> [current-sha]",
+      );
     }
-    const result = await checkProjectTransitions(process.argv[2]);
+    const result = await checkProjectTransitions(
+      process.argv[2],
+      process.argv[3],
+    );
     process.stdout.write(
       `[Slop] validated ${result.previous} existing project policy transitions across ${result.current} current projects\n`,
     );

--- a/scripts/deployment-contract.test.mjs
+++ b/scripts/deployment-contract.test.mjs
@@ -14,6 +14,10 @@ const workflow = readFileSync(
   join(repositoryRoot, ".github", "workflows", "deploy.yml"),
   "utf8",
 );
+const transitionWorkflow = readFileSync(
+  join(repositoryRoot, ".github", "workflows", "project-transitions.yml"),
+  "utf8",
+);
 const packageManifest = JSON.parse(
   readFileSync(join(packageRoot, "package.json"), "utf8"),
 );
@@ -234,19 +238,48 @@ describe("slop.cash deployment contract", () => {
     expect(deployJob).toContain("name: eliza-army-production");
   });
 
-  it("validates immutable project policy transitions before the registry", () => {
+  it("preserves an immutable-sha transition gate on trusted develop pushes", () => {
     const transitionGate = qualityJob.indexOf(
-      'node scripts/check-project-transitions.mjs "$PROJECT_POLICY_BASE_SHA"',
+      'node scripts/check-project-transitions.mjs "$PROJECT_POLICY_BASE_SHA" "$PROJECT_POLICY_HEAD_SHA"',
     );
     const registryGate = qualityJob.indexOf("bun run projects:check");
     expect(qualityJob).toContain(
-      `PROJECT_POLICY_BASE_SHA: ${"$"}{{ github.event.pull_request.base.sha || github.event.before }}`,
+      `PROJECT_POLICY_BASE_SHA: ${"$"}{{ github.event.before }}`,
     );
     expect(qualityJob).toContain(
-      `if [ "${"$"}{{ github.event_name }}" = "pull_request" ] || [ "${"$"}{{ github.event_name }}" = "push" ]; then`,
+      `PROJECT_POLICY_HEAD_SHA: ${"$"}{{ github.sha }}`,
+    );
+    expect(qualityJob).toContain(
+      `if [ "${"$"}{{ github.event_name }}" = "push" ]; then`,
     );
     expect(transitionGate).toBeGreaterThan(-1);
     expect(registryGate).toBeGreaterThan(transitionGate);
+  });
+
+  it("executes the PR transition gate only from the immutable trusted base", () => {
+    expect(transitionWorkflow).toContain("pull_request_target:");
+    expect(transitionWorkflow).toContain("permissions:\n  contents: read");
+    expect(transitionWorkflow).toContain(
+      `ref: ${"$"}{{ github.event.pull_request.base.sha }}`,
+    );
+    expect(transitionWorkflow).toContain("persist-credentials: false");
+    expect(transitionWorkflow).toContain(
+      'test "$(git rev-parse HEAD)" = "$PROJECT_POLICY_BASE_SHA"',
+    );
+    expect(transitionWorkflow).toContain(
+      '"+refs/pull/$PROJECT_POLICY_PR_NUMBER/head:refs/remotes/origin/slop-transition-head"',
+    );
+    expect(transitionWorkflow).toContain(
+      'test "$fetched_head" = "$PROJECT_POLICY_HEAD_SHA"',
+    );
+    expect(transitionWorkflow).toContain(
+      '"$PROJECT_POLICY_BASE_SHA" "$PROJECT_POLICY_HEAD_SHA"',
+    );
+    expect(transitionWorkflow).not.toContain("secrets.");
+    expect(transitionWorkflow).not.toContain("bun install");
+    expect(transitionWorkflow).not.toContain(
+      `ref: ${"$"}{{ github.event.pull_request.head.sha }}`,
+    );
   });
 
   it("has no candidate-controlled production release path", () => {

--- a/src/lib/project-policy.mjs
+++ b/src/lib/project-policy.mjs
@@ -5,6 +5,74 @@
 
 import { assertProjectDefinition } from "./project-schema.mjs";
 
+function assertFundingRouteTransition(previousRoutes, nextRoutes) {
+  if (
+    nextRoutes.length < previousRoutes.length ||
+    nextRoutes.length > previousRoutes.length + 1
+  ) {
+    throw new TypeError(
+      "funding history must remain an append-only prefix with at most one successor",
+    );
+  }
+  let closedIndex = null;
+  for (let index = 0; index < previousRoutes.length; index += 1) {
+    const previous = previousRoutes[index];
+    const next = nextRoutes[index];
+    if (
+      previous.network !== next.network ||
+      previous.asset !== next.asset ||
+      previous.address !== next.address ||
+      previous.effectiveAt !== next.effectiveAt
+    ) {
+      throw new TypeError(
+        "historical funding routes must remain an exact append-only prefix",
+      );
+    }
+    if (previous.replacedAt !== null) {
+      if (previous.replacedAt !== next.replacedAt) {
+        throw new TypeError("closed funding routes are immutable");
+      }
+    } else if (next.replacedAt !== null) {
+      if (closedIndex !== null) {
+        throw new TypeError("a transition may close at most one funding route");
+      }
+      closedIndex = index;
+    }
+  }
+  const successor = nextRoutes[previousRoutes.length];
+  if (successor === undefined) {
+    if (closedIndex !== null) {
+      throw new TypeError(
+        "an active funding route may close only with a successor",
+      );
+    }
+    return;
+  }
+  if (successor.replacedAt !== null) {
+    throw new TypeError("an appended funding successor must be active");
+  }
+  const activePredecessor = previousRoutes.findIndex(
+    (route) =>
+      route.network === successor.network &&
+      route.asset === successor.asset &&
+      route.replacedAt === null,
+  );
+  if (activePredecessor === -1) {
+    if (closedIndex !== null) {
+      throw new TypeError("a funding successor must rotate the closed route");
+    }
+    return;
+  }
+  if (
+    closedIndex !== activePredecessor ||
+    nextRoutes[activePredecessor].replacedAt !== successor.effectiveAt
+  ) {
+    throw new TypeError(
+      "a funding rotation must close its active predecessor exactly when its successor starts",
+    );
+  }
+}
+
 function canonical(value) {
   if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`;
   if (value && typeof value === "object") {
@@ -25,6 +93,10 @@ export function assertProjectPolicyTransition(previousValue, nextValue) {
   const previous = assertProjectDefinition(previousValue);
   const next = assertProjectDefinition(nextValue);
   if (previous.id !== next.id) throw new TypeError("project id cannot change");
+  assertFundingRouteTransition(
+    previous.funding.addresses,
+    next.funding.addresses,
+  );
   if (
     previous.authority.repositoryId !== next.authority.repositoryId ||
     previous.authority.repositoryNodeId !== next.authority.repositoryNodeId ||

--- a/src/lib/project-policy.test.ts
+++ b/src/lib/project-policy.test.ts
@@ -6,6 +6,38 @@ import {
 } from "./project-policy.mjs";
 
 describe("project policy transitions", () => {
+  interface MutableFundingRoute {
+    network: "solana";
+    asset: "USDC";
+    address: string;
+    effectiveAt: string;
+    replacedAt: string | null;
+  }
+
+  function fundingFixture(routes: MutableFundingRoute[]) {
+    const fixture = structuredClone(eliza) as unknown as {
+      funding: { addresses: MutableFundingRoute[] };
+    };
+    fixture.funding.addresses = routes;
+    return fixture;
+  }
+
+  const firstRoute = (): MutableFundingRoute => ({
+    network: "solana",
+    asset: "USDC",
+    address: "11111111111111111111111111111111",
+    effectiveAt: "2026-08-17T00:00:00.000Z",
+    replacedAt: null,
+  });
+
+  const successorRoute = (): MutableFundingRoute => ({
+    network: "solana",
+    asset: "USDC",
+    address: "Vote111111111111111111111111111111111111111",
+    effectiveAt: "2026-08-18T00:00:00.000Z",
+    replacedAt: null,
+  });
+
   interface MutableReceiptBinding {
     policyRevision: string;
     licenseSha256: string;
@@ -109,6 +141,89 @@ describe("project policy transitions", () => {
     expect(() => assertPaymentDoesNotMutateTerms(eliza, rewritten)).toThrow(
       /cannot mutate/u,
     );
+  });
+
+  it("allows only a bounded append-only funding rotation", () => {
+    const previous = fundingFixture([firstRoute()]);
+    const rotated = structuredClone(previous);
+    rotated.funding.addresses[0].replacedAt = successorRoute().effectiveAt;
+    rotated.funding.addresses.push(successorRoute());
+    expect(assertProjectPolicyTransition(previous, rotated)).toEqual(rotated);
+
+    const initial = fundingFixture([]);
+    const first = fundingFixture([firstRoute()]);
+    expect(assertProjectPolicyTransition(initial, first)).toEqual(first);
+
+    const closeOnly = structuredClone(previous);
+    closeOnly.funding.addresses[0].replacedAt = successorRoute().effectiveAt;
+    expect(() => assertProjectPolicyTransition(previous, closeOnly)).toThrow(
+      /only with a successor/u,
+    );
+
+    const wrongCutover = structuredClone(rotated);
+    wrongCutover.funding.addresses[0].replacedAt = "2026-08-17T23:59:59.000Z";
+    expect(() => assertProjectPolicyTransition(previous, wrongCutover)).toThrow(
+      /exactly when/u,
+    );
+  });
+
+  it("rejects funding history alteration, deletion, reorder, and backfill", () => {
+    const first = firstRoute();
+    first.replacedAt = successorRoute().effectiveAt;
+    const previous = fundingFixture([first, successorRoute()]);
+
+    const altered = structuredClone(previous);
+    altered.funding.addresses[0].address =
+      "Stake11111111111111111111111111111111111111";
+    expect(() => assertProjectPolicyTransition(previous, altered)).toThrow(
+      /append-only prefix/u,
+    );
+
+    const closedOnlyRoute = firstRoute();
+    closedOnlyRoute.replacedAt = successorRoute().effectiveAt;
+    const closedOnly = fundingFixture([closedOnlyRoute]);
+    const reopened = structuredClone(closedOnly);
+    reopened.funding.addresses[0].replacedAt = null;
+    expect(() => assertProjectPolicyTransition(closedOnly, reopened)).toThrow(
+      /closed funding routes are immutable/u,
+    );
+
+    const movedClosure = structuredClone(previous);
+    movedClosure.funding.addresses[0].replacedAt = "2026-08-17T23:59:59.000Z";
+    expect(() => assertProjectPolicyTransition(previous, movedClosure)).toThrow(
+      /closed funding routes are immutable/u,
+    );
+
+    const deleted = fundingFixture([successorRoute()]);
+    expect(() => assertProjectPolicyTransition(previous, deleted)).toThrow(
+      /append-only prefix/u,
+    );
+
+    const reordered = fundingFixture([successorRoute(), first]);
+    expect(() => assertProjectPolicyTransition(previous, reordered)).toThrow(
+      /append-only prefix/u,
+    );
+
+    const backfilledFirst = firstRoute();
+    backfilledFirst.replacedAt = successorRoute().effectiveAt;
+    const multiAppend = fundingFixture([
+      backfilledFirst,
+      {
+        ...successorRoute(),
+      },
+    ]);
+    expect(() =>
+      assertProjectPolicyTransition(fundingFixture([]), multiAppend),
+    ).toThrow(/at most one successor/u);
+
+    const preclosed = fundingFixture([]);
+    preclosed.funding.addresses.push({
+      ...firstRoute(),
+      replacedAt: "2026-08-18T00:00:00.000Z",
+    });
+    expect(() =>
+      assertProjectPolicyTransition(fundingFixture([]), preclosed),
+    ).toThrow(/successor must be active/u);
   });
 
   it("preserves receipt activation and every historical binding append-only", () => {


### PR DESCRIPTION
## Summary

- run project-policy transition validation from an immutable, base-controlled `pull_request_target` workflow with read-only contents access, no secrets or dependency install, and the PR head fetched only as bounded Git object data
- compare immutable base/head manifest trees without checking out or executing PR-controlled code, while preserving a post-merge develop push gate
- enforce append-only funding route history: immutable prior fields, at most one successor, and an exact non-overlapping close/start rotation
- add workflow-contract and adversarial funding-history tests

Addresses #115 and #114. This is a narrow follow-up to the post-merge audit of #136; it does not close either product issue.

## Security model

The trusted job checks out `github.event.pull_request.base.sha` and verifies that exact checkout before fetching `refs/pull/<number>/head`. It verifies the fetched object equals `github.event.pull_request.head.sha`, then executes the checker and schema modules from the trusted base only. It never checks out or invokes the PR head, installs dependencies, accesses secrets, or grants write permission.

Schema/checker evolution therefore fails closed: a PR cannot weaken the checker that evaluates itself. The develop push workflow separately compares immutable `before` and current SHAs.

## Validation

- `bun install --frozen-lockfile --ignore-scripts`
- `bun run projects:check`
- `bun run evaluations:check`
- `bun run cycles:check`
- `bun run typecheck`
- `bun run lint:check`
- `bun run format:check`
- focused transition/workflow suite: 17/17 passing
- isolated `scripts/prepare-site.test.ts`: 9/9 passing
- `bun run build`
- exact Git-object transition check from `f6ad561395edbb2c8376c0c3f468249d5c80dee2` to `00f3d2a9970d6906086cc6287f9ecd1f76f94d26`: 4/4 projects validated

A parallel full Vitest run was attempted twice. The first reached 435 passing tests with only the 10-second `prepare-site` setup timeout; the second, under host load, reached 430 passing and timed out in the same setup plus five existing 5/15-second UI/installer tests. The affected prepare-site suite passes 9/9 in isolation; the targeted UI/installer retry remained timing-sensitive under the same host load. No product assertion failure remains in the changed transition tests.

## Required ruleset follow-up (not changed here)

Ruleset `20220584` is active with no bypass actors, but currently has no required status checks. After this workflow exists on `develop`, require the status context **Trusted project transition gate** with `strict_required_status_checks_policy: true` (or the equivalent current-branch requirement), retaining zero bypass actors. This closes the base-advance gap; `pull_request_target` alone does not rerun merely because `develop` advances.
