### PR TITLE
Bind score bonuses to verified outcomes

### DIFF
--- a/scripts/generate-leaderboard.ts
+++ b/scripts/generate-leaderboard.ts
@@ -2855,20 +2855,8 @@ export async function generateLeaderboardFromGitHub(
     verificationWindowFrom: verificationWindowFrom.toISOString(),
     verifiedEvidence: evidenceVerification.artifacts,
     evaluatedContributions: options.evaluatedContributions ?? [],
+    verifyRunReceipt: verifyRunReceiptSignature,
   });
-  for (const attribution of snapshot.attributions) {
-    if (attribution.run === null) continue;
-    try {
-      verifyRunReceiptSignature(attribution.run);
-    } catch (error: unknown) {
-      snapshot.invalidAttributionMarkers.push({
-        sourceId: attribution.sourceId,
-        sourceUrl: attribution.sourceUrl,
-        reason: `run receipt excluded: ${error instanceof Error ? error.message : "signature verification failed"}`,
-      });
-      attribution.run = null;
-    }
-  }
   return snapshot;
 }
 

--- a/src/lib/leaderboard.test.ts
+++ b/src/lib/leaderboard.test.ts
@@ -499,6 +499,74 @@ describe("score v2 work units", () => {
       ),
     ).toHaveLength(1);
   });
+
+  it("awards automated review credit only after receipt signature verification", () => {
+    const reviewer = actor("reviewer");
+    const body = reviewAttribution(
+      {
+        provider: "openai",
+        model: "gpt-5.6-sol",
+        client: "codex",
+      },
+      {
+        schemaVersion: "2",
+        splitRisk: "none",
+        effortBand: "small",
+        complexity: "moderate",
+        impact: "meaningful",
+        reviewLoad: "standard",
+        recommendedTier: "small",
+        recommendedThirds: 3,
+        workUnitId: "wu_eliza_verified_review",
+        confidenceBasisPoints: 9_000,
+        valueRationale:
+          "The review reproduced the change and checked the important failure paths.",
+      },
+    );
+    const source = {
+      ...textSource("COMMENT_V2_REVIEW", body, reviewer),
+      createdAt: "2026-08-18T02:00:00.000Z",
+      updatedAt: "2026-08-18T02:00:00.000Z",
+    };
+    const pr = pullRequest({
+      createdAt: "2026-08-17T08:00:00.000Z",
+      updatedAt: "2026-08-18T03:00:00.000Z",
+      mergedAt: "2026-08-18T03:00:00.000Z",
+      comments: [source],
+    });
+
+    const rejected = createLeaderboardSnapshot({
+      ...v2Input([pr]),
+      verifyRunReceipt: () => {
+        throw new TypeError("test signature is invalid");
+      },
+    });
+    expect(
+      rejected.ledger.filter(
+        (event) => event.category === "substantive-review",
+      ),
+    ).toEqual([]);
+
+    const accepted = createLeaderboardSnapshot({
+      ...v2Input([pr]),
+      verifyRunReceipt: (value) => value as ProjectRunReceipt,
+    });
+    expect(
+      accepted.ledger.find((event) => event.category === "substantive-review"),
+    ).toMatchObject({
+      scoreThirds: 3,
+      evidenceBonusBasisPoints: 1_500,
+    });
+    const detached = structuredClone(accepted);
+    const detachedReview = detached.ledger.find(
+      (event) => event.category === "substantive-review",
+    );
+    if (!detachedReview) throw new Error("expected a scored review fixture");
+    detachedReview.evidenceBonusBasisPoints = 2_500;
+    expect(() => assertLeaderboardSnapshot(detached)).toThrow(
+      "has no exact receipt for its evidence bonus",
+    );
+  });
 });
 
 describe("model attribution", () => {

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -277,6 +277,11 @@ export interface AttributionAssessment {
   coverage: AttributionCoverage;
 }
 
+export interface AttributionAssessmentOptions {
+  requireEverySource?: boolean;
+  verifyRunReceipt?: (value: unknown) => ProjectRunReceipt;
+}
+
 export interface AttributionCoverage {
   status: "complete" | "partial" | "missing" | "invalid";
   eligibleSourceCount: number;
@@ -300,6 +305,7 @@ export interface ScoreEvent {
   category: ScoreCategory;
   points: number;
   scoreThirds?: number;
+  evidenceBonusBasisPoints?: 0 | 1_000 | 1_500 | 2_500;
   workUnitId?: string;
   scoreDecisionSourceId?: string;
   occurredAt: string;
@@ -564,6 +570,7 @@ export interface LeaderboardInput {
   verificationWindowFrom: string;
   verifiedEvidence: VerifiedEvidenceArtifact[];
   evaluatedContributions?: ScoreEvent[];
+  verifyRunReceipt?: (value: unknown) => ProjectRunReceipt;
 }
 
 const EVIDENCE_WEIGHTS: Record<EvidenceCategory, number> = {
@@ -1288,7 +1295,7 @@ function markerFooterError(
 
 export function assessModelAttribution(
   sources: GitHubTextSource[],
-  options: { requireEverySource?: boolean } = {},
+  options: AttributionAssessmentOptions = {},
 ): AttributionAssessment {
   const declarations: ModelAttribution[] = [];
   const invalidMarkers: InvalidAttributionMarker[] = [];
@@ -1397,6 +1404,21 @@ export function assessModelAttribution(
           continue;
         }
       }
+      let verifiedRun = marker.run;
+      if (options.verifyRunReceipt) {
+        try {
+          verifiedRun = options.verifyRunReceipt(marker.run);
+        } catch (error: unknown) {
+          invalidSourceIds.add(source.id);
+          invalidMarkers.push({
+            sourceId: source.id,
+            sourceUrl: source.url,
+            reason: `run receipt excluded: ${error instanceof Error ? error.message : "signature verification failed"}`,
+          });
+          markerIndex += 1;
+          continue;
+        }
+      }
       const identifier = exactIdentifier(marker.provider, marker.model);
       validSourceIds.add(source.id);
       markerIdentifiers.add(identifier.toLowerCase());
@@ -1411,7 +1433,7 @@ export function assessModelAttribution(
         identifier,
         client: marker.client,
         skillRevision: marker.skillRevision,
-        run: marker.run,
+        run: verifiedRun,
         format: "machine-marker",
         status: "self-reported",
       });
@@ -2864,6 +2886,17 @@ export function createLeaderboardSnapshot(
           );
         }
         const proposedReview = assertReviewRecord(proposal);
+        const proposalAssessment = assessModelAttribution([reviewSource], {
+          requireEverySource: true,
+          verifyRunReceipt: input.verifyRunReceipt,
+        });
+        const proposalReceipt = input.verifyRunReceipt
+          ? (proposalAssessment.declarations[0]?.run ?? null)
+          : null;
+        assertReviewRecordReceiptJoin(proposedReview, proposalReceipt, {
+          artifactUrl: pullRequest.url,
+          headSha: pullRequest.headRefOid,
+        });
         if (
           proposedReview.securityRisk !== "none" &&
           record.coRatifierNodeIds.length === 0
@@ -2910,6 +2943,27 @@ export function createLeaderboardSnapshot(
       authorEntry.rawActivity.additions += pullRequest.additions;
       authorEntry.rawActivity.deletions += pullRequest.deletions;
       const ratification = scoreRatifications.get(pullRequest.id);
+      const contributionAssessment = assessModelAttribution(
+        [pullRequestBodySource(pullRequest)],
+        {
+          requireEverySource: true,
+          verifyRunReceipt: input.verifyRunReceipt,
+        },
+      );
+      const contributionRun = input.verifyRunReceipt
+        ? contributionAssessment.declarations.find(
+            (declaration) =>
+              declaration.actor?.id === pullRequest.author?.id &&
+              declaration.artifactId === pullRequest.id,
+          )?.run
+        : null;
+      const contributionBonus = contributionRun
+        ? (contributionRun.traceUpload ? 1_500 : 0) +
+          (["exact", "bounded"].includes(contributionRun.usage.confidence) &&
+          contributionRun.usage.totalTokens > 0
+            ? 1_000
+            : 0)
+        : 0;
       const scored = addScore(entries, ledger, {
         id: `${pullRequest.id}:merged`,
         actor: pullRequest.author,
@@ -2919,6 +2973,11 @@ export function createLeaderboardSnapshot(
         parseIsoTime(SCORE_V2_EFFECTIVE_AT)
           ? {
               scoreThirds: ratification?.record.scoreThirds ?? 1,
+              evidenceBonusBasisPoints: contributionBonus as
+                | 0
+                | 1_000
+                | 1_500
+                | 2_500,
               workUnitId:
                 ratification?.record.workUnitId ??
                 `wu_${repositoryIdFromUrl(pullRequest.url)
@@ -3041,8 +3100,11 @@ export function createLeaderboardSnapshot(
         continue;
       const assessment = assessModelAttribution([source], {
         requireEverySource: true,
+        verifyRunReceipt: input.verifyRunReceipt,
       });
-      const receipt = assessment.declarations[0]?.run ?? null;
+      const receipt = input.verifyRunReceipt
+        ? (assessment.declarations[0]?.run ?? null)
+        : null;
       if (receipt === null) continue;
       let record: ReviewRecord;
       try {
@@ -3071,6 +3133,11 @@ export function createLeaderboardSnapshot(
           category: "substantive-review",
           points: reviewThirds / 3,
           scoreThirds: reviewThirds,
+          evidenceBonusBasisPoints: ((receipt.traceUpload ? 1_500 : 0) +
+            (["exact", "bounded"].includes(receipt.usage.confidence) &&
+            receipt.usage.totalTokens > 0
+              ? 1_000
+              : 0)) as 0 | 1_000 | 1_500 | 2_500,
           workUnitId: `${record.workUnitId}_review_${source.author.id.toLowerCase().replace(/[^a-z0-9_-]+/gu, "_")}`,
           occurredAt: source.createdAt,
           repository: repositoryIdFromUrl(pullRequest.url),
@@ -3307,7 +3374,10 @@ export function createLeaderboardSnapshot(
   );
   const overallAttribution = assessModelAttribution(
     [...scoredAttributionSources.values()],
-    { requireEverySource: true },
+    {
+      requireEverySource: true,
+      verifyRunReceipt: input.verifyRunReceipt,
+    },
   );
   const attributions = overallAttribution.declarations;
   for (const attribution of attributions) {
@@ -4354,6 +4424,17 @@ function assertLedgerValue(
     eventPoints === Number(scoreThirds) / 3 &&
     typeof event.workUnitId === "string" &&
     /^wu_[a-z0-9][a-z0-9_-]{2,255}$/u.test(event.workUnitId);
+  if (
+    "evidenceBonusBasisPoints" in event &&
+    (!isV2 ||
+      ![0, 1_000, 1_500, 2_500].includes(
+        Number(event.evidenceBonusBasisPoints),
+      ))
+  ) {
+    throw new Error(
+      `${path}.evidenceBonusBasisPoints must be an allowed v2 outcome bonus`,
+    );
+  }
   const validLegacy =
     (!isV2 &&
       event.category === "merged-pull-request" &&
@@ -4998,7 +5079,7 @@ export function assertLeaderboardSnapshot(
     }
     if (
       event.category === "substantive-review" &&
-      event.source.kind === "review"
+      (event.source.kind === "review" || event.source.kind === "comment")
     ) {
       causalAttributionKeys.add(
         `${event.actor.id}\0source\0${event.source.id}`,
@@ -5036,6 +5117,29 @@ export function assertLeaderboardSnapshot(
     if (!hasCausalLedgerEvent) {
       throw new Error(
         `snapshot attribution ${attribution.id} is not causally linked to a public ledger event by the same actor`,
+      );
+    }
+  }
+  for (const event of validatedLedger) {
+    const publishedBonus = event.evidenceBonusBasisPoints ?? 0;
+    if (publishedBonus === 0) continue;
+    const matchingRun = validatedAttributions.find(
+      (attribution) =>
+        attribution.actor?.id === event.actor.id &&
+        (attribution.artifactId === event.source.id ||
+          attribution.sourceId === event.source.id) &&
+        attribution.run !== null,
+    )?.run;
+    const expectedBonus = matchingRun
+      ? (matchingRun.traceUpload ? 1_500 : 0) +
+        (["exact", "bounded"].includes(matchingRun.usage.confidence) &&
+        matchingRun.usage.totalTokens > 0
+          ? 1_000
+          : 0)
+      : 0;
+    if (publishedBonus !== expectedBonus) {
+      throw new Error(
+        `snapshot.ledger event ${event.id} has no exact receipt for its evidence bonus`,
       );
     }
   }

--- a/src/lib/project-view.test.ts
+++ b/src/lib/project-view.test.ts
@@ -251,6 +251,27 @@ describe("project views", () => {
     expect(view.leaders[0].adjustedWeight).toBe(240_000);
   });
 
+  it("binds a compute bonus to its exact scored outcome", () => {
+    const snapshot = snapshotFixture();
+    const event = snapshot.ledger[0];
+    const baseline = createProjectView(snapshot, "eliza", "2026-07");
+    event.scoreThirds = event.points * 3;
+    event.workUnitId = "wu_eliza_exact_bonus_outcome";
+    event.evidenceBonusBasisPoints = 2_500;
+
+    const view = createProjectView(snapshot, "eliza", "2026-07");
+    expect(view.leaders[0].adjustedWeight).toBe(
+      baseline.leaders[0].adjustedWeight + event.points * 2_500,
+    );
+    expect(view.leaders[0].computeBonusBasisPoints).toBe(
+      Math.floor((event.points * 3 * 2_500) / (baseline.leaders[0].score * 3)),
+    );
+    expect(view.leaders[0].score).toBe(baseline.leaders[0].score);
+    expect(view.leaders[0].adjustedWeight).not.toBe(
+      baseline.leaders[0].adjustedWeight,
+    );
+  });
+
   it("drops copied run receipts instead of crediting either identity", () => {
     const snapshot = snapshotFixture();
     const shared = receipt();

--- a/src/lib/project-view.ts
+++ b/src/lib/project-view.ts
@@ -441,33 +441,6 @@ function usageForActor(
   return usage;
 }
 
-function evidenceBonusForActor(
-  actorId: string,
-  events: readonly ScoreEvent[],
-  runs: readonly UniqueRun[],
-): number {
-  const relevant = runs.filter(
-    (run) =>
-      run.attribution.actor?.id === actorId &&
-      events.some(
-        (event) =>
-          event.scoreThirds !== undefined && eventMatchesRun(event, run),
-      ),
-  );
-  const traceBonus = relevant.some((run) => run.receipt.traceUpload !== null)
-    ? 1_500
-    : 0;
-  const usageBonus = relevant.some(
-    (run) =>
-      (run.receipt.usage.confidence === "exact" ||
-        run.receipt.usage.confidence === "bounded") &&
-      run.receipt.usage.totalTokens > 0,
-  )
-    ? 1_000
-    : 0;
-  return traceBonus + usageBonus;
-}
-
 function aggregateUsage(
   entries: readonly ProjectContributor[],
 ): ProjectUsageSummary {
@@ -585,11 +558,18 @@ export function createProjectView(
       (total, event) => total + (event.scoreThirds ?? event.points * 3),
       0,
     );
-    const computeBonus = evidenceBonusForActor(actor.id, events, runs);
-    const weightedThirds = Math.floor(
-      (rawThirds * (10_000 + computeBonus)) / 10_000,
+    const weightedThirdBasisPoints = events.reduce(
+      (total, event) =>
+        total +
+        (event.scoreThirds ?? event.points * 3) *
+          (10_000 + (event.evidenceBonusBasisPoints ?? 0)),
+      0,
     );
-    const score = Math.floor(weightedThirds / 3);
+    const computeBonus =
+      rawThirds === 0
+        ? 0
+        : Math.floor(weightedThirdBasisPoints / rawThirds) - 10_000;
+    const score = Math.floor(rawThirds / 3);
     const points = {
       "merged-pull-request": 0,
       "resolved-issue": 0,
@@ -603,7 +583,7 @@ export function createProjectView(
       rank: 0,
       actor,
       score,
-      adjustedWeight: score * 10_000,
+      adjustedWeight: Math.floor(weightedThirdBasisPoints / 3),
       computeBonusBasisPoints: computeBonus,
       points,
       acceptedOutcomeCount: events.length,


### PR DESCRIPTION
## Outcome

Keeps score v2 and closes the integrity gaps identified in #176 without reverting the requested payout policy.

## Security and accounting changes

- verifies Ed25519 run receipts before automated review credit, maintainer proposal acceptance, or evidence bonuses
- binds each 15% trace and 10% exact/bounded-usage bonus to the exact actor and PR/comment outcome
- applies payout weight per outcome, so one receipt cannot boost unrelated work by the same actor
- keeps public leaderboard score and project score identical; evidence changes payout weight only
- rejects published bonus metadata without the matching exact receipt
- recognizes both GitHub review objects and review comments in the causal attribution invariant

## Policy retained

- August 1 score-v2 migration
- integer thirds with rounding only after aggregation
- no account caps or diminishing post-August credit
- maintainer-ratified effort tiers and co-review for XL/security cases
- automated reviewer and maintainer compute in the same project pool
- $2 minimum payout accrual
- all four registered projects accepting contribution runs
- no finite 60-second test ceiling

## Validation

- `bun run typecheck`
- `bun run lint:check`
- `bun run format:check`
- focused scoring/project tests: 93 passed
- Vitest full suite: 61 files, 578 passed in 211.78s
- exact isolated Bun ownership test: 1 passed in 14.87s

The aggregate Bun runner killed that same child process during cleanup (`status: null`); the exact owning test passes alone. No finite timeout is configured.

This supersedes the wholesale revert in #176.
