### PR TITLE
Restore fail-closed project activation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,11 +77,9 @@ skills/contribute-to-<project-id>/
 skills/review-<project-id>-contributions/
 ```
 
-Once reviewed and merged, new projects accept contributions. Verify immutable
-repository and actor IDs, repository license facts, GitHub stewardship,
-integration branch, reward policy, and failure paths when evidence is available;
-publish unknown authority or terms explicitly without blocking work.
-Stewardship is a GitHub identity only.
+New projects begin paused. Verify immutable repository and actor IDs, repository
+license facts, GitHub stewardship, integration branch, reward policy, and
+failure paths before activation. Stewardship is a GitHub identity only.
 
 The contributor skill must inspect live GitHub, select bounded unblocked work,
 follow the target repository’s rules, test the result, prepare evidence, and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,11 +77,9 @@ skills/contribute-to-<project-id>/
 skills/review-<project-id>-contributions/
 ```
 
-Once reviewed and merged, new projects accept contributions. Verify immutable
-repository and actor IDs, repository license facts, GitHub stewardship,
-integration branch, reward policy, and failure paths when evidence is available;
-publish unknown authority or terms explicitly without blocking work.
-Stewardship is a GitHub identity only.
+New projects begin paused. Verify immutable repository and actor IDs, repository
+license facts, GitHub stewardship, integration branch, reward policy, and
+failure paths before activation. Stewardship is a GitHub identity only.
 
 The contributor skill must inspect live GitHub, select bounded unblocked work,
 follow the target repository’s rules, test the result, prepare evidence, and

--- a/README.md
+++ b/README.md
@@ -79,11 +79,9 @@ The pull request must establish:
 - a clearly labeled monthly pool or external opportunity;
 - focused tests for validation, installation, and failure paths.
 
-Reviewed projects accept contributions even when repository authority, license,
-or inbound terms are unknown; the product discloses those unknowns instead of
-blocking work. Funding, payout, and deployment states still require their own
-independent evidence. For the full review checklist, see
-[CONTRIBUTING.md](CONTRIBUTING.md).
+New projects begin paused. Reward, receipt, funding, and deployment states turn
+on only after their separate authority and operational checks pass. For the
+full review checklist, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## What the public record means
 

--- a/src/lib/project-schema.mjs
+++ b/src/lib/project-schema.mjs
@@ -890,16 +890,30 @@ function validateProjectDefinition(
     project.steward,
     { allowLegacyUnsupportedOwnershipClaim },
   );
+  if (project.status === "active" && project.authority.state !== "verified") {
+    throw new TypeError(
+      "active projects require verified repository authority",
+    );
+  }
+  if (project.status === "active") {
+    if (
+      project.terms.receiptPolicy.state !== "active" ||
+      project.terms.receiptPolicy.activatedAt !==
+        project.authority.proof.verifiedAt
+    ) {
+      throw new TypeError(
+        "active projects require receipt cutover at the immutable authority activation",
+      );
+    }
+  }
   if (
     project.status === "active" &&
-    project.authority.state === "verified" &&
-    (project.terms.receiptPolicy.state !== "active" ||
-      project.terms.receiptPolicy.activatedAt !==
-        project.authority.proof.verifiedAt)
+    (project.terms.inbound.mode === "unknown" ||
+      project.terms.repositoryLicense.state === "unknown" ||
+      (project.reward.kind === "external-prize-share" &&
+        project.terms.externalPrize?.version === "unknown"))
   ) {
-    throw new TypeError(
-      "verified project authority requires its immutable receipt cutover",
-    );
+    throw new TypeError("active projects require known mandatory terms");
   }
   const modelPolicy = record(project.modelPolicy, "project.modelPolicy");
   exactKeys(modelPolicy, ["disclosureRequired", "mode"], "project.modelPolicy");

--- a/src/lib/project-schema.test.ts
+++ b/src/lib/project-schema.test.ts
@@ -295,7 +295,7 @@ describe("project proposal schema", () => {
     );
   });
 
-  it("discloses unverified authority without blocking contribution", () => {
+  it("fails closed on inferred or mutable project authority", () => {
     const activeWithoutProof = structuredClone(eliza);
     activeWithoutProof.status = "active";
     const unprovenAuthority = activeWithoutProof.authority as Record<
@@ -305,7 +305,9 @@ describe("project proposal schema", () => {
     unprovenAuthority.state = "unverified";
     unprovenAuthority.reason = "missing-repository-proof";
     unprovenAuthority.proof = null;
-    expect(assertProjectDefinition(activeWithoutProof).status).toBe("active");
+    expect(() => assertProjectDefinition(activeWithoutProof)).toThrow(
+      /verified repository authority/u,
+    );
 
     const loginAsIdentity = structuredClone(eliza);
     loginAsIdentity.steward.github.actorId = "elizaOS";
@@ -447,7 +449,7 @@ describe("project proposal schema", () => {
     );
   });
 
-  it("represents a missing repository license as unknown without blocking contribution", () => {
+  it("represents a missing repository license as unknown and paused", () => {
     expect(assertProjectDefinition(heirElements).status).toBe("paused");
     expect(heirElements.terms.repositoryLicense).toEqual({
       state: "unknown",
@@ -458,7 +460,8 @@ describe("project proposal schema", () => {
     });
     const active = structuredClone(heirElements);
     active.status = "active";
-    expect(assertProjectDefinition(active).status).toBe("active");
-    expect(assertProjectDefinition(active).authority.state).toBe("unverified");
+    expect(() => assertProjectDefinition(active)).toThrow(
+      /verified repository authority/u,
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Revert #170 exactly.
- Restore the fail-closed rule that an active project requires verified repository authority, immutable receipt activation, and known mandatory terms.
- Keep broad declared-model participation separate from project activation authority.

## Validation

- `bun test src/lib/project-schema.test.ts src/lib/project-policy.test.ts` — 20 passed, 0 failed.
- `bun run projects:check` — passed.
- `bun run typecheck` — passed.
- `bun run lint:check` — passed.
- `bun run format:check` — passed.
- `cmp -s AGENTS.md CLAUDE.md` — passed.
- The five reverted files are byte-identical to the parent of #170.

## Evidence

- Before screenshots: N/A - schema, tests, and policy documentation only.
- After screenshots: N/A - no rendered UI changed.
- Walkthrough video: N/A - no interactive surface changed.
- Backend logs: `20 pass / 0 fail` from the project schema and transition suites.
- Frontend console/network logs: N/A - no frontend runtime changed.
- Real-LLM trajectory: N/A - deterministic schema transition.
- Domain artifacts: exact reverse diff of #170.

## Contribution provenance

- AI assistance: Yes
- AI provider/model: OpenAI / GPT-5
- Client / agent tooling: Codex Desktop
- Contribution skill revision: N/A - maintainer repair, no installed contributor skill used.
- Attribution status: self-reported

## Slop protocol changes

- Project manifest (`projects/<id>/project.json`): N/A
- Contributor skill (`skills/contribute-to-<id>/`): N/A
- Isolated reviewer skill (`skills/review-<id>-contributions/`): N/A
- Evaluated-contribution award (`evaluations/<id>/award-*.json`): N/A
- Reward-cycle transition (`cycles/<id>/<YYYY-MM>/`): N/A

## Safety review

- [x] No private key, seed phrase, API token, raw private trajectory, or secret was added.
- [x] Untrusted project code is not executed with repository or deployment credentials.
- [x] New telemetry is bounded, disclosed, project-attributed, and covered by adversarial tests. N/A - no telemetry changed.
- [x] Money state is derived from validated manifests and finalized on-chain evidence, not a transaction signature alone. N/A - no money state changed.

<!-- evidence-head:1f6907118a55b5048cdd99bb8d65e11ba841df7b -->