### PR TITLE
fix(skills): detect direct terms-preflight runs through symlinked paths

### DIFF
--- a/skill-tests/terms-preflight.test.ts
+++ b/skill-tests/terms-preflight.test.ts
@@ -1,5 +1,8 @@
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
+import { mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import { preflight } from "../skills/contribute-to-eliza/scripts/terms-preflight.mjs";
@@ -139,5 +142,32 @@ describe("project terms preflight", () => {
     );
     expect(direct.status).toBe(1);
     expect(direct.stderr).toMatch(/authority overrides are forbidden/u);
+  });
+
+  it("detects direct invocation through a symlinked script path", () => {
+    const script = fileURLToPath(
+      new URL(
+        "../skills/contribute-to-eliza/scripts/terms-preflight.mjs",
+        import.meta.url,
+      ),
+    );
+    const linkRoot = mkdtempSync(join(tmpdir(), "terms-preflight-link-"));
+    const link = join(linkRoot, "terms-preflight.mjs");
+    try {
+      symlinkSync(script, link);
+      // Spawn node explicitly: node resolves the entry module to its realpath,
+      // so import.meta.url and a symlinked argv[1] diverge — the case that made
+      // the old comparison silently classify a direct CLI run as an import.
+      // (bun preserves the symlinked path, so bun cannot reproduce the bug.)
+      const viaSymlink = spawnSync(
+        "node",
+        [link, "--project", "eliza", "--authority", "file:///tmp/"],
+        { encoding: "utf8" },
+      );
+      expect(viaSymlink.status).toBe(1);
+      expect(viaSymlink.stderr).toMatch(/authority overrides are forbidden/u);
+    } finally {
+      rmSync(linkRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/skills/contribute-to-asi/scripts/terms-preflight.mjs
+++ b/skills/contribute-to-asi/scripts/terms-preflight.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { createHash } from "node:crypto";
+import { existsSync, realpathSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 
@@ -216,8 +217,10 @@ export async function preflight(projectId, options = {}) {
 }
 
 const direct =
-  process.argv[1] &&
-  import.meta.url === new URL(`file://${process.argv[1]}`).href;
+  typeof process.argv[1] === "string" &&
+  existsSync(process.argv[1]) &&
+  realpathSync(fileURLToPath(import.meta.url)) ===
+    realpathSync(process.argv[1]);
 if (direct) {
   try {
     const projectIndex = process.argv.indexOf("--project");

--- a/skills/contribute-to-delta-star/scripts/terms-preflight.mjs
+++ b/skills/contribute-to-delta-star/scripts/terms-preflight.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { createHash } from "node:crypto";
+import { existsSync, realpathSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 
@@ -216,8 +217,10 @@ export async function preflight(projectId, options = {}) {
 }
 
 const direct =
-  process.argv[1] &&
-  import.meta.url === new URL(`file://${process.argv[1]}`).href;
+  typeof process.argv[1] === "string" &&
+  existsSync(process.argv[1]) &&
+  realpathSync(fileURLToPath(import.meta.url)) ===
+    realpathSync(process.argv[1]);
 if (direct) {
   try {
     const projectIndex = process.argv.indexOf("--project");

--- a/skills/contribute-to-eliza/scripts/terms-preflight.mjs
+++ b/skills/contribute-to-eliza/scripts/terms-preflight.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { createHash } from "node:crypto";
+import { existsSync, realpathSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 
@@ -216,8 +217,10 @@ export async function preflight(projectId, options = {}) {
 }
 
 const direct =
-  process.argv[1] &&
-  import.meta.url === new URL(`file://${process.argv[1]}`).href;
+  typeof process.argv[1] === "string" &&
+  existsSync(process.argv[1]) &&
+  realpathSync(fileURLToPath(import.meta.url)) ===
+    realpathSync(process.argv[1]);
 if (direct) {
   try {
     const projectIndex = process.argv.indexOf("--project");

--- a/skills/contribute-to-heir-elements-sdk/scripts/terms-preflight.mjs
+++ b/skills/contribute-to-heir-elements-sdk/scripts/terms-preflight.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { createHash } from "node:crypto";
+import { existsSync, realpathSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 
@@ -216,8 +217,10 @@ export async function preflight(projectId, options = {}) {
 }
 
 const direct =
-  process.argv[1] &&
-  import.meta.url === new URL(`file://${process.argv[1]}`).href;
+  typeof process.argv[1] === "string" &&
+  existsSync(process.argv[1]) &&
+  realpathSync(fileURLToPath(import.meta.url)) ===
+    realpathSync(process.argv[1]);
 if (direct) {
   try {
     const projectIndex = process.argv.indexOf("--project");


### PR DESCRIPTION
## Bug

The direct-invocation gate in every project's `terms-preflight.mjs` compares `import.meta.url` against `new URL(\`file://\${process.argv[1]}\`)`. Node resolves the entry module to its **realpath**, so when the CLI is invoked through a **symlinked path** — exactly the layout produced by versioned skill installs, where `skills/<name>` is a symlink into a version store — the two sides diverge, `direct` is false, and the script **silently exits 0 without performing the preflight**. An operator or wrapper reading exit 0 as "terms verified" has verified nothing. (Found in the field: our agent's first preflight run "passed" this way; the receipt CLI's imported preflight then failed honestly.)

Repro on this branch's base:
```
$ ln -s .../skills/contribute-to-eliza/scripts/terms-preflight.mjs /tmp/l/tp.mjs
$ node /tmp/l/tp.mjs --project eliza --authority file:///tmp/   # forbidden flag
$ echo $?
0        # silent no-op — should be a loud refusal
```

## Fix

Align all four project copies (asi, eliza, delta-star, heir-elements-sdk) with the realpath comparison **already used by `run-receipt.mjs` and `live-report.mjs`** in this repo:

```js
const direct =
  typeof process.argv[1] === "string" &&
  existsSync(process.argv[1]) &&
  realpathSync(fileURLToPath(import.meta.url)) ===
    realpathSync(process.argv[1]);
```

This also fixes the same comparison's latent breakage on paths containing spaces/percent-encodable characters (`file://` string-building vs `pathToFileURL` semantics).

## Test (failing-test-first)

`skill-tests/terms-preflight.test.ts` gains a symlink regression that spawns **node explicitly** — node resolves the entry realpath; bun preserves the symlinked path, so the repo's bun runner cannot reproduce the divergence with `process.execPath` (comment in-test documents this). On base: 4 pass / **1 fail**; with the fix: **5 pass**.

## Verification

Commit: `15e49361f3888027c1eaa66a490d9a02b10e33ff`
```
bun test ./skill-tests            # 80 pass, 0 fail
biome check (5 touched files)     # clean
```

## Disclosure

Client `claude-code`, provider `anthropic`, model `claude-fable-5` (agent-authored, human-operated).

---
🤖 Built with [Emblem:build](https://emblem.build)
