### PR TITLE
feat: read-only Base, Ethereum, and Bitcoin funding verifiers

### DIFF
--- a/funding/README.md
+++ b/funding/README.md
@@ -57,6 +57,20 @@ bun run funding:verify-solana -- --signature <signature> --recipient <project-ow
 It emits candidate finality and verifier fields for human review; it never
 signs, broadcasts, handles a key, or writes a funding record.
 
+For Base and Ethereum mainnet USDC, the read-only verifier first checks the
+RPC's `eth_chainId`, reads the `finalized` head, and accepts only a successful
+receipt for the exact transaction hash whose canonical USDC `Transfer` logs
+credit the project owner the exact amount with balanced deltas, no undeclared
+positive credit, no mint or burn, and at least the network confirmation policy
+(12 on Base, 64 on Ethereum) behind the finalized head:
+
+```text
+bun run funding:verify-evm -- --network <base|ethereum> --transaction <0x-hash> --recipient <project-owner-address> --amount-minor <integer>
+```
+
+It has the same boundaries: read-only evidence for human review, never a key,
+signature, broadcast, or written funding record.
+
 Project payout plans remain unsigned and are executed outside Slop by the
 declared project settler. A transaction signature is only reported evidence;
 the cycle remains unpaid until deterministic finalized balance deltas reconcile

--- a/funding/README.md
+++ b/funding/README.md
@@ -74,6 +74,20 @@ It has the same boundaries: read-only evidence for human review, never a key,
 signature, broadcast, or written funding record. The production CLI has no RPC
 override; deterministic tests may inject only the fetch implementation.
 
+For Bitcoin mainnet BTC, the read-only verifier accepts only a confirmed
+transaction whose block hash still sits in the current best chain at its
+height, with at least 6 confirmations behind the tip, a coherent fee that
+exactly reconciles input and output sums, no coinbase input, no input spending
+the recipient's own coins, no dust-level credited output, and non-dust
+recipient outputs summing to the exact amount:
+
+```text
+bun run funding:verify-bitcoin -- --transaction <txid> --recipient <project-owner-address> --amount-minor <satoshis>
+```
+
+Same boundaries again: read-only evidence for human review, never a key,
+signature, broadcast, or written funding record.
+
 Project payout plans remain unsigned and are executed outside Slop by the
 declared project settler. A transaction signature is only reported evidence;
 the cycle remains unpaid until deterministic finalized balance deltas reconcile

--- a/funding/README.md
+++ b/funding/README.md
@@ -57,19 +57,22 @@ bun run funding:verify-solana -- --signature <signature> --recipient <project-ow
 It emits candidate finality and verifier fields for human review; it never
 signs, broadcasts, handles a key, or writes a funding record.
 
-For Base and Ethereum mainnet USDC, the read-only verifier first checks the
-RPC's `eth_chainId`, reads the `finalized` head, and accepts only a successful
-receipt for the exact transaction hash whose canonical USDC `Transfer` logs
-credit the project owner the exact amount with balanced deltas, no undeclared
-positive credit, no mint or burn, and at least the network confirmation policy
-(12 on Base, 64 on Ethereum) behind the finalized head:
+For Base and Ethereum mainnet USDC, the read-only verifier queries three fixed,
+independent public RPC authorities for `eth_chainId`, the `finalized` head, and
+the canonical block at the receipt height. At least two must agree on the exact
+transaction and block identity. It then accepts only a successful receipt whose
+block-bound canonical USDC `Transfer` logs credit the project owner the exact
+amount with balanced deltas, no undeclared positive credit, no mint or burn,
+and at least the network confirmation policy (12 on Base, 64 on Ethereum)
+behind each agreeing authority's finalized head:
 
 ```text
 bun run funding:verify-evm -- --network <base|ethereum> --transaction <0x-hash> --recipient <project-owner-address> --amount-minor <integer>
 ```
 
 It has the same boundaries: read-only evidence for human review, never a key,
-signature, broadcast, or written funding record.
+signature, broadcast, or written funding record. The production CLI has no RPC
+override; deterministic tests may inject only the fetch implementation.
 
 Project payout plans remain unsigned and are executed outside Slop by the
 declared project settler. A transaction signature is only reported evidence;

--- a/funding/README.md
+++ b/funding/README.md
@@ -74,9 +74,12 @@ It has the same boundaries: read-only evidence for human review, never a key,
 signature, broadcast, or written funding record. The production CLI has no RPC
 override; deterministic tests may inject only the fetch implementation.
 
-For Bitcoin mainnet BTC, the read-only verifier accepts only a confirmed
-transaction whose block hash still sits in the current best chain at its
-height, with at least 6 confirmations behind the tip, a coherent fee that
+For Bitcoin mainnet BTC, the read-only verifier queries three fixed,
+independent public Esplora authorities for the transaction, the chain tip, and
+the canonical block hash at the transaction height. At least two must agree on
+the exact transaction and block identity. It then accepts only a confirmed
+transaction whose block hash still sits in each agreeing authority's best
+chain, with at least 6 confirmations behind each tip, a coherent fee that
 exactly reconciles input and output sums, no coinbase input, no input spending
 the recipient's own coins, no dust-level credited output, and non-dust
 recipient outputs summing to the exact amount:
@@ -86,7 +89,8 @@ bun run funding:verify-bitcoin -- --transaction <txid> --recipient <project-owne
 ```
 
 Same boundaries again: read-only evidence for human review, never a key,
-signature, broadcast, or written funding record.
+signature, broadcast, or written funding record. The production CLI has no API
+override; deterministic tests may inject only the fetch implementation.
 
 Project payout plans remain unsigned and are executed outside Slop by the
 declared project settler. A transaction signature is only reported evidence;

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "funding:check": "bun scripts/sync-funding-index.ts --check",
     "funding:verify-solana": "bun scripts/verify-funding-solana.ts",
     "funding:verify-evm": "bun scripts/verify-funding-evm.ts",
+    "funding:verify-bitcoin": "bun scripts/verify-funding-bitcoin.ts",
     "cycles:sync": "bun scripts/sync-cycle-index.ts",
     "cycles:check": "bun scripts/sync-cycle-index.ts --check",
     "cycles:verify": "bun scripts/sync-cycle-index.ts --check --online",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "funding:sync": "bun scripts/sync-funding-index.ts",
     "funding:check": "bun scripts/sync-funding-index.ts --check",
     "funding:verify-solana": "bun scripts/verify-funding-solana.ts",
+    "funding:verify-evm": "bun scripts/verify-funding-evm.ts",
     "cycles:sync": "bun scripts/sync-cycle-index.ts",
     "cycles:check": "bun scripts/sync-cycle-index.ts --check",
     "cycles:verify": "bun scripts/sync-cycle-index.ts --check --online",

--- a/scripts/verify-funding-bitcoin.test.ts
+++ b/scripts/verify-funding-bitcoin.test.ts
@@ -1,63 +1,81 @@
-/** Proves the read-only Bitcoin verifier pins best-chain data and fails closed. */
+/** Proves the read-only Bitcoin verifier pins a bounded, canonical API quorum. */
 
 import { describe, expect, it } from "vitest";
-import { verifyFundingBitcoin } from "./verify-funding-bitcoin";
+import {
+  BITCOIN_FUNDING_API_AUTHORITIES,
+  parseBitcoinFundingArguments,
+  verifyFundingBitcoin,
+} from "./verify-funding-bitcoin";
 
 const RECIPIENT = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
 const SENDER = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4";
 const TXID = "a".repeat(64);
 const BLOCK_HASH = "f".repeat(64);
 
-function apiResponses(overrides: Record<string, string> = {}) {
-  return {
-    [`/tx/${TXID}`]: JSON.stringify({
-      txid: TXID,
-      status: {
-        confirmed: true,
-        block_height: 800_000,
-        block_hash: BLOCK_HASH,
+function transactionBody(blockHash = BLOCK_HASH) {
+  return JSON.stringify({
+    txid: TXID,
+    status: { confirmed: true, block_height: 800_000, block_hash: blockHash },
+    vin: [
+      {
+        is_coinbase: false,
+        prevout: { scriptpubkey_address: SENDER, value: 200_000 },
       },
-      vin: [
-        {
-          is_coinbase: false,
-          prevout: { scriptpubkey_address: SENDER, value: 200_000 },
-        },
-      ],
-      vout: [
-        { scriptpubkey_address: RECIPIENT, value: 150_000 },
-        { scriptpubkey_address: SENDER, value: 49_000 },
-      ],
-      fee: 1_000,
-    }),
+    ],
+    vout: [
+      { scriptpubkey_address: RECIPIENT, value: 150_000 },
+      { scriptpubkey_address: SENDER, value: 49_000 },
+    ],
+    fee: 1_000,
+  });
+}
+
+function authorityResponses(overrides: Record<string, string> = {}) {
+  return {
+    [`/tx/${TXID}`]: transactionBody(),
     "/blocks/tip/height": "800010",
     "/block-height/800000": BLOCK_HASH,
     ...overrides,
   } as Record<string, string>;
 }
 
-function fetchFor(responses: Record<string, string>, paths: string[] = []) {
+function fetchFor(
+  perHost: Record<string, Record<string, string>>,
+  requests: string[] = [],
+) {
   return async (url: URL) => {
     const path = url.pathname.replace(/^\/api/u, "");
-    paths.push(path);
-    if (!(path in responses)) throw new Error(`unexpected API path ${path}`);
+    requests.push(`${url.host}${path}`);
+    const responses = perHost[url.host];
+    if (!responses || !(path in responses)) {
+      throw new Error(`unexpected API request ${url.host}${path}`);
+    }
     return new Response(responses[path]);
   };
 }
 
+const HOSTS = BITCOIN_FUNDING_API_AUTHORITIES.map(
+  (authority) => new URL(authority).host,
+);
+
+function allHosts(responses: Record<string, string>) {
+  return Object.fromEntries(HOSTS.map((host) => [host, responses]));
+}
+
 describe("Bitcoin funding verifier", () => {
-  it("checks tip and best-chain hash, then emits reviewed record fields", async () => {
-    const paths: string[] = [];
+  it("reaches quorum across fixed authorities and emits reviewed fields", async () => {
+    const requests: string[] = [];
     const result = await verifyFundingBitcoin({
       transactionId: TXID,
       recipient: RECIPIENT,
       amountMinor: "150000",
-      fetchImpl: fetchFor(apiResponses(), paths),
+      fetchImpl: fetchFor(allHosts(authorityResponses()), requests),
     });
-    expect(paths).toEqual([
-      `/tx/${TXID}`,
-      "/blocks/tip/height",
-      "/block-height/800000",
-    ]);
+    for (const host of HOSTS) {
+      expect(requests).toContain(`${host}/tx/${TXID}`);
+      expect(requests).toContain(`${host}/blocks/tip/height`);
+      expect(requests).toContain(`${host}/block-height/800000`);
+    }
     expect(result).toMatchObject({
       state: "verified-on-chain",
       finality: { kind: "confirmations", confirmations: 11 },
@@ -72,22 +90,50 @@ describe("Bitcoin funding verifier", () => {
         blockHash: BLOCK_HASH,
       },
     });
+    expect(result.chainEvidence.authorities).toHaveLength(HOSTS.length);
   });
 
-  it("rejects a transaction whose block left the best chain", async () => {
+  it("uses the minimum agreeing confirmations and survives one divergence", async () => {
+    const result = await verifyFundingBitcoin({
+      transactionId: TXID,
+      recipient: RECIPIENT,
+      amountMinor: "150000",
+      fetchImpl: fetchFor({
+        [HOSTS[0]]: authorityResponses({ "/blocks/tip/height": "800020" }),
+        [HOSTS[1]]: authorityResponses(),
+        [HOSTS[2]]: authorityResponses({
+          "/block-height/800000": "e".repeat(64),
+        }),
+      }),
+    });
+    expect(result.finality).toEqual({
+      kind: "confirmations",
+      confirmations: 11,
+    });
+    expect(result.chainEvidence.authorities).toHaveLength(2);
+  });
+
+  it("fails closed when authorities cannot reach canonical quorum", async () => {
     await expect(
       verifyFundingBitcoin({
         transactionId: TXID,
         recipient: RECIPIENT,
         amountMinor: "150000",
-        fetchImpl: fetchFor(
-          apiResponses({ "/block-height/800000": "e".repeat(64) }),
-        ),
+        fetchImpl: fetchFor({
+          [HOSTS[0]]: authorityResponses(),
+          [HOSTS[1]]: authorityResponses({
+            "/block-height/800000": "e".repeat(64),
+          }),
+          [HOSTS[2]]: authorityResponses({
+            [`/tx/${TXID}`]: transactionBody("d".repeat(64)),
+            "/block-height/800000": "d".repeat(64),
+          }),
+        }),
       }),
-    ).rejects.toThrow(/best chain/u);
+    ).rejects.toThrow(/quorum/u);
   });
 
-  it("rejects invalid inputs and credentialed APIs before querying", async () => {
+  it("rejects invalid inputs before querying any authority", async () => {
     let queried = false;
     const spy = async () => {
       queried = true;
@@ -113,11 +159,38 @@ describe("Bitcoin funding verifier", () => {
       verifyFundingBitcoin({
         transactionId: TXID,
         recipient: RECIPIENT,
-        amountMinor: "150000",
-        apiUrl: "https://user:pass@mempool.example.com/api",
+        amountMinor: "1".repeat(41),
         fetchImpl: spy,
       }),
-    ).rejects.toThrow(/credential-free/u);
+    ).rejects.toThrow(/invalid/u);
     expect(queried).toBe(false);
+  });
+
+  it("rejects malformed, repeated, or unknown CLI arguments", () => {
+    expect(
+      parseBitcoinFundingArguments([
+        "--transaction",
+        TXID,
+        "--recipient",
+        RECIPIENT,
+        "--amount-minor",
+        "150000",
+      ]),
+    ).toEqual({
+      transactionId: TXID,
+      recipient: RECIPIENT,
+      amountMinor: "150000",
+    });
+    expect(() =>
+      parseBitcoinFundingArguments(["--api-url", "https://example.com"]),
+    ).toThrow(/Usage/u);
+    expect(() =>
+      parseBitcoinFundingArguments([
+        "--transaction",
+        TXID,
+        "--transaction",
+        TXID,
+      ]),
+    ).toThrow(/Usage/u);
   });
 });

--- a/scripts/verify-funding-bitcoin.test.ts
+++ b/scripts/verify-funding-bitcoin.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it } from "vitest";
 import {
   BITCOIN_FUNDING_API_AUTHORITIES,
+  MAX_BITCOIN_API_BYTES,
   parseBitcoinFundingArguments,
   verifyFundingBitcoin,
 } from "./verify-funding-bitcoin";
@@ -42,10 +43,12 @@ function authorityResponses(overrides: Record<string, string> = {}) {
 function fetchFor(
   perHost: Record<string, Record<string, string>>,
   requests: string[] = [],
+  redirects: Array<RequestRedirect | undefined> = [],
 ) {
-  return async (url: URL) => {
+  return async (url: URL, init?: RequestInit) => {
     const path = url.pathname.replace(/^\/api/u, "");
     requests.push(`${url.host}${path}`);
+    redirects.push(init?.redirect);
     const responses = perHost[url.host];
     if (!responses || !(path in responses)) {
       throw new Error(`unexpected API request ${url.host}${path}`);
@@ -65,17 +68,19 @@ function allHosts(responses: Record<string, string>) {
 describe("Bitcoin funding verifier", () => {
   it("reaches quorum across fixed authorities and emits reviewed fields", async () => {
     const requests: string[] = [];
+    const redirects: Array<RequestRedirect | undefined> = [];
     const result = await verifyFundingBitcoin({
       transactionId: TXID,
       recipient: RECIPIENT,
       amountMinor: "150000",
-      fetchImpl: fetchFor(allHosts(authorityResponses()), requests),
+      fetchImpl: fetchFor(allHosts(authorityResponses()), requests, redirects),
     });
     for (const host of HOSTS) {
       expect(requests).toContain(`${host}/tx/${TXID}`);
       expect(requests).toContain(`${host}/blocks/tip/height`);
       expect(requests).toContain(`${host}/block-height/800000`);
     }
+    expect(redirects.every((redirect) => redirect === "error")).toBe(true);
     expect(result).toMatchObject({
       state: "verified-on-chain",
       finality: { kind: "confirmations", confirmations: 11 },
@@ -109,6 +114,19 @@ describe("Bitcoin funding verifier", () => {
     expect(result.finality).toEqual({
       kind: "confirmations",
       confirmations: 11,
+    });
+    expect(result.chainEvidence.authorities).toHaveLength(2);
+  });
+
+  it("survives one unavailable authority", async () => {
+    const result = await verifyFundingBitcoin({
+      transactionId: TXID,
+      recipient: RECIPIENT,
+      amountMinor: "150000",
+      fetchImpl: fetchFor({
+        [HOSTS[0]]: authorityResponses(),
+        [HOSTS[1]]: authorityResponses(),
+      }),
     });
     expect(result.chainEvidence.authorities).toHaveLength(2);
   });
@@ -192,5 +210,38 @@ describe("Bitcoin funding verifier", () => {
         TXID,
       ]),
     ).toThrow(/Usage/u);
+  });
+
+  it("rejects declared and streamed bodies above 8 MiB", async () => {
+    await expect(
+      verifyFundingBitcoin({
+        transactionId: TXID,
+        recipient: RECIPIENT,
+        amountMinor: "150000",
+        fetchImpl: async () =>
+          new Response("{}", {
+            headers: {
+              "content-length": String(MAX_BITCOIN_API_BYTES + 1),
+            },
+          }),
+      }),
+    ).rejects.toThrow(/quorum/u);
+    await expect(
+      verifyFundingBitcoin({
+        transactionId: TXID,
+        recipient: RECIPIENT,
+        amountMinor: "150000",
+        fetchImpl: async () =>
+          new Response(
+            new ReadableStream({
+              start(controller) {
+                controller.enqueue(new Uint8Array(MAX_BITCOIN_API_BYTES));
+                controller.enqueue(new Uint8Array(1));
+                controller.close();
+              },
+            }),
+          ),
+      }),
+    ).rejects.toThrow(/quorum/u);
   });
 });

--- a/scripts/verify-funding-bitcoin.test.ts
+++ b/scripts/verify-funding-bitcoin.test.ts
@@ -1,0 +1,123 @@
+/** Proves the read-only Bitcoin verifier pins best-chain data and fails closed. */
+
+import { describe, expect, it } from "vitest";
+import { verifyFundingBitcoin } from "./verify-funding-bitcoin";
+
+const RECIPIENT = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
+const SENDER = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4";
+const TXID = "a".repeat(64);
+const BLOCK_HASH = "f".repeat(64);
+
+function apiResponses(overrides: Record<string, string> = {}) {
+  return {
+    [`/tx/${TXID}`]: JSON.stringify({
+      txid: TXID,
+      status: {
+        confirmed: true,
+        block_height: 800_000,
+        block_hash: BLOCK_HASH,
+      },
+      vin: [
+        {
+          is_coinbase: false,
+          prevout: { scriptpubkey_address: SENDER, value: 200_000 },
+        },
+      ],
+      vout: [
+        { scriptpubkey_address: RECIPIENT, value: 150_000 },
+        { scriptpubkey_address: SENDER, value: 49_000 },
+      ],
+      fee: 1_000,
+    }),
+    "/blocks/tip/height": "800010",
+    "/block-height/800000": BLOCK_HASH,
+    ...overrides,
+  } as Record<string, string>;
+}
+
+function fetchFor(responses: Record<string, string>, paths: string[] = []) {
+  return async (url: URL) => {
+    const path = url.pathname.replace(/^\/api/u, "");
+    paths.push(path);
+    if (!(path in responses)) throw new Error(`unexpected API path ${path}`);
+    return new Response(responses[path]);
+  };
+}
+
+describe("Bitcoin funding verifier", () => {
+  it("checks tip and best-chain hash, then emits reviewed record fields", async () => {
+    const paths: string[] = [];
+    const result = await verifyFundingBitcoin({
+      transactionId: TXID,
+      recipient: RECIPIENT,
+      amountMinor: "150000",
+      fetchImpl: fetchFor(apiResponses(), paths),
+    });
+    expect(paths).toEqual([
+      `/tx/${TXID}`,
+      "/blocks/tip/height",
+      "/block-height/800000",
+    ]);
+    expect(result).toMatchObject({
+      state: "verified-on-chain",
+      finality: { kind: "confirmations", confirmations: 11 },
+      verifier: {
+        version: "funding-bitcoin-v1",
+        evidenceUrl: `https://mempool.space/tx/${TXID}`,
+        reason: null,
+      },
+      chainEvidence: {
+        transactionId: TXID,
+        blockHeight: 800_000,
+        blockHash: BLOCK_HASH,
+      },
+    });
+  });
+
+  it("rejects a transaction whose block left the best chain", async () => {
+    await expect(
+      verifyFundingBitcoin({
+        transactionId: TXID,
+        recipient: RECIPIENT,
+        amountMinor: "150000",
+        fetchImpl: fetchFor(
+          apiResponses({ "/block-height/800000": "e".repeat(64) }),
+        ),
+      }),
+    ).rejects.toThrow(/best chain/u);
+  });
+
+  it("rejects invalid inputs and credentialed APIs before querying", async () => {
+    let queried = false;
+    const spy = async () => {
+      queried = true;
+      return new Response();
+    };
+    await expect(
+      verifyFundingBitcoin({
+        transactionId: `0x${"a".repeat(62)}`,
+        recipient: RECIPIENT,
+        amountMinor: "150000",
+        fetchImpl: spy,
+      }),
+    ).rejects.toThrow(/invalid/u);
+    await expect(
+      verifyFundingBitcoin({
+        transactionId: TXID,
+        recipient: `${RECIPIENT.slice(0, -1)}Q`,
+        amountMinor: "150000",
+        fetchImpl: spy,
+      }),
+    ).rejects.toThrow(/invalid/u);
+    await expect(
+      verifyFundingBitcoin({
+        transactionId: TXID,
+        recipient: RECIPIENT,
+        amountMinor: "150000",
+        apiUrl: "https://user:pass@mempool.example.com/api",
+        fetchImpl: spy,
+      }),
+    ).rejects.toThrow(/credential-free/u);
+    expect(queried).toBe(false);
+  });
+});

--- a/scripts/verify-funding-bitcoin.ts
+++ b/scripts/verify-funding-bitcoin.ts
@@ -1,0 +1,148 @@
+/** Queries confirmed Bitcoin data and emits reviewed direct-funding evidence. */
+
+import {
+  assertConfirmedBtcFundingTransfer,
+  BITCOIN_FUNDING_VERIFIER_VERSION,
+  isBitcoinBlockHash,
+  isBitcoinTransactionId,
+} from "../src/lib/bitcoin-funding";
+import { isFundingAddress } from "../src/lib/funding-address.mjs";
+
+const DEFAULT_API = "https://mempool.space/api";
+const MAX_RESPONSE_BYTES = 8 * 1024 * 1024;
+
+function argument(name: string): string | null {
+  const index = process.argv.indexOf(name);
+  if (index < 0) return null;
+  const value = process.argv[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new TypeError(`${name} requires a value`);
+  }
+  return value;
+}
+
+async function apiGet(
+  base: URL,
+  fetchImpl: (url: URL, init?: RequestInit) => Promise<Response>,
+  path: string,
+): Promise<Uint8Array> {
+  const url = new URL(`${base.pathname.replace(/\/$/u, "")}${path}`, base);
+  const response = await fetchImpl(url, {
+    method: "GET",
+    signal: AbortSignal.timeout(20_000),
+  });
+  if (!response.ok) {
+    throw new Error(`Bitcoin API ${path} returned HTTP ${response.status}`);
+  }
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  if (bytes.length === 0 || bytes.length > MAX_RESPONSE_BYTES) {
+    throw new RangeError(`Bitcoin API ${path} response is empty or oversized`);
+  }
+  return bytes;
+}
+
+function decodeText(bytes: Uint8Array, field: string): string {
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch (error) {
+    throw new TypeError(`${field} is not valid UTF-8`, { cause: error });
+  }
+}
+
+function decodeJson(bytes: Uint8Array, field: string): unknown {
+  try {
+    return JSON.parse(decodeText(bytes, field));
+  } catch (error) {
+    throw new TypeError(`${field} is invalid JSON`, { cause: error });
+  }
+}
+
+export async function verifyFundingBitcoin(input: {
+  amountMinor: string;
+  apiUrl?: string;
+  fetchImpl?: (url: URL, init?: RequestInit) => Promise<Response>;
+  recipient: string;
+  transactionId: string;
+}) {
+  if (
+    !isBitcoinTransactionId(input.transactionId) ||
+    !isFundingAddress("bitcoin", input.recipient) ||
+    input.amountMinor.length > 40 ||
+    !/^[1-9]\d*$/u.test(input.amountMinor)
+  ) {
+    throw new TypeError("transaction id, recipient, or amount is invalid");
+  }
+  const api = new URL(input.apiUrl ?? DEFAULT_API);
+  if (api.protocol !== "https:" || api.username || api.password || api.hash) {
+    throw new TypeError("Bitcoin API must be a credential-free HTTPS URL");
+  }
+  const fetchImpl = input.fetchImpl ?? fetch;
+
+  const transaction = decodeJson(
+    await apiGet(api, fetchImpl, `/tx/${input.transactionId}`),
+    "Bitcoin transaction response",
+  );
+  const tipText = decodeText(
+    await apiGet(api, fetchImpl, "/blocks/tip/height"),
+    "Bitcoin tip height response",
+  ).trim();
+  if (!/^\d{1,9}$/u.test(tipText)) {
+    throw new TypeError("Bitcoin tip height response is invalid");
+  }
+  const status =
+    typeof transaction === "object" && transaction !== null
+      ? (transaction as Record<string, unknown>).status
+      : null;
+  const blockHeight =
+    typeof status === "object" && status !== null
+      ? (status as Record<string, unknown>).block_height
+      : null;
+  if (!Number.isSafeInteger(blockHeight) || Number(blockHeight) < 0) {
+    throw new TypeError("Bitcoin transaction is unconfirmed");
+  }
+  const bestChainHash = decodeText(
+    await apiGet(api, fetchImpl, `/block-height/${Number(blockHeight)}`),
+    "Bitcoin block-height response",
+  ).trim();
+  if (!isBitcoinBlockHash(bestChainHash)) {
+    throw new TypeError("Bitcoin block-height response is invalid");
+  }
+  const verified = assertConfirmedBtcFundingTransfer(
+    transaction,
+    input.transactionId,
+    input.recipient,
+    input.amountMinor,
+    Number(tipText),
+    bestChainHash,
+  );
+  const checkedAt = new Date().toISOString();
+  return {
+    state: "verified-on-chain" as const,
+    finality: {
+      kind: "confirmations" as const,
+      confirmations: verified.confirmations,
+    },
+    verifier: {
+      version: BITCOIN_FUNDING_VERIFIER_VERSION,
+      checkedAt,
+      evidenceUrl: `https://mempool.space/tx/${input.transactionId}`,
+      reason: null,
+    },
+    chainEvidence: verified,
+  };
+}
+
+if (import.meta.main) {
+  const transactionId = argument("--transaction");
+  const recipient = argument("--recipient");
+  const amountMinor = argument("--amount-minor");
+  const apiUrl = argument("--api-url") ?? undefined;
+  if (!transactionId || !recipient || !amountMinor) {
+    throw new TypeError(
+      "Usage: verify-funding-bitcoin.ts --transaction <txid> --recipient <bech32-address> --amount-minor <satoshis> [--api-url <https-url>]",
+    );
+  }
+  process.stdout.write(
+    `${JSON.stringify(await verifyFundingBitcoin({ transactionId, recipient, amountMinor, apiUrl }), null, 2)}\n`,
+  );
+}

--- a/scripts/verify-funding-bitcoin.ts
+++ b/scripts/verify-funding-bitcoin.ts
@@ -8,87 +8,124 @@ import {
 } from "../src/lib/bitcoin-funding";
 import { isFundingAddress } from "../src/lib/funding-address.mjs";
 
-const DEFAULT_API = "https://mempool.space/api";
-const MAX_RESPONSE_BYTES = 8 * 1024 * 1024;
+export const BITCOIN_FUNDING_API_AUTHORITIES = [
+  "https://mempool.space/api",
+  "https://blockstream.info/api",
+  "https://mempool.emzy.de/api",
+] as const;
+const BITCOIN_FUNDING_API_QUORUM = 2;
+export const MAX_BITCOIN_API_BYTES = 8 * 1024 * 1024;
 
-function argument(name: string): string | null {
-  const index = process.argv.indexOf(name);
-  if (index < 0) return null;
-  const value = process.argv[index + 1];
-  if (!value || value.startsWith("--")) {
-    throw new TypeError(`${name} requires a value`);
+type FetchLike = (url: URL, init?: RequestInit) => Promise<Response>;
+
+const CLI_ARGUMENTS = new Set([
+  "--transaction",
+  "--recipient",
+  "--amount-minor",
+]);
+
+export function parseBitcoinFundingArguments(argv: readonly string[]) {
+  const parsed = new Map<string, string>();
+  for (let index = 0; index < argv.length; index += 2) {
+    const name = argv[index];
+    const value = argv[index + 1];
+    if (
+      !name ||
+      !CLI_ARGUMENTS.has(name) ||
+      !value ||
+      value.startsWith("--") ||
+      parsed.has(name)
+    ) {
+      throw new TypeError(
+        "Usage: verify-funding-bitcoin.ts --transaction <txid> --recipient <bech32-address> --amount-minor <satoshis>",
+      );
+    }
+    parsed.set(name, value);
   }
-  return value;
+  return {
+    transactionId: parsed.get("--transaction") ?? null,
+    recipient: parsed.get("--recipient") ?? null,
+    amountMinor: parsed.get("--amount-minor") ?? null,
+  };
+}
+
+async function boundedBody(response: Response): Promise<string> {
+  const declaredLength = response.headers.get("content-length");
+  if (declaredLength !== null) {
+    const parsedLength = Number(declaredLength);
+    if (!Number.isSafeInteger(parsedLength) || parsedLength < 0) {
+      throw new TypeError("Bitcoin API returned an invalid Content-Length");
+    }
+    if (parsedLength > MAX_BITCOIN_API_BYTES) {
+      throw new RangeError("Bitcoin API response exceeded its size limit");
+    }
+  }
+  const reader = response.body?.getReader();
+  if (!reader) throw new TypeError("Bitcoin API returned no readable body");
+  const decoder = new TextDecoder("utf-8", { fatal: true });
+  let byteLength = 0;
+  let body = "";
+  try {
+    for (;;) {
+      const chunk = await reader.read();
+      if (chunk.done) break;
+      byteLength += chunk.value.byteLength;
+      if (byteLength > MAX_BITCOIN_API_BYTES) {
+        throw new RangeError("Bitcoin API response exceeded its size limit");
+      }
+      body += decoder.decode(chunk.value, { stream: true });
+    }
+    body += decoder.decode();
+  } catch (error) {
+    if (error instanceof TypeError) {
+      throw new TypeError("Bitcoin API response is not valid UTF-8", {
+        cause: error,
+      });
+    }
+    throw error;
+  }
+  if (byteLength === 0) throw new RangeError("Bitcoin API response is empty");
+  return body;
 }
 
 async function apiGet(
   base: URL,
-  fetchImpl: (url: URL, init?: RequestInit) => Promise<Response>,
+  fetchImpl: FetchLike,
   path: string,
-): Promise<Uint8Array> {
+): Promise<string> {
   const url = new URL(`${base.pathname.replace(/\/$/u, "")}${path}`, base);
   const response = await fetchImpl(url, {
     method: "GET",
+    redirect: "error",
     signal: AbortSignal.timeout(20_000),
   });
   if (!response.ok) {
     throw new Error(`Bitcoin API ${path} returned HTTP ${response.status}`);
   }
-  const bytes = new Uint8Array(await response.arrayBuffer());
-  if (bytes.length === 0 || bytes.length > MAX_RESPONSE_BYTES) {
-    throw new RangeError(`Bitcoin API ${path} response is empty or oversized`);
-  }
-  return bytes;
+  return boundedBody(response);
 }
 
-function decodeText(bytes: Uint8Array, field: string): string {
+async function verifyWithAuthority(
+  input: { amountMinor: string; recipient: string; transactionId: string },
+  authority: string,
+  fetchImpl: FetchLike,
+) {
+  const api = new URL(authority);
+  let transaction: unknown;
   try {
-    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+    transaction = JSON.parse(
+      await apiGet(api, fetchImpl, `/tx/${input.transactionId}`),
+    );
   } catch (error) {
-    throw new TypeError(`${field} is not valid UTF-8`, { cause: error });
+    throw new TypeError("Bitcoin transaction response is invalid JSON", {
+      cause: error,
+    });
   }
-}
-
-function decodeJson(bytes: Uint8Array, field: string): unknown {
-  try {
-    return JSON.parse(decodeText(bytes, field));
-  } catch (error) {
-    throw new TypeError(`${field} is invalid JSON`, { cause: error });
-  }
-}
-
-export async function verifyFundingBitcoin(input: {
-  amountMinor: string;
-  apiUrl?: string;
-  fetchImpl?: (url: URL, init?: RequestInit) => Promise<Response>;
-  recipient: string;
-  transactionId: string;
-}) {
-  if (
-    !isBitcoinTransactionId(input.transactionId) ||
-    !isFundingAddress("bitcoin", input.recipient) ||
-    input.amountMinor.length > 40 ||
-    !/^[1-9]\d*$/u.test(input.amountMinor)
-  ) {
-    throw new TypeError("transaction id, recipient, or amount is invalid");
-  }
-  const api = new URL(input.apiUrl ?? DEFAULT_API);
-  if (api.protocol !== "https:" || api.username || api.password || api.hash) {
-    throw new TypeError("Bitcoin API must be a credential-free HTTPS URL");
-  }
-  const fetchImpl = input.fetchImpl ?? fetch;
-
-  const transaction = decodeJson(
-    await apiGet(api, fetchImpl, `/tx/${input.transactionId}`),
-    "Bitcoin transaction response",
-  );
-  const tipText = decodeText(
-    await apiGet(api, fetchImpl, "/blocks/tip/height"),
-    "Bitcoin tip height response",
-  ).trim();
+  const tipText = (await apiGet(api, fetchImpl, "/blocks/tip/height")).trim();
   if (!/^\d{1,9}$/u.test(tipText)) {
     throw new TypeError("Bitcoin tip height response is invalid");
   }
+  const tipHeight = Number(tipText);
   const status =
     typeof transaction === "object" && transaction !== null
       ? (transaction as Record<string, unknown>).status
@@ -100,9 +137,8 @@ export async function verifyFundingBitcoin(input: {
   if (!Number.isSafeInteger(blockHeight) || Number(blockHeight) < 0) {
     throw new TypeError("Bitcoin transaction is unconfirmed");
   }
-  const bestChainHash = decodeText(
-    await apiGet(api, fetchImpl, `/block-height/${Number(blockHeight)}`),
-    "Bitcoin block-height response",
+  const bestChainHash = (
+    await apiGet(api, fetchImpl, `/block-height/${Number(blockHeight)}`)
   ).trim();
   if (!isBitcoinBlockHash(bestChainHash)) {
     throw new TypeError("Bitcoin block-height response is invalid");
@@ -112,15 +148,62 @@ export async function verifyFundingBitcoin(input: {
     input.transactionId,
     input.recipient,
     input.amountMinor,
-    Number(tipText),
+    tipHeight,
     bestChainHash,
+  );
+  return { authority: api.toString(), tipHeight, verified };
+}
+
+export async function verifyFundingBitcoin(input: {
+  amountMinor: string;
+  fetchImpl?: FetchLike;
+  recipient: string;
+  transactionId: string;
+}) {
+  if (
+    !isBitcoinTransactionId(input.transactionId) ||
+    !isFundingAddress("bitcoin", input.recipient) ||
+    input.amountMinor.length > 40 ||
+    !/^[1-9]\d*$/u.test(input.amountMinor)
+  ) {
+    throw new TypeError("transaction id, recipient, or amount is invalid");
+  }
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const settled = await Promise.allSettled(
+    BITCOIN_FUNDING_API_AUTHORITIES.map((authority) =>
+      verifyWithAuthority(input, authority, fetchImpl),
+    ),
+  );
+  const groups = new Map<
+    string,
+    Array<Awaited<ReturnType<typeof verifyWithAuthority>>>
+  >();
+  for (const result of settled) {
+    if (result.status !== "fulfilled") continue;
+    const { verified } = result.value;
+    const key = `${verified.transactionId}:${verified.blockHeight}:${verified.blockHash}`;
+    const group = groups.get(key) ?? [];
+    group.push(result.value);
+    groups.set(key, group);
+  }
+  const results = [...groups.values()].sort(
+    (left, right) => right.length - left.length,
+  )[0];
+  const first = results?.[0];
+  if (!first || !results || results.length < BITCOIN_FUNDING_API_QUORUM) {
+    throw new TypeError(
+      "Bitcoin API authorities did not reach canonical transaction quorum",
+    );
+  }
+  const confirmations = Math.min(
+    ...results.map(({ verified }) => verified.confirmations),
   );
   const checkedAt = new Date().toISOString();
   return {
     state: "verified-on-chain" as const,
     finality: {
       kind: "confirmations" as const,
-      confirmations: verified.confirmations,
+      confirmations,
     },
     verifier: {
       version: BITCOIN_FUNDING_VERIFIER_VERSION,
@@ -128,21 +211,26 @@ export async function verifyFundingBitcoin(input: {
       evidenceUrl: `https://mempool.space/tx/${input.transactionId}`,
       reason: null,
     },
-    chainEvidence: verified,
+    chainEvidence: {
+      ...first.verified,
+      confirmations,
+      authorities: results.map(({ authority, tipHeight }) => ({
+        authority,
+        tipHeight,
+      })),
+    },
   };
 }
 
 if (import.meta.main) {
-  const transactionId = argument("--transaction");
-  const recipient = argument("--recipient");
-  const amountMinor = argument("--amount-minor");
-  const apiUrl = argument("--api-url") ?? undefined;
+  const { transactionId, recipient, amountMinor } =
+    parseBitcoinFundingArguments(process.argv.slice(2));
   if (!transactionId || !recipient || !amountMinor) {
     throw new TypeError(
-      "Usage: verify-funding-bitcoin.ts --transaction <txid> --recipient <bech32-address> --amount-minor <satoshis> [--api-url <https-url>]",
+      "Usage: verify-funding-bitcoin.ts --transaction <txid> --recipient <bech32-address> --amount-minor <satoshis>",
     );
   }
   process.stdout.write(
-    `${JSON.stringify(await verifyFundingBitcoin({ transactionId, recipient, amountMinor, apiUrl }), null, 2)}\n`,
+    `${JSON.stringify(await verifyFundingBitcoin({ transactionId, recipient, amountMinor }), null, 2)}\n`,
   );
 }

--- a/scripts/verify-funding-evm.test.ts
+++ b/scripts/verify-funding-evm.test.ts
@@ -1,0 +1,162 @@
+/** Proves the read-only EVM verifier pins mainnet finality and fails closed. */
+
+import { describe, expect, it } from "vitest";
+import { EVM_FUNDING_USDC_CONTRACTS } from "../src/lib/evm-funding";
+import { verifyFundingEvm } from "./verify-funding-evm";
+
+const RECIPIENT = `0x${"1".repeat(40)}`;
+const SENDER = `0x${"2".repeat(40)}`;
+const HASH = `0x${"a".repeat(64)}`;
+const TRANSFER_TOPIC =
+  "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+
+function chainResponses(overrides: Record<string, unknown> = {}) {
+  return {
+    eth_chainId: "0x1",
+    eth_getBlockByNumber: { number: "0x1000" },
+    eth_getTransactionReceipt: {
+      status: "0x1",
+      transactionHash: HASH,
+      blockNumber: "0x100",
+      logs: [
+        {
+          address: EVM_FUNDING_USDC_CONTRACTS.ethereum,
+          topics: [
+            TRANSFER_TOPIC,
+            `0x${"0".repeat(24)}${SENDER.slice(2)}`,
+            `0x${"0".repeat(24)}${RECIPIENT.slice(2)}`,
+          ],
+          data: `0x${1_000_000n.toString(16).padStart(64, "0")}`,
+          removed: false,
+        },
+      ],
+    },
+    ...overrides,
+  } as Record<string, unknown>;
+}
+
+function fetchFor(responses: Record<string, unknown>, calls: string[] = []) {
+  return async (_url: URL, init?: RequestInit) => {
+    const body = JSON.parse(String(init?.body)) as {
+      method: string;
+      params: unknown[];
+    };
+    calls.push(body.method);
+    if (!(body.method in responses)) {
+      throw new Error(`unexpected RPC method ${body.method}`);
+    }
+    return new Response(
+      JSON.stringify({ jsonrpc: "2.0", id: 1, result: responses[body.method] }),
+    );
+  };
+}
+
+describe("EVM funding verifier", () => {
+  it("checks chain id and finalized head, then emits reviewed record fields", async () => {
+    const calls: string[] = [];
+    const result = await verifyFundingEvm({
+      network: "ethereum",
+      transactionHash: HASH,
+      recipient: RECIPIENT,
+      amountMinor: "1000000",
+      fetchImpl: fetchFor(chainResponses(), calls),
+    });
+    expect(calls).toEqual([
+      "eth_chainId",
+      "eth_getBlockByNumber",
+      "eth_getTransactionReceipt",
+    ]);
+    expect(result).toMatchObject({
+      state: "verified-on-chain",
+      finality: { kind: "confirmations", confirmations: 0x1000 - 0x100 + 1 },
+      verifier: {
+        version: "funding-ethereum-v1",
+        evidenceUrl: `https://etherscan.io/tx/${HASH}`,
+        reason: null,
+      },
+      chainEvidence: { transactionHash: HASH, blockNumber: 0x100 },
+    });
+  });
+
+  it("rejects an RPC that is not the declared mainnet", async () => {
+    await expect(
+      verifyFundingEvm({
+        network: "base",
+        transactionHash: HASH,
+        recipient: RECIPIENT,
+        amountMinor: "1000000",
+        fetchImpl: fetchFor(chainResponses()),
+      }),
+    ).rejects.toThrow(/not base mainnet/u);
+  });
+
+  it("rejects an absent receipt at the finalized head", async () => {
+    await expect(
+      verifyFundingEvm({
+        network: "ethereum",
+        transactionHash: HASH,
+        recipient: RECIPIENT,
+        amountMinor: "1000000",
+        fetchImpl: fetchFor(
+          chainResponses({ eth_getTransactionReceipt: null }),
+        ),
+      }),
+    ).rejects.toThrow(/receipt is absent/u);
+  });
+
+  it("rejects an RPC error envelope", async () => {
+    await expect(
+      verifyFundingEvm({
+        network: "ethereum",
+        transactionHash: HASH,
+        recipient: RECIPIENT,
+        amountMinor: "1000000",
+        fetchImpl: async () =>
+          new Response(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              id: 1,
+              error: { code: -32601, message: "nope" },
+            }),
+          ),
+      }),
+    ).rejects.toThrow(/returned an error/u);
+  });
+
+  it("rejects invalid inputs and credentialed RPCs before querying", async () => {
+    let queried = false;
+    const spy = async () => {
+      queried = true;
+      return new Response();
+    };
+    await expect(
+      verifyFundingEvm({
+        network: "ethereum",
+        transactionHash: HASH,
+        recipient: RECIPIENT,
+        amountMinor: "1".repeat(41),
+        fetchImpl: spy,
+      }),
+    ).rejects.toThrow(/invalid/u);
+    await expect(
+      verifyFundingEvm({
+        network: "ethereum",
+        transactionHash: HASH.toUpperCase(),
+        recipient: RECIPIENT,
+        amountMinor: "1000000",
+        fetchImpl: spy,
+      }),
+    ).rejects.toThrow(/invalid/u);
+    await expect(
+      verifyFundingEvm({
+        network: "ethereum",
+        transactionHash: HASH,
+        recipient: RECIPIENT,
+        amountMinor: "1000000",
+        rpcUrl: "https://user:pass@rpc.example.com",
+        fetchImpl: spy,
+      }),
+    ).rejects.toThrow(/credential-free/u);
+    expect(queried).toBe(false);
+  });
+});

--- a/scripts/verify-funding-evm.test.ts
+++ b/scripts/verify-funding-evm.test.ts
@@ -1,129 +1,263 @@
-/** Proves the read-only EVM verifier pins mainnet finality and fails closed. */
+/** Proves the read-only EVM verifier pins a bounded, canonical RPC quorum. */
 
 import { describe, expect, it } from "vitest";
 import { EVM_FUNDING_USDC_CONTRACTS } from "../src/lib/evm-funding";
-import { verifyFundingEvm } from "./verify-funding-evm";
+import {
+  EVM_FUNDING_RPC_AUTHORITIES,
+  MAX_EVM_RPC_BYTES,
+  parseEvmFundingArguments,
+  verifyFundingEvm,
+} from "./verify-funding-evm";
 
 const RECIPIENT = `0x${"1".repeat(40)}`;
 const SENDER = `0x${"2".repeat(40)}`;
 const HASH = `0x${"a".repeat(64)}`;
+const BLOCK_HASH = `0x${"b".repeat(64)}`;
+const FINALIZED_HASH = `0x${"c".repeat(64)}`;
 const TRANSFER_TOPIC =
   "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
 
-function chainResponses(overrides: Record<string, unknown> = {}) {
+function chainResponses(
+  overrides: {
+    blockHash?: string;
+    chainId?: string;
+    finalizedNumber?: string;
+    receipt?: unknown;
+  } = {},
+) {
+  const blockHash = overrides.blockHash ?? BLOCK_HASH;
   return {
-    eth_chainId: "0x1",
-    eth_getBlockByNumber: { number: "0x1000" },
-    eth_getTransactionReceipt: {
-      status: "0x1",
-      transactionHash: HASH,
-      blockNumber: "0x100",
-      logs: [
-        {
-          address: EVM_FUNDING_USDC_CONTRACTS.ethereum,
-          topics: [
-            TRANSFER_TOPIC,
-            `0x${"0".repeat(24)}${SENDER.slice(2)}`,
-            `0x${"0".repeat(24)}${RECIPIENT.slice(2)}`,
-          ],
-          data: `0x${1_000_000n.toString(16).padStart(64, "0")}`,
-          removed: false,
-        },
-      ],
+    chainId: overrides.chainId ?? "0x1",
+    finalizedBlock: {
+      number: overrides.finalizedNumber ?? "0x1000",
+      hash: FINALIZED_HASH,
     },
-    ...overrides,
-  } as Record<string, unknown>;
+    canonicalBlock: { number: "0x100", hash: blockHash },
+    receipt:
+      overrides.receipt === undefined
+        ? {
+            status: "0x1",
+            transactionHash: HASH,
+            blockNumber: "0x100",
+            blockHash,
+            logs: [
+              {
+                address: EVM_FUNDING_USDC_CONTRACTS.ethereum,
+                topics: [
+                  TRANSFER_TOPIC,
+                  `0x${"0".repeat(24)}${SENDER.slice(2)}`,
+                  `0x${"0".repeat(24)}${RECIPIENT.slice(2)}`,
+                ],
+                data: `0x${1_000_000n.toString(16).padStart(64, "0")}`,
+                removed: false,
+                transactionHash: HASH,
+                blockNumber: "0x100",
+                blockHash,
+              },
+            ],
+          }
+        : overrides.receipt,
+  };
 }
 
-function fetchFor(responses: Record<string, unknown>, calls: string[] = []) {
-  return async (_url: URL, init?: RequestInit) => {
+interface RpcCall {
+  id: string;
+  method: string;
+  redirect: RequestRedirect | undefined;
+  url: string;
+}
+
+function fetchFor(
+  selectResponses: (url: URL) => ReturnType<typeof chainResponses> = () =>
+    chainResponses(),
+  calls: RpcCall[] = [],
+) {
+  return async (url: URL, init?: RequestInit) => {
     const body = JSON.parse(String(init?.body)) as {
+      id: string;
       method: string;
       params: unknown[];
     };
-    calls.push(body.method);
-    if (!(body.method in responses)) {
-      throw new Error(`unexpected RPC method ${body.method}`);
-    }
+    calls.push({
+      id: body.id,
+      method: body.method,
+      redirect: init?.redirect,
+      url: url.toString(),
+    });
+    const responses = selectResponses(url);
+    let result: unknown;
+    if (body.method === "eth_chainId") result = responses.chainId;
+    else if (body.method === "eth_getTransactionReceipt") {
+      result = responses.receipt;
+    } else if (body.method === "eth_getBlockByNumber") {
+      result =
+        body.params[0] === "finalized"
+          ? responses.finalizedBlock
+          : responses.canonicalBlock;
+    } else throw new Error(`unexpected RPC method ${body.method}`);
     return new Response(
-      JSON.stringify({ jsonrpc: "2.0", id: 1, result: responses[body.method] }),
+      JSON.stringify({ jsonrpc: "2.0", id: body.id, result }),
     );
   };
 }
 
+function verification(fetchImpl: ReturnType<typeof fetchFor>) {
+  return verifyFundingEvm({
+    network: "ethereum",
+    transactionHash: HASH,
+    recipient: RECIPIENT,
+    amountMinor: "1000000",
+    fetchImpl,
+  });
+}
+
 describe("EVM funding verifier", () => {
-  it("checks chain id and finalized head, then emits reviewed record fields", async () => {
-    const calls: string[] = [];
-    const result = await verifyFundingEvm({
-      network: "ethereum",
-      transactionHash: HASH,
-      recipient: RECIPIENT,
-      amountMinor: "1000000",
-      fetchImpl: fetchFor(chainResponses(), calls),
-    });
-    expect(calls).toEqual([
-      "eth_chainId",
-      "eth_getBlockByNumber",
-      "eth_getTransactionReceipt",
-    ]);
+  it("requires fixed authorities and emits conservative canonical evidence", async () => {
+    const calls: RpcCall[] = [];
+    const result = await verification(
+      fetchFor(
+        (url) =>
+          chainResponses({
+            finalizedNumber:
+              url.hostname === "eth.drpc.org" ? "0xff0" : "0x1000",
+          }),
+        calls,
+      ),
+    );
+    expect(new Set(calls.map(({ url }) => url))).toEqual(
+      new Set(
+        EVM_FUNDING_RPC_AUTHORITIES.ethereum.map((url) =>
+          new URL(url).toString(),
+        ),
+      ),
+    );
+    expect(calls).toHaveLength(12);
+    expect(calls.every(({ redirect }) => redirect === "error")).toBe(true);
+    expect(new Set(calls.map(({ id }) => id)).size).toBe(12);
     expect(result).toMatchObject({
       state: "verified-on-chain",
-      finality: { kind: "confirmations", confirmations: 0x1000 - 0x100 + 1 },
+      finality: { kind: "confirmations", confirmations: 0xff0 - 0x100 + 1 },
       verifier: {
         version: "funding-ethereum-v1",
         evidenceUrl: `https://etherscan.io/tx/${HASH}`,
         reason: null,
       },
-      chainEvidence: { transactionHash: HASH, blockNumber: 0x100 },
+      chainEvidence: {
+        transactionHash: HASH,
+        blockNumber: 0x100,
+        blockHash: BLOCK_HASH,
+        authorities: [{}, {}, {}],
+      },
     });
   });
 
-  it("rejects an RPC that is not the declared mainnet", async () => {
+  it("rejects a wrong chain or absent receipt from either authority", async () => {
     await expect(
       verifyFundingEvm({
         network: "base",
         transactionHash: HASH,
         recipient: RECIPIENT,
         amountMinor: "1000000",
-        fetchImpl: fetchFor(chainResponses()),
+        fetchImpl: fetchFor(() => chainResponses()),
       }),
-    ).rejects.toThrow(/not base mainnet/u);
+    ).rejects.toThrow(/quorum/u);
+    await expect(
+      verification(fetchFor(() => chainResponses({ receipt: null }))),
+    ).rejects.toThrow(/quorum/u);
   });
 
-  it("rejects an absent receipt at the finalized head", async () => {
+  it("rejects malformed JSON-RPC versions, ids, and error envelopes", async () => {
+    for (const envelope of [
+      { jsonrpc: "1.0", id: "wrong", result: "0x1" },
+      { jsonrpc: "2.0", id: "wrong", result: "0x1" },
+    ]) {
+      await expect(
+        verification(async () => new Response(JSON.stringify(envelope))),
+      ).rejects.toThrow(/quorum/u);
+    }
     await expect(
-      verifyFundingEvm({
-        network: "ethereum",
-        transactionHash: HASH,
-        recipient: RECIPIENT,
-        amountMinor: "1000000",
-        fetchImpl: fetchFor(
-          chainResponses({ eth_getTransactionReceipt: null }),
-        ),
+      verification(async (_url, init) => {
+        const { id } = JSON.parse(String(init?.body)) as { id: string };
+        return new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id,
+            error: { code: -32601, message: "nope" },
+          }),
+        );
       }),
-    ).rejects.toThrow(/receipt is absent/u);
+    ).rejects.toThrow(/quorum/u);
   });
 
-  it("rejects an RPC error envelope", async () => {
+  it("tolerates one disagreement but rejects without a two-authority quorum", async () => {
+    const tolerated = await verification(
+      fetchFor((url) =>
+        chainResponses({
+          blockHash:
+            url.hostname === "eth.drpc.org"
+              ? `0x${"d".repeat(64)}`
+              : BLOCK_HASH,
+        }),
+      ),
+    );
+    expect(tolerated.chainEvidence.authorities).toHaveLength(2);
+    const healthyFetch = fetchFor();
+    const outageTolerated = await verification((url, init) => {
+      if (url.hostname === "rpc.flashbots.net") {
+        throw new Error("simulated authority outage");
+      }
+      return healthyFetch(url, init);
+    });
+    expect(outageTolerated.chainEvidence.authorities).toHaveLength(2);
     await expect(
-      verifyFundingEvm({
-        network: "ethereum",
-        transactionHash: HASH,
-        recipient: RECIPIENT,
-        amountMinor: "1000000",
-        fetchImpl: async () =>
+      verification(
+        fetchFor((url) => {
+          const suffix =
+            url.hostname === "ethereum-rpc.publicnode.com"
+              ? "b"
+              : url.hostname === "eth.drpc.org"
+                ? "d"
+                : "e";
+          return chainResponses({ blockHash: `0x${suffix.repeat(64)}` });
+        }),
+      ),
+    ).rejects.toThrow(/quorum/u);
+  });
+
+  it("enforces declared and streamed response byte bounds", async () => {
+    await expect(
+      verification(
+        async () =>
+          new Response("x", {
+            headers: { "content-length": String(MAX_EVM_RPC_BYTES + 1) },
+          }),
+      ),
+    ).rejects.toThrow(/quorum/u);
+    await expect(
+      verification(
+        async () =>
           new Response(
-            JSON.stringify({
-              jsonrpc: "2.0",
-              id: 1,
-              error: { code: -32601, message: "nope" },
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.enqueue(new Uint8Array(MAX_EVM_RPC_BYTES));
+                controller.enqueue(new Uint8Array(1));
+                controller.close();
+              },
             }),
           ),
-      }),
-    ).rejects.toThrow(/returned an error/u);
+      ),
+    ).rejects.toThrow(/quorum/u);
   });
 
-  it("rejects invalid inputs and credentialed RPCs before querying", async () => {
+  it("rejects arbitrary RPC CLI arguments and invalid inputs before querying", async () => {
+    expect(() =>
+      parseEvmFundingArguments([
+        "--network",
+        "ethereum",
+        "--rpc-url",
+        "https://attacker.example",
+      ]),
+    ).toThrow(/Usage/u);
     let queried = false;
     const spy = async () => {
       queried = true;
@@ -147,16 +281,6 @@ describe("EVM funding verifier", () => {
         fetchImpl: spy,
       }),
     ).rejects.toThrow(/invalid/u);
-    await expect(
-      verifyFundingEvm({
-        network: "ethereum",
-        transactionHash: HASH,
-        recipient: RECIPIENT,
-        amountMinor: "1000000",
-        rpcUrl: "https://user:pass@rpc.example.com",
-        fetchImpl: spy,
-      }),
-    ).rejects.toThrow(/credential-free/u);
     expect(queried).toBe(false);
   });
 });

--- a/scripts/verify-funding-evm.ts
+++ b/scripts/verify-funding-evm.ts
@@ -1,0 +1,182 @@
+/** Queries confirmed Base/Ethereum data and emits reviewed direct-funding evidence. */
+
+import {
+  assertConfirmedUsdcFundingTransfer,
+  EVM_FUNDING_CHAIN_IDS,
+  EVM_FUNDING_VERIFIER_VERSIONS,
+  type EvmFundingNetwork,
+  evmQuantity,
+  isEvmFundingNetwork,
+  isEvmTransactionHash,
+} from "../src/lib/evm-funding";
+import { isFundingAddress } from "../src/lib/funding-address.mjs";
+
+const DEFAULT_RPCS = {
+  base: "https://mainnet.base.org",
+  ethereum: "https://ethereum-rpc.publicnode.com",
+} as const;
+const EVIDENCE_HOSTS = {
+  base: "https://basescan.org",
+  ethereum: "https://etherscan.io",
+} as const;
+const MAX_RPC_BYTES = 8 * 1024 * 1024;
+
+function argument(name: string): string | null {
+  const index = process.argv.indexOf(name);
+  if (index < 0) return null;
+  const value = process.argv[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new TypeError(`${name} requires a value`);
+  }
+  return value;
+}
+
+async function rpcCall(
+  rpc: URL,
+  fetchImpl: (url: URL, init?: RequestInit) => Promise<Response>,
+  method: string,
+  params: readonly unknown[],
+): Promise<unknown> {
+  const response = await fetchImpl(rpc, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+    signal: AbortSignal.timeout(20_000),
+  });
+  if (!response.ok) {
+    throw new Error(`EVM RPC ${method} returned HTTP ${response.status}`);
+  }
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  if (bytes.length === 0 || bytes.length > MAX_RPC_BYTES) {
+    throw new RangeError(`EVM RPC ${method} response is empty or oversized`);
+  }
+  let envelope: unknown;
+  try {
+    envelope = JSON.parse(
+      new TextDecoder("utf-8", { fatal: true }).decode(bytes),
+    );
+  } catch (error) {
+    throw new TypeError(`EVM RPC ${method} response is invalid JSON`, {
+      cause: error,
+    });
+  }
+  if (
+    typeof envelope !== "object" ||
+    envelope === null ||
+    Array.isArray(envelope)
+  ) {
+    throw new TypeError(`EVM RPC ${method} response is invalid`);
+  }
+  const body = envelope as Record<string, unknown>;
+  if (body.error !== undefined && body.error !== null) {
+    throw new TypeError(
+      `EVM RPC ${method} returned an error: ${JSON.stringify(body.error)}`,
+    );
+  }
+  if (!("result" in body)) {
+    throw new TypeError(`EVM RPC ${method} response has no result`);
+  }
+  return body.result;
+}
+
+export async function verifyFundingEvm(input: {
+  amountMinor: string;
+  fetchImpl?: (url: URL, init?: RequestInit) => Promise<Response>;
+  network: EvmFundingNetwork;
+  recipient: string;
+  rpcUrl?: string;
+  transactionHash: string;
+}) {
+  if (
+    !isEvmFundingNetwork(input.network) ||
+    !isEvmTransactionHash(input.transactionHash) ||
+    !isFundingAddress(input.network, input.recipient) ||
+    input.amountMinor.length > 40 ||
+    !/^[1-9]\d*$/u.test(input.amountMinor)
+  ) {
+    throw new TypeError(
+      "network, transaction hash, recipient, or amount is invalid",
+    );
+  }
+  const rpc = new URL(input.rpcUrl ?? DEFAULT_RPCS[input.network]);
+  if (rpc.protocol !== "https:" || rpc.username || rpc.password || rpc.hash) {
+    throw new TypeError("EVM RPC must be a credential-free HTTPS URL");
+  }
+  const fetchImpl = input.fetchImpl ?? fetch;
+
+  const chainId = evmQuantity(
+    await rpcCall(rpc, fetchImpl, "eth_chainId", []),
+    "eth_chainId result",
+  );
+  if (chainId !== EVM_FUNDING_CHAIN_IDS[input.network]) {
+    throw new TypeError(
+      `EVM RPC chain id ${chainId} is not ${input.network} mainnet`,
+    );
+  }
+  const finalizedBlock = await rpcCall(rpc, fetchImpl, "eth_getBlockByNumber", [
+    "finalized",
+    false,
+  ]);
+  if (
+    typeof finalizedBlock !== "object" ||
+    finalizedBlock === null ||
+    Array.isArray(finalizedBlock)
+  ) {
+    throw new TypeError("EVM RPC did not return a finalized block");
+  }
+  const finalizedBlockNumber = evmQuantity(
+    (finalizedBlock as Record<string, unknown>).number,
+    "finalized block number",
+  );
+  const receipt = await rpcCall(rpc, fetchImpl, "eth_getTransactionReceipt", [
+    input.transactionHash,
+  ]);
+  if (receipt === null || receipt === undefined) {
+    throw new TypeError("EVM transaction receipt is absent");
+  }
+  const verified = assertConfirmedUsdcFundingTransfer(
+    receipt,
+    input.network,
+    input.transactionHash,
+    input.recipient,
+    input.amountMinor,
+    finalizedBlockNumber,
+  );
+  const checkedAt = new Date().toISOString();
+  return {
+    state: "verified-on-chain" as const,
+    finality: {
+      kind: "confirmations" as const,
+      confirmations: verified.confirmations,
+    },
+    verifier: {
+      version: EVM_FUNDING_VERIFIER_VERSIONS[input.network],
+      checkedAt,
+      evidenceUrl: `${EVIDENCE_HOSTS[input.network]}/tx/${input.transactionHash}`,
+      reason: null,
+    },
+    chainEvidence: verified,
+  };
+}
+
+if (import.meta.main) {
+  const network = argument("--network");
+  const transactionHash = argument("--transaction");
+  const recipient = argument("--recipient");
+  const amountMinor = argument("--amount-minor");
+  const rpcUrl = argument("--rpc-url") ?? undefined;
+  if (
+    !network ||
+    !isEvmFundingNetwork(network) ||
+    !transactionHash ||
+    !recipient ||
+    !amountMinor
+  ) {
+    throw new TypeError(
+      "Usage: verify-funding-evm.ts --network <base|ethereum> --transaction <0x-hash> --recipient <0x-address> --amount-minor <integer> [--rpc-url <https-url>]",
+    );
+  }
+  process.stdout.write(
+    `${JSON.stringify(await verifyFundingEvm({ network, transactionHash, recipient, amountMinor, rpcUrl }), null, 2)}\n`,
+  );
+}

--- a/scripts/verify-funding-evm.ts
+++ b/scripts/verify-funding-evm.ts
@@ -2,6 +2,7 @@
 
 import {
   assertConfirmedUsdcFundingTransfer,
+  assertEvmCanonicalBlock,
   EVM_FUNDING_CHAIN_IDS,
   EVM_FUNDING_VERIFIER_VERSIONS,
   type EvmFundingNetwork,
@@ -11,50 +12,120 @@ import {
 } from "../src/lib/evm-funding";
 import { isFundingAddress } from "../src/lib/funding-address.mjs";
 
-const DEFAULT_RPCS = {
-  base: "https://mainnet.base.org",
-  ethereum: "https://ethereum-rpc.publicnode.com",
+export const EVM_FUNDING_RPC_AUTHORITIES = {
+  base: [
+    "https://mainnet.base.org",
+    "https://base-rpc.publicnode.com",
+    "https://base.drpc.org",
+  ],
+  ethereum: [
+    "https://ethereum-rpc.publicnode.com",
+    "https://eth.drpc.org",
+    "https://rpc.flashbots.net",
+  ],
 } as const;
+const EVM_FUNDING_RPC_QUORUM = 2;
 const EVIDENCE_HOSTS = {
   base: "https://basescan.org",
   ethereum: "https://etherscan.io",
 } as const;
-const MAX_RPC_BYTES = 8 * 1024 * 1024;
+export const MAX_EVM_RPC_BYTES = 8 * 1024 * 1024;
 
-function argument(name: string): string | null {
-  const index = process.argv.indexOf(name);
-  if (index < 0) return null;
-  const value = process.argv[index + 1];
-  if (!value || value.startsWith("--")) {
-    throw new TypeError(`${name} requires a value`);
+type FetchLike = (url: URL, init?: RequestInit) => Promise<Response>;
+
+const CLI_ARGUMENTS = new Set([
+  "--network",
+  "--transaction",
+  "--recipient",
+  "--amount-minor",
+]);
+
+export function parseEvmFundingArguments(argv: readonly string[]) {
+  const parsed = new Map<string, string>();
+  for (let index = 0; index < argv.length; index += 2) {
+    const name = argv[index];
+    const value = argv[index + 1];
+    if (
+      !name ||
+      !CLI_ARGUMENTS.has(name) ||
+      !value ||
+      value.startsWith("--") ||
+      parsed.has(name)
+    ) {
+      throw new TypeError(
+        "Usage: verify-funding-evm.ts --network <base|ethereum> --transaction <0x-hash> --recipient <0x-address> --amount-minor <integer>",
+      );
+    }
+    parsed.set(name, value);
   }
-  return value;
+  return {
+    network: parsed.get("--network") ?? null,
+    transactionHash: parsed.get("--transaction") ?? null,
+    recipient: parsed.get("--recipient") ?? null,
+    amountMinor: parsed.get("--amount-minor") ?? null,
+  };
+}
+
+async function boundedBody(response: Response): Promise<string> {
+  const declaredLength = response.headers.get("content-length");
+  if (declaredLength !== null) {
+    const parsedLength = Number(declaredLength);
+    if (!Number.isSafeInteger(parsedLength) || parsedLength < 0) {
+      throw new TypeError("EVM RPC returned an invalid Content-Length");
+    }
+    if (parsedLength > MAX_EVM_RPC_BYTES) {
+      throw new RangeError("EVM RPC response exceeded its size limit");
+    }
+  }
+  const reader = response.body?.getReader();
+  if (!reader) throw new TypeError("EVM RPC returned no readable body");
+  const decoder = new TextDecoder("utf-8", { fatal: true });
+  let byteLength = 0;
+  let body = "";
+  try {
+    for (;;) {
+      const chunk = await reader.read();
+      if (chunk.done) break;
+      byteLength += chunk.value.byteLength;
+      if (byteLength > MAX_EVM_RPC_BYTES) {
+        throw new RangeError("EVM RPC response exceeded its size limit");
+      }
+      body += decoder.decode(chunk.value, { stream: true });
+    }
+    body += decoder.decode();
+  } catch (error) {
+    if (error instanceof TypeError) {
+      throw new TypeError("EVM RPC response is not valid UTF-8", {
+        cause: error,
+      });
+    }
+    throw error;
+  }
+  if (byteLength === 0) throw new RangeError("EVM RPC response is empty");
+  return body;
 }
 
 async function rpcCall(
   rpc: URL,
-  fetchImpl: (url: URL, init?: RequestInit) => Promise<Response>,
+  fetchImpl: FetchLike,
   method: string,
   params: readonly unknown[],
+  id: string,
 ): Promise<unknown> {
   const response = await fetchImpl(rpc, {
     method: "POST",
     headers: { "content-type": "application/json" },
-    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+    body: JSON.stringify({ jsonrpc: "2.0", id, method, params }),
+    redirect: "error",
     signal: AbortSignal.timeout(20_000),
   });
   if (!response.ok) {
     throw new Error(`EVM RPC ${method} returned HTTP ${response.status}`);
   }
-  const bytes = new Uint8Array(await response.arrayBuffer());
-  if (bytes.length === 0 || bytes.length > MAX_RPC_BYTES) {
-    throw new RangeError(`EVM RPC ${method} response is empty or oversized`);
-  }
+  const responseBody = await boundedBody(response);
   let envelope: unknown;
   try {
-    envelope = JSON.parse(
-      new TextDecoder("utf-8", { fatal: true }).decode(bytes),
-    );
+    envelope = JSON.parse(responseBody);
   } catch (error) {
     throw new TypeError(`EVM RPC ${method} response is invalid JSON`, {
       cause: error,
@@ -68,6 +139,9 @@ async function rpcCall(
     throw new TypeError(`EVM RPC ${method} response is invalid`);
   }
   const body = envelope as Record<string, unknown>;
+  if (body.jsonrpc !== "2.0" || body.id !== id) {
+    throw new TypeError(`EVM RPC ${method} response identity is invalid`);
+  }
   if (body.error !== undefined && body.error !== null) {
     throw new TypeError(
       `EVM RPC ${method} returned an error: ${JSON.stringify(body.error)}`,
@@ -79,12 +153,73 @@ async function rpcCall(
   return body.result;
 }
 
+async function verifyWithAuthority(
+  input: {
+    amountMinor: string;
+    network: EvmFundingNetwork;
+    recipient: string;
+    transactionHash: string;
+  },
+  authority: string,
+  authorityIndex: number,
+  fetchImpl: FetchLike,
+) {
+  const rpc = new URL(authority);
+  let requestIndex = 0;
+  const request = (method: string, params: readonly unknown[]) =>
+    rpcCall(
+      rpc,
+      fetchImpl,
+      method,
+      params,
+      `slop-funding:${input.network}:${authorityIndex}:${requestIndex++}:${method}`,
+    );
+  const chainId = evmQuantity(
+    await request("eth_chainId", []),
+    "eth_chainId result",
+  );
+  if (chainId !== EVM_FUNDING_CHAIN_IDS[input.network]) {
+    throw new TypeError(
+      `EVM RPC chain id ${chainId} is not ${input.network} mainnet`,
+    );
+  }
+  const finalizedBlock = assertEvmCanonicalBlock(
+    await request("eth_getBlockByNumber", ["finalized", false]),
+    "finalized block",
+  );
+  const receipt = await request("eth_getTransactionReceipt", [
+    input.transactionHash,
+  ]);
+  if (
+    typeof receipt !== "object" ||
+    receipt === null ||
+    Array.isArray(receipt)
+  ) {
+    throw new TypeError("EVM transaction receipt is absent or invalid");
+  }
+  const receiptBlockNumber = (receipt as Record<string, unknown>).blockNumber;
+  evmQuantity(receiptBlockNumber, "receipt.blockNumber");
+  const receiptBlock = assertEvmCanonicalBlock(
+    await request("eth_getBlockByNumber", [receiptBlockNumber, false]),
+    "canonical receipt block",
+  );
+  const verified = assertConfirmedUsdcFundingTransfer(
+    receipt,
+    input.network,
+    input.transactionHash,
+    input.recipient,
+    input.amountMinor,
+    finalizedBlock,
+    receiptBlock,
+  );
+  return { authority: rpc.toString(), finalizedBlock, verified };
+}
+
 export async function verifyFundingEvm(input: {
   amountMinor: string;
-  fetchImpl?: (url: URL, init?: RequestInit) => Promise<Response>;
+  fetchImpl?: FetchLike;
   network: EvmFundingNetwork;
   recipient: string;
-  rpcUrl?: string;
   transactionHash: string;
 }) {
   if (
@@ -98,56 +233,43 @@ export async function verifyFundingEvm(input: {
       "network, transaction hash, recipient, or amount is invalid",
     );
   }
-  const rpc = new URL(input.rpcUrl ?? DEFAULT_RPCS[input.network]);
-  if (rpc.protocol !== "https:" || rpc.username || rpc.password || rpc.hash) {
-    throw new TypeError("EVM RPC must be a credential-free HTTPS URL");
-  }
   const fetchImpl = input.fetchImpl ?? fetch;
-
-  const chainId = evmQuantity(
-    await rpcCall(rpc, fetchImpl, "eth_chainId", []),
-    "eth_chainId result",
+  const authorities = EVM_FUNDING_RPC_AUTHORITIES[input.network];
+  const settled = await Promise.allSettled(
+    authorities.map((authority, index) =>
+      verifyWithAuthority(input, authority, index, fetchImpl),
+    ),
   );
-  if (chainId !== EVM_FUNDING_CHAIN_IDS[input.network]) {
+  const groups = new Map<
+    string,
+    Array<Awaited<ReturnType<typeof verifyWithAuthority>>>
+  >();
+  for (const result of settled) {
+    if (result.status !== "fulfilled") continue;
+    const { verified } = result.value;
+    const key = `${verified.transactionHash}:${verified.blockNumber}:${verified.blockHash}`;
+    const group = groups.get(key) ?? [];
+    group.push(result.value);
+    groups.set(key, group);
+  }
+  const results = [...groups.values()].sort(
+    (left, right) => right.length - left.length,
+  )[0];
+  const first = results?.[0];
+  if (!first || !results || results.length < EVM_FUNDING_RPC_QUORUM) {
     throw new TypeError(
-      `EVM RPC chain id ${chainId} is not ${input.network} mainnet`,
+      "EVM RPC authorities did not reach canonical transaction quorum",
     );
   }
-  const finalizedBlock = await rpcCall(rpc, fetchImpl, "eth_getBlockByNumber", [
-    "finalized",
-    false,
-  ]);
-  if (
-    typeof finalizedBlock !== "object" ||
-    finalizedBlock === null ||
-    Array.isArray(finalizedBlock)
-  ) {
-    throw new TypeError("EVM RPC did not return a finalized block");
-  }
-  const finalizedBlockNumber = evmQuantity(
-    (finalizedBlock as Record<string, unknown>).number,
-    "finalized block number",
-  );
-  const receipt = await rpcCall(rpc, fetchImpl, "eth_getTransactionReceipt", [
-    input.transactionHash,
-  ]);
-  if (receipt === null || receipt === undefined) {
-    throw new TypeError("EVM transaction receipt is absent");
-  }
-  const verified = assertConfirmedUsdcFundingTransfer(
-    receipt,
-    input.network,
-    input.transactionHash,
-    input.recipient,
-    input.amountMinor,
-    finalizedBlockNumber,
+  const confirmations = Math.min(
+    ...results.map(({ verified }) => verified.confirmations),
   );
   const checkedAt = new Date().toISOString();
   return {
     state: "verified-on-chain" as const,
     finality: {
       kind: "confirmations" as const,
-      confirmations: verified.confirmations,
+      confirmations,
     },
     verifier: {
       version: EVM_FUNDING_VERIFIER_VERSIONS[input.network],
@@ -155,16 +277,21 @@ export async function verifyFundingEvm(input: {
       evidenceUrl: `${EVIDENCE_HOSTS[input.network]}/tx/${input.transactionHash}`,
       reason: null,
     },
-    chainEvidence: verified,
+    chainEvidence: {
+      ...first.verified,
+      confirmations,
+      authorities: results.map(({ authority, finalizedBlock }) => ({
+        authority,
+        finalizedBlockHash: finalizedBlock.hash,
+        finalizedBlockNumber: Number(finalizedBlock.number),
+      })),
+    },
   };
 }
 
 if (import.meta.main) {
-  const network = argument("--network");
-  const transactionHash = argument("--transaction");
-  const recipient = argument("--recipient");
-  const amountMinor = argument("--amount-minor");
-  const rpcUrl = argument("--rpc-url") ?? undefined;
+  const { network, transactionHash, recipient, amountMinor } =
+    parseEvmFundingArguments(process.argv.slice(2));
   if (
     !network ||
     !isEvmFundingNetwork(network) ||
@@ -173,10 +300,10 @@ if (import.meta.main) {
     !amountMinor
   ) {
     throw new TypeError(
-      "Usage: verify-funding-evm.ts --network <base|ethereum> --transaction <0x-hash> --recipient <0x-address> --amount-minor <integer> [--rpc-url <https-url>]",
+      "Usage: verify-funding-evm.ts --network <base|ethereum> --transaction <0x-hash> --recipient <0x-address> --amount-minor <integer>",
     );
   }
   process.stdout.write(
-    `${JSON.stringify(await verifyFundingEvm({ network, transactionHash, recipient, amountMinor, rpcUrl }), null, 2)}\n`,
+    `${JSON.stringify(await verifyFundingEvm({ network, transactionHash, recipient, amountMinor }), null, 2)}\n`,
   );
 }

--- a/src/lib/bitcoin-funding.test.ts
+++ b/src/lib/bitcoin-funding.test.ts
@@ -247,6 +247,60 @@ describe("Bitcoin funding transfer verification", () => {
     ).toThrow(/expectation is invalid/u);
   });
 
+  it("rejects aggregate input and output totals above the 21 million BTC supply", () => {
+    expect(() =>
+      assertConfirmedBtcFundingTransfer(
+        transaction({
+          vin: [
+            {
+              is_coinbase: false,
+              prevout: {
+                scriptpubkey_address: SENDER,
+                value: 2_100_000_000_000_000,
+              },
+            },
+            {
+              is_coinbase: false,
+              prevout: { scriptpubkey_address: SENDER, value: 1 },
+            },
+          ],
+        }),
+        TXID,
+        RECIPIENT,
+        "150000",
+        TIP,
+        BLOCK_HASH,
+      ),
+    ).toThrow(/input total exceeds/u);
+    expect(() =>
+      assertConfirmedBtcFundingTransfer(
+        transaction({
+          vin: [
+            {
+              is_coinbase: false,
+              prevout: {
+                scriptpubkey_address: SENDER,
+                value: 2_100_000_000_000_000,
+              },
+            },
+          ],
+          vout: [
+            { scriptpubkey_address: RECIPIENT, value: 150_000 },
+            {
+              scriptpubkey_address: SENDER,
+              value: 2_100_000_000_000_000,
+            },
+          ],
+        }),
+        TXID,
+        RECIPIENT,
+        "150000",
+        TIP,
+        BLOCK_HASH,
+      ),
+    ).toThrow(/output total exceeds/u);
+  });
+
   it("produces verifier fields the funding record schema accepts", () => {
     const routes = assertProjectFundingAddresses([
       {

--- a/src/lib/bitcoin-funding.test.ts
+++ b/src/lib/bitcoin-funding.test.ts
@@ -1,0 +1,300 @@
+/** Proves Bitcoin funding credits verify by exact UTXO sums and fail closed. */
+
+import { describe, expect, it } from "vitest";
+import {
+  assertConfirmedBtcFundingTransfer,
+  BITCOIN_FUNDING_VERIFIER_VERSION,
+} from "./bitcoin-funding";
+import {
+  assertProjectFundingAddresses,
+  assertProjectFundingRecord,
+} from "./funding";
+
+const RECIPIENT = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
+const SENDER = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4";
+const TXID = "a".repeat(64);
+const BLOCK_HASH = "f".repeat(64);
+const TIP = 800_010;
+
+function transaction(overrides: Record<string, unknown> = {}) {
+  return {
+    txid: TXID,
+    status: {
+      confirmed: true,
+      block_height: 800_000,
+      block_hash: BLOCK_HASH,
+    },
+    vin: [
+      {
+        is_coinbase: false,
+        prevout: { scriptpubkey_address: SENDER, value: 200_000 },
+      },
+    ],
+    vout: [
+      { scriptpubkey_address: RECIPIENT, value: 150_000 },
+      { scriptpubkey_address: SENDER, value: 49_000 },
+    ],
+    fee: 1_000,
+    ...overrides,
+  };
+}
+
+describe("Bitcoin funding transfer verification", () => {
+  it("verifies an exact confirmed credit with a reconciled fee", () => {
+    expect(
+      assertConfirmedBtcFundingTransfer(
+        transaction(),
+        TXID,
+        RECIPIENT,
+        "150000",
+        TIP,
+        BLOCK_HASH,
+      ),
+    ).toEqual({
+      transactionId: TXID,
+      blockHash: BLOCK_HASH,
+      blockHeight: 800_000,
+      confirmations: 11,
+    });
+  });
+
+  it("sums multiple non-dust credits to the recipient", () => {
+    expect(
+      assertConfirmedBtcFundingTransfer(
+        transaction({
+          vout: [
+            { scriptpubkey_address: RECIPIENT, value: 100_000 },
+            { scriptpubkey_address: RECIPIENT, value: 50_000 },
+            { scriptpubkey_address: SENDER, value: 49_000 },
+          ],
+        }),
+        TXID,
+        RECIPIENT,
+        "150000",
+        TIP,
+        BLOCK_HASH,
+      ).confirmations,
+    ).toBe(11);
+  });
+
+  it("rejects unconfirmed, reorged, shallow, or mismatched transactions", () => {
+    expect(() =>
+      assertConfirmedBtcFundingTransfer(
+        transaction({ status: { confirmed: false } }),
+        TXID,
+        RECIPIENT,
+        "150000",
+        TIP,
+        BLOCK_HASH,
+      ),
+    ).toThrow(/unconfirmed/u);
+    expect(() =>
+      assertConfirmedBtcFundingTransfer(
+        transaction(),
+        TXID,
+        RECIPIENT,
+        "150000",
+        TIP,
+        "e".repeat(64),
+      ),
+    ).toThrow(/best chain/u);
+    expect(() =>
+      assertConfirmedBtcFundingTransfer(
+        transaction(),
+        TXID,
+        RECIPIENT,
+        "150000",
+        800_004,
+        BLOCK_HASH,
+      ),
+    ).toThrow(/finality policy/u);
+    expect(() =>
+      assertConfirmedBtcFundingTransfer(
+        transaction({ txid: "b".repeat(64) }),
+        TXID,
+        RECIPIENT,
+        "150000",
+        TIP,
+        BLOCK_HASH,
+      ),
+    ).toThrow(/does not match/u);
+  });
+
+  it("rejects wrong amounts, self-funding, coinbase, dust, and bad fees", () => {
+    expect(() =>
+      assertConfirmedBtcFundingTransfer(
+        transaction(),
+        TXID,
+        RECIPIENT,
+        "149999",
+        TIP,
+        BLOCK_HASH,
+      ),
+    ).toThrow(/exact amount/u);
+    expect(() =>
+      assertConfirmedBtcFundingTransfer(
+        transaction({
+          vin: [
+            {
+              is_coinbase: false,
+              prevout: { scriptpubkey_address: RECIPIENT, value: 200_000 },
+            },
+          ],
+        }),
+        TXID,
+        RECIPIENT,
+        "150000",
+        TIP,
+        BLOCK_HASH,
+      ),
+    ).toThrow(/recipient's own coins/u);
+    expect(() =>
+      assertConfirmedBtcFundingTransfer(
+        transaction({
+          vin: [{ is_coinbase: true, prevout: {} }],
+        }),
+        TXID,
+        RECIPIENT,
+        "150000",
+        TIP,
+        BLOCK_HASH,
+      ),
+    ).toThrow(/coinbase/u);
+    expect(() =>
+      assertConfirmedBtcFundingTransfer(
+        transaction(),
+        TXID,
+        RECIPIENT,
+        "500",
+        TIP,
+        BLOCK_HASH,
+      ),
+    ).toThrow(/dust/u);
+    expect(() =>
+      assertConfirmedBtcFundingTransfer(
+        transaction({
+          vout: [
+            { scriptpubkey_address: RECIPIENT, value: 546 },
+            { scriptpubkey_address: RECIPIENT, value: 149_454 },
+            { scriptpubkey_address: SENDER, value: 49_000 },
+          ],
+        }),
+        TXID,
+        RECIPIENT,
+        "150000",
+        TIP,
+        BLOCK_HASH,
+      ),
+    ).toThrow(/dust-level output/u);
+    expect(() =>
+      assertConfirmedBtcFundingTransfer(
+        transaction({ fee: 2_000 }),
+        TXID,
+        RECIPIENT,
+        "150000",
+        TIP,
+        BLOCK_HASH,
+      ),
+    ).toThrow(/fee does not reconcile/u);
+    expect(() =>
+      assertConfirmedBtcFundingTransfer(
+        transaction({
+          fee: 0,
+          vout: [
+            { scriptpubkey_address: RECIPIENT, value: 150_000 },
+            { scriptpubkey_address: SENDER, value: 50_000 },
+          ],
+        }),
+        TXID,
+        RECIPIENT,
+        "150000",
+        TIP,
+        BLOCK_HASH,
+      ),
+    ).toThrow(/fee does not reconcile/u);
+  });
+
+  it("rejects malformed expectations before reading the transaction", () => {
+    expect(() =>
+      assertConfirmedBtcFundingTransfer(
+        transaction(),
+        TXID,
+        "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa",
+        "150000",
+        TIP,
+        BLOCK_HASH,
+      ),
+    ).toThrow(/expectation is invalid/u);
+    expect(() =>
+      assertConfirmedBtcFundingTransfer(
+        transaction(),
+        `0x${"a".repeat(62)}`,
+        RECIPIENT,
+        "150000",
+        TIP,
+        BLOCK_HASH,
+      ),
+    ).toThrow(/expectation is invalid/u);
+    expect(() =>
+      assertConfirmedBtcFundingTransfer(
+        transaction(),
+        TXID,
+        RECIPIENT,
+        "1".repeat(41),
+        TIP,
+        BLOCK_HASH,
+      ),
+    ).toThrow(/expectation is invalid/u);
+  });
+
+  it("produces verifier fields the funding record schema accepts", () => {
+    const routes = assertProjectFundingAddresses([
+      {
+        network: "bitcoin",
+        asset: "BTC",
+        address: RECIPIENT,
+        effectiveAt: "2026-08-01T00:00:00.000Z",
+        replacedAt: null,
+      },
+    ]);
+    const verified = assertConfirmedBtcFundingTransfer(
+      transaction(),
+      TXID,
+      RECIPIENT,
+      "150000",
+      TIP,
+      BLOCK_HASH,
+    );
+    expect(
+      assertProjectFundingRecord(
+        {
+          schemaVersion: "1",
+          kind: "project-funding",
+          recordId: "fund_fixture_01",
+          projectId: "eliza",
+          manifestRevision: "b".repeat(40),
+          network: "bitcoin",
+          asset: "BTC",
+          transactionId: TXID,
+          recipient: RECIPIENT,
+          amountMinor: "150000",
+          observedAt: "2026-08-02T00:00:00.000Z",
+          state: "verified-on-chain",
+          donor: { attribution: "anonymous" },
+          finality: {
+            kind: "confirmations",
+            confirmations: verified.confirmations,
+          },
+          verifier: {
+            version: BITCOIN_FUNDING_VERIFIER_VERSION,
+            checkedAt: "2026-08-02T01:00:00.000Z",
+            evidenceUrl: `https://mempool.space/tx/${TXID}`,
+            reason: null,
+          },
+          supersedes: null,
+        },
+        routes,
+      ),
+    ).toMatchObject({ state: "verified-on-chain" });
+  });
+});

--- a/src/lib/bitcoin-funding.ts
+++ b/src/lib/bitcoin-funding.ts
@@ -156,6 +156,11 @@ export function assertConfirmedBtcFundingTransfer(
       prevout.value,
       `Bitcoin vin[${index}].prevout.value`,
     );
+    if (inputTotal > MAX_SATS) {
+      throw new TypeError(
+        "Bitcoin transaction input total exceeds the satoshi supply",
+      );
+    }
   });
   let outputTotal = 0n;
   let recipientCredit = 0n;
@@ -163,6 +168,11 @@ export function assertConfirmedBtcFundingTransfer(
     const output = record(entry, `Bitcoin vout[${index}]`);
     const value = satoshis(output.value, `Bitcoin vout[${index}].value`);
     outputTotal += value;
+    if (outputTotal > MAX_SATS) {
+      throw new TypeError(
+        "Bitcoin transaction output total exceeds the satoshi supply",
+      );
+    }
     if (output.scriptpubkey_address === recipient) {
       if (value <= BITCOIN_FUNDING_DUST_MINIMUM_SATS) {
         throw new TypeError(

--- a/src/lib/bitcoin-funding.ts
+++ b/src/lib/bitcoin-funding.ts
@@ -1,0 +1,192 @@
+/**
+ * Verifies confirmed Bitcoin mainnet direct-funding credits from Esplora
+ * transaction data by reconciling exact UTXO output sums, coherent fees, the
+ * standard dust floor, and best-chain membership at check time. A transaction
+ * id alone never counts as evidence.
+ */
+
+import { isFundingAddress } from "./funding-address.mjs";
+
+export const BITCOIN_FUNDING_VERIFIER_VERSION = "funding-bitcoin-v1" as const;
+
+export const BITCOIN_FUNDING_MIN_CONFIRMATIONS = 6;
+
+/** Outputs at or below the standard 546-satoshi dust bound are not funding. */
+export const BITCOIN_FUNDING_DUST_MINIMUM_SATS = 546n;
+
+const MAX_SATS = 2_100_000_000_000_000n;
+const MAX_TRANSACTION_IO = 10_000;
+
+export interface VerifiedBitcoinTransaction {
+  blockHash: string;
+  blockHeight: number;
+  confirmations: number;
+  transactionId: string;
+}
+
+function record(value: unknown, field: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new TypeError(`${field} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+export function isBitcoinTransactionId(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    /^[0-9a-f]{64}$/u.test(value) &&
+    !value.startsWith("0x")
+  );
+}
+
+export function isBitcoinBlockHash(value: unknown): value is string {
+  return typeof value === "string" && /^[0-9a-f]{64}$/u.test(value);
+}
+
+function satoshis(value: unknown, field: string): bigint {
+  if (
+    typeof value !== "number" ||
+    !Number.isSafeInteger(value) ||
+    value < 0 ||
+    BigInt(value) > MAX_SATS
+  ) {
+    throw new TypeError(`${field} must be a bounded satoshi integer`);
+  }
+  return BigInt(value);
+}
+
+function blockHeight(value: unknown, field: string): bigint {
+  if (
+    typeof value !== "number" ||
+    !Number.isSafeInteger(value) ||
+    value < 0 ||
+    value > 100_000_000
+  ) {
+    throw new TypeError(`${field} must be a bounded block height`);
+  }
+  return BigInt(value);
+}
+
+/** Validates one confirmed direct-funding credit without trusting its sender. */
+export function assertConfirmedBtcFundingTransfer(
+  transactionValue: unknown,
+  expectedTransactionId: string,
+  recipient: string,
+  amountMinor: string,
+  tipHeight: unknown,
+  bestChainHashAtHeight: unknown,
+): VerifiedBitcoinTransaction {
+  if (
+    !isBitcoinTransactionId(expectedTransactionId) ||
+    !isFundingAddress("bitcoin", recipient) ||
+    amountMinor.length > 40 ||
+    !/^[1-9]\d*$/u.test(amountMinor)
+  ) {
+    throw new TypeError("funding transfer expectation is invalid");
+  }
+  const expected = BigInt(amountMinor);
+  if (expected < BITCOIN_FUNDING_DUST_MINIMUM_SATS) {
+    throw new TypeError(
+      "Bitcoin funding amount is at or below the standard dust bound",
+    );
+  }
+  if (expected > MAX_SATS) {
+    throw new TypeError("Bitcoin funding amount exceeds the satoshi supply");
+  }
+  const tip = blockHeight(tipHeight, "Bitcoin tip height");
+  const transaction = record(transactionValue, "Bitcoin transaction");
+  if (transaction.txid !== expectedTransactionId) {
+    throw new TypeError(
+      "Bitcoin transaction id does not match the funding record",
+    );
+  }
+  const status = record(transaction.status, "Bitcoin transaction.status");
+  if (status.confirmed !== true) {
+    throw new TypeError("Bitcoin transaction is unconfirmed");
+  }
+  const height = blockHeight(
+    status.block_height,
+    "Bitcoin transaction.status.block_height",
+  );
+  if (!isBitcoinBlockHash(status.block_hash)) {
+    throw new TypeError("Bitcoin transaction block hash is invalid");
+  }
+  if (
+    !isBitcoinBlockHash(bestChainHashAtHeight) ||
+    bestChainHashAtHeight !== status.block_hash
+  ) {
+    throw new TypeError(
+      "Bitcoin transaction block is not in the current best chain",
+    );
+  }
+  if (height > tip) {
+    throw new TypeError("Bitcoin transaction height is beyond the chain tip");
+  }
+  const confirmations = tip - height + 1n;
+  if (confirmations < BigInt(BITCOIN_FUNDING_MIN_CONFIRMATIONS)) {
+    throw new TypeError(
+      "Bitcoin transaction does not meet the network finality policy",
+    );
+  }
+  const inputs = transaction.vin;
+  const outputs = transaction.vout;
+  if (
+    !Array.isArray(inputs) ||
+    !Array.isArray(outputs) ||
+    inputs.length === 0 ||
+    outputs.length === 0 ||
+    inputs.length > MAX_TRANSACTION_IO ||
+    outputs.length > MAX_TRANSACTION_IO
+  ) {
+    throw new TypeError("Bitcoin transaction inputs or outputs are invalid");
+  }
+  let inputTotal = 0n;
+  inputs.forEach((entry, index) => {
+    const input = record(entry, `Bitcoin vin[${index}]`);
+    if (input.is_coinbase === true) {
+      throw new TypeError("Bitcoin funding cannot come from a coinbase");
+    }
+    const prevout = record(input.prevout, `Bitcoin vin[${index}].prevout`);
+    if (prevout.scriptpubkey_address === recipient) {
+      throw new TypeError(
+        "Bitcoin funding transaction spends the recipient's own coins",
+      );
+    }
+    inputTotal += satoshis(
+      prevout.value,
+      `Bitcoin vin[${index}].prevout.value`,
+    );
+  });
+  let outputTotal = 0n;
+  let recipientCredit = 0n;
+  outputs.forEach((entry, index) => {
+    const output = record(entry, `Bitcoin vout[${index}]`);
+    const value = satoshis(output.value, `Bitcoin vout[${index}].value`);
+    outputTotal += value;
+    if (output.scriptpubkey_address === recipient) {
+      if (value <= BITCOIN_FUNDING_DUST_MINIMUM_SATS) {
+        throw new TypeError(
+          "Bitcoin funding credit includes a dust-level output",
+        );
+      }
+      recipientCredit += value;
+    }
+  });
+  const fee = satoshis(transaction.fee, "Bitcoin transaction.fee");
+  if (fee === 0n || inputTotal !== outputTotal + fee) {
+    throw new TypeError(
+      "Bitcoin transaction fee does not reconcile inputs and outputs",
+    );
+  }
+  if (recipientCredit !== expected) {
+    throw new TypeError(
+      "Bitcoin funding recipient did not receive the exact amount",
+    );
+  }
+  return {
+    transactionId: expectedTransactionId,
+    blockHash: status.block_hash as string,
+    blockHeight: Number(height),
+    confirmations: Number(confirmations),
+  };
+}

--- a/src/lib/evm-funding.test.ts
+++ b/src/lib/evm-funding.test.ts
@@ -1,0 +1,314 @@
+/** Proves EVM funding credits verify by exact USDC deltas and fail closed. */
+
+import { describe, expect, it } from "vitest";
+import {
+  assertConfirmedUsdcFundingTransfer,
+  EVM_FUNDING_MIN_CONFIRMATIONS,
+  EVM_FUNDING_USDC_CONTRACTS,
+  EVM_FUNDING_VERIFIER_VERSIONS,
+  type EvmFundingNetwork,
+} from "./evm-funding";
+import {
+  assertProjectFundingAddresses,
+  assertProjectFundingRecord,
+} from "./funding";
+
+const RECIPIENT = `0x${"1".repeat(40)}`;
+const SENDER = `0x${"2".repeat(40)}`;
+const OTHER = `0x${"3".repeat(40)}`;
+const ZERO = `0x${"0".repeat(40)}`;
+const HASH = `0x${"a".repeat(64)}`;
+const TRANSFER_TOPIC =
+  "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+
+function topic(address: string) {
+  return `0x${"0".repeat(24)}${address.slice(2)}`;
+}
+
+function amountData(value: bigint) {
+  return `0x${value.toString(16).padStart(64, "0")}`;
+}
+
+function transferLog(
+  network: EvmFundingNetwork,
+  from: string,
+  to: string,
+  value: bigint,
+) {
+  return {
+    address: EVM_FUNDING_USDC_CONTRACTS[network],
+    topics: [TRANSFER_TOPIC, topic(from), topic(to)],
+    data: amountData(value),
+    removed: false,
+  };
+}
+
+function receipt(
+  network: EvmFundingNetwork,
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    status: "0x1",
+    transactionHash: HASH,
+    blockNumber: "0x100",
+    logs: [transferLog(network, SENDER, RECIPIENT, 1_000_000n)],
+    ...overrides,
+  };
+}
+
+const FINALIZED = 0x1000n;
+
+describe("EVM funding transfer verification", () => {
+  it("verifies an exact confirmed USDC credit on both networks", () => {
+    for (const network of ["base", "ethereum"] as const) {
+      expect(
+        assertConfirmedUsdcFundingTransfer(
+          receipt(network),
+          network,
+          HASH,
+          RECIPIENT,
+          "1000000",
+          FINALIZED,
+        ),
+      ).toEqual({
+        transactionHash: HASH,
+        blockNumber: 0x100,
+        confirmations: 0x1000 - 0x100 + 1,
+      });
+    }
+  });
+
+  it("sums multiple USDC credits and ignores unrelated logs and events", () => {
+    const logs = [
+      transferLog("ethereum", SENDER, RECIPIENT, 400_000n),
+      transferLog("ethereum", SENDER, RECIPIENT, 600_000n),
+      {
+        address: `0x${"9".repeat(40)}`,
+        topics: [TRANSFER_TOPIC, topic(SENDER), topic(OTHER)],
+        data: amountData(5n),
+      },
+      {
+        address: EVM_FUNDING_USDC_CONTRACTS.ethereum,
+        topics: [`0x${"b".repeat(64)}`, topic(SENDER), topic(OTHER)],
+        data: amountData(5n),
+      },
+    ];
+    expect(
+      assertConfirmedUsdcFundingTransfer(
+        receipt("ethereum", { logs }),
+        "ethereum",
+        HASH,
+        RECIPIENT,
+        "1000000",
+        FINALIZED,
+      ).confirmations,
+    ).toBeGreaterThanOrEqual(EVM_FUNDING_MIN_CONFIRMATIONS.ethereum);
+  });
+
+  it("rejects failed, mismatched, unconfirmed, or unfinalized transactions", () => {
+    expect(() =>
+      assertConfirmedUsdcFundingTransfer(
+        receipt("ethereum", { status: "0x0" }),
+        "ethereum",
+        HASH,
+        RECIPIENT,
+        "1000000",
+        FINALIZED,
+      ),
+    ).toThrow(/did not execute successfully/u);
+    expect(() =>
+      assertConfirmedUsdcFundingTransfer(
+        receipt("ethereum", { transactionHash: `0x${"b".repeat(64)}` }),
+        "ethereum",
+        HASH,
+        RECIPIENT,
+        "1000000",
+        FINALIZED,
+      ),
+    ).toThrow(/does not match/u);
+    expect(() =>
+      assertConfirmedUsdcFundingTransfer(
+        receipt("ethereum", { blockNumber: "0x2000" }),
+        "ethereum",
+        HASH,
+        RECIPIENT,
+        "1000000",
+        FINALIZED,
+      ),
+    ).toThrow(/not finalized/u);
+    expect(() =>
+      assertConfirmedUsdcFundingTransfer(
+        receipt("ethereum"),
+        "ethereum",
+        HASH,
+        RECIPIENT,
+        "1000000",
+        0x100n + BigInt(EVM_FUNDING_MIN_CONFIRMATIONS.ethereum) - 2n,
+      ),
+    ).toThrow(/finality policy/u);
+    expect(() =>
+      assertConfirmedUsdcFundingTransfer(
+        receipt("base"),
+        "base",
+        HASH,
+        RECIPIENT,
+        "1000000",
+        0x100n + BigInt(EVM_FUNDING_MIN_CONFIRMATIONS.base) - 2n,
+      ),
+    ).toThrow(/finality policy/u);
+  });
+
+  it("rejects wrong amounts, undeclared credits, mints, and reorged logs", () => {
+    expect(() =>
+      assertConfirmedUsdcFundingTransfer(
+        receipt("ethereum"),
+        "ethereum",
+        HASH,
+        RECIPIENT,
+        "999999",
+        FINALIZED,
+      ),
+    ).toThrow(/exact amount/u);
+    expect(() =>
+      assertConfirmedUsdcFundingTransfer(
+        receipt("ethereum", {
+          logs: [
+            transferLog("ethereum", SENDER, RECIPIENT, 1_000_000n),
+            transferLog("ethereum", SENDER, OTHER, 1n),
+          ],
+        }),
+        "ethereum",
+        HASH,
+        RECIPIENT,
+        "1000000",
+        FINALIZED,
+      ),
+    ).toThrow(/undeclared credit/u);
+    expect(() =>
+      assertConfirmedUsdcFundingTransfer(
+        receipt("ethereum", {
+          logs: [transferLog("ethereum", ZERO, RECIPIENT, 1_000_000n)],
+        }),
+        "ethereum",
+        HASH,
+        RECIPIENT,
+        "1000000",
+        FINALIZED,
+      ),
+    ).toThrow(/mints or burns/u);
+    expect(() =>
+      assertConfirmedUsdcFundingTransfer(
+        receipt("ethereum", {
+          logs: [
+            {
+              ...transferLog("ethereum", SENDER, RECIPIENT, 1_000_000n),
+              removed: true,
+            },
+          ],
+        }),
+        "ethereum",
+        HASH,
+        RECIPIENT,
+        "1000000",
+        FINALIZED,
+      ),
+    ).toThrow(/reorged/u);
+    expect(() =>
+      assertConfirmedUsdcFundingTransfer(
+        receipt("ethereum", { logs: [] }),
+        "ethereum",
+        HASH,
+        RECIPIENT,
+        "1000000",
+        FINALIZED,
+      ),
+    ).toThrow(/exact amount/u);
+  });
+
+  it("rejects malformed expectations before reading the receipt", () => {
+    expect(() =>
+      assertConfirmedUsdcFundingTransfer(
+        receipt("ethereum"),
+        "ethereum",
+        HASH,
+        RECIPIENT.toUpperCase(),
+        "1000000",
+        FINALIZED,
+      ),
+    ).toThrow(/expectation is invalid/u);
+    expect(() =>
+      assertConfirmedUsdcFundingTransfer(
+        receipt("ethereum"),
+        "ethereum",
+        HASH,
+        RECIPIENT,
+        "1".repeat(41),
+        FINALIZED,
+      ),
+    ).toThrow(/expectation is invalid/u);
+    expect(() =>
+      assertConfirmedUsdcFundingTransfer(
+        receipt("ethereum"),
+        "ethereum",
+        HASH,
+        ZERO,
+        "1000000",
+        FINALIZED,
+      ),
+    ).toThrow(/expectation is invalid/u);
+  });
+
+  it("produces verifier fields the funding record schema accepts", () => {
+    for (const network of ["base", "ethereum"] as const) {
+      const routes = assertProjectFundingAddresses([
+        {
+          network,
+          asset: "USDC",
+          address: RECIPIENT,
+          effectiveAt: "2026-08-01T00:00:00.000Z",
+          replacedAt: null,
+        },
+      ]);
+      const verified = assertConfirmedUsdcFundingTransfer(
+        receipt(network),
+        network,
+        HASH,
+        RECIPIENT,
+        "1000000",
+        FINALIZED,
+      );
+      const host = network === "base" ? "basescan.org" : "etherscan.io";
+      expect(
+        assertProjectFundingRecord(
+          {
+            schemaVersion: "1",
+            kind: "project-funding",
+            recordId: "fund_fixture_01",
+            projectId: "eliza",
+            manifestRevision: "b".repeat(40),
+            network,
+            asset: "USDC",
+            transactionId: HASH,
+            recipient: RECIPIENT,
+            amountMinor: "1000000",
+            observedAt: "2026-08-02T00:00:00.000Z",
+            state: "verified-on-chain",
+            donor: { attribution: "anonymous" },
+            finality: {
+              kind: "confirmations",
+              confirmations: verified.confirmations,
+            },
+            verifier: {
+              version: EVM_FUNDING_VERIFIER_VERSIONS[network],
+              checkedAt: "2026-08-02T01:00:00.000Z",
+              evidenceUrl: `https://${host}/tx/${HASH}`,
+              reason: null,
+            },
+            supersedes: null,
+          },
+          routes,
+        ),
+      ).toMatchObject({ state: "verified-on-chain" });
+    }
+  });
+});

--- a/src/lib/evm-funding.test.ts
+++ b/src/lib/evm-funding.test.ts
@@ -2,11 +2,12 @@
 
 import { describe, expect, it } from "vitest";
 import {
-  assertConfirmedUsdcFundingTransfer,
+  assertConfirmedUsdcFundingTransfer as assertTransfer,
   EVM_FUNDING_MIN_CONFIRMATIONS,
   EVM_FUNDING_USDC_CONTRACTS,
   EVM_FUNDING_VERIFIER_VERSIONS,
   type EvmFundingNetwork,
+  MAX_EVM_FUNDING_RECEIPT_LOGS,
 } from "./evm-funding";
 import {
   assertProjectFundingAddresses,
@@ -18,6 +19,8 @@ const SENDER = `0x${"2".repeat(40)}`;
 const OTHER = `0x${"3".repeat(40)}`;
 const ZERO = `0x${"0".repeat(40)}`;
 const HASH = `0x${"a".repeat(64)}`;
+const BLOCK_HASH = `0x${"b".repeat(64)}`;
+const FINALIZED_HASH = `0x${"c".repeat(64)}`;
 const TRANSFER_TOPIC =
   "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
 
@@ -40,6 +43,9 @@ function transferLog(
     topics: [TRANSFER_TOPIC, topic(from), topic(to)],
     data: amountData(value),
     removed: false,
+    transactionHash: HASH,
+    blockHash: BLOCK_HASH,
+    blockNumber: "0x100",
   };
 }
 
@@ -51,12 +57,38 @@ function receipt(
     status: "0x1",
     transactionHash: HASH,
     blockNumber: "0x100",
+    blockHash: BLOCK_HASH,
     logs: [transferLog(network, SENDER, RECIPIENT, 1_000_000n)],
     ...overrides,
   };
 }
 
-const FINALIZED = 0x1000n;
+const FINALIZED = { number: 0x1000n, hash: FINALIZED_HASH };
+
+function assertConfirmedUsdcFundingTransfer(
+  receiptValue: unknown,
+  network: EvmFundingNetwork,
+  expectedTransactionHash: string,
+  recipient: string,
+  amountMinor: string,
+  finalized: bigint | typeof FINALIZED,
+) {
+  const candidate = receiptValue as {
+    blockHash: string;
+    blockNumber: string;
+  };
+  return assertTransfer(
+    receiptValue,
+    network,
+    expectedTransactionHash,
+    recipient,
+    amountMinor,
+    typeof finalized === "bigint"
+      ? { number: finalized, hash: FINALIZED_HASH }
+      : finalized,
+    { number: BigInt(candidate.blockNumber), hash: candidate.blockHash },
+  );
+}
 
 describe("EVM funding transfer verification", () => {
   it("verifies an exact confirmed USDC credit on both networks", () => {
@@ -72,6 +104,7 @@ describe("EVM funding transfer verification", () => {
         ),
       ).toEqual({
         transactionHash: HASH,
+        blockHash: BLOCK_HASH,
         blockNumber: 0x100,
         confirmations: 0x1000 - 0x100 + 1,
       });
@@ -223,6 +256,82 @@ describe("EVM funding transfer verification", () => {
         FINALIZED,
       ),
     ).toThrow(/exact amount/u);
+  });
+
+  it("binds the receipt and counted logs to one canonical transaction block", () => {
+    expect(() =>
+      assertTransfer(
+        receipt("ethereum"),
+        "ethereum",
+        HASH,
+        RECIPIENT,
+        "1000000",
+        FINALIZED,
+        { number: 0x100n, hash: `0x${"d".repeat(64)}` },
+      ),
+    ).toThrow(/canonical block/u);
+    for (const logOverride of [
+      { transactionHash: `0x${"d".repeat(64)}` },
+      { blockHash: `0x${"d".repeat(64)}` },
+      { blockNumber: "0x101" },
+      { removed: undefined },
+    ]) {
+      expect(() =>
+        assertConfirmedUsdcFundingTransfer(
+          receipt("ethereum", {
+            logs: [
+              {
+                ...transferLog("ethereum", SENDER, RECIPIENT, 1_000_000n),
+                ...logOverride,
+              },
+            ],
+          }),
+          "ethereum",
+          HASH,
+          RECIPIENT,
+          "1000000",
+          FINALIZED,
+        ),
+      ).toThrow(/funding transaction block/u);
+    }
+  });
+
+  it("bounds receipt work and rejects an unsafe confirmation conversion", () => {
+    expect(() =>
+      assertConfirmedUsdcFundingTransfer(
+        receipt("ethereum", {
+          logs: Array.from(
+            { length: MAX_EVM_FUNDING_RECEIPT_LOGS + 1 },
+            () => ({ address: `0x${"9".repeat(40)}` }),
+          ),
+        }),
+        "ethereum",
+        HASH,
+        RECIPIENT,
+        "1000000",
+        FINALIZED,
+      ),
+    ).toThrow(/at most/u);
+    const zeroBlockReceipt = receipt("ethereum", {
+      blockNumber: "0x0",
+      logs: [
+        {
+          ...transferLog("ethereum", SENDER, RECIPIENT, 1_000_000n),
+          blockNumber: "0x0",
+        },
+      ],
+    });
+    expect(() =>
+      assertTransfer(
+        zeroBlockReceipt,
+        "ethereum",
+        HASH,
+        RECIPIENT,
+        "1000000",
+        { number: BigInt(Number.MAX_SAFE_INTEGER), hash: FINALIZED_HASH },
+        { number: 0n, hash: BLOCK_HASH },
+      ),
+    ).toThrow(/safe integer/u);
   });
 
   it("rejects malformed expectations before reading the receipt", () => {

--- a/src/lib/evm-funding.ts
+++ b/src/lib/evm-funding.ts
@@ -23,14 +23,22 @@ export const EVM_FUNDING_MIN_CONFIRMATIONS = {
   ethereum: 64,
 } as const;
 
+export const MAX_EVM_FUNDING_RECEIPT_LOGS = 4_096;
+
 const ERC20_TRANSFER_TOPIC =
   "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
 const ZERO_EVM_ADDRESS = `0x${"0".repeat(40)}`;
 
 export interface VerifiedEvmTransaction {
+  blockHash: string;
   blockNumber: number;
   confirmations: number;
   transactionHash: string;
+}
+
+export interface EvmCanonicalBlock {
+  hash: string;
+  number: bigint;
 }
 
 function record(value: unknown, field: string): Record<string, unknown> {
@@ -62,6 +70,24 @@ export function evmQuantity(value: unknown, field: string): bigint {
   return BigInt(value);
 }
 
+function evmHash(value: unknown, field: string): string {
+  if (typeof value !== "string" || !/^0x[0-9a-f]{64}$/u.test(value)) {
+    throw new TypeError(`${field} is not a canonical EVM hash`);
+  }
+  return value;
+}
+
+export function assertEvmCanonicalBlock(
+  value: unknown,
+  field: string,
+): EvmCanonicalBlock {
+  const block = record(value, field);
+  return {
+    hash: evmHash(block.hash, `${field}.hash`),
+    number: evmQuantity(block.number, `${field}.number`),
+  };
+}
+
 function topicAddress(value: unknown, field: string): string {
   if (typeof value !== "string" || !/^0x0{24}[0-9a-f]{40}$/u.test(value)) {
     throw new TypeError(`${field} is not an ABI-encoded EVM address topic`);
@@ -83,7 +109,8 @@ export function assertConfirmedUsdcFundingTransfer(
   expectedTransactionHash: string,
   recipient: string,
   amountMinor: string,
-  finalizedBlockNumber: bigint,
+  finalizedBlock: EvmCanonicalBlock,
+  receiptBlock: EvmCanonicalBlock,
 ): VerifiedEvmTransaction {
   if (!isEvmFundingNetwork(network)) {
     throw new TypeError("funding network must be base or ethereum");
@@ -99,8 +126,12 @@ export function assertConfirmedUsdcFundingTransfer(
     throw new TypeError("funding transfer expectation is invalid");
   }
   if (
-    finalizedBlockNumber < 0n ||
-    finalizedBlockNumber > BigInt(Number.MAX_SAFE_INTEGER)
+    finalizedBlock.number < 0n ||
+    finalizedBlock.number > BigInt(Number.MAX_SAFE_INTEGER) ||
+    receiptBlock.number < 0n ||
+    receiptBlock.number > BigInt(Number.MAX_SAFE_INTEGER) ||
+    !/^0x[0-9a-f]{64}$/u.test(finalizedBlock.hash) ||
+    !/^0x[0-9a-f]{64}$/u.test(receiptBlock.hash)
   ) {
     throw new TypeError("finalized block number is invalid");
   }
@@ -114,18 +145,29 @@ export function assertConfirmedUsdcFundingTransfer(
     );
   }
   const blockNumber = evmQuantity(receipt.blockNumber, "receipt.blockNumber");
-  if (blockNumber > finalizedBlockNumber) {
+  const blockHash = evmHash(receipt.blockHash, "receipt.blockHash");
+  if (blockNumber !== receiptBlock.number || blockHash !== receiptBlock.hash) {
+    throw new TypeError(
+      "EVM receipt is not bound to the canonical block at its height",
+    );
+  }
+  if (blockNumber > finalizedBlock.number) {
     throw new TypeError("EVM transaction block is not finalized yet");
   }
-  const confirmations = finalizedBlockNumber - blockNumber + 1n;
+  const confirmations = finalizedBlock.number - blockNumber + 1n;
   const minimum = BigInt(EVM_FUNDING_MIN_CONFIRMATIONS[network]);
   if (confirmations < minimum) {
     throw new TypeError(
       "EVM transaction does not meet the network finality policy",
     );
   }
-  if (!Array.isArray(receipt.logs)) {
-    throw new TypeError("EVM receipt logs must be an array");
+  if (
+    !Array.isArray(receipt.logs) ||
+    receipt.logs.length > MAX_EVM_FUNDING_RECEIPT_LOGS
+  ) {
+    throw new TypeError(
+      `EVM receipt logs must be an array of at most ${MAX_EVM_FUNDING_RECEIPT_LOGS} entries`,
+    );
   }
   const usdcContract = EVM_FUNDING_USDC_CONTRACTS[network];
   const deltas = new Map<string, bigint>();
@@ -147,6 +189,17 @@ export function assertConfirmedUsdcFundingTransfer(
     if (log.topics.length !== 3) {
       throw new TypeError(
         `receipt.logs[${index}] is not a canonical ERC-20 Transfer`,
+      );
+    }
+    if (
+      log.removed !== false ||
+      log.transactionHash !== expectedTransactionHash ||
+      log.blockHash !== blockHash ||
+      evmQuantity(log.blockNumber, `receipt.logs[${index}].blockNumber`) !==
+        blockNumber
+    ) {
+      throw new TypeError(
+        `receipt.logs[${index}] is not bound to the funding transaction block`,
       );
     }
     const from = topicAddress(log.topics[1], `receipt.logs[${index}].from`);
@@ -180,8 +233,12 @@ export function assertConfirmedUsdcFundingTransfer(
   if (netDelta !== 0n) {
     throw new TypeError("EVM funding transaction USDC deltas do not balance");
   }
+  if (confirmations > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new TypeError("EVM confirmation count is not a safe integer");
+  }
   return {
     transactionHash: expectedTransactionHash,
+    blockHash,
     blockNumber: Number(blockNumber),
     confirmations: Number(confirmations),
   };

--- a/src/lib/evm-funding.ts
+++ b/src/lib/evm-funding.ts
@@ -1,0 +1,188 @@
+/**
+ * Verifies confirmed Base and Ethereum mainnet USDC direct-funding credits by
+ * reconciling exact ERC-20 Transfer deltas from a successful receipt against a
+ * finalized chain head. A transaction hash alone never counts as evidence.
+ */
+
+export type EvmFundingNetwork = "base" | "ethereum";
+
+export const EVM_FUNDING_VERIFIER_VERSIONS = {
+  base: "funding-base-v1",
+  ethereum: "funding-ethereum-v1",
+} as const;
+
+export const EVM_FUNDING_USDC_CONTRACTS = {
+  base: "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+  ethereum: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+} as const;
+
+export const EVM_FUNDING_CHAIN_IDS = { base: 8453n, ethereum: 1n } as const;
+
+export const EVM_FUNDING_MIN_CONFIRMATIONS = {
+  base: 12,
+  ethereum: 64,
+} as const;
+
+const ERC20_TRANSFER_TOPIC =
+  "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+const ZERO_EVM_ADDRESS = `0x${"0".repeat(40)}`;
+
+export interface VerifiedEvmTransaction {
+  blockNumber: number;
+  confirmations: number;
+  transactionHash: string;
+}
+
+function record(value: unknown, field: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new TypeError(`${field} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+export function isEvmFundingNetwork(
+  value: unknown,
+): value is EvmFundingNetwork {
+  return value === "base" || value === "ethereum";
+}
+
+export function isEvmTransactionHash(value: unknown): value is string {
+  return typeof value === "string" && /^0x[0-9a-f]{64}$/u.test(value);
+}
+
+/** Parses a canonical EVM JSON-RPC hex quantity into a bounded bigint. */
+export function evmQuantity(value: unknown, field: string): bigint {
+  if (
+    typeof value !== "string" ||
+    value.length > 66 ||
+    !/^0x(?:0|[1-9a-f][0-9a-f]*)$/u.test(value)
+  ) {
+    throw new TypeError(`${field} is not a canonical EVM hex quantity`);
+  }
+  return BigInt(value);
+}
+
+function topicAddress(value: unknown, field: string): string {
+  if (typeof value !== "string" || !/^0x0{24}[0-9a-f]{40}$/u.test(value)) {
+    throw new TypeError(`${field} is not an ABI-encoded EVM address topic`);
+  }
+  return `0x${value.slice(26)}`;
+}
+
+function transferValue(value: unknown, field: string): bigint {
+  if (typeof value !== "string" || !/^0x[0-9a-f]{64}$/u.test(value)) {
+    throw new TypeError(`${field} is not an ABI-encoded ERC-20 value`);
+  }
+  return BigInt(value);
+}
+
+/** Validates one confirmed direct-funding credit without trusting its sender. */
+export function assertConfirmedUsdcFundingTransfer(
+  receiptValue: unknown,
+  network: EvmFundingNetwork,
+  expectedTransactionHash: string,
+  recipient: string,
+  amountMinor: string,
+  finalizedBlockNumber: bigint,
+): VerifiedEvmTransaction {
+  if (!isEvmFundingNetwork(network)) {
+    throw new TypeError("funding network must be base or ethereum");
+  }
+  if (
+    !isEvmTransactionHash(expectedTransactionHash) ||
+    typeof recipient !== "string" ||
+    !/^0x[0-9a-f]{40}$/u.test(recipient) ||
+    recipient === ZERO_EVM_ADDRESS ||
+    amountMinor.length > 40 ||
+    !/^[1-9]\d*$/u.test(amountMinor)
+  ) {
+    throw new TypeError("funding transfer expectation is invalid");
+  }
+  if (
+    finalizedBlockNumber < 0n ||
+    finalizedBlockNumber > BigInt(Number.MAX_SAFE_INTEGER)
+  ) {
+    throw new TypeError("finalized block number is invalid");
+  }
+  const receipt = record(receiptValue, "EVM transaction receipt");
+  if (receipt.status !== "0x1") {
+    throw new TypeError("EVM transaction did not execute successfully");
+  }
+  if (receipt.transactionHash !== expectedTransactionHash) {
+    throw new TypeError(
+      "EVM receipt transaction hash does not match the funding record",
+    );
+  }
+  const blockNumber = evmQuantity(receipt.blockNumber, "receipt.blockNumber");
+  if (blockNumber > finalizedBlockNumber) {
+    throw new TypeError("EVM transaction block is not finalized yet");
+  }
+  const confirmations = finalizedBlockNumber - blockNumber + 1n;
+  const minimum = BigInt(EVM_FUNDING_MIN_CONFIRMATIONS[network]);
+  if (confirmations < minimum) {
+    throw new TypeError(
+      "EVM transaction does not meet the network finality policy",
+    );
+  }
+  if (!Array.isArray(receipt.logs)) {
+    throw new TypeError("EVM receipt logs must be an array");
+  }
+  const usdcContract = EVM_FUNDING_USDC_CONTRACTS[network];
+  const deltas = new Map<string, bigint>();
+  receipt.logs.forEach((entry, index) => {
+    const log = record(entry, `receipt.logs[${index}]`);
+    if (log.removed === true) {
+      throw new TypeError("EVM receipt contains a reorged log");
+    }
+    if (
+      typeof log.address !== "string" ||
+      log.address.toLowerCase() !== usdcContract
+    ) {
+      return;
+    }
+    if (!Array.isArray(log.topics) || log.topics.length === 0) {
+      throw new TypeError(`receipt.logs[${index}] has no event topics`);
+    }
+    if (log.topics[0] !== ERC20_TRANSFER_TOPIC) return;
+    if (log.topics.length !== 3) {
+      throw new TypeError(
+        `receipt.logs[${index}] is not a canonical ERC-20 Transfer`,
+      );
+    }
+    const from = topicAddress(log.topics[1], `receipt.logs[${index}].from`);
+    const to = topicAddress(log.topics[2], `receipt.logs[${index}].to`);
+    if (from === ZERO_EVM_ADDRESS || to === ZERO_EVM_ADDRESS) {
+      throw new TypeError(
+        "EVM funding transaction mints or burns USDC instead of transferring",
+      );
+    }
+    const value = transferValue(log.data, `receipt.logs[${index}].data`);
+    deltas.set(to, (deltas.get(to) ?? 0n) + value);
+    deltas.set(from, (deltas.get(from) ?? 0n) - value);
+  });
+  const expected = BigInt(amountMinor);
+  if (deltas.get(recipient) !== expected) {
+    throw new TypeError(
+      "EVM funding recipient did not receive the exact amount",
+    );
+  }
+  if (
+    [...deltas.entries()].some(
+      ([owner, delta]) => delta > 0n && owner !== recipient,
+    )
+  ) {
+    throw new TypeError("EVM funding transaction has an undeclared credit");
+  }
+  const netDelta = [...deltas.values()].reduce(
+    (total, delta) => total + delta,
+    0n,
+  );
+  if (netDelta !== 0n) {
+    throw new TypeError("EVM funding transaction USDC deltas do not balance");
+  }
+  return {
+    transactionHash: expectedTransactionHash,
+    blockNumber: Number(blockNumber),
+    confirmations: Number(confirmations),
+  };
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -19,6 +19,7 @@
     "scripts/**/*.ts",
     "src/lib/cycle-index.ts",
     "src/lib/evaluator-awards.ts",
+    "src/lib/evm-funding.ts",
     "src/lib/funding.ts",
     "src/lib/leaderboard.ts",
     "src/lib/model-identity.ts",

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -17,6 +17,7 @@
     "workers/**/*.ts",
     "functions/**/*.ts",
     "scripts/**/*.ts",
+    "src/lib/bitcoin-funding.ts",
     "src/lib/cycle-index.ts",
     "src/lib/evaluator-awards.ts",
     "src/lib/evm-funding.ts",


### PR DESCRIPTION
## Summary

Implements the read-only Base, Ethereum, and Bitcoin verification portions of #114. This advances but does not close #114: production project receiving addresses, the public fee recipient, and a reviewed mainnet route/canary remain outstanding.

### Base and Ethereum USDC

- Fixed three-authority production RPC sets with a 2-of-3 quorum; direct CLI callers cannot select an arbitrary endpoint.
- Every authority independently joins the expected mainnet chain ID, successful receipt, canonical block at the receipt height, and finalized head. Quorum binds exact transaction/block identity and uses the conservative minimum confirmations.
- Counted USDC logs bind transaction hash, block number/hash, non-removed state, exact recipient credit, balanced deltas, and no mint, burn, or undeclared positive credit.
- JSON-RPC version/ID are exact; redirects fail; response bodies are streamed through an 8 MiB bound; receipt logs and confirmation conversion are bounded.

### Bitcoin BTC

- Fixed Esplora authorities: `mempool.space`, `blockstream.info`, and `mempool.emzy.de`; a 2-of-3 quorum is required and the CLI has no API override.
- Each authority independently supplies the full transaction/prevouts/outputs/fee, tip height, and canonical best-chain hash at the transaction height. Quorum binds exact transaction/block identity and reports the minimum agreeing confirmations.
- Exact recipient output sum, coherent nonzero fee, no coinbase/self-funding input, dust policy, 6-confirmation minimum, bounded transaction I/O, safe integers, and aggregate input/output totals no greater than 21 million BTC all fail closed.
- Redirects fail and declared/streamed bodies are bounded to 8 MiB before strict UTF-8/JSON parsing.

All verifiers are read-only and non-custodial: no keys, signing, broadcasting, custody, or funding-record writes. Programmatic fetch injection exists only for deterministic tests.

## Exact-head evidence

- Base: `a75be6df21684a138391aadade6026e059df1912` (`develop`)
- Head: `202e848e339e915442d97020d5dcd04b951fce04`
- PR diff is exactly 11 verifier/docs/config files; the duplicate leaderboard and `.gitignore` changes were dropped after #143 merged.
- Full local suite: 51 Vitest files / 498 tests and 74 Bun skill tests passed.
- Also passed: frozen install, `typecheck`, `lint:check` (186 files), `format:check` (185 files), `projects:check`, `funding:check`, `evaluations:check`, `cycles:check`, `build` (176-file deployment manifest), `audit:dependencies`, `git diff --check`, and byte-identical `AGENTS.md` / `CLAUDE.md`.
- Exact-head live Base forward test: transaction `0x9b84a912e5fc09f8f9623a6ce1806fa2b6d1f49084964702dff549498a844eda`, recipient `0xe9030014f5dae217d0a152f02a043567b16c1abf`, 7,222 minor units; two fixed authorities agreed on canonical receipt/finalized evidence (1,746 confirmations at check time).
- Exact-head live Ethereum forward test: transaction `0xe2c44f9da831ee80ef99d6fc7767e5d063d96bee526fc0f5ad2662313a8e61a8`, recipient `0x260b364fe0d3d37e6fd3cda0fa50926a06c54cea`, 468,000,000 minor units; all three fixed authorities agreed (352 confirmations at check time).
- Exact-head live Bitcoin forward test: transaction `29ff25e8004c585bfd0ab98b76e79f99d261d6bd9befade95b160ddbdc2f8265`, recipient `bc1qerpwktdf0c7y7syc2lxztux2tf0t2ch6xt32nj`, 140,761 sats, block 962761 / `000000000000000000002bc742ca5b53a2c63f718fe038777f1d42a7e56a169b`; all three fixed authorities agreed (16 confirmations at check time).

## Review boundary

Ready for independent review after exact-head CI. This PR deliberately does not close #114 or add any receiving address, fee recipient, custody, signing, broadcast, or settlement operation.
