### PR TITLE
Harden evidence-head capture and diagnostics

### DIFF
--- a/scripts/check-pr-evidence.mjs
+++ b/scripts/check-pr-evidence.mjs
@@ -32,17 +32,57 @@ export const SURFACE_OCR_EVIDENCE_ROW = {
   label: "OCR visual text review",
 };
 
-export function hasMatchingEvidenceHead(body, headSha) {
-  if (!/^[a-f0-9]{40}$/i.test(String(headSha ?? ""))) return false;
+export function inspectEvidenceHead(body, headSha) {
+  const expected = String(headSha ?? "").toLowerCase();
+  if (!/^[a-f0-9]{40}$/i.test(expected)) {
+    return {
+      ok: false,
+      status: "head-mismatch",
+      detail: "current PR head SHA must be a complete 40-character SHA",
+    };
+  }
   const matches = [
     ...String(body ?? "").matchAll(
       /<!--\s*evidence-head:([a-f0-9]{40})\s*-->/gi,
     ),
   ];
-  return (
-    matches.length === 1 &&
-    matches[0][1].toLowerCase() === String(headSha).toLowerCase()
-  );
+  if (matches.length !== 1) {
+    return {
+      ok: false,
+      status: "head-mismatch",
+      detail:
+        "exactly one evidence-head marker must contain the current PR head SHA",
+    };
+  }
+
+  const observed = matches[0][1].toLowerCase();
+  if (observed === expected) return { ok: true, status: "ok", detail: "" };
+
+  let sharedPrefixLength = 0;
+  while (
+    sharedPrefixLength < expected.length &&
+    observed[sharedPrefixLength] === expected[sharedPrefixLength]
+  ) {
+    sharedPrefixLength += 1;
+  }
+  if (sharedPrefixLength >= 8) {
+    return {
+      ok: false,
+      status: "likely-short-sha-reconstruction",
+      detail:
+        "evidence-head marker shares a short prefix with the current head and appears reconstructed; re-capture the full value verbatim with git rev-parse HEAD",
+    };
+  }
+
+  return {
+    ok: false,
+    status: "head-mismatch",
+    detail: "evidence-head marker must match the current PR head SHA",
+  };
+}
+
+export function hasMatchingEvidenceHead(body, headSha) {
+  return inspectEvidenceHead(body, headSha).ok;
 }
 
 /**
@@ -2315,6 +2355,33 @@ export function runSelfTest() {
   const failures = [];
 
   {
+    const expected = "0835c66b420cebd18c693deb98d8b181c0a30faa";
+    const exact = inspectEvidenceHead(
+      `<!-- evidence-head:${expected} -->`,
+      expected,
+    );
+    const reconstructed = inspectEvidenceHead(
+      "<!-- evidence-head:0835c66b42b6a22fdfbf9fc7ea7d1be7b11d615f -->",
+      expected,
+    );
+    const unrelated = inspectEvidenceHead(
+      "<!-- evidence-head:ffffffffffffffffffffffffffffffffffffffff -->",
+      expected,
+    );
+    if (!exact.ok) failures.push("exact evidence head should pass");
+    if (reconstructed.status !== "likely-short-sha-reconstruction") {
+      failures.push(
+        "shared short-SHA prefix should receive a specific diagnostic",
+      );
+    }
+    if (unrelated.status !== "head-mismatch") {
+      failures.push(
+        "unrelated evidence head should retain the generic diagnostic",
+      );
+    }
+  }
+
+  {
     const { ok } = evaluatePrEvidence(buildFixtureBody());
     if (!ok) failures.push("all-filled fixture should pass");
   }
@@ -2557,7 +2624,7 @@ export function runSelfTest() {
     for (const failure of failures) console.error(`  - ${failure}`);
     process.exit(1);
   }
-  console.log("check-pr-evidence self-test passed (14 cases).");
+  console.log("check-pr-evidence self-test passed (15 cases).");
 }
 
 // The diagnostic for a PR body carrying NONE of the template's evidence-row
@@ -2614,13 +2681,17 @@ async function main() {
     evaluation.findings,
     verification.findings,
   );
-  const headOk = headSha === null || hasMatchingEvidenceHead(body, headSha);
+  const headInspection =
+    headSha === null
+      ? { ok: true, status: "ok", detail: "" }
+      : inspectEvidenceHead(body, headSha);
+  const headOk = headInspection.ok;
   if (!headOk) {
     findings.push({
       id: "evidence-head",
       label: "Evidence head SHA",
-      status: "head-mismatch",
-      detail: "evidence-head marker must match the current PR head SHA",
+      status: headInspection.status,
+      detail: headInspection.detail,
     });
   }
   const allOk =

--- a/skills/contribute-to-asi/SKILL.md
+++ b/skills/contribute-to-asi/SKILL.md
@@ -292,6 +292,10 @@ Bind it to the head you measured with a single marker, and attach artifacts as
 immutable GitHub attachment URLs — mutable release assets, inline text, and
 comment copies do not verify:
 
+Capture the marker value in the same run with `git rev-parse HEAD` and paste
+all 40 characters verbatim. Never reconstruct it from `git log --oneline`, a
+short SHA, memory, or model completion.
+
 ```text
 <!-- evidence-head:<40-character head SHA> -->
 <!-- evidence-row:logs -->

--- a/skills/contribute-to-delta-star/SKILL.md
+++ b/skills/contribute-to-delta-star/SKILL.md
@@ -155,7 +155,10 @@ proof is blocked.
    relevant checks.
 6. Capture the exact Lean commands, checked declarations, assumption audit,
    logs, counterexample or research artifact, and live-model trajectory. Open
-   and inspect each artifact.
+   and inspect each artifact. When the repository template requires an
+   evidence-head marker, capture it with `git rev-parse HEAD` in the same run
+   and paste the complete 40-character output verbatim; never expand a short
+   SHA or compose it from memory.
 7. Open or update a focused PR using the repository's title convention, link the issue
    or frontier lane, state the verified head SHA, and explain both progress and
    remaining residuals. Leave acceptance and merge to independent maintainers.

--- a/skills/contribute-to-eliza/SKILL.md
+++ b/skills/contribute-to-eliza/SKILL.md
@@ -201,7 +201,10 @@ details or secrets in public project data or a run receipt.
 5. Capture the applicable logs, screenshots, recording, live-model trajectory,
    and domain artifact. Open and inspect every artifact. Preserve every stable
    PR-template evidence row and use a specific `N/A - <reason>` only when the
-   repository allows it.
+   repository allows it. When the template requires an evidence-head marker,
+   capture it with `git rev-parse HEAD` in the same run and paste the complete
+   40-character output verbatim; never expand a short SHA or compose it from
+   memory.
 6. Open or update a PR against `develop`, link its issue, and leave final
    approval and merge to an independent maintainer. Never self-approve,
    self-merge, or represent an unmerged change as accepted.

--- a/skills/contribute-to-heir-elements-sdk/SKILL.md
+++ b/skills/contribute-to-heir-elements-sdk/SKILL.md
@@ -174,7 +174,10 @@ data or a run receipt.
 4. Run focused package checks, then repository `npm run build` and
    `npm run test`. Rebase again before final proof.
 5. Capture validator output, failing-then-passing tests, and any sandbox or
-   permission proof. Open and inspect every artifact.
+   permission proof. Open and inspect every artifact. When the repository
+   template requires an evidence-head marker, capture it with
+   `git rev-parse HEAD` in the same run and paste the complete 40-character
+   output verbatim; never expand a short SHA or compose it from memory.
 6. Open or update a PR against `main`, link its issue, and leave final
    approval and merge to `main` by `awidearray`. Never self-approve,
    self-merge, or represent an unmerged change as accepted.


### PR DESCRIPTION
## Summary

- Require every canonical contributor skill to capture the full evidence head verbatim from `git rev-parse HEAD` in the same run.
- Distinguish a likely short-SHA reconstruction (at least eight shared leading hex characters) from an ordinary stale or incorrect marker.
- Preserve the existing exact, single-marker fail-closed rule.

Closes #168

## Validation

- `bun scripts/check-pr-evidence.mjs --self-test` — passed (15 cases, including the exact #168 fabricated marker).
- `bun test ./skill-tests` — 79 passed, 0 failed.
- `bun run projects:check` — passed.
- `bun run typecheck` — passed.
- `bun run lint:check` — passed.
- `bun run format:check` — passed.
- `git diff --check` — passed.

## Evidence

- Before screenshots: N/A - verifier and contributor-skill documentation change; no rendered UI.
- After screenshots: N/A - verifier and contributor-skill documentation change; no rendered UI.
- Walkthrough video: N/A - no interactive user surface changed.
- Backend logs: `check-pr-evidence self-test passed (15 cases)` and `79 pass / 0 fail` from the exact committed tree.
- Frontend console/network logs: N/A - no frontend runtime changed.
- Real-LLM trajectory: N/A - deterministic verifier regression uses the exact issue-reported marker and live-head pair.
- Domain artifacts: `scripts/check-pr-evidence.mjs` self-test fixture for the exact reconstructed-SHA incident.

## Contribution provenance

- AI assistance: Yes
- AI provider/model: OpenAI / GPT-5
- Client / agent tooling: Codex Desktop
- Contribution skill revision: N/A - repository maintainer repair, no installed contributor skill used.
- Attribution status: self-reported

## Slop protocol changes

- Project manifest (`projects/<id>/project.json`): N/A
- Contributor skill (`skills/contribute-to-<id>/`): all four canonical sources hardened
- Isolated reviewer skill (`skills/review-<id>-contributions/`): N/A
- Evaluated-contribution award (`evaluations/<id>/award-*.json`): N/A
- Reward-cycle transition (`cycles/<id>/<YYYY-MM>/`): N/A

## Safety review

- [x] No private key, seed phrase, API token, raw private trajectory, or secret was added.
- [x] Untrusted project code is not executed with repository or deployment credentials.
- [x] New telemetry is bounded, disclosed, project-attributed, and covered by adversarial tests. N/A - no telemetry changed.
- [x] Money state is derived from validated manifests and finalized on-chain evidence, not a transaction signature alone. N/A - no money state changed.

<!-- evidence-head:996eb99197d4c04bedfae8532995f4ef7a5d1622 -->