### PR TITLE
Complete cross-cycle reward accrual

### DIFF
--- a/cycles/README.md
+++ b/cycles/README.md
@@ -27,6 +27,13 @@ carried amount; settlement may proceed only when the combined approved intent
 is at least 2 USDC. The 1% fee applies only to principal actually approved for
 payment.
 
+The next proposal derives carry only from the immediately preceding reviewed
+cycle. `held-below-minimum` and `unclaimed` balances carry even when the actor
+did no new work; approved payout intents stay in their original cycle, while
+excluded and manually held rows never become new payment proposals
+automatically. An unfinished review or unresolved proposed row fails the next
+cycle closed instead of guessing what is owed.
+
 - `allocation.json` — reviewed and approved payout intents;
 - `execution-plan.json` — an unsigned, exact Solana USDC transfer plan;
 - `transactions.json` — submitted public transaction signatures;

--- a/scripts/prepare-reward-cycle.test.ts
+++ b/scripts/prepare-reward-cycle.test.ts
@@ -1,0 +1,60 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { snapshotFixture } from "../tests/fixtures";
+import {
+  parsePrepareRewardCycleArguments,
+  prepareRewardCycle,
+} from "./prepare-reward-cycle";
+
+describe("prepare reward cycle accrual", () => {
+  it("wires prior balances and carried-only wallet observations into the proposal", async () => {
+    const snapshot = snapshotFixture();
+    snapshot.window.from = "2026-06-28T00:00:00.000Z";
+    snapshot.window.to = "2026-08-02T00:00:00.000Z";
+    snapshot.source.fetchedAt = snapshot.generatedAt;
+    snapshot.source.cutoffAt = snapshot.window.to;
+    snapshot.source.verificationWindow.from = snapshot.window.from;
+    snapshot.source.verificationWindow.to = snapshot.window.to;
+    const root = await mkdtemp(join(tmpdir(), "slop-prepare-cycle-"));
+    const snapshotPath = join(root, "snapshot.json");
+    await writeFile(snapshotPath, JSON.stringify(snapshot));
+    const arguments_ = parsePrepareRewardCycleArguments([
+      "--project",
+      "eliza",
+      "--cycle",
+      "2026-07",
+      "--snapshot",
+      snapshotPath,
+    ]);
+    const observed: string[] = [];
+    const write = vi.fn(async () => undefined);
+    const proposal = await prepareRewardCycle(arguments_, {
+      generatedAt: snapshot.generatedAt,
+      loadPriorAccrual: async () => ({
+        actorLogins: new Map([["U_quiet", "quiet-contributor"]]),
+        accruedMinor: new Map([["U_quiet", "1500000"]]),
+      }),
+      observeWallet: async (actorId) => {
+        observed.push(actorId);
+        return null;
+      },
+      write,
+      writeSnapshot: write,
+    });
+
+    expect(observed.sort()).toEqual(["U_fixture", "U_quiet"]);
+    expect(proposal.kind).toBe("reward-allocation");
+    if (proposal.kind !== "reward-allocation") return;
+    expect(proposal.carriedMinor).toBe("1500000");
+    expect(proposal.allocations).toContainEqual(
+      expect.objectContaining({
+        actor: { id: "U_quiet", login: "quiet-contributor" },
+        accruedMinor: "1500000",
+        state: "unclaimed",
+      }),
+    );
+    expect(arguments_.snapshotPath).toBe(resolve(snapshotPath));
+  });
+});

--- a/scripts/prepare-reward-cycle.ts
+++ b/scripts/prepare-reward-cycle.ts
@@ -14,6 +14,8 @@ import { findProject, type ProjectId } from "../src/lib/projects.mjs";
 import { createRewardCycleProposal } from "../src/lib/reward-cycle";
 import type { WalletProof } from "../src/lib/rewards";
 import { fetchPublishedGithubWallet } from "./github-wallets";
+import type { PriorCycleAccrual } from "./prior-cycle-accrual";
+import { loadPriorCycleAccrual } from "./prior-cycle-accrual";
 import {
   ExistingFileError,
   writeNewFile,
@@ -150,6 +152,12 @@ export async function prepareRewardCycle(
   options: {
     generatedAt?: string;
     githubToken?: string;
+    loadPriorAccrual?: (input: {
+      asOf: string;
+      cycleId: string;
+      cyclesRoot: string;
+      projectId: ProjectId;
+    }) => Promise<PriorCycleAccrual>;
     observeWallet?: (
       actorId: string,
       login: string,
@@ -199,6 +207,19 @@ export async function prepareRewardCycle(
   const project = findProject(arguments_.projectId);
   if (!project) throw new TypeError(`Unknown project: ${arguments_.projectId}`);
 
+  const priorAccrual =
+    project.reward.kind === "monthly-pool"
+      ? await (options.loadPriorAccrual ?? loadPriorCycleAccrual)({
+          asOf: generatedAt,
+          cycleId: arguments_.cycleId,
+          cyclesRoot: CYCLES_ROOT,
+          projectId: arguments_.projectId,
+        })
+      : {
+          actorLogins: new Map<string, string>(),
+          accruedMinor: new Map<string, string>(),
+        };
+
   const wallets = new Map<string, WalletProof>();
   if (project.reward.kind === "monthly-pool") {
     const projectLeaders = createProjectView(
@@ -206,7 +227,13 @@ export async function prepareRewardCycle(
       arguments_.projectId,
       arguments_.cycleId,
     ).leaders;
-    if (projectLeaders.length > MAX_WALLET_LOOKUPS) {
+    const actors = new Map(
+      projectLeaders.map((leader) => [leader.actor.id, leader.actor.login]),
+    );
+    for (const [actorId, login] of priorAccrual.actorLogins) {
+      if (!actors.has(actorId)) actors.set(actorId, login);
+    }
+    if (actors.size > MAX_WALLET_LOOKUPS) {
       throw new RangeError(
         "Reward cycle exceeds the bounded wallet lookup limit",
       );
@@ -218,11 +245,11 @@ export async function prepareRewardCycle(
           token: options.githubToken,
         }));
     const observations = await mapWithConcurrency(
-      projectLeaders,
+      [...actors],
       WALLET_LOOKUP_CONCURRENCY,
-      async (leader) => ({
-        actorId: leader.actor.id,
-        wallet: await observe(leader.actor.id, leader.actor.login, generatedAt),
+      async ([actorId, login]) => ({
+        actorId,
+        wallet: await observe(actorId, login, generatedAt),
       }),
     );
     for (const observation of observations) {
@@ -240,6 +267,8 @@ export async function prepareRewardCycle(
       .update(sourceBytes)
       .digest("hex"),
     wallets,
+    priorAccruedMinor: priorAccrual.accruedMinor,
+    priorActorLogins: priorAccrual.actorLogins,
   });
   await (options.writeSnapshot ?? writeImmutableBytes)(
     arguments_.snapshotArchivePath,

--- a/scripts/prior-cycle-accrual.test.ts
+++ b/scripts/prior-cycle-accrual.test.ts
@@ -1,0 +1,110 @@
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { createRewardCycleProposal } from "../src/lib/reward-cycle";
+import { snapshotFixture } from "../tests/fixtures";
+import { loadPriorCycleAccrual, previousCycleId } from "./prior-cycle-accrual";
+
+function julyProposal() {
+  const snapshot = snapshotFixture();
+  snapshot.window.from = "2026-06-28T00:00:00.000Z";
+  snapshot.window.to = "2026-08-02T00:00:00.000Z";
+  snapshot.source.verificationWindow.from = snapshot.window.from;
+  snapshot.source.verificationWindow.to = snapshot.window.to;
+  const proposal = createRewardCycleProposal({
+    cycleId: "2026-07",
+    generatedAt: "2026-08-02T00:00:00.000Z",
+    projectId: "eliza",
+    snapshot,
+    sourceSnapshotSha256: "a".repeat(64),
+  });
+  if (proposal.kind !== "reward-allocation") throw new Error("wrong fixture");
+  return proposal;
+}
+
+describe("prior cycle accrual", () => {
+  it("handles calendar-year boundaries", () => {
+    expect(previousCycleId("2026-01")).toBe("2025-12");
+  });
+
+  it("loads reviewed unclaimed money and ignores paid or held intents", async () => {
+    const root = await mkdtemp(join(tmpdir(), "slop-prior-accrual-"));
+    const directory = join(root, "eliza", "2026-07");
+    await mkdir(directory, { recursive: true });
+    const proposal = julyProposal();
+    proposal.allocations[0].state = "unclaimed";
+    await writeFile(
+      join(directory, "proposal.json"),
+      `${JSON.stringify(proposal)}\n`,
+    );
+
+    const result = await loadPriorCycleAccrual({
+      asOf: "2026-09-02T00:00:00.000Z",
+      cycleId: "2026-08",
+      cyclesRoot: root,
+      projectId: "eliza",
+    });
+    expect(result.accruedMinor.get("U_fixture")).toBe("10000000000");
+    expect(result.actorLogins.get("U_fixture")).toBe("finish-line");
+
+    proposal.allocations[0].state = "held";
+    proposal.allocations[0].adjustmentReason =
+      "Maintainer placed this intent on a manual hold.";
+    await writeFile(
+      join(directory, "allocation.json"),
+      `${JSON.stringify({
+        ...proposal,
+        status: "approved",
+        approvedAt: "2026-08-17T00:00:00.000Z",
+      })}\n`,
+    );
+    const held = await loadPriorCycleAccrual({
+      asOf: "2026-09-02T00:00:00.000Z",
+      cycleId: "2026-08",
+      cyclesRoot: root,
+      projectId: "eliza",
+    });
+    expect([...held.accruedMinor]).toEqual([]);
+  });
+
+  it("refuses an unresolved prior review", async () => {
+    const root = await mkdtemp(join(tmpdir(), "slop-prior-accrual-"));
+    const directory = join(root, "eliza", "2026-07");
+    await mkdir(directory, { recursive: true });
+    const proposal = julyProposal();
+    proposal.allocations[0].state = "proposed";
+    proposal.allocations[0].wallet = {
+      address: "11111111111111111111111111111111",
+      chain: "solana",
+      observedAt: "2026-08-02T00:00:00.000Z",
+      sourceCommit: "b".repeat(40),
+      sourceUrl: `https://github.com/finish-line/finish-line/blob/${"b".repeat(40)}/README.md`,
+    };
+    await writeFile(
+      join(directory, "proposal.json"),
+      `${JSON.stringify(proposal)}\n`,
+    );
+    await expect(
+      loadPriorCycleAccrual({
+        asOf: "2026-09-02T00:00:00.000Z",
+        cycleId: "2026-08",
+        cyclesRoot: root,
+        projectId: "eliza",
+      }),
+    ).rejects.toThrow("has unresolved proposals");
+  });
+
+  it("refuses a partial prior cycle directory", async () => {
+    const root = await mkdtemp(join(tmpdir(), "slop-prior-accrual-"));
+    await mkdir(join(root, "eliza", "2026-07"), { recursive: true });
+    await expect(
+      loadPriorCycleAccrual({
+        asOf: "2026-09-02T00:00:00.000Z",
+        cycleId: "2026-08",
+        cyclesRoot: root,
+        projectId: "eliza",
+      }),
+    ).rejects.toThrow("is partial");
+  });
+});

--- a/scripts/prior-cycle-accrual.ts
+++ b/scripts/prior-cycle-accrual.ts
@@ -1,0 +1,135 @@
+/** Loads the immediately preceding reviewed cycle state for deterministic carry. */
+
+import { lstat, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { ProjectId } from "../src/lib/projects.mjs";
+import {
+  assertRewardAllocationManifest,
+  type RewardAllocationManifest,
+} from "../src/lib/rewards";
+
+const MAX_MANIFEST_BYTES = 8 * 1024 * 1024;
+
+export interface PriorCycleAccrual {
+  actorLogins: ReadonlyMap<string, string>;
+  accruedMinor: ReadonlyMap<string, string>;
+}
+
+export function previousCycleId(cycleId: string): string {
+  if (!/^\d{4}-(?:0[1-9]|1[0-2])$/u.test(cycleId)) {
+    throw new TypeError("Cycle id must be YYYY-MM");
+  }
+  const [year, month] = cycleId.split("-").map(Number);
+  const previous = new Date(Date.UTC(year, month - 2, 1));
+  return `${previous.getUTCFullYear()}-${String(previous.getUTCMonth() + 1).padStart(2, "0")}`;
+}
+
+async function readManifest(
+  path: string,
+): Promise<RewardAllocationManifest | null> {
+  const stats = await lstat(path).catch((error: NodeJS.ErrnoException) => {
+    if (error.code === "ENOENT") return null;
+    throw error;
+  });
+  if (!stats) return null;
+  if (
+    !stats.isFile() ||
+    stats.isSymbolicLink() ||
+    stats.size <= 0 ||
+    stats.size > MAX_MANIFEST_BYTES
+  ) {
+    throw new TypeError(`${path} is not a bounded regular cycle manifest`);
+  }
+  const bytes = await readFile(path);
+  try {
+    return assertRewardAllocationManifest(JSON.parse(bytes.toString("utf8")));
+  } catch (error) {
+    throw new TypeError(`${path} is not a valid reward allocation manifest`, {
+      cause: error,
+    });
+  }
+}
+
+/**
+ * Carries only reviewed, unpaid accrual states. Approved payout intents remain
+ * attached to their original cycle, while exclusions and manual holds never
+ * become new payment proposals automatically.
+ */
+export async function loadPriorCycleAccrual(input: {
+  asOf: string;
+  cycleId: string;
+  cyclesRoot: string;
+  projectId: ProjectId;
+}): Promise<PriorCycleAccrual> {
+  if (
+    !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(input.asOf) ||
+    !Number.isFinite(Date.parse(input.asOf)) ||
+    new Date(input.asOf).toISOString() !== input.asOf
+  ) {
+    throw new TypeError("Prior accrual asOf must be an exact UTC timestamp");
+  }
+  const priorId = previousCycleId(input.cycleId);
+  const directory = join(input.cyclesRoot, input.projectId, priorId);
+  const directoryStats = await lstat(directory).catch(
+    (error: NodeJS.ErrnoException) => {
+      if (error.code === "ENOENT") return null;
+      throw error;
+    },
+  );
+  if (!directoryStats) {
+    return { actorLogins: new Map(), accruedMinor: new Map() };
+  }
+  if (!directoryStats.isDirectory() || directoryStats.isSymbolicLink()) {
+    throw new TypeError(`${directory} is not a real cycle directory`);
+  }
+  const reviewedProposal = await readManifest(join(directory, "proposal.json"));
+  if (!reviewedProposal) {
+    throw new TypeError(`Prior cycle ${input.projectId}/${priorId} is partial`);
+  }
+  const allocation = await readManifest(join(directory, "allocation.json"));
+  if (allocation?.status === "proposed") {
+    throw new TypeError(
+      `Prior cycle ${input.projectId}/${priorId} allocation is not approved`,
+    );
+  }
+  const proposal = allocation ?? reviewedProposal;
+  if (proposal.projectId !== input.projectId || proposal.cycleId !== priorId) {
+    throw new TypeError(
+      `Prior accrual manifest does not match ${input.projectId}/${priorId}`,
+    );
+  }
+  if (
+    Date.parse(proposal.review.lastMaterialChangeAt) > Date.parse(input.asOf) ||
+    (proposal.approvedAt !== null &&
+      Date.parse(proposal.approvedAt) > Date.parse(input.asOf))
+  ) {
+    throw new RangeError(
+      `Prior cycle ${input.projectId}/${priorId} contains future review state`,
+    );
+  }
+  if (!allocation) {
+    if (Date.parse(input.asOf) < Date.parse(proposal.review.endsAt)) {
+      throw new RangeError(
+        `Prior cycle ${input.projectId}/${priorId} is still under review`,
+      );
+    }
+    if (proposal.allocations.some((row) => row.state === "proposed")) {
+      throw new TypeError(
+        `Prior cycle ${input.projectId}/${priorId} has unresolved proposals`,
+      );
+    }
+  }
+
+  const accruedMinor = new Map<string, string>();
+  const actorLogins = new Map<string, string>();
+  for (const row of proposal.allocations) {
+    if (row.state !== "held-below-minimum" && row.state !== "unclaimed") {
+      continue;
+    }
+    const amount = row.accruedMinor ?? row.suggestedMinor;
+    if (BigInt(amount) === 0n) continue;
+    accruedMinor.set(row.actor.id, amount);
+    actorLogins.set(row.actor.id, row.actor.login);
+  }
+  return { actorLogins, accruedMinor };
+}

--- a/scripts/sync-cycle-index.ts
+++ b/scripts/sync-cycle-index.ts
@@ -27,7 +27,7 @@ import {
   assertLeaderboardSnapshot,
   type LeaderboardSnapshot,
 } from "../src/lib/leaderboard";
-import { findProject } from "../src/lib/projects.mjs";
+import { findProject, type ProjectId } from "../src/lib/projects.mjs";
 import { createRewardCycleProposal } from "../src/lib/reward-cycle";
 import { finalizeRewardAllocation } from "../src/lib/reward-finalization";
 import {
@@ -42,6 +42,7 @@ import {
   type SettlementExecutionPlan,
 } from "../src/lib/settlement-plan";
 import { verifyRewardSettlementOnchain } from "../src/lib/solana-settlement";
+import { loadPriorCycleAccrual } from "./prior-cycle-accrual";
 import {
   DEFAULT_SOLANA_RPC_URL,
   fetchFinalizedSolanaTransaction,
@@ -137,17 +138,25 @@ async function jsonFile(
   };
 }
 
-function verifyProposalAgainstSnapshot(
+async function verifyProposalAgainstSnapshot(
   proposal: RewardAllocationManifest,
   snapshot: LeaderboardSnapshot,
   snapshotDigest: string,
-): void {
+): Promise<void> {
+  const priorAccrual = await loadPriorCycleAccrual({
+    asOf: proposal.generatedAt,
+    cycleId: proposal.cycleId,
+    cyclesRoot: CYCLES_ROOT,
+    projectId: proposal.projectId as ProjectId,
+  });
   const baseline = createRewardCycleProposal({
     cycleId: proposal.cycleId,
     generatedAt: proposal.generatedAt,
     projectId: proposal.projectId,
     snapshot,
     sourceSnapshotSha256: snapshotDigest,
+    priorAccruedMinor: priorAccrual.accruedMinor,
+    priorActorLogins: priorAccrual.actorLogins,
   });
   if (baseline.kind !== "reward-allocation") {
     throw new TypeError("Monthly proposal regenerated as an external share");
@@ -335,7 +344,7 @@ async function buildCycle(
       "Reward proposal does not match its cycle path or state",
     );
   }
-  verifyProposalAgainstSnapshot(proposal, snapshot, snapshotFile.digest);
+  await verifyProposalAgainstSnapshot(proposal, snapshot, snapshotFile.digest);
 
   const allocationFile = loaded.get("allocation.json") ?? null;
   let allocation: RewardAllocationManifest | null = null;

--- a/src/lib/reward-cycle.test.ts
+++ b/src/lib/reward-cycle.test.ts
@@ -73,6 +73,46 @@ describe("reward cycle proposals", () => {
     });
   });
 
+  it("carries a prior below-minimum accrual for a cycle-inactive actor", () => {
+    const base = {
+      cycleId: "2026-07",
+      generatedAt: "2026-08-02T00:00:00.000Z",
+      projectId: "eliza" as const,
+      snapshot: closedSnapshot(),
+      sourceSnapshotSha256: SOURCE_SHA,
+      priorAccruedMinor: new Map([["U_quiet", "1500000"]]),
+    };
+    expect(() => createRewardCycleProposal(base)).toThrow("has no prior login");
+
+    const proposal = createRewardCycleProposal({
+      ...base,
+      priorActorLogins: new Map([["U_quiet", "quiet-contributor"]]),
+      wallets: new Map([
+        [
+          "U_quiet",
+          {
+            ...wallet(),
+            sourceUrl: `https://github.com/quiet-contributor/quiet-contributor/blob/${PROFILE_COMMIT}/README.md`,
+          },
+        ],
+      ]),
+    });
+    if (proposal.kind !== "reward-allocation")
+      throw new Error("wrong proposal");
+    expect(proposal.carriedMinor).toBe("1500000");
+    const carried = proposal.allocations.find(
+      (allocation) => allocation.actor.id === "U_quiet",
+    );
+    expect(carried).toMatchObject({
+      actor: { id: "U_quiet", login: "quiet-contributor" },
+      score: 0,
+      accruedMinor: "1500000",
+      approvedMinor: "0",
+      state: "held-below-minimum",
+      evidenceEventIds: [],
+    });
+  });
+
   it("publishes Delta Star only as a provisional external-prize share", () => {
     const proposal = createRewardCycleProposal({
       cycleId: "2026-07",

--- a/src/lib/reward-cycle.ts
+++ b/src/lib/reward-cycle.ts
@@ -31,6 +31,7 @@ export interface CreateRewardCycleProposalInput {
   sourceSnapshotSha256: string;
   wallets?: ReadonlyMap<string, WalletProof>;
   priorAccruedMinor?: ReadonlyMap<string, string>;
+  priorActorLogins?: ReadonlyMap<string, string>;
 }
 
 function cycleBounds(cycleId: string): { from: number; to: number } {
@@ -136,22 +137,33 @@ export function createRewardCycleProposal(
     });
   }
 
-  const carriedMinor = view.leaders
-    .reduce(
+  // Accrual is a debt to the actor, not a reward for this cycle's activity:
+  // a positive prior balance must survive a quiet month, so carried-only
+  // actors get their own allocation rows after the leaders.
+  const leaderIds = new Set(view.leaders.map((leader) => leader.actor.id));
+  const carriedOnly = [...(input.priorAccruedMinor ?? [])]
+    .filter(([actorId, minor]) => !leaderIds.has(actorId) && BigInt(minor) > 0n)
+    .sort(([left], [right]) => left.localeCompare(right));
+  const carriedOnlyMinor = carriedOnly.reduce(
+    (total, [, minor]) => total + BigInt(minor),
+    0n,
+  );
+  const carriedMinor = (
+    view.leaders.reduce(
       (total, leader) =>
         total + BigInt(input.priorAccruedMinor?.get(leader.actor.id) ?? "0"),
       0n,
-    )
-    .toString();
-  const suggestedMinor = view.leaders
-    .reduce(
+    ) + carriedOnlyMinor
+  ).toString();
+  const suggestedMinor = (
+    view.leaders.reduce(
       (total, leader) =>
         total +
         BigInt(leader.projectedMinor ?? "0") +
         BigInt(input.priorAccruedMinor?.get(leader.actor.id) ?? "0"),
       0n,
-    )
-    .toString();
+    ) + carriedOnlyMinor
+  ).toString();
   const reviewEndsAt = new Date(
     Date.parse(input.generatedAt) + REVIEW_WINDOW_DAYS * 86_400_000,
   ).toISOString();
@@ -181,31 +193,63 @@ export function createRewardCycleProposal(
     feeBasisPoints: view.project.reward.feeBasisPoints,
     scoringRuleVersion: input.snapshot.ruleVersion,
     sourceSnapshotSha256: input.sourceSnapshotSha256,
-    allocations: view.leaders.map((leader, index) => {
-      const wallet = input.wallets?.get(leader.actor.id) ?? null;
-      const accruedMinor = (
-        BigInt(input.priorAccruedMinor?.get(leader.actor.id) ?? "0") +
-        BigInt(leader.projectedMinor ?? "0")
-      ).toString();
-      return {
-        intentId: `pay_${intentComponent(input.projectId)}_${cycleComponent}_${String(index + 1).padStart(4, "0")}_${intentComponent(leader.actor.id)}`,
-        actor: { id: leader.actor.id, login: leader.actor.login },
-        score: leader.score,
-        suggestedMinor: accruedMinor,
-        accruedMinor,
-        approvedMinor: "0",
-        state: wallet
-          ? BigInt(accruedMinor) < BigInt(MINIMUM_TRANSFER_MINOR)
-            ? "held-below-minimum"
-            : "proposed"
-          : "unclaimed",
-        wallet,
-        evidenceEventIds: leader.evidenceEventIds,
-        adjustmentReason: null,
-        relatedParty: input.relatedPartyActorIds?.has(leader.actor.id) ?? false,
-        platformApproval: null,
-      };
-    }),
+    allocations: view.leaders
+      .map((leader, index) => {
+        const wallet = input.wallets?.get(leader.actor.id) ?? null;
+        const accruedMinor = (
+          BigInt(input.priorAccruedMinor?.get(leader.actor.id) ?? "0") +
+          BigInt(leader.projectedMinor ?? "0")
+        ).toString();
+        return {
+          intentId: `pay_${intentComponent(input.projectId)}_${cycleComponent}_${String(index + 1).padStart(4, "0")}_${intentComponent(leader.actor.id)}`,
+          actor: { id: leader.actor.id, login: leader.actor.login },
+          score: leader.score,
+          suggestedMinor: accruedMinor,
+          accruedMinor,
+          approvedMinor: "0",
+          state: wallet
+            ? BigInt(accruedMinor) < BigInt(MINIMUM_TRANSFER_MINOR)
+              ? "held-below-minimum"
+              : "proposed"
+            : "unclaimed",
+          wallet,
+          evidenceEventIds: leader.evidenceEventIds,
+          adjustmentReason: null,
+          relatedParty:
+            input.relatedPartyActorIds?.has(leader.actor.id) ?? false,
+          platformApproval: null,
+        };
+      })
+      .concat(
+        carriedOnly.map(([actorId, minor], offset) => {
+          const login = input.priorActorLogins?.get(actorId);
+          if (!login) {
+            throw new TypeError(
+              `carried accrual for ${actorId} has no prior login; pass priorActorLogins from the prior manifest`,
+            );
+          }
+          const wallet = input.wallets?.get(actorId) ?? null;
+          const index = view.leaders.length + offset;
+          return {
+            intentId: `pay_${intentComponent(input.projectId)}_${cycleComponent}_${String(index + 1).padStart(4, "0")}_${intentComponent(actorId)}`,
+            actor: { id: actorId, login },
+            score: 0,
+            suggestedMinor: minor,
+            accruedMinor: minor,
+            approvedMinor: "0",
+            state: wallet
+              ? BigInt(minor) < BigInt(MINIMUM_TRANSFER_MINOR)
+                ? ("held-below-minimum" as const)
+                : ("proposed" as const)
+              : ("unclaimed" as const),
+            wallet,
+            evidenceEventIds: [],
+            adjustmentReason: null,
+            relatedParty: input.relatedPartyActorIds?.has(actorId) ?? false,
+            platformApproval: null,
+          };
+        }),
+      ),
     totals: {
       suggestedMinor,
       approvedMinor: "0",


### PR DESCRIPTION
## Summary

- preserve prior `held-below-minimum` and `unclaimed` balances for actors with or without current-cycle work
- load those balances in the production monthly proposal command and re-observe carried-only actors wallets
- regenerate the identical carry during cycle-index verification, so committed proposals cannot drift from their prior reviewed state
- fail closed on partial, future-dated, still-under-review, or unresolved prior cycles
- keep approved payout intents in their original cycle and do not automatically release exclusions or manual holds

This completes the useful direction from #182; that PR changed only the pure helper and left both production callers disconnected. #184 already covers the post-merge review exclusion and self-ratification guard from #180/#181.

## Validation

- 586/586 Vitest tests passed in the unbounded full run (189.5s)
- all 12 focused reward/accrual tests pass after rebase to current `develop`
- TypeScript, Biome format/lint, project/evaluation/funding/cycle/protocol checks, and dependency audit pass
- production build passes
- the one process-spawning receipt test that Bun killed during the aggregate skill run passes in isolation in 27.9s; no timeout was applied

AI provider/model: OpenAI / GPT-5.6
Client / agent tooling: Codex
Attribution status: self-reported
— [codex]