### PR TITLE
fix: bound oversized live titles in published opportunities

### DIFF
--- a/src/lib/leaderboard.test.ts
+++ b/src/lib/leaderboard.test.ts
@@ -3076,6 +3076,37 @@ describe("work queue claims and prioritization", () => {
     ).toBe(true);
   });
 
+  it("bounds oversized live titles instead of failing the snapshot", () => {
+    const author = actor("author");
+    const longTitle = `fix: ${"very ".repeat(80)}long upstream title`;
+    expect(longTitle.length).toBeGreaterThan(256);
+    const openNearTest = pullRequest({
+      id: "PR_OPEN_LONG_TITLE",
+      number: 55,
+      title: longTitle,
+      mergedAt: null,
+      author,
+      updatedAt: "2026-07-29T10:00:00.000Z",
+      files: [
+        { path: "src/feature.test.ts", additions: 6, deletions: 0 },
+        { path: "src/feature.ts", additions: 20, deletions: 2 },
+      ],
+    });
+
+    const snapshot = createLeaderboardSnapshot(
+      input({ openPullRequests: [openNearTest] }),
+    );
+
+    const published = snapshot.opportunities.filter(
+      (opportunity) => opportunity.source.id === openNearTest.id,
+    );
+    expect(published.length).toBeGreaterThan(0);
+    for (const opportunity of published) {
+      expect(opportunity.source.title.length).toBeLessThanOrEqual(256);
+      expect(opportunity.source.title.endsWith("…")).toBe(true);
+    }
+  });
+
   it("skips draft pull requests when publishing opportunities", () => {
     const author = actor("author");
     const reviewer = actor("reviewer");

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -2427,6 +2427,16 @@ function hasOpenPullRequestOpportunitySignal(
   );
 }
 
+/**
+ * Bounds a live GitHub title to the published 256-character opportunity limit
+ * without splitting a surrogate pair, so one long upstream title cannot fail
+ * the whole snapshot.
+ */
+function boundedSourceTitle(title: string): string {
+  if (title.length <= 256) return title;
+  return `${title.slice(0, 255).replace(/[\uD800-\uDBFF]$/u, "")}…`;
+}
+
 function collectOpenPullRequestOpportunities(
   openPullRequests: PullRequestRecord[],
   verifiedEvidence: VerifiedEvidenceArtifact[],
@@ -2442,7 +2452,7 @@ function collectOpenPullRequestOpportunities(
       id: pullRequest.id,
       kind: "pull-request" as const,
       number: pullRequest.number,
-      title: pullRequest.title,
+      title: boundedSourceTitle(pullRequest.title),
       url: pullRequest.url,
     };
 
@@ -2561,7 +2571,7 @@ function collectOpenPullRequestOpportunities(
           id: review.id,
           kind: "review",
           number: pullRequest.number,
-          title: pullRequest.title,
+          title: boundedSourceTitle(pullRequest.title),
           url: review.url,
         },
         reason:


### PR DESCRIPTION
## Outcome

Live CI (including PR #142's rerun and any future develop push) currently fails in `Generate live contribution data`:

```
error: snapshot.opportunities[3].source.title is too long
```

A tracked GitHub item now has a title longer than the published 256-character bound, and the generator copied it raw into opportunity sources, failing the whole snapshot on live data.

## Change

- `boundedSourceTitle` truncates a live title to the published limit with surrogate-safe slicing and a visible ellipsis; applied at all three opportunity build sites (near-material-test / evidence via `pullRequestSource`, and expand-review).
- The snapshot validator's 256-character publication bound is unchanged — the generator now conforms instead of failing closed on presentation data.
- Regression test: an open PR with a >256-character title publishes opportunities with bounded titles instead of failing snapshot creation.

## Verification

- `vitest src/lib/leaderboard.test.ts`: 79/79
- `typecheck`, `lint:check`, `format:check`: pass
- Live proof: `bun run leaderboard:generate` against current GitHub data — previously failing — now completes (100 leaders, 3177 score events, 179 GraphQL requests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)