### PR TITLE
fix: serve nested project funding routes

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -2,6 +2,8 @@
 /deck / 200
 /deck/* / 200
 /projects/new / 200
+/projects/:project/funding/ / 200
+/projects/:project/funding / 200
 /projects/:project/manage / 200
 /projects/:project / 200
 /contributors/:login / 200

--- a/scripts/prepare-site.test.ts
+++ b/scripts/prepare-site.test.ts
@@ -461,6 +461,8 @@ describe("contribution skill package", () => {
       "/projects/:project/downloads/:archive\n  Content-Type: application/octet-stream",
     );
     expect(redirects).toContain("/skill.md /projects/eliza/skill.md 301");
+    expect(redirects).toContain("/projects/:project/funding/ / 200");
+    expect(redirects).toContain("/projects/:project/funding / 200");
     expect(redirects).toContain("/projects/:project / 200");
     expect(redirects).toContain("/cycles/:project/:cycle / 200");
     expect(readFileSync(join(publicRoot, "404.html"), "utf8")).toContain(


### PR DESCRIPTION
## Outcome

Makes both direct forms of the nested project funding route load through Cloudflare Pages instead of the custom 404 page:

- `/projects/:project/funding`
- `/projects/:project/funding/`

The SPA route already existed. This adds the exact 200 proxy rules to the checked-in Pages redirect contract and pins both forms in the packaging test.

Fixes #137.

## Evidence

Exact head: `619b1f2c41970968229d0e81fec45ad39d1bd019` on base `f6ad561395edbb2c8376c0c3f468249d5c80dee2`.

### Before

Trusted production source `de958cf89dc8f7c1a0f9124ef427a610f5e200ec`:

- both direct funding URL forms returned HTTP 404
- exact deployed-source Playwright: 36/40 passed
- the same primary-route failure occurred in wide desktop, desktop, tablet, and narrow mobile
- the GitHub-native agent handoff itself passed in all four viewports

### After

Built the current source and served `dist` with Wrangler 4.123.0 Pages local development:

- direct funding URL: HTTP 200
- trailing-slash funding URL: HTTP 200
- existing project and manage routes: HTTP 200
- exact live leaderboard bytes were supplied to the ignored local `dist` fixture, SHA-256 `c31b3a98d0db0f6f49f55c1820bce0cea7f7cf81a055c4060e7e5c4833985324`
- `SLOP_BASE_URL=http://127.0.0.1:43137 bunx playwright test tests/e2e/site.spec.ts --reporter=line` => **40/40 passed in 3.9m**
- all four viewport groups passed project handoff, artifact integrity, error states, funding route, accessibility, overflow, and first-party request diagnostics

### Repository gates

- `bun install --frozen-lockfile` — pass
- `bun test scripts/prepare-site.test.ts` — 9/9, 178 expectations
- `bun run test` — 46 files / 441 Vitest tests plus 72 skill tests, all pass
- `bun run typecheck` — pass
- `bun run lint:check` — 176 files pass
- `bun run format:check` — 175 files pass
- `bun run build` — pass, 175-file deployment manifest
- `git diff --check` — pass

## Safety and review artifacts

- Routing-only; no funding policy, wallet, signing, settlement, fee, reward, or payout change.
- Payments remain disabled.
- No direct production mutation; deployment remains exclusively through the protected trusted `develop` workflow.
- Screenshots/video: N/A — no visual or layout change. The exact desktop/tablet/mobile browser matrix proves the identical rendered UI and accessibility path.
- Backend/model/trajectory evidence: N/A — static Pages route contract only.
