### PR TITLE
fix: carry prior below-minimum accrual for cycle-inactive actors

### DIFF
--- a/src/lib/reward-cycle.test.ts
+++ b/src/lib/reward-cycle.test.ts
@@ -73,6 +73,46 @@ describe("reward cycle proposals", () => {
     });
   });
 
+  it("carries a prior below-minimum accrual for a cycle-inactive actor", () => {
+    const base = {
+      cycleId: "2026-07",
+      generatedAt: "2026-08-02T00:00:00.000Z",
+      projectId: "eliza" as const,
+      snapshot: closedSnapshot(),
+      sourceSnapshotSha256: SOURCE_SHA,
+      priorAccruedMinor: new Map([["U_quiet", "1500000"]]),
+    };
+    expect(() => createRewardCycleProposal(base)).toThrow("has no prior login");
+
+    const proposal = createRewardCycleProposal({
+      ...base,
+      priorActorLogins: new Map([["U_quiet", "quiet-contributor"]]),
+      wallets: new Map([
+        [
+          "U_quiet",
+          {
+            ...wallet(),
+            sourceUrl: `https://github.com/quiet-contributor/quiet-contributor/blob/${PROFILE_COMMIT}/README.md`,
+          },
+        ],
+      ]),
+    });
+    if (proposal.kind !== "reward-allocation")
+      throw new Error("wrong proposal");
+    expect(proposal.carriedMinor).toBe("1500000");
+    const carried = proposal.allocations.find(
+      (allocation) => allocation.actor.id === "U_quiet",
+    );
+    expect(carried).toMatchObject({
+      actor: { id: "U_quiet", login: "quiet-contributor" },
+      score: 0,
+      accruedMinor: "1500000",
+      approvedMinor: "0",
+      state: "held-below-minimum",
+      evidenceEventIds: [],
+    });
+  });
+
   it("publishes Delta Star only as a provisional external-prize share", () => {
     const proposal = createRewardCycleProposal({
       cycleId: "2026-07",

--- a/src/lib/reward-cycle.ts
+++ b/src/lib/reward-cycle.ts
@@ -31,6 +31,7 @@ export interface CreateRewardCycleProposalInput {
   sourceSnapshotSha256: string;
   wallets?: ReadonlyMap<string, WalletProof>;
   priorAccruedMinor?: ReadonlyMap<string, string>;
+  priorActorLogins?: ReadonlyMap<string, string>;
 }
 
 function cycleBounds(cycleId: string): { from: number; to: number } {
@@ -136,22 +137,33 @@ export function createRewardCycleProposal(
     });
   }
 
-  const carriedMinor = view.leaders
-    .reduce(
+  // Accrual is a debt to the actor, not a reward for this cycle's activity:
+  // a positive prior balance must survive a quiet month, so carried-only
+  // actors get their own allocation rows after the leaders.
+  const leaderIds = new Set(view.leaders.map((leader) => leader.actor.id));
+  const carriedOnly = [...(input.priorAccruedMinor ?? [])]
+    .filter(([actorId, minor]) => !leaderIds.has(actorId) && BigInt(minor) > 0n)
+    .sort(([left], [right]) => left.localeCompare(right));
+  const carriedOnlyMinor = carriedOnly.reduce(
+    (total, [, minor]) => total + BigInt(minor),
+    0n,
+  );
+  const carriedMinor = (
+    view.leaders.reduce(
       (total, leader) =>
         total + BigInt(input.priorAccruedMinor?.get(leader.actor.id) ?? "0"),
       0n,
-    )
-    .toString();
-  const suggestedMinor = view.leaders
-    .reduce(
+    ) + carriedOnlyMinor
+  ).toString();
+  const suggestedMinor = (
+    view.leaders.reduce(
       (total, leader) =>
         total +
         BigInt(leader.projectedMinor ?? "0") +
         BigInt(input.priorAccruedMinor?.get(leader.actor.id) ?? "0"),
       0n,
-    )
-    .toString();
+    ) + carriedOnlyMinor
+  ).toString();
   const reviewEndsAt = new Date(
     Date.parse(input.generatedAt) + REVIEW_WINDOW_DAYS * 86_400_000,
   ).toISOString();
@@ -181,31 +193,63 @@ export function createRewardCycleProposal(
     feeBasisPoints: view.project.reward.feeBasisPoints,
     scoringRuleVersion: input.snapshot.ruleVersion,
     sourceSnapshotSha256: input.sourceSnapshotSha256,
-    allocations: view.leaders.map((leader, index) => {
-      const wallet = input.wallets?.get(leader.actor.id) ?? null;
-      const accruedMinor = (
-        BigInt(input.priorAccruedMinor?.get(leader.actor.id) ?? "0") +
-        BigInt(leader.projectedMinor ?? "0")
-      ).toString();
-      return {
-        intentId: `pay_${intentComponent(input.projectId)}_${cycleComponent}_${String(index + 1).padStart(4, "0")}_${intentComponent(leader.actor.id)}`,
-        actor: { id: leader.actor.id, login: leader.actor.login },
-        score: leader.score,
-        suggestedMinor: accruedMinor,
-        accruedMinor,
-        approvedMinor: "0",
-        state: wallet
-          ? BigInt(accruedMinor) < BigInt(MINIMUM_TRANSFER_MINOR)
-            ? "held-below-minimum"
-            : "proposed"
-          : "unclaimed",
-        wallet,
-        evidenceEventIds: leader.evidenceEventIds,
-        adjustmentReason: null,
-        relatedParty: input.relatedPartyActorIds?.has(leader.actor.id) ?? false,
-        platformApproval: null,
-      };
-    }),
+    allocations: view.leaders
+      .map((leader, index) => {
+        const wallet = input.wallets?.get(leader.actor.id) ?? null;
+        const accruedMinor = (
+          BigInt(input.priorAccruedMinor?.get(leader.actor.id) ?? "0") +
+          BigInt(leader.projectedMinor ?? "0")
+        ).toString();
+        return {
+          intentId: `pay_${intentComponent(input.projectId)}_${cycleComponent}_${String(index + 1).padStart(4, "0")}_${intentComponent(leader.actor.id)}`,
+          actor: { id: leader.actor.id, login: leader.actor.login },
+          score: leader.score,
+          suggestedMinor: accruedMinor,
+          accruedMinor,
+          approvedMinor: "0",
+          state: wallet
+            ? BigInt(accruedMinor) < BigInt(MINIMUM_TRANSFER_MINOR)
+              ? "held-below-minimum"
+              : "proposed"
+            : "unclaimed",
+          wallet,
+          evidenceEventIds: leader.evidenceEventIds,
+          adjustmentReason: null,
+          relatedParty:
+            input.relatedPartyActorIds?.has(leader.actor.id) ?? false,
+          platformApproval: null,
+        };
+      })
+      .concat(
+        carriedOnly.map(([actorId, minor], offset) => {
+          const login = input.priorActorLogins?.get(actorId);
+          if (!login) {
+            throw new TypeError(
+              `carried accrual for ${actorId} has no prior login; pass priorActorLogins from the prior manifest`,
+            );
+          }
+          const wallet = input.wallets?.get(actorId) ?? null;
+          const index = view.leaders.length + offset;
+          return {
+            intentId: `pay_${intentComponent(input.projectId)}_${cycleComponent}_${String(index + 1).padStart(4, "0")}_${intentComponent(actorId)}`,
+            actor: { id: actorId, login },
+            score: 0,
+            suggestedMinor: minor,
+            accruedMinor: minor,
+            approvedMinor: "0",
+            state: wallet
+              ? BigInt(minor) < BigInt(MINIMUM_TRANSFER_MINOR)
+                ? ("held-below-minimum" as const)
+                : ("proposed" as const)
+              : ("unclaimed" as const),
+            wallet,
+            evidenceEventIds: [],
+            adjustmentReason: null,
+            relatedParty: input.relatedPartyActorIds?.has(actorId) ?? false,
+            platformApproval: null,
+          };
+        }),
+      ),
     totals: {
       suggestedMinor,
       approvedMinor: "0",


### PR DESCRIPTION
## Summary

- Emit allocation rows for actors who hold a prior accrued balance but have no events in the current cycle, so a quiet month never discards a sub-2-USDC carry.
- Include those balances in the manifest's `carriedMinor` and `suggestedMinor` totals.
- Add `priorActorLogins` to the proposal input (backward compatible; both existing callers unchanged) and fail closed when a carried balance's login cannot be resolved from the prior manifest.
- Regression: a below-minimum carry for a cycle-inactive actor produces a `held-below-minimum` row with score 0 and joins `carriedMinor`; a carry without a resolvable login throws.

## Why

`createRewardCycleProposal` built `carriedMinor` and allocations exclusively from `view.leaders`, i.e. actors with events in the current cycle. An actor holding a `held-below-minimum` accrual who had a quiet month got no allocation row, so their carry silently vanished from the next manifest. `cycles/README.md` promises sub-2-USDC awards "accrue without being discarded or redistributed"; this makes the proposal generator keep that promise. Accrual is a debt to the actor, not a reward for this cycle's activity.

This is blocker 4 from my review on #172, applying to `develop` since tonight's slice merges. Blocker 1 is #180 and blocker 3 is #181; this completes the set I offered to fix. Blocker 2 (review-credit authority) needs a design decision first, and I am happy to write that up as a short proposal if useful.

## Validation

- New regression fails on unfixed `develop` (the carried actor's row is absent), passes with the fix.
- `bun test src/lib/reward-cycle.test.ts src/lib/rewards.test.ts` — 19 passed, 0 failed.
- `bun run typecheck` — clean.
- `bun run lint:check` — clean (206 files).
- Not run here: `bun run test:e2e` and `bun run build` (reward library + unit test only). Reporting the boundary precisely per AGENTS.md.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
Attribution status: self-reported
— [claude-code-wbaxterh]
