### PR TITLE
fix: exclude post-merge slop-reviews instead of failing the snapshot

### DIFF
--- a/src/lib/leaderboard.test.ts
+++ b/src/lib/leaderboard.test.ts
@@ -567,6 +567,56 @@ describe("score v2 work units", () => {
       "has no exact receipt for its evidence bonus",
     );
   });
+
+  it("excludes a slop-review posted after merge without failing the snapshot", () => {
+    const reviewer = actor("reviewer");
+    const body = reviewAttribution(
+      {
+        provider: "openai",
+        model: "gpt-5.6-sol",
+        client: "codex",
+      },
+      {
+        schemaVersion: "2",
+        splitRisk: "none",
+        effortBand: "small",
+        complexity: "moderate",
+        impact: "meaningful",
+        reviewLoad: "standard",
+        recommendedTier: "small",
+        recommendedThirds: 3,
+        workUnitId: "wu_eliza_post_merge_review",
+        confidenceBasisPoints: 9_000,
+        valueRationale:
+          "The review arrived after merge and must be excluded, not fatal.",
+      },
+    );
+    const source = {
+      ...textSource("COMMENT_V2_LATE_REVIEW", body, reviewer),
+      createdAt: "2026-08-18T04:00:00.000Z",
+      updatedAt: "2026-08-18T04:00:00.000Z",
+    };
+    const pr = pullRequest({
+      createdAt: "2026-08-17T08:00:00.000Z",
+      updatedAt: "2026-08-18T03:00:00.000Z",
+      mergedAt: "2026-08-18T03:00:00.000Z",
+      comments: [source],
+    });
+    const snapshot = createLeaderboardSnapshot({
+      ...v2Input([pr]),
+      verifyRunReceipt: (value) => value as ProjectRunReceipt,
+    });
+    expect(
+      snapshot.ledger.filter(
+        (event) => event.category === "substantive-review",
+      ),
+    ).toEqual([]);
+    expect(
+      snapshot.ledger.filter(
+        (event) => event.category === "merged-pull-request",
+      ),
+    ).toHaveLength(1);
+  });
 });
 
 describe("model attribution", () => {

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -3116,8 +3116,10 @@ export function createLeaderboardSnapshot(
         continue;
       }
       if (record.workUnitId.includes("_legacy_")) continue;
+      // Post-merge review is excluded, never fatal: an unprivileged comment on
+      // a merged pull request must not fail snapshot generation.
       if (parseIsoTime(source.createdAt) > parseIsoTime(pullRequest.mergedAt)) {
-        throw new TypeError("slop-review was posted after merge");
+        continue;
       }
       const reviewThirds = {
         triage: 1,


### PR DESCRIPTION
## Summary

- Exclude a `slop-review` posted after merge instead of throwing from `createLeaderboardSnapshot`.
- Add the regression: a post-merge automated review scores nothing and the snapshot still generates (the merge itself still scores its 1/3).

## Why now

The v2 review loop landed on `develop` tonight with this path intact: a structurally valid `slop-review` comment (well-formed record + receipt join) posted after merge hits `throw new TypeError("slop-review was posted after merge")` inside the source loop, while every other disqualifying condition in that loop `continue`s. Comment authors are unprivileged, so one late comment on any detailed merged PR fails every subsequent trusted ledger regeneration, including the deploy path. `AGENTS.md` already defines the intended contract ("Exclude bots, self-review, post-merge review, and repeated low-value comments"); this makes the code match it.

This is blocker 1 from my review on #172, now applying to `develop` directly. Blockers 3 (self-ratification guard) and 4 (sub-2-USDC carry for cycle-inactive actors) are coming as separate scoped PRs.

## Validation

- New regression fails on unfixed `develop` with the exact production `TypeError` at `leaderboard.ts:3120`, passes with the fix.
- `bun test src/lib/leaderboard.test.ts` — 84 passed, 0 failed.
- `bun run typecheck` — clean.
- `bun run lint:check`, `bun run format:check` — clean.
- `bun run projects:check` — registry current.
- Not run here: `bun run test:e2e` and `bun run build` (no UI or build-path change; scoring library + its unit test only). Reporting the boundary precisely per AGENTS.md.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
Attribution status: self-reported
— [claude-code-wbaxterh]
