### PR TITLE
test: accept valid upload race outcomes

### DIFF
--- a/functions/api/v1/trace-api.test.ts
+++ b/functions/api/v1/trace-api.test.ts
@@ -1017,7 +1017,11 @@ describe("private trace API", () => {
       handleTraceApi(makeUpload(), deps),
       handleTraceApi(makeUpload(), deps),
     ]);
-    expect(responses.map(({ status }) => status).sort()).toEqual([201, 409]);
+    const statuses = responses.map(({ status }) => status);
+    expect(statuses.filter((status) => status === 201)).toHaveLength(1);
+    const loserStatuses = statuses.filter((status) => status !== 201);
+    expect(loserStatuses).toHaveLength(1);
+    expect([409, 410]).toContain(loserStatuses[0]);
     expect(store.uploads.size).toBe(1);
     expect(store.objects.size).toBe(1);
     expect((await handleTraceApi(makeUpload(), deps)).status).toBe(410);


### PR DESCRIPTION
## Summary
- require exactly one successful upload-capability consumer
- accept either contract-valid loser state: 409 when both requests race into atomic attachment, or 410 when the winner consumes before the loser lookup
- preserve the subsequent replay requirement of 410

## Evidence
- focused trace API suite passed 10 consecutive runs
- typecheck, format, lint, and diff checks passed

Test-only; no production behavior changes.