### PR TITLE
fix: require a second maintainer for self slop-score ratification

### DIFF
--- a/src/lib/leaderboard.test.ts
+++ b/src/lib/leaderboard.test.ts
@@ -500,6 +500,99 @@ describe("score v2 work units", () => {
     ).toHaveLength(1);
   });
 
+  it("rejects a self slop-score without a second maintainer co-ratifier", () => {
+    const author = actor("author");
+    const pr = pullRequest({
+      id: "PR_SELF_SCORE",
+      number: 9,
+      createdAt: "2026-08-17T08:00:00.000Z",
+      updatedAt: "2026-08-18T03:00:00.000Z",
+      mergedAt: "2026-08-18T03:00:00.000Z",
+      author,
+    });
+    const record = {
+      schemaVersion: "1",
+      ruleVersion: "slop-score-v2",
+      projectId: "eliza",
+      pullRequestNodeId: pr.id,
+      headSha: pr.headRefOid,
+      workUnitId: "wu_self_scored_outcome",
+      tier: "micro",
+      scoreThirds: 1,
+      proposalReviewNodeIds: [],
+      coRatifierNodeIds: [],
+      reason: "Scoring my own accepted outcome without a second maintainer.",
+      supersedes: null,
+    };
+    pr.comments = [
+      {
+        ...textSource(
+          "COMMENT_SELF_SCORE",
+          `\`\`\`slop-score\n${JSON.stringify(record)}\n\`\`\``,
+          author,
+        ),
+        artifactId: pr.id,
+        url: "https://github.com/elizaOS/eliza/pull/9#issuecomment-901",
+        createdAt: "2026-08-18T04:00:00.000Z",
+        updatedAt: "2026-08-18T04:00:00.000Z",
+        authorAssociation: "MEMBER",
+      },
+    ];
+    expect(() => createLeaderboardSnapshot(v2Input([pr]))).toThrow(
+      "self slop-score requires a second maintainer co-ratifier",
+    );
+
+    const coRatifier = actor("co-ratifier");
+    const approval = {
+      schemaVersion: "1",
+      ruleVersion: "slop-score-v2",
+      decision: "approve",
+      projectId: "eliza",
+      pullRequestNodeId: pr.id,
+      headSha: pr.headRefOid,
+      workUnitId: record.workUnitId,
+      tier: record.tier,
+      reason: "Independently reviewed the outcome and the proposed tier.",
+    };
+    const approvalComment = {
+      ...textSource(
+        "COMMENT_SELF_SCORE_APPROVAL",
+        `\`\`\`slop-score-approval\n${JSON.stringify(approval)}\n\`\`\``,
+        coRatifier,
+      ),
+      artifactId: pr.id,
+      url: "https://github.com/elizaOS/eliza/pull/9#issuecomment-902",
+      createdAt: "2026-08-18T04:30:00.000Z",
+      updatedAt: "2026-08-18T04:30:00.000Z",
+      authorAssociation: "MEMBER",
+    };
+    const ratified = {
+      ...record,
+      coRatifierNodeIds: ["COMMENT_SELF_SCORE_APPROVAL"],
+    };
+    pr.comments = [
+      {
+        ...textSource(
+          "COMMENT_SELF_SCORE_2",
+          `\`\`\`slop-score\n${JSON.stringify(ratified)}\n\`\`\``,
+          author,
+        ),
+        artifactId: pr.id,
+        url: "https://github.com/elizaOS/eliza/pull/9#issuecomment-903",
+        createdAt: "2026-08-18T05:00:00.000Z",
+        updatedAt: "2026-08-18T05:00:00.000Z",
+        authorAssociation: "MEMBER",
+      },
+      approvalComment,
+    ];
+    const snapshot = createLeaderboardSnapshot(v2Input([pr]));
+    expect(
+      snapshot.ledger.filter(
+        (event) => event.category === "merged-pull-request",
+      ),
+    ).toHaveLength(1);
+  });
+
   it("awards automated review credit only after receipt signature verification", () => {
     const reviewer = actor("reviewer");
     const body = reviewAttribution(

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -2866,6 +2866,16 @@ export function createLeaderboardSnapshot(
           "slop-score correction must supersede the current record",
         );
       }
+      // Related-party scoring requires a second maintainer regardless of tier:
+      // a ratifier must never be the sole authority over their own outcome.
+      if (
+        sameActor(source.author, pullRequest.author) &&
+        record.coRatifierNodeIds.length === 0
+      ) {
+        throw new TypeError(
+          "self slop-score requires a second maintainer co-ratifier",
+        );
+      }
       for (const reviewNodeId of record.proposalReviewNodeIds) {
         const reviewSource = sourceById.get(reviewNodeId);
         const proposal = reviewSource


### PR DESCRIPTION
## Summary

- Require a second-maintainer co-ratifier for any `slop-score` whose author is the pull request's own author, regardless of tier.
- Add the regression pair: a self slop-score without a co-ratifier fails snapshot generation with a precise error; the same record with an independent maintainer's `slop-score-approval` scores normally.

## Why

`assertScoreRatificationContext` validates project, node, head SHA, maintainer association, and immutability, but never compares the ratification author to the PR author, and the merge-score path applies `record.scoreThirds` unconditionally. The co-ratifier requirement only fires at XL/exceptional or `securityRisk !== "none"`, so a lone maintainer could ratify their own PR to `large` (8 points) with a self-produced proposal. `protocol/scoring-v2.md` already states related-party cases require a second maintainer; this makes the code enforce it uniformly. The existing co-ratifier validation (must differ from the ratification author, immutable maintainer comment, matching approval record) then guarantees the second party is independent.

This is blocker 3 from my review on #172, applying to `develop` since tonight's slice merges. Blocker 1 is #180; blocker 4 (sub-2-USDC carry for cycle-inactive actors) comes next as its own scoped PR.

Design note: the guard throws, matching the loop's existing fail-closed convention for maintainer-authored records (supersede-chain violations throw the same way); unlike the post-merge case in #180, this input is privileged, so failing loudly is the correct shape.

## Validation

- New regression fails on unfixed `develop` (no throw occurs where one is required), passes with the guard.
- `bun test src/lib/leaderboard.test.ts` — 84 passed, 0 failed.
- `bun run typecheck` — clean.
- `bun run lint:check` — clean.
- Not run here: `bun run test:e2e` and `bun run build` (scoring library + unit test only). Reporting the boundary precisely per AGENTS.md.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
Attribution status: self-reported
— [claude-code-wbaxterh]
