### PR TITLE
Separate contribution access from authority evidence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,9 +77,11 @@ skills/contribute-to-<project-id>/
 skills/review-<project-id>-contributions/
 ```
 
-New projects begin paused. Verify immutable repository and actor IDs, repository
-license facts, GitHub stewardship, integration branch, reward policy, and
-failure paths before activation. Stewardship is a GitHub identity only.
+Once reviewed and merged, new projects accept contributions. Verify immutable
+repository and actor IDs, repository license facts, GitHub stewardship,
+integration branch, reward policy, and failure paths when evidence is available;
+publish unknown authority or terms explicitly without blocking work.
+Stewardship is a GitHub identity only.
 
 The contributor skill must inspect live GitHub, select bounded unblocked work,
 follow the target repository’s rules, test the result, prepare evidence, and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,9 +77,11 @@ skills/contribute-to-<project-id>/
 skills/review-<project-id>-contributions/
 ```
 
-New projects begin paused. Verify immutable repository and actor IDs, repository
-license facts, GitHub stewardship, integration branch, reward policy, and
-failure paths before activation. Stewardship is a GitHub identity only.
+Once reviewed and merged, new projects accept contributions. Verify immutable
+repository and actor IDs, repository license facts, GitHub stewardship,
+integration branch, reward policy, and failure paths when evidence is available;
+publish unknown authority or terms explicitly without blocking work.
+Stewardship is a GitHub identity only.
 
 The contributor skill must inspect live GitHub, select bounded unblocked work,
 follow the target repository’s rules, test the result, prepare evidence, and

--- a/README.md
+++ b/README.md
@@ -79,9 +79,11 @@ The pull request must establish:
 - a clearly labeled monthly pool or external opportunity;
 - focused tests for validation, installation, and failure paths.
 
-New projects begin paused. Reward, receipt, funding, and deployment states turn
-on only after their separate authority and operational checks pass. For the
-full review checklist, see [CONTRIBUTING.md](CONTRIBUTING.md).
+Reviewed projects accept contributions even when repository authority, license,
+or inbound terms are unknown; the product discloses those unknowns instead of
+blocking work. Funding, payout, and deployment states still require their own
+independent evidence. For the full review checklist, see
+[CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## What the public record means
 

--- a/src/lib/project-schema.mjs
+++ b/src/lib/project-schema.mjs
@@ -890,30 +890,16 @@ function validateProjectDefinition(
     project.steward,
     { allowLegacyUnsupportedOwnershipClaim },
   );
-  if (project.status === "active" && project.authority.state !== "verified") {
-    throw new TypeError(
-      "active projects require verified repository authority",
-    );
-  }
-  if (project.status === "active") {
-    if (
-      project.terms.receiptPolicy.state !== "active" ||
-      project.terms.receiptPolicy.activatedAt !==
-        project.authority.proof.verifiedAt
-    ) {
-      throw new TypeError(
-        "active projects require receipt cutover at the immutable authority activation",
-      );
-    }
-  }
   if (
     project.status === "active" &&
-    (project.terms.inbound.mode === "unknown" ||
-      project.terms.repositoryLicense.state === "unknown" ||
-      (project.reward.kind === "external-prize-share" &&
-        project.terms.externalPrize?.version === "unknown"))
+    project.authority.state === "verified" &&
+    (project.terms.receiptPolicy.state !== "active" ||
+      project.terms.receiptPolicy.activatedAt !==
+        project.authority.proof.verifiedAt)
   ) {
-    throw new TypeError("active projects require known mandatory terms");
+    throw new TypeError(
+      "verified project authority requires its immutable receipt cutover",
+    );
   }
   const modelPolicy = record(project.modelPolicy, "project.modelPolicy");
   exactKeys(modelPolicy, ["disclosureRequired", "mode"], "project.modelPolicy");

--- a/src/lib/project-schema.test.ts
+++ b/src/lib/project-schema.test.ts
@@ -295,7 +295,7 @@ describe("project proposal schema", () => {
     );
   });
 
-  it("fails closed on inferred or mutable project authority", () => {
+  it("discloses unverified authority without blocking contribution", () => {
     const activeWithoutProof = structuredClone(eliza);
     activeWithoutProof.status = "active";
     const unprovenAuthority = activeWithoutProof.authority as Record<
@@ -305,9 +305,7 @@ describe("project proposal schema", () => {
     unprovenAuthority.state = "unverified";
     unprovenAuthority.reason = "missing-repository-proof";
     unprovenAuthority.proof = null;
-    expect(() => assertProjectDefinition(activeWithoutProof)).toThrow(
-      /verified repository authority/u,
-    );
+    expect(assertProjectDefinition(activeWithoutProof).status).toBe("active");
 
     const loginAsIdentity = structuredClone(eliza);
     loginAsIdentity.steward.github.actorId = "elizaOS";
@@ -449,7 +447,7 @@ describe("project proposal schema", () => {
     );
   });
 
-  it("represents a missing repository license as unknown and paused", () => {
+  it("represents a missing repository license as unknown without blocking contribution", () => {
     expect(assertProjectDefinition(heirElements).status).toBe("paused");
     expect(heirElements.terms.repositoryLicense).toEqual({
       state: "unknown",
@@ -460,8 +458,7 @@ describe("project proposal schema", () => {
     });
     const active = structuredClone(heirElements);
     active.status = "active";
-    expect(() => assertProjectDefinition(active)).toThrow(
-      /verified repository authority/u,
-    );
+    expect(assertProjectDefinition(active).status).toBe("active");
+    expect(assertProjectDefinition(active).authority.state).toBe("unverified");
   });
 });


### PR DESCRIPTION
Stages the project-policy compatibility needed before activating reviewed projects with disclosed unknown authority or terms. This PR changes no project status, receipt cutover, funding state, or payout state. Verified projects still require an immutable proof-bound receipt cutover; funding and payouts remain independently evidence-gated.\n\nValidation: 20 focused schema/policy tests, typecheck, lint, format, AGENTS/CLAUDE identity, and diff check pass.\n\nThis must merge before #165 so the trusted base checker can validate the all-four activation without a protection bypass.