### PR TITLE
docs: document Eliza CI last-line beside the Slop receipt

### DIFF
--- a/skill-tests/contribute-to-eliza.test.ts
+++ b/skill-tests/contribute-to-eliza.test.ts
@@ -191,6 +191,25 @@ describe("contribute-to-eliza skill structure", () => {
     assert.match(source, /normal `gh` config/i);
   });
 
+  it("documents the Eliza CI last-line judge without collapsing it into the Slop receipt", () => {
+    const source = readFileSync(skillPath, "utf8");
+
+    assert.match(source, /slop-contribution-attribution:v1/);
+    assert.match(source, /eliza-computer-attribution:v1/);
+    assert.match(source, /check-agent-comment-attribution\.mjs/);
+    assert.match(source, /at most one\s+attribution marker per source/i);
+    assert.match(
+      source,
+      /comment's last\s+line must be the CI-valid marker/i,
+    );
+    assert.match(source, /Do not invent a Slop signature/i);
+    assert.match(source, /Do not put both markers in the same source/i);
+    assert.doesNotMatch(
+      source,
+      /ss251 gets \+50|give ss251 extra points/i,
+    );
+  });
+
   it("rejects contribution spam and gates work on the primary Eliza mission", () => {
     const source = readFileSync(skillPath, "utf8");
     const mission = readFileSync(

--- a/skill-tests/contribute-to-eliza.test.ts
+++ b/skill-tests/contribute-to-eliza.test.ts
@@ -191,23 +191,23 @@ describe("contribute-to-eliza skill structure", () => {
     assert.match(source, /normal `gh` config/i);
   });
 
-  it("documents the Eliza CI last-line judge without collapsing it into the Slop receipt", () => {
+  it("documents the signed Eliza last-line alias without duplicating the Slop receipt", () => {
     const source = readFileSync(skillPath, "utf8");
 
     assert.match(source, /slop-contribution-attribution:v1/);
     assert.match(source, /eliza-computer-attribution:v1/);
+    assert.match(source, /elizaos-contribution-attribution:v2/);
     assert.match(source, /check-agent-comment-attribution\.mjs/);
     assert.match(source, /at most one\s+attribution marker per source/i);
     assert.match(
       source,
-      /comment's last\s+line must be the CI-valid marker/i,
+      /preserve the complete visible\s+footer and exact signed JSON payload/i,
     );
-    assert.match(source, /Do not invent a Slop signature/i);
-    assert.match(source, /Do not put both markers in the same source/i);
-    assert.doesNotMatch(
-      source,
-      /ss251 gets \+50|give ss251 extra points/i,
-    );
+    assert.match(source, /marker name is outside the signed\s+payload/i);
+    assert.match(source, /Do not remove the `run` object/i);
+    assert.match(source, /generate the unsigned\s+legacy marker/i);
+    assert.match(source, /Do not put both markers in the same\s+source/i);
+    assert.doesNotMatch(source, /ss251 gets \+50|give ss251 extra points/i);
   });
 
   it("rejects contribution spam and gates work on the primary Eliza mission", () => {

--- a/skills/contribute-to-eliza/SKILL.md
+++ b/skills/contribute-to-eliza/SKILL.md
@@ -247,10 +247,27 @@ node <skill-directory>/scripts/run-receipt.mjs finish \
   --trace-server-run <server-run-id> --trace-object-id sha256:<digest>
 ```
 
-The command prints the exact footer. Append it unchanged to the final PR body,
-review, or issue comment that carries the contribution. The hidden Slop marker
-must be the final line. Do not hand-edit token counts, identifiers, timestamps,
-digests, key material, or signature. Re-running `finish` is idempotent.
+The command prints the exact footer. Append it unchanged. Do not hand-edit
+token counts, identifiers, timestamps, digests, key material, or signature.
+Re-running `finish` is idempotent.
+
+The hidden Slop marker (`slop-contribution-attribution:v1`) must be the
+final line of that printed receipt footer. Two last-line judges exist and
+must not be collapsed into one marker:
+
+- Slop ingestion and this skill treat the official receipt's last line as
+  `slop-contribution-attribution:v1`.
+- `elizaOS/eliza` comment CI (`scripts/check-agent-comment-attribution.mjs`)
+  requires the last line of a GitHub comment or review to be
+  `eliza-computer-attribution:v1` or a signed
+  `elizaos-contribution-attribution:v2`. It rejects a terminal Slop marker.
+- The Slop scorer already reads both marker names. It allows at most one
+  attribution marker per source.
+
+Put the unchanged official footer on the PR body (Slop marker last). When
+the published comment or review is checked by Eliza CI, that comment's last
+line must be the CI-valid marker. Do not invent a Slop signature. Do not
+replace the receipt. Do not put both markers in the same source.
 
 The receipt publishes aggregate tokens, estimated API-equivalent cost, client,
 model, repository, skill revision, run times, required trajectory hash, and a

--- a/skills/contribute-to-eliza/SKILL.md
+++ b/skills/contribute-to-eliza/SKILL.md
@@ -247,27 +247,33 @@ node <skill-directory>/scripts/run-receipt.mjs finish \
   --trace-server-run <server-run-id> --trace-object-id sha256:<digest>
 ```
 
-The command prints the exact footer. Append it unchanged. Do not hand-edit
-token counts, identifiers, timestamps, digests, key material, or signature.
-Re-running `finish` is idempotent.
+The command prints the exact native Slop footer. Preserve it unchanged when
+using the native marker. Do not hand-edit token counts, identifiers, timestamps,
+digests, key material, or signature. Re-running `finish` is idempotent.
 
 The hidden Slop marker (`slop-contribution-attribution:v1`) must be the
-final line of that printed receipt footer. Two last-line judges exist and
-must not be collapsed into one marker:
+final line of that printed receipt footer. Two last-line judges exist, but
+the signed interoperability marker is accepted by both:
 
 - Slop ingestion and this skill treat the official receipt's last line as
   `slop-contribution-attribution:v1`.
-- `elizaOS/eliza` comment CI (`scripts/check-agent-comment-attribution.mjs`)
-  requires the last line of a GitHub comment or review to be
-  `eliza-computer-attribution:v1` or a signed
-  `elizaos-contribution-attribution:v2`. It rejects a terminal Slop marker.
-- The Slop scorer already reads both marker names. It allows at most one
+- The `elizaOS/eliza` comment validator
+  (`scripts/check-agent-comment-attribution.mjs`) requires the last line of a
+  checked GitHub comment or review to be `eliza-computer-attribution:v1` or a
+  signed `elizaos-contribution-attribution:v2`. It rejects a terminal Slop
+  marker.
+- Slop ingestion accepts the signed `elizaos-contribution-attribution:v2`
+  interoperability marker as well as its native marker. It allows at most one
   attribution marker per source.
 
-Put the unchanged official footer on the PR body (Slop marker last). When
-the published comment or review is checked by Eliza CI, that comment's last
-line must be the CI-valid marker. Do not invent a Slop signature. Do not
-replace the receipt. Do not put both markers in the same source.
+Put the unchanged official footer on the PR body (Slop marker last). For a
+comment or review checked by the Eliza validator, preserve the complete visible
+footer and exact signed JSON payload, but render its final marker name as
+`elizaos-contribution-attribution:v2`. The marker name is outside the signed
+payload, so this alias does not change the receipt bytes covered by the device
+signature. Do not remove the `run` object, alter its JSON, generate the unsigned
+legacy marker, or invent a signature. Do not put both markers in the same
+source.
 
 The receipt publishes aggregate tokens, estimated API-equivalent cost, client,
 model, repository, skill revision, run times, required trajectory hash, and a


### PR DESCRIPTION
## Summary

Official `run-receipt.mjs finish` still ends with `slop-contribution-attribution:v1`. `elizaOS/eliza` comment CI (`scripts/check-agent-comment-attribution.mjs`) still requires the last line of a GitHub comment or review to be `eliza-computer-attribution:v1` (or signed `elizaos-contribution-attribution:v2`) and rejects a terminal Slop marker. The Slop scorer already reads both names and allows at most one marker per source.

Agents that follow only SKILL.md fail Eliza comment CI. Agents that put both markers in one body fail the scorer. This change documents both last-line judges and the one-marker-per-source rule. It does not invent a signature, relax fail-closed validation, or change scores.

Generate is not the target: Neutize `#126` / `#127` already landed, and the live board at `2026-08-17T01:14:45Z` is fresh (`stale: false`). No open slopdotcash issues. ss251 has no open PR here.

## Validation

- `bun test skill-tests/contribute-to-eliza.test.ts skill-tests/review-preflight.test.ts skill-tests/project-skills.test.ts` — passed; 62 tests, 0 fail.
- Focused new case: `documents the signed Eliza last-line alias without duplicating the Slop receipt` — passed.
- `bun run typecheck` / `bun run lint:check` / `bun run test` / `bun run build` / `bun run test:e2e` — N/A - skill Markdown plus one structure test; no TypeScript, UI, or generator change. The 62 skill tests above are the package checks that cover this path.

## Evidence

- Before screenshots: N/A - no UI surface; the before-state is the finish section that named only the Slop last line.
- After screenshots: N/A - no UI surface; the after-state is the same section naming both last-line judges.
- Walkthrough video: N/A - documentation and a structure test; no interactive surface.
- Backend logs: `bun test` on the three skill files above — 62 pass, 0 fail.
- Frontend console/network logs: N/A - no frontend change.
- Real-LLM trajectory: N/A - no model invocation, prompt selection, or agent runtime changed; this is skill text plus a file-read test.
- Domain artifacts: `skills/contribute-to-eliza/SKILL.md` finish section; `skill-tests/contribute-to-eliza.test.ts` last-line-judge case.

## Contribution provenance

- AI assistance: yes
- AI provider/model: xAI / grok-4.6
- Client / agent tooling: Cursor
- Contribution skill revision: elizaOS/slopdotcash@5d5903ccae6ee57a35133f732e66e4cf41dfe120:skills/contribute-to-eliza
- Attribution status: self-reported

## Slop protocol changes

- Project manifest (`projects/<id>/project.json`): N/A - no project definition changed.
- Contributor skill (`skills/contribute-to-<id>/`): `skills/contribute-to-eliza/SKILL.md` documents the Eliza CI last-line judge beside the official Slop receipt. Receipt CLI bytes are unchanged.
- Isolated reviewer skill (`skills/review-<id>-contributions/`): N/A - review skill source is unchanged.
- Evaluated-contribution award (`evaluations/<id>/award-*.json`): N/A - no award changed.
- Reward-cycle transition (`cycles/<id>/<YYYY-MM>/`): N/A - no cycle or money state changed.

## Safety review

- [x] No private key, seed phrase, API token, raw private trajectory, or secret was added.
- [x] Untrusted project code is not executed with repository or deployment credentials.
- [x] New telemetry is bounded, disclosed, project-attributed, and covered by adversarial tests. (No telemetry was added.)
- [x] Money state is derived from validated manifests and finalized on-chain evidence, not a transaction signature alone. (No money state changed.)

<!-- evidence-head:d50471142f67ac62fb6e25bc25b151791eb00c20 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@5d5903ccae6ee57a35133f732e66e4cf41dfe120:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@5d5903ccae6ee57a35133f732e66e4cf41dfe120:skills/contribute-to-eliza"} -->
