### PR TITLE
test: harden Pages funding route regressions

### DIFF
--- a/scripts/deployment-contract.test.mjs
+++ b/scripts/deployment-contract.test.mjs
@@ -63,9 +63,9 @@ describe("slop.cash deployment contract", () => {
     const redirects = pagesRedirects.trim().split("\n");
     expect(redirects).toContain("/projects/:project/funding/ / 200");
     expect(redirects).toContain("/projects/:project/funding / 200");
-    expect(
-      redirects.indexOf("/projects/:project/funding/ / 200"),
-    ).toBeLessThan(redirects.indexOf("/projects/:project / 200"));
+    expect(redirects.indexOf("/projects/:project/funding/ / 200")).toBeLessThan(
+      redirects.indexOf("/projects/:project / 200"),
+    );
     expect(redirects.indexOf("/projects/:project/funding / 200")).toBeLessThan(
       redirects.indexOf("/projects/:project / 200"),
     );

--- a/scripts/deployment-contract.test.mjs
+++ b/scripts/deployment-contract.test.mjs
@@ -37,6 +37,10 @@ const pagesHeaders = readFileSync(
   join(packageRoot, "public", "_headers"),
   "utf8",
 );
+const pagesRedirects = readFileSync(
+  join(packageRoot, "public", "_redirects"),
+  "utf8",
+);
 const pagesRoutes = JSON.parse(
   readFileSync(join(packageRoot, "public", "_routes.json"), "utf8"),
 );
@@ -55,6 +59,14 @@ const qualityJob = workflow.slice(
 const deployJob = workflow.slice(workflow.indexOf("\n  deploy:"));
 
 describe("slop.cash deployment contract", () => {
+  it("rewrites the nested project funding route through the Pages SPA", () => {
+    const redirects = pagesRedirects.trim().split("\n");
+    expect(redirects).toContain("/projects/:project/funding / 200");
+    expect(redirects.indexOf("/projects/:project/funding / 200")).toBeLessThan(
+      redirects.indexOf("/projects/:project / 200"),
+    );
+  });
+
   it("deploys only the exact tested SHA through wrangler.toml", () => {
     expect(qualityJob).toContain(`ref: ${"$"}{{ github.sha }}`);
     expect(qualityJob).toContain("does not match the event SHA $GITHUB_SHA");

--- a/scripts/deployment-contract.test.mjs
+++ b/scripts/deployment-contract.test.mjs
@@ -61,7 +61,11 @@ const deployJob = workflow.slice(workflow.indexOf("\n  deploy:"));
 describe("slop.cash deployment contract", () => {
   it("rewrites the nested project funding route through the Pages SPA", () => {
     const redirects = pagesRedirects.trim().split("\n");
+    expect(redirects).toContain("/projects/:project/funding/ / 200");
     expect(redirects).toContain("/projects/:project/funding / 200");
+    expect(
+      redirects.indexOf("/projects/:project/funding/ / 200"),
+    ).toBeLessThan(redirects.indexOf("/projects/:project / 200"));
     expect(redirects.indexOf("/projects/:project/funding / 200")).toBeLessThan(
       redirects.indexOf("/projects/:project / 200"),
     );

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -600,6 +600,11 @@ test("serves byte-consistent install and read-only artifacts for every project",
   expect(legacySkillResponse.headers().location).toBe(
     "/projects/eliza/skill.md",
   );
+  const fundingRouteResponse = await request.get("/projects/eliza/funding", {
+    maxRedirects: 0,
+  });
+  expect(fundingRouteResponse.status()).toBe(200);
+  expect(await fundingRouteResponse.text()).toContain('<div id="root"></div>');
 
   const [
     bootstrapResponse,

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -847,6 +847,11 @@ test("keeps primary routes accessible and inside the viewport", async ({
         }),
       ).toBeVisible();
     }
+    if (path === "/projects/eliza/funding") {
+      await expect(
+        page.getByRole("heading", { exact: true, name: "Project funding" }),
+      ).toBeVisible();
+    }
     const results = await new AxeBuilder({ page })
       .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
       .analyze();

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -605,6 +605,14 @@ test("serves byte-consistent install and read-only artifacts for every project",
   });
   expect(fundingRouteResponse.status()).toBe(200);
   expect(await fundingRouteResponse.text()).toContain('<div id="root"></div>');
+  const trailingFundingRouteResponse = await request.get(
+    "/projects/eliza/funding/",
+    { maxRedirects: 0 },
+  );
+  expect(trailingFundingRouteResponse.status()).toBe(200);
+  expect(await trailingFundingRouteResponse.text()).toContain(
+    '<div id="root"></div>',
+  );
 
   const [
     bootstrapResponse,
@@ -835,6 +843,7 @@ test("keeps primary routes accessible and inside the viewport", async ({
     "/",
     ...PROJECTS.map((project) => `/projects/${project.id}`),
     "/projects/eliza/funding",
+    "/projects/eliza/funding/",
     "/projects/eliza/manage",
     "/projects/new",
   ]) {
@@ -847,7 +856,7 @@ test("keeps primary routes accessible and inside the viewport", async ({
         }),
       ).toBeVisible();
     }
-    if (path === "/projects/eliza/funding") {
+    if (path.startsWith("/projects/eliza/funding")) {
       await expect(
         page.getByRole("heading", { exact: true, name: "Project funding" }),
       ).toBeVisible();


### PR DESCRIPTION
## Outcome

Test-only follow-up to #137 and merged functional fix #139. This PR adds no redirect or product change.

- Locks both `/projects/:project/funding` and `/projects/:project/funding/` into the lightweight Pages deployment contract, including precedence before the generic project rewrite.
- Requests both direct URL forms through the Wrangler Pages emulator and requires HTTP 200 plus the SPA root artifact.
- Drives both direct URL forms through the wide-desktop, desktop, tablet, and narrow-mobile browser route matrix and requires the real `Project funding` heading, WCAG checks, and no horizontal overflow.

## Exact scope

- Base: `74e12710f203f7d6e2c8c481d384682a7f3589f5` (merged #139)
- Head: `ac20f098dd17493bf23f5d29efc2f84d21058e24`
- Diff: `scripts/deployment-contract.test.mjs` and `tests/e2e/site.spec.ts` only
- `public/_redirects`: unchanged from merged #139
- Funding policy, wallets, signing, settlement, rewards, protected environments, and deployment authority: unchanged
- Production deployment: not performed

## Local validation

- `bunx vitest run scripts/deployment-contract.test.mjs`: 10/10 passed
- `bun run typecheck`: passed
- `bun run lint:check`: 176 files passed
- `bun run format:check`: 175 files passed
- `bun run build`: passed; 175 public files in the deployment manifest
- `git diff --check`: passed
- `AGENTS.md` and `CLAUDE.md`: byte-identical

Exact-head hosted quality, trusted transition, and browser checks passed: https:\/\/github.com\/elizaOS\/slopdotcash\/actions\/runs\/31965564186. Deploy was correctly skipped for this PR.

## Evidence applicability

- Screenshots/video: N/A — test-only change with no rendered UI delta.
- Production URL verification: N/A — merged #139 owns the route fix and trusted deployment lifecycle; this PR does not deploy.
- Private trace/model receipt: N/A — repository test hardening only; no contribution trace was created or uploaded.

AI provider/model: OpenAI / GPT-5.6
Client: Codex