### PR TITLE
Bind run receipts to GitHub artifacts

### DIFF
--- a/src/lib/leaderboard.test.ts
+++ b/src/lib/leaderboard.test.ts
@@ -567,6 +567,37 @@ describe("score v2 work units", () => {
       "has no exact receipt for its evidence bonus",
     );
   });
+
+  it("rejects a signed receipt replayed onto an outcome in another repository", () => {
+    const body = reviewAttribution({
+      projectId: "asi",
+      repositoryId: "elizaOS/asi",
+      skillRevision: `elizaOS/slopdotcash@${"a".repeat(40)}:skills/contribute-to-asi`,
+    }).replace(/^Findings: none\.\n\n```slop-review\n[^\n]+\n```\n\n/u, "");
+    const pr = pullRequest({
+      createdAt: "2026-08-17T08:00:00.000Z",
+      updatedAt: "2026-08-18T03:00:00.000Z",
+      mergedAt: "2026-08-18T03:00:00.000Z",
+      body,
+    });
+
+    const snapshot = createLeaderboardSnapshot({
+      ...v2Input([pr]),
+      verifyRunReceipt: (value) => value as ProjectRunReceipt,
+    });
+
+    expect(snapshot.ledger[0]).toMatchObject({
+      repository: "elizaOS/eliza",
+      evidenceBonusBasisPoints: 0,
+    });
+    expect(snapshot.attributions).toEqual([]);
+    expect(snapshot.invalidAttributionMarkers).toContainEqual(
+      expect.objectContaining({
+        sourceId: `${pr.id}:body`,
+        reason: "run receipt repository does not match its GitHub artifact",
+      }),
+    );
+  });
 });
 
 describe("model attribution", () => {

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -1312,6 +1312,7 @@ export function assessModelAttribution(
   const validSourceIds = new Set<string>();
   const invalidSourceIds = new Set<string>();
   const humanOnlySourceIds = new Set<string>();
+  const receiptArtifactMismatchSourceIds = new Set<string>();
 
   for (const source of eligibleSources) {
     if (hasMarkdownLine(source.body, HUMAN_ONLY_PATTERN)) {
@@ -1419,6 +1420,21 @@ export function assessModelAttribution(
           continue;
         }
       }
+      if (
+        verifiedRun !== null &&
+        source.artifactUrl !== undefined &&
+        verifiedRun.repositoryId !== repositoryIdFromUrl(source.artifactUrl)
+      ) {
+        invalidSourceIds.add(source.id);
+        receiptArtifactMismatchSourceIds.add(source.id);
+        invalidMarkers.push({
+          sourceId: source.id,
+          sourceUrl: source.url,
+          reason: "run receipt repository does not match its GitHub artifact",
+        });
+        markerIndex += 1;
+        continue;
+      }
       const identifier = exactIdentifier(marker.provider, marker.model);
       validSourceIds.add(source.id);
       markerIdentifiers.add(identifier.toLowerCase());
@@ -1440,7 +1456,11 @@ export function assessModelAttribution(
       markerIndex += 1;
     }
 
-    if (reviewRecord !== null && invalidSourceIds.has(source.id)) {
+    if (
+      (reviewRecord !== null ||
+        receiptArtifactMismatchSourceIds.has(source.id)) &&
+      invalidSourceIds.has(source.id)
+    ) {
       continue;
     }
 
@@ -1563,7 +1583,7 @@ export function issueTextSources(issue: IssueRecord): GitHubTextSource[] {
     {
       id: `${issue.id}:body`,
       artifactId: issue.id,
-      kind: "body",
+      kind: "body" as const,
       body: issue.body,
       url: issue.url,
       createdAt: issue.createdAt,
@@ -1571,7 +1591,7 @@ export function issueTextSources(issue: IssueRecord): GitHubTextSource[] {
       author: issue.author,
     },
     ...issue.comments,
-  ]);
+  ]).map((source) => ({ ...source, artifactUrl: issue.url }));
 }
 
 export function qualifiesResolvedIssue(issue: IssueRecord): boolean {
@@ -2094,6 +2114,7 @@ function pullRequestBodySource(
         ? (pullRequest.lastEditedAt ?? pullRequest.createdAt)
         : pullRequest.updatedAt,
     author: pullRequest.author,
+    artifactUrl: pullRequest.url,
   };
 }
 


### PR DESCRIPTION
## Security outcome

Closes the remaining cross-repository replay gap after #177: a valid signed receipt for one registered repository can no longer contribute payout weight or model attribution when copied onto an outcome in another repository.

## Changes

- attach immutable artifact URLs to pull request bodies and issue text sources
- require every verified run receipt repository to match its GitHub artifact repository
- suppress visible-declaration fallback for a repository-mismatched machine receipt
- add an adversarial ASI-receipt-on-Eliza-PR regression proving zero evidence bonus and no accepted attribution

## Validation

- exact head: `9e317902e40a38b7ca5eadacec566fab77c71a23`
- leaderboard tests: 84 passed
- full Vitest: 61 files / 579 passed
- Bun skill aggregate: 80 passed; the known process-cleanup case was killed with `status: null`
- exact owning Bun test rerun alone: 1 passed in 13.67s
- `bun run typecheck`
- `bun run lint:check`
- `bun run format:check`
