### PR TITLE
fix: preserve deployed trace auth key

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -780,34 +780,6 @@ jobs:
           echo "::error::Cloudflare did not report a new, successful, clean production deployment for commit $GITHUB_SHA."
           exit 1
 
-      - name: Verify private trace API fail-closed boundary
-        run: |
-          set -euo pipefail
-          response="$RUNNER_TEMP/slop-private-api-response.json"
-          status="$(
-            curl --silent --show-error \
-              --connect-timeout 10 \
-              --max-time 30 \
-              --max-filesize 65536 \
-              --output "$response" \
-              --write-out "%{http_code}" \
-              --header "Cache-Control: no-cache" \
-              --header "Content-Type: application/json" \
-              --data '{}' \
-              "https://api.slop.cash/api/v1/runs?verify=$GITHUB_SHA-$GITHUB_RUN_ATTEMPT"
-          )"
-          if [ "$status" != "401" ]; then
-            echo "::error::Private trace API returned HTTP $status without authentication; expected 401."
-            exit 1
-          fi
-          node - "$response" <<'NODE'
-          const { readFileSync } = require("node:fs");
-          const value = JSON.parse(readFileSync(process.argv[2], "utf8"));
-          if (value?.error !== "unauthorized") {
-            throw new TypeError("private trace API returned an unexpected unauthenticated response");
-          }
-          NODE
-
       - name: Verify deck custom domain, DNS, TLS, and deployed bytes
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -929,6 +901,44 @@ jobs:
           # The inventory checks /index.html; this additional request proves the
           # public root route resolves to those same tested bytes.
           verify_download / dist/index.html index.html
+
+      - name: Verify active private trace API boundary
+        run: |
+          set -euo pipefail
+          response="$RUNNER_TEMP/slop-active-private-api-response.json"
+          headers="$RUNNER_TEMP/slop-active-private-api-response.headers"
+          for attempt in $(seq 1 18); do
+            status="$(
+              curl --silent --show-error \
+                --connect-timeout 10 \
+                --max-time 30 \
+                --max-filesize 65536 \
+                --output "$response" \
+                --dump-header "$headers" \
+                --write-out "%{http_code}" \
+                --header "Cache-Control: no-cache" \
+                --header "Content-Type: application/json" \
+                --data '{}' \
+                "https://api.slop.cash/api/v1/runs?verify=$GITHUB_SHA-$GITHUB_RUN_ATTEMPT-active-$attempt"
+            )"
+            if [ "$status" = "401" ] && node - "$response" "$headers" <<'NODE'
+          const { readFileSync } = require("node:fs");
+          const value = JSON.parse(readFileSync(process.argv[2], "utf8"));
+          const headers = readFileSync(process.argv[3], "utf8");
+          const contract = headers.match(/^x-slop-trace-api-contract:\s*([^\r\n]+)$/imu)?.[1]?.trim();
+          if (
+            value?.error !== "unauthorized" ||
+            contract !== "private-trace-v1-opaque-hmac-v1"
+          ) process.exit(1);
+          NODE
+            then
+              exit 0
+            fi
+            echo "::warning::Active private trace boundary returned HTTP $status (attempt $attempt/18)."
+            sleep 5
+          done
+          echo "::error::Active private trace API did not reach its fail-closed unauthenticated boundary."
+          exit 1
 
       - name: Require public identity OAuth app
         env:

--- a/backend/trace/README.md
+++ b/backend/trace/README.md
@@ -133,8 +133,9 @@ service = "slop-identity"
 ```
 
 Set `OPERATOR_GITHUB_IDS` to an explicit comma-separated list of numeric IDs.
-`TRACE_AUTH_SECRET` must be a canonical base64url encoding of exactly 32 random
-bytes and must never be configured as a checked-in `[vars]` value. Generate it
+`TRACE_AUTH_SECRET` is opaque HMAC key material and must contain 32-128
+high-entropy printable ASCII characters. It must never be configured as a
+checked-in `[vars]` value. Generate a recommended 43-character base64url value
 with `node -e 'process.stdout.write(require("node:crypto").randomBytes(32).toString("base64url"))'`.
 Bind `SLOP_IDENTITY` to the
 separately deployed OAuth/PKCE identity Worker; it must consume assertions once

--- a/backend/trace/auth.ts
+++ b/backend/trace/auth.ts
@@ -42,19 +42,16 @@ function ownedBuffer(bytes: Uint8Array): ArrayBuffer {
 }
 
 function secretBytes(secret: string): Uint8Array {
-  if (!/^[A-Za-z0-9_-]{43}$/u.test(secret)) {
-    throw new Error("TRACE_AUTH_SECRET must be canonical base64url");
+  // This secret was originally provisioned as opaque high-entropy text and
+  // used byte-for-byte as the HMAC key. Preserve that key material across the
+  // stricter validation rollout; decoding an existing base64-looking value
+  // silently changes the key and invalidates every token.
+  if (!/^[\x21-\x7e]{32,128}$/u.test(secret)) {
+    throw new Error(
+      "TRACE_AUTH_SECRET must be 32-128 printable ASCII characters",
+    );
   }
-  let bytes: Uint8Array;
-  try {
-    bytes = decodeBase64Url(secret);
-  } catch {
-    throw new Error("TRACE_AUTH_SECRET must be canonical base64url");
-  }
-  if (bytes.byteLength !== 32 || encodeBase64Url(bytes) !== secret) {
-    throw new Error("TRACE_AUTH_SECRET must decode to exactly 32 bytes");
-  }
-  return bytes;
+  return encoder.encode(secret);
 }
 
 async function hmacKey(secret: string): Promise<CryptoKey> {

--- a/backend/trace/handler.ts
+++ b/backend/trace/handler.ts
@@ -40,6 +40,8 @@ export type TraceApiDependencies = {
 
 type ApiError = Error & { status?: number; code?: string };
 
+export const TRACE_API_CONTRACT_VERSION = "private-trace-v1-opaque-hmac-v1";
+
 function fail(status: number, code: string, message: string): never {
   const error: ApiError = new Error(message);
   error.status = status;
@@ -55,6 +57,7 @@ function json(status: number, body: Record<string, unknown>): Response {
       "content-type": "application/json; charset=utf-8",
       "referrer-policy": "no-referrer",
       "x-content-type-options": "nosniff",
+      "x-slop-trace-api-contract": TRACE_API_CONTRACT_VERSION,
     },
   });
 }

--- a/functions/api/v1/trace-api.test.ts
+++ b/functions/api/v1/trace-api.test.ts
@@ -15,6 +15,7 @@ import type {
 } from "../../../backend/trace/contracts";
 import {
   handleTraceApi,
+  TRACE_API_CONTRACT_VERSION,
   type TraceApiDependencies,
 } from "../../../backend/trace/handler";
 import { readJsonObject, sha256Hex } from "../../../backend/trace/validation";
@@ -476,6 +477,9 @@ describe("private trace API", () => {
       },
     });
     expect(response.status).toBe(401);
+    expect(response.headers.get("x-slop-trace-api-contract")).toBe(
+      TRACE_API_CONTRACT_VERSION,
+    );
     expect(await response.json()).toMatchObject({ error: "unauthorized" });
   });
 
@@ -657,9 +661,25 @@ describe("private trace API", () => {
       exp: now + 600,
       jti: "strict_claims_token_0001",
     };
-    await expect(signApiToken(claims, "x".repeat(43))).rejects.toThrow(
+    await expect(signApiToken(claims, "x".repeat(31))).rejects.toThrow(
       /TRACE_AUTH_SECRET/u,
     );
+    await expect(signApiToken(claims, `${"x".repeat(31)}\n`)).rejects.toThrow(
+      /TRACE_AUTH_SECRET/u,
+    );
+    await expect(signApiToken(claims, "x".repeat(129))).rejects.toThrow(
+      /TRACE_AUTH_SECRET/u,
+    );
+    const legacySecret = "x".repeat(32);
+    const legacyToken = await signApiToken(claims, legacySecret);
+    await expect(
+      verifyApiToken({
+        authorization: `Bearer ${legacyToken}`,
+        secret: legacySecret,
+        operatorGithubIds: new Set(),
+        nowSeconds: now,
+      }),
+    ).resolves.toMatchObject({ githubId: "42", roles: ["contributor"] });
     await expect(
       signApiToken({ ...claims, extra: "not-authorized" } as never, SECRET),
     ).rejects.toThrow(/claims/u);

--- a/scripts/deployment-contract.test.mjs
+++ b/scripts/deployment-contract.test.mjs
@@ -196,7 +196,22 @@ describe("slop.cash deployment contract", () => {
     );
     expect(
       deployJob.indexOf("Verify published skill and leaderboard"),
+    ).toBeLessThan(
+      deployJob.indexOf("Verify active private trace API boundary"),
+    );
+    expect(
+      deployJob.indexOf("Verify active private trace API boundary"),
     ).toBeLessThan(deployJob.indexOf("Require public identity OAuth app"));
+    expect(deployJob).toContain(
+      "Active private trace API did not reach its fail-closed unauthenticated boundary.",
+    );
+    expect(deployJob).toContain('--dump-header "$headers"');
+    expect(deployJob).toContain(
+      'contract !== "private-trace-v1-opaque-hmac-v1"',
+    );
+    expect(
+      deployJob.match(/https:\/\/api\.slop\.cash\/api\/v1\/runs\?verify=/gu),
+    ).toHaveLength(1);
     expect(deployJob).not.toContain("wrangler deploy \\");
     expect(deployJob).toContain("has no zone-level Workers Routes permission");
     expect(deployJob).not.toContain("working-directory:");


### PR DESCRIPTION
## Summary
- preserve the existing opaque TRACE_AUTH_SECRET byte semantics while enforcing bounded printable high-entropy configuration
- reject short, control-containing, and oversized secrets; retain base64url generation as the recommended provisioning format
- add a post-propagation private API boundary probe after exact deployed-byte verification so stale Pages responses cannot make a release green

## Production evidence
Run 32062845883 deployed exact SHA 38bc955 successfully, but the active custom-domain function subsequently returned sanitized HTTP 500 because #155 reinterpreted the existing opaque secret as decoded base64url bytes. The immediate pre-propagation probe had hit the prior deployment and returned 401.

## Local evidence
- focused Vitest 34/34
- typecheck
- format and lint
- actionlint
- diff check

No secret value is read, logged, or changed.