### PR TITLE
fix: make trace migration remote D1 compatible

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -438,7 +438,7 @@ jobs:
             --remote \
             --json \
             --config workers/identity/wrangler.toml \
-            --command "SELECT type, name FROM sqlite_schema WHERE name IN ('identity_assertions','identity_oauth_flows','identity_rate_limits','private_audit_events','run_progress_events','trace_objects','trace_read_grants','trace_runs','trace_upload_intents','trace_uploads','wallet_claims','wallet_claims_no_delete','wallet_claims_no_update','wallet_claims_one_root_per_actor','wallet_claims_one_successor') ORDER BY type, name" \
+            --command "SELECT type, name FROM sqlite_schema WHERE name IN ('identity_assertions','identity_oauth_flows','identity_rate_limits','private_audit_events','run_progress_events','trace_attachment_commit_validate','trace_attachment_commits','trace_attachment_commits_no_delete','trace_attachment_commits_no_update','trace_objects','trace_read_grants','trace_runs','trace_upload_intents','trace_uploads','wallet_claims','wallet_claims_no_delete','wallet_claims_no_update','wallet_claims_one_root_per_actor','wallet_claims_one_successor') ORDER BY type, name" \
             > "$schema_response"
           node - "$schema_response" <<'NODE'
           const { readFileSync } = require("node:fs");
@@ -451,12 +451,16 @@ jobs:
             "table:identity_rate_limits",
             "table:private_audit_events",
             "table:run_progress_events",
+            "table:trace_attachment_commits",
             "table:trace_objects",
             "table:trace_read_grants",
             "table:trace_runs",
             "table:trace_upload_intents",
             "table:trace_uploads",
             "table:wallet_claims",
+            "trigger:trace_attachment_commit_validate",
+            "trigger:trace_attachment_commits_no_delete",
+            "trigger:trace_attachment_commits_no_update",
             "trigger:wallet_claims_no_delete",
             "trigger:wallet_claims_no_update",
           ];

--- a/functions/api/v1/atomic-trace-attachment.test.ts
+++ b/functions/api/v1/atomic-trace-attachment.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import { DatabaseSync } from "node:sqlite";
 import { describe, expect, it } from "vitest";
 
@@ -80,6 +80,31 @@ function attemptAttachment(db: DatabaseSync, updateRun: boolean): void {
 }
 
 describe("atomic trace attachment migration", () => {
+  it("keeps every migration compatible with the remote D1 trigger parser", () => {
+    const incompatibleCaseTerminator =
+      /\bCASE\b(?:(?!\bEND\b)[\s\S])*?\bEND\s*;/iu;
+    expect(
+      incompatibleCaseTerminator.test(
+        "CREATE TRIGGER example BEGIN SELECT CASE WHEN 1 THEN 1 END; END;",
+      ),
+    ).toBe(true);
+    const incompatible = readdirSync("migrations")
+      .filter((name) => name.endsWith(".sql"))
+      .filter((name) => {
+        const migration = readFileSync(`migrations/${name}`, "utf8");
+        // Remote D1 rejects a CASE whose own END is statement-terminating
+        // inside a trigger, even though local SQLite accepts it.
+        return incompatibleCaseTerminator.test(migration);
+      });
+    expect(incompatible).toEqual([]);
+
+    const migration = readFileSync(
+      "migrations/0005_atomic_trace_attachment.sql",
+      "utf8",
+    );
+    expect(migration.match(/^END;$/gmu)).toHaveLength(3);
+  });
+
   it("rolls back intent consumption when a later attachment invariant fails", () => {
     const db = database();
     expect(() => attemptAttachment(db, false)).toThrow(

--- a/migrations/0005_atomic_trace_attachment.sql
+++ b/migrations/0005_atomic_trace_attachment.sql
@@ -12,7 +12,7 @@ CREATE TABLE trace_attachment_commits (
 CREATE TRIGGER trace_attachment_commit_validate
 BEFORE INSERT ON trace_attachment_commits
 BEGIN
-  SELECT CASE WHEN NOT EXISTS (
+  SELECT RAISE(ABORT, 'incomplete trace attachment') WHERE NOT EXISTS (
     SELECT 1
     FROM trace_upload_intents AS intent
     JOIN trace_uploads AS upload
@@ -33,7 +33,7 @@ BEGIN
       AND intent.consumed_at = NEW.consumed_at
       AND object.size_bytes = intent.size_bytes
       AND object.content_type = intent.content_type
-  ) THEN RAISE(ABORT, 'incomplete trace attachment') END;
+  );
 END;
 
 CREATE TRIGGER trace_attachment_commits_no_update

--- a/scripts/deployment-contract.test.mjs
+++ b/scripts/deployment-contract.test.mjs
@@ -131,6 +131,14 @@ describe("slop.cash deployment contract", () => {
     expect(deployJob).toContain(
       "./node_modules/.bin/wrangler d1 execute slop-private \\",
     );
+    for (const schemaObject of [
+      "trace_attachment_commits",
+      "trace_attachment_commit_validate",
+      "trace_attachment_commits_no_delete",
+      "trace_attachment_commits_no_update",
+    ]) {
+      expect(deployJob).toContain(schemaObject);
+    }
     expect(deployJob).toContain('--tag="$GITHUB_SHA"');
     expect(deployJob).toContain('--version-id="$identity_version_id"');
     expect(deployJob).toContain("--percentage=100");


### PR DESCRIPTION
## Summary
- remove nested CASE/END syntax that Cloudflare remote D1 rejects while preserving the atomic trace-attachment assertion
- require the deployment to verify the receipt table and all immutable/invariant triggers before releasing
- add a regression for remote-D1-compatible trigger terminators

## Evidence
- `bunx vitest run functions/api/v1/atomic-trace-attachment.test.ts scripts/deployment-contract.test.mjs`
- fresh `wrangler d1 migrations apply --local` across migrations 0001-0005
- `bun run typecheck`
- focused Biome and `git diff --check`

Repairs production run 32007523627, which failed before any Worker or Pages deployment with remote D1 `incomplete input`.