### PR TITLE
fix(receipts): allow explicit unavailable usage

### DIFF
--- a/skill-tests/contribute-to-eliza.test.ts
+++ b/skill-tests/contribute-to-eliza.test.ts
@@ -458,13 +458,7 @@ describe("live report parsing", () => {
     ];
     const commands = [
       ["doctor", ...identity],
-      [
-        "start",
-        ...identity,
-        "--lane",
-        "parser-test",
-        "--allow-local-usage",
-      ],
+      ["start", ...identity, "--lane", "parser-test", "--allow-local-usage"],
       [
         "finish",
         ...identity,
@@ -482,9 +476,13 @@ describe("live report parsing", () => {
     ];
 
     for (const command of commands) {
-      const missing = spawnSync(process.execPath, [runReceiptPath, ...command], {
-        encoding: "utf8",
-      });
+      const missing = spawnSync(
+        process.execPath,
+        [runReceiptPath, ...command],
+        {
+          encoding: "utf8",
+        },
+      );
       assert.strictEqual(missing.status, 1);
       assert.match(missing.stderr, /requires exactly one of/u);
 
@@ -2719,11 +2717,7 @@ try {
         ],
         { encoding: "utf8", env: environment },
       );
-      assert.strictEqual(
-        unavailableDoctor.status,
-        0,
-        unavailableDoctor.stderr,
-      );
+      assert.strictEqual(unavailableDoctor.status, 0, unavailableDoctor.stderr);
       const unavailableDoctorReport = JSON.parse(unavailableDoctor.stdout);
       assert.strictEqual(unavailableDoctorReport.ok, true);
       assert.deepStrictEqual(unavailableDoctorReport.ccusage, {
@@ -2771,12 +2765,7 @@ try {
 
       const unavailableStarted = spawnSync(
         process.execPath,
-        [
-          entrypoint,
-          "start",
-          ...unavailableArguments,
-          "--usage-unavailable",
-        ],
+        [entrypoint, "start", ...unavailableArguments, "--usage-unavailable"],
         { encoding: "utf8", env: environment },
       );
       assert.strictEqual(
@@ -2864,12 +2853,7 @@ try {
 
       const missingConsent = spawnSync(
         process.execPath,
-        [
-          entrypoint,
-          "start",
-          ...cliArguments,
-          "--allow-package-execution",
-        ],
+        [entrypoint, "start", ...cliArguments, "--allow-package-execution"],
         { encoding: "utf8", env: environment },
       );
       assert.strictEqual(missingConsent.status, 1, missingConsent.stdout);
@@ -3135,10 +3119,7 @@ try {
         readFileSync(runnerLog, "utf8"),
         runnerLogBeforeDowngrade,
       );
-      assert.strictEqual(
-        readFileSync(argsLog, "utf8"),
-        argsLogBeforeDowngrade,
-      );
+      assert.strictEqual(readFileSync(argsLog, "utf8"), argsLogBeforeDowngrade);
       rmSync(
         join(
           stateRoot,
@@ -3151,12 +3132,7 @@ try {
       const argsLogBeforeUnavailable = readFileSync(argsLog, "utf8");
       const unavailableRestarted = spawnSync(
         process.execPath,
-        [
-          entrypoint,
-          "start",
-          ...unavailableArguments,
-          "--usage-unavailable",
-        ],
+        [entrypoint, "start", ...unavailableArguments, "--usage-unavailable"],
         { encoding: "utf8", env: environment },
       );
       assert.strictEqual(
@@ -3209,11 +3185,7 @@ try {
         ],
         { encoding: "utf8", env: environment },
       );
-      assert.strictEqual(
-        unavailableReplay.status,
-        0,
-        unavailableReplay.stderr,
-      );
+      assert.strictEqual(unavailableReplay.status, 0, unavailableReplay.stderr);
       assert.strictEqual(
         JSON.parse(unavailableReplay.stdout).footer,
         unavailableFinishReport.footer,

--- a/skill-tests/contribute-to-eliza.test.ts
+++ b/skill-tests/contribute-to-eliza.test.ts
@@ -429,7 +429,10 @@ describe("live report parsing", () => {
       ["start", "--run", `run_${"0".repeat(26)}`],
       ["doctor", "--lane", "ignored-lane"],
       ["preview", "--model", "ignored-model"],
+      ["preview", "--usage-unavailable"],
       ["status", "--repo-root", "/tmp"],
+      ["status", "--usage-unavailable"],
+      ["trace", "--usage-unavailable"],
     ];
     for (const argumentsValue of cases) {
       const result = spawnSync(
@@ -439,6 +442,64 @@ describe("live report parsing", () => {
       );
       assert.strictEqual(result.status, 1);
       assert.match(result.stderr, /is not valid with/u);
+    }
+  });
+
+  it("requires one explicit usage mode for every measured command", () => {
+    const identity = [
+      "--repo-root",
+      ".",
+      "--client",
+      "codex",
+      "--provider",
+      "openai",
+      "--model",
+      "gpt-5.6-sol",
+    ];
+    const commands = [
+      ["doctor", ...identity],
+      [
+        "start",
+        ...identity,
+        "--lane",
+        "parser-test",
+        "--allow-local-usage",
+      ],
+      [
+        "finish",
+        ...identity,
+        "--lane",
+        "parser-test",
+        "--run",
+        `run_${"0".repeat(26)}`,
+        "--trajectory",
+        "proof.json",
+        "--trace-server-run",
+        "server_parser_test",
+        "--trace-object-id",
+        `sha256:${"0".repeat(64)}`,
+      ],
+    ];
+
+    for (const command of commands) {
+      const missing = spawnSync(process.execPath, [runReceiptPath, ...command], {
+        encoding: "utf8",
+      });
+      assert.strictEqual(missing.status, 1);
+      assert.match(missing.stderr, /requires exactly one of/u);
+
+      const ambiguous = spawnSync(
+        process.execPath,
+        [
+          runReceiptPath,
+          ...command,
+          "--allow-package-execution",
+          "--usage-unavailable",
+        ],
+        { encoding: "utf8" },
+      );
+      assert.strictEqual(ambiguous.status, 1);
+      assert.match(ambiguous.stderr, /choose exactly one/u);
     }
   });
 
@@ -2465,13 +2526,16 @@ describe("run receipt CLI", () => {
       const shimDir = join(fixtureRoot, "bin");
       mkdirSync(shimDir);
       const argsLog = join(fixtureRoot, "ccusage-args.log");
+      const runnerLog = join(fixtureRoot, "package-runner.log");
       const fixturePayload = join(fixtureRoot, "ccusage-report.json");
       const failureFlag = join(fixtureRoot, "ccusage-fail");
       const quotedArgsLog = `'${argsLog.replaceAll("'", `'"'"'`)}'`;
+      const quotedRunnerLog = `'${runnerLog.replaceAll("'", `'"'"'`)}'`;
       const quotedFixture = `'${fixturePayload.replaceAll("'", `'"'"'`)}'`;
       const quotedFailureFlag = `'${failureFlag.replaceAll("'", `'"'"'`)}'`;
       const shimSource = [
         "#!/bin/sh",
+        `printf '%s\\n' "bun $*" >> ${quotedRunnerLog}`,
         'if [ "$1" = "--version" ]; then',
         "  echo 1.3.14",
         "  exit 0",
@@ -2490,6 +2554,16 @@ describe("run receipt CLI", () => {
       ].join("\n");
       writeFileSync(join(shimDir, "bun"), shimSource);
       chmodSync(join(shimDir, "bun"), 0o755);
+      writeFileSync(
+        join(shimDir, "npx"),
+        [
+          "#!/bin/sh",
+          `printf '%s\\n' "npx $*" >> ${quotedRunnerLog}`,
+          "exit 97",
+          "",
+        ].join("\n"),
+      );
+      chmodSync(join(shimDir, "npx"), 0o755);
 
       const encodedRepo = encodedDirectoryName(repoRoot);
       const environment = {
@@ -2530,6 +2604,23 @@ try {
         "skill-tests",
         "--json",
       ];
+      const unavailableIdentityArguments = [
+        "--repo-root",
+        repoRoot,
+        "--client",
+        "codex",
+        "--provider",
+        "openai",
+        "--model",
+        "gpt-5.6-sol",
+        "--json",
+      ];
+      const unavailableArguments = [
+        ...unavailableIdentityArguments,
+        "--lane",
+        "skill-tests-unavailable",
+      ];
+      const stateRoot = join(environment.XDG_CONFIG_HOME, "slop", "runs");
 
       const preview = spawnSync(
         process.execPath,
@@ -2556,9 +2647,26 @@ try {
         previewReport.packageExecutionConsentFlag,
         "--allow-package-execution",
       );
+      assert.strictEqual(
+        previewReport.usageUnavailableFlag,
+        "--usage-unavailable",
+      );
+      assert.match(
+        previewReport.usageReadDisclosure,
+        /invokes no package manager.*reads no usage logs.*signed zero.*forfeits.*bonus/u,
+      );
+      assert.match(
+        previewReport.network.join("\n"),
+        /https:\/\/slop\.cash\/projects\/eliza\/terms\.json.*digest-bound LICENSE.*raw\.githubusercontent\.com/su,
+      );
+      assert.match(
+        previewReport.usageReadDisclosure,
+        /policy checks and trace networking remain/u,
+      );
       assert.match(previewReport.linkabilityDisclosure, /link receipts/u);
       assert.match(previewReport.localReads.join("\n"), /claude.*projects/is);
       assert.strictEqual(existsSync(argsLog), false);
+      assert.strictEqual(existsSync(runnerLog), false);
       assert.strictEqual(existsSync(join(fixtureRoot, "config")), false);
 
       const missingDoctorConsent = spawnSync(
@@ -2581,9 +2689,148 @@ try {
       assert.strictEqual(missingDoctorConsent.status, 1);
       assert.match(
         missingDoctorConsent.stderr,
-        /requires --allow-package-execution/u,
+        /requires exactly one of --allow-package-execution or --usage-unavailable/u,
       );
       assert.strictEqual(existsSync(argsLog), false);
+      assert.strictEqual(existsSync(runnerLog), false);
+
+      const ambiguousDoctor = spawnSync(
+        process.execPath,
+        [
+          entrypoint,
+          "doctor",
+          ...unavailableIdentityArguments,
+          "--allow-package-execution",
+          "--usage-unavailable",
+        ],
+        { encoding: "utf8", env: environment },
+      );
+      assert.strictEqual(ambiguousDoctor.status, 1);
+      assert.match(ambiguousDoctor.stderr, /choose exactly one/u);
+      assert.strictEqual(existsSync(runnerLog), false);
+
+      const unavailableDoctor = spawnSync(
+        process.execPath,
+        [
+          entrypoint,
+          "doctor",
+          ...unavailableIdentityArguments,
+          "--usage-unavailable",
+        ],
+        { encoding: "utf8", env: environment },
+      );
+      assert.strictEqual(
+        unavailableDoctor.status,
+        0,
+        unavailableDoctor.stderr,
+      );
+      const unavailableDoctorReport = JSON.parse(unavailableDoctor.stdout);
+      assert.strictEqual(unavailableDoctorReport.ok, true);
+      assert.deepStrictEqual(unavailableDoctorReport.ccusage, {
+        expectedVersion: "20.0.20",
+        version: null,
+        runner: null,
+        status: "intentional-unavailable",
+        logsRead: false,
+      });
+      assert.match(
+        unavailableDoctorReport.message,
+        /package execution and local usage-log reads are disabled/u,
+      );
+      assert.strictEqual(existsSync(runnerLog), false);
+
+      for (const unsupportedClient of [
+        "custom-agent",
+        "constructor",
+        "toString",
+      ]) {
+        const unsupportedUnavailableDoctor = spawnSync(
+          process.execPath,
+          [
+            entrypoint,
+            "doctor",
+            "--repo-root",
+            repoRoot,
+            "--client",
+            unsupportedClient,
+            "--provider",
+            "custom-provider",
+            "--model",
+            "custom-model",
+            "--usage-unavailable",
+          ],
+          { encoding: "utf8", env: environment },
+        );
+        assert.strictEqual(unsupportedUnavailableDoctor.status, 1);
+        assert.match(
+          unsupportedUnavailableDoctor.stderr,
+          /valid only for a supported usage adapter/u,
+        );
+        assert.strictEqual(existsSync(runnerLog), false);
+      }
+
+      const unavailableStarted = spawnSync(
+        process.execPath,
+        [
+          entrypoint,
+          "start",
+          ...unavailableArguments,
+          "--usage-unavailable",
+        ],
+        { encoding: "utf8", env: environment },
+      );
+      assert.strictEqual(
+        unavailableStarted.status,
+        0,
+        unavailableStarted.stderr,
+      );
+      const unavailableStartReport = JSON.parse(unavailableStarted.stdout);
+      assert.strictEqual(unavailableStartReport.usageStatus, "unavailable");
+      const unavailableActivePath = join(
+        stateRoot,
+        "active",
+        `${unavailableStartReport.runId}.json`,
+      );
+      assert.strictEqual(
+        JSON.parse(readFileSync(unavailableActivePath, "utf8")).baseline,
+        null,
+      );
+      assert.strictEqual(existsSync(runnerLog), false);
+      rmSync(unavailableActivePath);
+
+      const unavailableWithLocalConsent = spawnSync(
+        process.execPath,
+        [
+          entrypoint,
+          "start",
+          ...unavailableArguments,
+          "--usage-unavailable",
+          "--allow-local-usage",
+        ],
+        { encoding: "utf8", env: environment },
+      );
+      assert.strictEqual(unavailableWithLocalConsent.status, 1);
+      assert.match(
+        unavailableWithLocalConsent.stderr,
+        /--allow-local-usage is not valid with --usage-unavailable/u,
+      );
+      assert.strictEqual(existsSync(runnerLog), false);
+
+      const ambiguousStart = spawnSync(
+        process.execPath,
+        [
+          entrypoint,
+          "start",
+          ...unavailableArguments,
+          "--allow-package-execution",
+          "--usage-unavailable",
+          "--allow-local-usage",
+        ],
+        { encoding: "utf8", env: environment },
+      );
+      assert.strictEqual(ambiguousStart.status, 1);
+      assert.match(ambiguousStart.stderr, /choose exactly one/u);
+      assert.strictEqual(existsSync(runnerLog), false);
 
       const doctor = spawnSync(
         process.execPath,
@@ -2603,7 +2850,11 @@ try {
         ],
         { encoding: "utf8", env: environment },
       );
-      assert.strictEqual(doctor.status, 0, doctor.stderr);
+      assert.strictEqual(
+        doctor.status,
+        0,
+        `${doctor.stderr}\n${doctor.stdout}`,
+      );
       const doctorReport = JSON.parse(doctor.stdout);
       assert.strictEqual(doctorReport.ccusage.version, "20.0.20");
       assert.strictEqual(doctorReport.ccusage.logsRead, false);
@@ -2613,7 +2864,12 @@ try {
 
       const missingConsent = spawnSync(
         process.execPath,
-        [entrypoint, "start", ...cliArguments],
+        [
+          entrypoint,
+          "start",
+          ...cliArguments,
+          "--allow-package-execution",
+        ],
         { encoding: "utf8", env: environment },
       );
       assert.strictEqual(missingConsent.status, 1, missingConsent.stdout);
@@ -2623,7 +2879,6 @@ try {
         1,
       );
 
-      const stateRoot = join(environment.XDG_CONFIG_HOME, "slop", "runs");
       writeFileSync(
         fixturePayload,
         JSON.stringify({
@@ -2806,6 +3061,173 @@ try {
         "--trace-object-id",
         `sha256:${trajectorySha256}`,
       ];
+      const expectedUnavailableUsage = {
+        source: "ccusage-session-v20",
+        confidence: "unavailable",
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheCreationTokens: 0,
+        cacheReadTokens: 0,
+        totalTokens: 0,
+        costMicroUsd: "0",
+        sessionCount: 0,
+      };
+      const measuredBeforeUnavailableFinish = spawnSync(
+        process.execPath,
+        [
+          entrypoint,
+          "start",
+          ...cliArguments,
+          "--allow-package-execution",
+          "--allow-local-usage",
+        ],
+        { encoding: "utf8", env: environment },
+      );
+      assert.strictEqual(
+        measuredBeforeUnavailableFinish.status,
+        0,
+        measuredBeforeUnavailableFinish.stderr,
+      );
+      const measuredBeforeUnavailableFinishId = JSON.parse(
+        measuredBeforeUnavailableFinish.stdout,
+      ).runId;
+      const measuredBeforeUnavailableFinishState = JSON.parse(
+        readFileSync(
+          join(
+            stateRoot,
+            "active",
+            `${measuredBeforeUnavailableFinishId}.json`,
+          ),
+          "utf8",
+        ),
+      );
+      assert.notStrictEqual(
+        measuredBeforeUnavailableFinishState.baseline,
+        null,
+      );
+      const runnerLogBeforeDowngrade = readFileSync(runnerLog, "utf8");
+      const argsLogBeforeDowngrade = readFileSync(argsLog, "utf8");
+      const unavailableDowngrade = spawnSync(
+        process.execPath,
+        [
+          entrypoint,
+          "finish",
+          ...cliArguments,
+          "--run",
+          measuredBeforeUnavailableFinishId,
+          "--trajectory",
+          trajectoryPath,
+          ...traceArguments,
+          "--usage-unavailable",
+        ],
+        { encoding: "utf8", env: environment },
+      );
+      assert.strictEqual(
+        unavailableDowngrade.status,
+        0,
+        unavailableDowngrade.stderr,
+      );
+      assert.deepStrictEqual(
+        JSON.parse(unavailableDowngrade.stdout).receipt.usage,
+        expectedUnavailableUsage,
+      );
+      assert.strictEqual(
+        readFileSync(runnerLog, "utf8"),
+        runnerLogBeforeDowngrade,
+      );
+      assert.strictEqual(
+        readFileSync(argsLog, "utf8"),
+        argsLogBeforeDowngrade,
+      );
+      rmSync(
+        join(
+          stateRoot,
+          "completed",
+          `${measuredBeforeUnavailableFinishId}.json`,
+        ),
+      );
+
+      const runnerLogBeforeUnavailable = readFileSync(runnerLog, "utf8");
+      const argsLogBeforeUnavailable = readFileSync(argsLog, "utf8");
+      const unavailableRestarted = spawnSync(
+        process.execPath,
+        [
+          entrypoint,
+          "start",
+          ...unavailableArguments,
+          "--usage-unavailable",
+        ],
+        { encoding: "utf8", env: environment },
+      );
+      assert.strictEqual(
+        unavailableRestarted.status,
+        0,
+        unavailableRestarted.stderr,
+      );
+      const unavailableRunId = JSON.parse(unavailableRestarted.stdout).runId;
+      const unavailableFinished = spawnSync(
+        process.execPath,
+        [
+          entrypoint,
+          "finish",
+          ...unavailableArguments,
+          "--run",
+          unavailableRunId,
+          "--trajectory",
+          trajectoryPath,
+          ...traceArguments,
+          "--usage-unavailable",
+        ],
+        { encoding: "utf8", env: environment },
+      );
+      assert.strictEqual(
+        unavailableFinished.status,
+        0,
+        unavailableFinished.stderr,
+      );
+      const unavailableFinishReport = JSON.parse(unavailableFinished.stdout);
+      assert.deepStrictEqual(
+        unavailableFinishReport.receipt.usage,
+        expectedUnavailableUsage,
+      );
+      assert.match(
+        unavailableFinishReport.footer,
+        /Compute receipt: 0 project-attributed tokens \(unavailable;/u,
+      );
+      const unavailableReplay = spawnSync(
+        process.execPath,
+        [
+          entrypoint,
+          "finish",
+          ...unavailableArguments,
+          "--run",
+          unavailableRunId,
+          "--trajectory",
+          trajectoryPath,
+          ...traceArguments,
+          "--usage-unavailable",
+        ],
+        { encoding: "utf8", env: environment },
+      );
+      assert.strictEqual(
+        unavailableReplay.status,
+        0,
+        unavailableReplay.stderr,
+      );
+      assert.strictEqual(
+        JSON.parse(unavailableReplay.stdout).footer,
+        unavailableFinishReport.footer,
+      );
+      assert.strictEqual(
+        readFileSync(runnerLog, "utf8"),
+        runnerLogBeforeUnavailable,
+      );
+      assert.strictEqual(
+        readFileSync(argsLog, "utf8"),
+        argsLogBeforeUnavailable,
+      );
+      rmSync(join(stateRoot, "completed", `${unavailableRunId}.json`));
+
       const finished = spawnSync(
         process.execPath,
         [
@@ -3217,6 +3639,7 @@ try {
       );
       const npxShimSource = [
         "#!/bin/sh",
+        `printf '%s\\n' "npx $*" >> ${quotedRunnerLog}`,
         'if [ "$1" = "--version" ]; then',
         "  echo 11.0.0",
         "  exit 0",

--- a/skill-tests/contribute-to-eliza.test.ts
+++ b/skill-tests/contribute-to-eliza.test.ts
@@ -2651,7 +2651,7 @@ try {
       );
       assert.match(
         previewReport.usageReadDisclosure,
-        /invokes no package manager.*reads no usage logs.*signed zero.*forfeits.*bonus/u,
+        /invokes no package manager.*reads no usage logs.*signed zero.*usage never affects scoring/u,
       );
       assert.match(
         previewReport.network.join("\n"),

--- a/skill-tests/project-skills.test.ts
+++ b/skill-tests/project-skills.test.ts
@@ -78,6 +78,11 @@ describe("project skill contracts", () => {
       assert.match(source, /run-receipt\.mjs preview/u);
       assert.match(source, /run-receipt\.mjs doctor/u);
       assert.match(source, /--allow-local-usage/u);
+      assert.match(source, /--usage-unavailable/u);
+      assert.match(
+        source,
+        /invokes no package manager.*reads no usage logs.*forfeits the usage evidence bonus/is,
+      );
       assert.match(source, /--trajectory <path>/u);
       assert.match(source, /permanent\s+private\s+upload/u);
       assert.match(
@@ -386,6 +391,15 @@ describe("project skill contracts", () => {
           project.skill.id,
         );
         assert.match(result.stdout, /preview[\s\S]+doctor[\s\S]+status/u);
+        assert.match(result.stdout, /--usage-unavailable/u);
+        assert.match(
+          result.stdout,
+          /exactly one:[\s\S]+--allow-package-execution[\s\S]+--usage-unavailable/u,
+        );
+        assert.match(
+          result.stdout,
+          /signed zero-usage receipt without the usage bonus/u,
+        );
         const reportResult = spawnSync(
           process.execPath,
           [join(installedSkill, "scripts", "live-report.mjs"), "--help"],

--- a/skill-tests/project-skills.test.ts
+++ b/skill-tests/project-skills.test.ts
@@ -81,7 +81,7 @@ describe("project skill contracts", () => {
       assert.match(source, /--usage-unavailable/u);
       assert.match(
         source,
-        /invokes no package manager.*reads no usage logs.*forfeits the usage evidence bonus/is,
+        /invokes no package manager.*reads no usage logs.*usage evidence is diagnostic.*never changes score/is,
       );
       assert.match(source, /--trajectory <path>/u);
       assert.match(source, /permanent\s+private\s+upload/u);
@@ -398,7 +398,7 @@ describe("project skill contracts", () => {
         );
         assert.match(
           result.stdout,
-          /signed zero-usage receipt without the usage bonus/u,
+          /signed zero-usage receipt; usage never affects scoring/u,
         );
         const reportResult = spawnSync(
           process.execPath,

--- a/skills/contribute-to-asi/SKILL.md
+++ b/skills/contribute-to-asi/SKILL.md
@@ -86,6 +86,14 @@ clients continue with usage marked unavailable and omit
 `--allow-package-execution`. The receipt creates a local Ed25519 device key only
 when the run finishes.
 
+If the operator does not authorize package execution, use
+`--usage-unavailable` instead of `--allow-package-execution` for `doctor`,
+`start`, and `finish`; also omit `--allow-local-usage` from `start`. This mode
+invokes no package manager, reads no usage logs, records signed
+zero/unavailable usage, and forfeits the usage evidence bonus. Policy preflight
+and trace networking still run. Because receipts bind the exact skill revision,
+restart any active run created before this option was installed.
+
 6. Build the bounded, read-only inventory of live work before choosing:
 
 ```bash
@@ -402,6 +410,9 @@ node <skill-directory>/scripts/run-receipt.mjs finish \
   --run <run-id> --allow-package-execution --trajectory <path> \
   --trace-server-run <server-run-id> --trace-object-id sha256:<digest>
 ```
+
+For an unavailable-mode run, replace `--allow-package-execution` with
+`--usage-unavailable`.
 
 Append the emitted footer unchanged to the final pull request body, review, or
 issue comment. The hidden Slop marker must remain the final line. Do not

--- a/skills/contribute-to-asi/SKILL.md
+++ b/skills/contribute-to-asi/SKILL.md
@@ -89,8 +89,9 @@ when the run finishes.
 If the operator does not authorize package execution, use
 `--usage-unavailable` instead of `--allow-package-execution` for `doctor`,
 `start`, and `finish`; also omit `--allow-local-usage` from `start`. This mode
-invokes no package manager, reads no usage logs, records signed
-zero/unavailable usage, and forfeits the usage evidence bonus. Policy preflight
+invokes no package manager, reads no usage logs, and records signed
+zero/unavailable usage. Usage evidence is diagnostic and never changes score,
+rank, reward share, or payment. Policy preflight
 and trace networking still run. Because receipts bind the exact skill revision,
 restart any active run created before this option was installed.
 

--- a/skills/contribute-to-asi/scripts/run-receipt.mjs
+++ b/skills/contribute-to-asi/scripts/run-receipt.mjs
@@ -2065,9 +2065,7 @@ function parseArguments(args) {
       "finish requires finalized --trace-server-run and --trace-object-id evidence",
     );
   }
-  const measuredAction = ["doctor", "finish", "start"].includes(
-    options.action,
-  );
+  const measuredAction = ["doctor", "finish", "start"].includes(options.action);
   const usageAdapter = usageAdapterFor(options.client);
   if (options.allowPackageExecution && options.usageUnavailable) {
     fail(
@@ -2296,10 +2294,9 @@ function startRun(options, testOptions) {
     {
       runId,
       message: `Project run started. Keep this id: ${runId}`,
-      usageStatus:
-        options.usageUnavailable
-          ? "unavailable"
-          : usageAdapter === null
+      usageStatus: options.usageUnavailable
+        ? "unavailable"
+        : usageAdapter === null
           ? "unsupported"
           : state.baseline === null
             ? "unavailable"

--- a/skills/contribute-to-asi/scripts/run-receipt.mjs
+++ b/skills/contribute-to-asi/scripts/run-receipt.mjs
@@ -113,7 +113,7 @@ For a configured usage adapter, doctor, start, and finish require exactly one:
   --usage-unavailable       Skip package execution and all usage-log reads
 
 Measured starts also require --allow-local-usage after preview. Unavailable
-starts omit it and produce a signed zero-usage receipt without the usage bonus.
+starts omit it and produce a signed zero-usage receipt; usage never affects scoring.
 `;
 
 function fail(message) {
@@ -2169,7 +2169,7 @@ function previewRun(options) {
     packageExecutionConsentFlag: "--allow-package-execution",
     usageUnavailableFlag: "--usage-unavailable",
     usageReadDisclosure:
-      "--usage-unavailable invokes no package manager and reads no usage logs, but policy checks and trace networking remain; it records signed zero/unavailable usage and forfeits the usage evidence bonus.",
+      "--usage-unavailable invokes no package manager and reads no usage logs, but policy checks and trace networking remain; it records signed zero/unavailable usage, and usage never affects scoring.",
     localStateDisclosure:
       "Active baselines retain aggregate counters and SHA-256 session identifiers until finish.",
     linkabilityDisclosure:

--- a/skills/contribute-to-asi/scripts/run-receipt.mjs
+++ b/skills/contribute-to-asi/scripts/run-receipt.mjs
@@ -91,7 +91,7 @@ Commands:
   preview  Show local reads, writes, network access, and public receipt fields
   doctor   Verify repository, skill provenance, declarations, and local runners
   status   List this project's local active and completed measured runs
-  start    Capture a local ccusage baseline after explicit usage consent
+  start    Capture a local ccusage baseline or record usage as unavailable
   trace    Permanently upload this run's private trace and finalize it
   finish   Close a measured run and print its device-signed GitHub footer
 
@@ -103,13 +103,17 @@ Common options:
   --client-version <version>  Exact declared agent/client version
   --json              Emit machine-readable JSON
 
-Start and finish also require --lane <public-lane>. Start requires
---allow-local-usage after preview. Finish requires --run <run-id> and accepts
-a required --trajectory <path>, --trace-server-run <id>, and
---trace-object-id sha256:<digest> returned by the finalized private Slop trace
-upload. Publish only this upload evidence and digest. Supported usage adapters
-also require --allow-package-execution after preview because package-manager
-resolution may fetch code and write caches.
+Start and finish also require --lane <public-lane>. Finish requires --run
+<run-id> and accepts a required --trajectory <path>, --trace-server-run <id>,
+and --trace-object-id sha256:<digest> returned by the finalized private Slop
+trace upload. Publish only this upload evidence and digest.
+
+For a configured usage adapter, doctor, start, and finish require exactly one:
+  --allow-package-execution  Resolve the pinned adapter and measure usage
+  --usage-unavailable       Skip package execution and all usage-log reads
+
+Measured starts also require --allow-local-usage after preview. Unavailable
+starts omit it and produce a signed zero-usage receipt without the usage bonus.
 `;
 
 function fail(message) {
@@ -432,6 +436,12 @@ function unavailableUsage(source = "ccusage-session-v20") {
   };
 }
 
+function usageAdapterFor(client) {
+  return Object.hasOwn(PROJECT.usageAdapters, client)
+    ? PROJECT.usageAdapters[client]
+    : null;
+}
+
 function commandExists(command, executionRoot) {
   return (
     spawnSync(command, ["--version"], {
@@ -548,7 +558,7 @@ function inspectCcusageRunner() {
 }
 
 function collectUsage(client, repositoryRoot) {
-  const ccusageSource = PROJECT.usageAdapters[client];
+  const ccusageSource = usageAdapterFor(client);
   if (!ccusageSource) return null;
   return withPackageExecution((executionRoot) => {
     for (const runner of ccusageRunners(executionRoot)) {
@@ -1904,6 +1914,7 @@ function parseArguments(args) {
     traceObjectId: null,
     traceServerRun: null,
     trajectory: null,
+    usageUnavailable: false,
   };
   for (let index = 1; index < args.length; index += 1) {
     const argument = args[index];
@@ -1912,6 +1923,8 @@ function parseArguments(args) {
     if (argument === "--json") options.json = true;
     else if (argument === "--allow-package-execution") {
       options.allowPackageExecution = true;
+    } else if (argument === "--usage-unavailable") {
+      options.usageUnavailable = true;
     } else if (argument === "--allow-local-usage") {
       options.allowLocalUsage = true;
     } else if (
@@ -1964,6 +1977,7 @@ function parseArguments(args) {
       "--model",
       "--provider",
       "--repo-root",
+      "--usage-unavailable",
     ]),
     finish: new Set([
       "--allow-package-execution",
@@ -1977,6 +1991,7 @@ function parseArguments(args) {
       "--trace-object-id",
       "--trace-server-run",
       "--trajectory",
+      "--usage-unavailable",
     ]),
     help: new Set(),
     preview: new Set(["--client", "--json", "--repo-root"]),
@@ -1989,6 +2004,7 @@ function parseArguments(args) {
       "--model",
       "--provider",
       "--repo-root",
+      "--usage-unavailable",
     ]),
     status: new Set(["--json"]),
     trace: new Set([
@@ -2049,31 +2065,51 @@ function parseArguments(args) {
       "finish requires finalized --trace-server-run and --trace-object-id evidence",
     );
   }
-  if (options.action === "start" && !options.allowLocalUsage) {
+  const measuredAction = ["doctor", "finish", "start"].includes(
+    options.action,
+  );
+  const usageAdapter = usageAdapterFor(options.client);
+  if (options.allowPackageExecution && options.usageUnavailable) {
+    fail(
+      "choose exactly one of --allow-package-execution or --usage-unavailable",
+    );
+  }
+  if (
+    measuredAction &&
+    usageAdapter &&
+    !options.allowPackageExecution &&
+    !options.usageUnavailable
+  ) {
+    fail(
+      `${options.action} requires exactly one of --allow-package-execution or --usage-unavailable after reviewing the preview output`,
+    );
+  }
+  if ((!measuredAction || !usageAdapter) && options.allowPackageExecution) {
+    fail(
+      "--allow-package-execution is valid only for a supported usage adapter",
+    );
+  }
+  if ((!measuredAction || !usageAdapter) && options.usageUnavailable) {
+    fail("--usage-unavailable is valid only for a supported usage adapter");
+  }
+  if (
+    options.action === "start" &&
+    !options.usageUnavailable &&
+    !options.allowLocalUsage
+  ) {
     fail(
       "start requires --allow-local-usage after reviewing the preview output",
     );
   }
+  if (
+    options.action === "start" &&
+    options.usageUnavailable &&
+    options.allowLocalUsage
+  ) {
+    fail("--allow-local-usage is not valid with --usage-unavailable");
+  }
   if (options.action !== "start" && options.allowLocalUsage) {
     fail("--allow-local-usage is valid only with start");
-  }
-  if (
-    ["doctor", "finish", "start"].includes(options.action) &&
-    PROJECT.usageAdapters[options.client] &&
-    !options.allowPackageExecution
-  ) {
-    fail(
-      `${options.action} requires --allow-package-execution after reviewing the preview output`,
-    );
-  }
-  if (
-    (!["doctor", "finish", "start"].includes(options.action) ||
-      !PROJECT.usageAdapters[options.client]) &&
-    options.allowPackageExecution
-  ) {
-    fail(
-      "--allow-package-execution is valid only for a supported usage adapter",
-    );
   }
   return options;
 }
@@ -2088,7 +2124,7 @@ function previewRun(options) {
   const provenance = resolveSkillProvenance();
   const repositoryRoot = requireRepository(options.repoRoot);
   const stateRoot = configurationRoot();
-  const usageAdapter = PROJECT.usageAdapters[options.client] ?? null;
+  const usageAdapter = usageAdapterFor(options.client);
   const result = {
     projectId: PROJECT.projectId,
     repositoryId: PROJECT.repositoryId,
@@ -2106,10 +2142,11 @@ function previewRun(options) {
       join(stateRoot, "device-ed25519.pem"),
     ],
     packageManagerCacheWrites: [
-      "Bun or npm package cache and diagnostic logs during doctor/start/finish",
+      "Bun or npm package cache and diagnostic logs only with --allow-package-execution; none with --usage-unavailable",
     ],
     network: [
-      `Resolve exact ccusage@${CCUSAGE_VERSION} during doctor and measured runs; fetch it from the package registry only when it is not already cached`,
+      `With --allow-package-execution, resolve exact ccusage@${CCUSAGE_VERSION} during doctor and measured runs; fetch it from the package registry only when it is not already cached`,
+      `On start and finish, fetch current project terms from https://slop.cash/projects/${PROJECT.projectId}/terms.json and any digest-bound LICENSE, inbound terms, or prize rules from github.com, raw.githubusercontent.com, or proximityprize.org as named by that policy`,
       `Verify the public private-request intake gate at ${PRIVATE_REQUEST_INTAKE_STATUS}; trace upload remains blocked unless it reports enabled`,
       `After a local byte/digest disclosure, authenticate with GitHub and permanently upload the inspected trace through ${TRACE_AUTHORITY} under ${TRACE_PRIVACY_CONTRACT}`,
     ],
@@ -2132,6 +2169,9 @@ function previewRun(options) {
     ],
     consentFlag: "--allow-local-usage",
     packageExecutionConsentFlag: "--allow-package-execution",
+    usageUnavailableFlag: "--usage-unavailable",
+    usageReadDisclosure:
+      "--usage-unavailable invokes no package manager and reads no usage logs, but policy checks and trace networking remain; it records signed zero/unavailable usage and forfeits the usage evidence bonus.",
     localStateDisclosure:
       "Active baselines retain aggregate counters and SHA-256 session identifiers until finish.",
     linkabilityDisclosure:
@@ -2147,8 +2187,8 @@ function previewRun(options) {
         `Local usage reads: ${result.localReads.join(", ") || "none; this client has no usage adapter"}`,
         `Local state: ${stateRoot}`,
         "Automatic uploads: none.",
-        `Doctor only after consent with ${result.packageExecutionConsentFlag}.`,
-        `Start only after consent with ${result.consentFlag}.`,
+        `For configured adapters, choose ${result.packageExecutionConsentFlag} or ${result.usageUnavailableFlag}.`,
+        `Measured starts require ${result.consentFlag}; unavailable starts omit it.`,
       ].join("\n"),
     },
     options.json,
@@ -2158,12 +2198,16 @@ function previewRun(options) {
 function doctorRun(options) {
   const provenance = resolveSkillProvenance();
   const repositoryRoot = requireRepository(options.repoRoot);
-  const usageAdapter = PROJECT.usageAdapters[options.client] ?? null;
-  const probe = usageAdapter
-    ? inspectCcusageRunner()
-    : { runner: null, status: "unsupported", version: null };
+  const usageAdapter = usageAdapterFor(options.client);
+  const probe = options.usageUnavailable
+    ? { runner: null, status: "intentional-unavailable", version: null }
+    : usageAdapter
+      ? inspectCcusageRunner()
+      : { runner: null, status: "unsupported", version: null };
   const result = {
-    ok: probe.status === "available" || probe.status === "unsupported",
+    ok: ["available", "intentional-unavailable", "unsupported"].includes(
+      probe.status,
+    ),
     projectId: PROJECT.projectId,
     repositoryId: PROJECT.repositoryId,
     repositoryRoot,
@@ -2186,7 +2230,9 @@ function doctorRun(options) {
     {
       ...result,
       message: result.ok
-        ? `Slop receipt doctor passed for ${result.repositoryId}; no usage logs were read${usageAdapter ? "." : "; this client has no usage adapter, so usage will be unavailable."}`
+        ? options.usageUnavailable
+          ? `Slop receipt doctor passed for ${result.repositoryId}; package execution and local usage-log reads are disabled, so usage will be unavailable.`
+          : `Slop receipt doctor passed for ${result.repositoryId}; no usage logs were read${usageAdapter ? "." : "; this client has no usage adapter, so usage will be unavailable."}`
         : `Slop receipt doctor failed: exact ccusage@${CCUSAGE_VERSION} could not be executed.`,
     },
     options.json,
@@ -2225,7 +2271,7 @@ function statusRun(options) {
 function startRun(options, testOptions) {
   const provenance = resolveSkillProvenance();
   const repositoryRoot = requireRepository(options.repoRoot);
-  const usageAdapter = PROJECT.usageAdapters[options.client] ?? null;
+  const usageAdapter = usageAdapterFor(options.client);
   const runId = createRunId();
   const state = validateActiveRecord({
     schemaVersion: "2",
@@ -2238,7 +2284,9 @@ function startRun(options, testOptions) {
     model: options.model,
     lane: options.lane,
     startedAt: canonicalIso(),
-    baseline: collectUsage(options.client, repositoryRoot),
+    baseline: options.usageUnavailable
+      ? null
+      : collectUsage(options.client, repositoryRoot),
     policyAcknowledgement: projectPolicyPreflight(testOptions),
     ...provenance,
   });
@@ -2249,7 +2297,9 @@ function startRun(options, testOptions) {
       runId,
       message: `Project run started. Keep this id: ${runId}`,
       usageStatus:
-        usageAdapter === null
+        options.usageUnavailable
+          ? "unavailable"
+          : usageAdapter === null
           ? "unsupported"
           : state.baseline === null
             ? "unavailable"
@@ -2363,13 +2413,15 @@ function finishRun(options, testOptions) {
   if (Date.parse(completedAt) + CLOCK_SKEW_MS < Date.parse(state.startedAt)) {
     fail("system clock moved backward during the run");
   }
-  const usage = PROJECT.usageAdapters[options.client]
-    ? usageDelta(
-        state.baseline,
-        collectUsage(options.client, repositoryRoot),
-        options.client,
-      )
-    : unavailableUsage("none");
+  const usage = options.usageUnavailable
+    ? unavailableUsage()
+    : usageAdapterFor(options.client)
+      ? usageDelta(
+          state.baseline,
+          collectUsage(options.client, repositoryRoot),
+          options.client,
+        )
+      : unavailableUsage("none");
   const key = deviceKey();
   const trajectorySha256 = trajectoryDigest(options.trajectory);
   const currentPolicy = projectPolicyPreflight(testOptions);

--- a/skills/contribute-to-delta-star/SKILL.md
+++ b/skills/contribute-to-delta-star/SKILL.md
@@ -83,8 +83,9 @@ clients continue with usage marked unavailable and omit
 If the operator does not authorize package execution, use
 `--usage-unavailable` instead of `--allow-package-execution` for `doctor`,
 `start`, and `finish`; also omit `--allow-local-usage` from `start`. This mode
-invokes no package manager, reads no usage logs, records signed
-zero/unavailable usage, and forfeits the usage evidence bonus. Policy preflight
+invokes no package manager, reads no usage logs, and records signed
+zero/unavailable usage. Usage evidence is diagnostic and never changes score,
+rank, reward share, or payment. Policy preflight
 and trace networking still run. Because receipts bind the exact skill revision,
 restart any active run created before this option was installed.
 

--- a/skills/contribute-to-delta-star/SKILL.md
+++ b/skills/contribute-to-delta-star/SKILL.md
@@ -80,6 +80,14 @@ Codex, Claude Code, and Grok Build have pinned `ccusage@20.0.20` adapters; unsup
 clients continue with usage marked unavailable and omit
 `--allow-package-execution`.
 
+If the operator does not authorize package execution, use
+`--usage-unavailable` instead of `--allow-package-execution` for `doctor`,
+`start`, and `finish`; also omit `--allow-local-usage` from `start`. This mode
+invokes no package manager, reads no usage logs, records signed
+zero/unavailable usage, and forfeits the usage evidence bonus. Policy preflight
+and trace networking still run. Because receipts bind the exact skill revision,
+restart any active run created before this option was installed.
+
 Build the bounded, read-only live inventory before selecting work:
 
 ```bash
@@ -197,6 +205,9 @@ node <skill-directory>/scripts/run-receipt.mjs finish \
   --run <run-id> --allow-package-execution --trajectory <path> \
   --trace-server-run <server-run-id> --trace-object-id sha256:<digest>
 ```
+
+For an unavailable-mode run, replace `--allow-package-execution` with
+`--usage-unavailable`.
 
 Append the emitted footer unchanged to the final PR body, review, or issue
 comment. The Slop marker must remain the final line. Its ccusage totals are

--- a/skills/contribute-to-delta-star/scripts/run-receipt.mjs
+++ b/skills/contribute-to-delta-star/scripts/run-receipt.mjs
@@ -2065,9 +2065,7 @@ function parseArguments(args) {
       "finish requires finalized --trace-server-run and --trace-object-id evidence",
     );
   }
-  const measuredAction = ["doctor", "finish", "start"].includes(
-    options.action,
-  );
+  const measuredAction = ["doctor", "finish", "start"].includes(options.action);
   const usageAdapter = usageAdapterFor(options.client);
   if (options.allowPackageExecution && options.usageUnavailable) {
     fail(
@@ -2296,10 +2294,9 @@ function startRun(options, testOptions) {
     {
       runId,
       message: `Project run started. Keep this id: ${runId}`,
-      usageStatus:
-        options.usageUnavailable
-          ? "unavailable"
-          : usageAdapter === null
+      usageStatus: options.usageUnavailable
+        ? "unavailable"
+        : usageAdapter === null
           ? "unsupported"
           : state.baseline === null
             ? "unavailable"

--- a/skills/contribute-to-delta-star/scripts/run-receipt.mjs
+++ b/skills/contribute-to-delta-star/scripts/run-receipt.mjs
@@ -113,7 +113,7 @@ For a configured usage adapter, doctor, start, and finish require exactly one:
   --usage-unavailable       Skip package execution and all usage-log reads
 
 Measured starts also require --allow-local-usage after preview. Unavailable
-starts omit it and produce a signed zero-usage receipt without the usage bonus.
+starts omit it and produce a signed zero-usage receipt; usage never affects scoring.
 `;
 
 function fail(message) {
@@ -2169,7 +2169,7 @@ function previewRun(options) {
     packageExecutionConsentFlag: "--allow-package-execution",
     usageUnavailableFlag: "--usage-unavailable",
     usageReadDisclosure:
-      "--usage-unavailable invokes no package manager and reads no usage logs, but policy checks and trace networking remain; it records signed zero/unavailable usage and forfeits the usage evidence bonus.",
+      "--usage-unavailable invokes no package manager and reads no usage logs, but policy checks and trace networking remain; it records signed zero/unavailable usage, and usage never affects scoring.",
     localStateDisclosure:
       "Active baselines retain aggregate counters and SHA-256 session identifiers until finish.",
     linkabilityDisclosure:

--- a/skills/contribute-to-delta-star/scripts/run-receipt.mjs
+++ b/skills/contribute-to-delta-star/scripts/run-receipt.mjs
@@ -91,7 +91,7 @@ Commands:
   preview  Show local reads, writes, network access, and public receipt fields
   doctor   Verify repository, skill provenance, declarations, and local runners
   status   List this project's local active and completed measured runs
-  start    Capture a local ccusage baseline after explicit usage consent
+  start    Capture a local ccusage baseline or record usage as unavailable
   trace    Permanently upload this run's private trace and finalize it
   finish   Close a measured run and print its device-signed GitHub footer
 
@@ -103,13 +103,17 @@ Common options:
   --client-version <version>  Exact declared agent/client version
   --json              Emit machine-readable JSON
 
-Start and finish also require --lane <public-lane>. Start requires
---allow-local-usage after preview. Finish requires --run <run-id> and accepts
-a required --trajectory <path>, --trace-server-run <id>, and
---trace-object-id sha256:<digest> returned by the finalized private Slop trace
-upload. Publish only this upload evidence and digest. Supported usage adapters
-also require --allow-package-execution after preview because package-manager
-resolution may fetch code and write caches.
+Start and finish also require --lane <public-lane>. Finish requires --run
+<run-id> and accepts a required --trajectory <path>, --trace-server-run <id>,
+and --trace-object-id sha256:<digest> returned by the finalized private Slop
+trace upload. Publish only this upload evidence and digest.
+
+For a configured usage adapter, doctor, start, and finish require exactly one:
+  --allow-package-execution  Resolve the pinned adapter and measure usage
+  --usage-unavailable       Skip package execution and all usage-log reads
+
+Measured starts also require --allow-local-usage after preview. Unavailable
+starts omit it and produce a signed zero-usage receipt without the usage bonus.
 `;
 
 function fail(message) {
@@ -432,6 +436,12 @@ function unavailableUsage(source = "ccusage-session-v20") {
   };
 }
 
+function usageAdapterFor(client) {
+  return Object.hasOwn(PROJECT.usageAdapters, client)
+    ? PROJECT.usageAdapters[client]
+    : null;
+}
+
 function commandExists(command, executionRoot) {
   return (
     spawnSync(command, ["--version"], {
@@ -548,7 +558,7 @@ function inspectCcusageRunner() {
 }
 
 function collectUsage(client, repositoryRoot) {
-  const ccusageSource = PROJECT.usageAdapters[client];
+  const ccusageSource = usageAdapterFor(client);
   if (!ccusageSource) return null;
   return withPackageExecution((executionRoot) => {
     for (const runner of ccusageRunners(executionRoot)) {
@@ -1904,6 +1914,7 @@ function parseArguments(args) {
     traceObjectId: null,
     traceServerRun: null,
     trajectory: null,
+    usageUnavailable: false,
   };
   for (let index = 1; index < args.length; index += 1) {
     const argument = args[index];
@@ -1912,6 +1923,8 @@ function parseArguments(args) {
     if (argument === "--json") options.json = true;
     else if (argument === "--allow-package-execution") {
       options.allowPackageExecution = true;
+    } else if (argument === "--usage-unavailable") {
+      options.usageUnavailable = true;
     } else if (argument === "--allow-local-usage") {
       options.allowLocalUsage = true;
     } else if (
@@ -1964,6 +1977,7 @@ function parseArguments(args) {
       "--model",
       "--provider",
       "--repo-root",
+      "--usage-unavailable",
     ]),
     finish: new Set([
       "--allow-package-execution",
@@ -1977,6 +1991,7 @@ function parseArguments(args) {
       "--trace-object-id",
       "--trace-server-run",
       "--trajectory",
+      "--usage-unavailable",
     ]),
     help: new Set(),
     preview: new Set(["--client", "--json", "--repo-root"]),
@@ -1989,6 +2004,7 @@ function parseArguments(args) {
       "--model",
       "--provider",
       "--repo-root",
+      "--usage-unavailable",
     ]),
     status: new Set(["--json"]),
     trace: new Set([
@@ -2049,31 +2065,51 @@ function parseArguments(args) {
       "finish requires finalized --trace-server-run and --trace-object-id evidence",
     );
   }
-  if (options.action === "start" && !options.allowLocalUsage) {
+  const measuredAction = ["doctor", "finish", "start"].includes(
+    options.action,
+  );
+  const usageAdapter = usageAdapterFor(options.client);
+  if (options.allowPackageExecution && options.usageUnavailable) {
+    fail(
+      "choose exactly one of --allow-package-execution or --usage-unavailable",
+    );
+  }
+  if (
+    measuredAction &&
+    usageAdapter &&
+    !options.allowPackageExecution &&
+    !options.usageUnavailable
+  ) {
+    fail(
+      `${options.action} requires exactly one of --allow-package-execution or --usage-unavailable after reviewing the preview output`,
+    );
+  }
+  if ((!measuredAction || !usageAdapter) && options.allowPackageExecution) {
+    fail(
+      "--allow-package-execution is valid only for a supported usage adapter",
+    );
+  }
+  if ((!measuredAction || !usageAdapter) && options.usageUnavailable) {
+    fail("--usage-unavailable is valid only for a supported usage adapter");
+  }
+  if (
+    options.action === "start" &&
+    !options.usageUnavailable &&
+    !options.allowLocalUsage
+  ) {
     fail(
       "start requires --allow-local-usage after reviewing the preview output",
     );
   }
+  if (
+    options.action === "start" &&
+    options.usageUnavailable &&
+    options.allowLocalUsage
+  ) {
+    fail("--allow-local-usage is not valid with --usage-unavailable");
+  }
   if (options.action !== "start" && options.allowLocalUsage) {
     fail("--allow-local-usage is valid only with start");
-  }
-  if (
-    ["doctor", "finish", "start"].includes(options.action) &&
-    PROJECT.usageAdapters[options.client] &&
-    !options.allowPackageExecution
-  ) {
-    fail(
-      `${options.action} requires --allow-package-execution after reviewing the preview output`,
-    );
-  }
-  if (
-    (!["doctor", "finish", "start"].includes(options.action) ||
-      !PROJECT.usageAdapters[options.client]) &&
-    options.allowPackageExecution
-  ) {
-    fail(
-      "--allow-package-execution is valid only for a supported usage adapter",
-    );
   }
   return options;
 }
@@ -2088,7 +2124,7 @@ function previewRun(options) {
   const provenance = resolveSkillProvenance();
   const repositoryRoot = requireRepository(options.repoRoot);
   const stateRoot = configurationRoot();
-  const usageAdapter = PROJECT.usageAdapters[options.client] ?? null;
+  const usageAdapter = usageAdapterFor(options.client);
   const result = {
     projectId: PROJECT.projectId,
     repositoryId: PROJECT.repositoryId,
@@ -2106,10 +2142,11 @@ function previewRun(options) {
       join(stateRoot, "device-ed25519.pem"),
     ],
     packageManagerCacheWrites: [
-      "Bun or npm package cache and diagnostic logs during doctor/start/finish",
+      "Bun or npm package cache and diagnostic logs only with --allow-package-execution; none with --usage-unavailable",
     ],
     network: [
-      `Resolve exact ccusage@${CCUSAGE_VERSION} during doctor and measured runs; fetch it from the package registry only when it is not already cached`,
+      `With --allow-package-execution, resolve exact ccusage@${CCUSAGE_VERSION} during doctor and measured runs; fetch it from the package registry only when it is not already cached`,
+      `On start and finish, fetch current project terms from https://slop.cash/projects/${PROJECT.projectId}/terms.json and any digest-bound LICENSE, inbound terms, or prize rules from github.com, raw.githubusercontent.com, or proximityprize.org as named by that policy`,
       `Verify the public private-request intake gate at ${PRIVATE_REQUEST_INTAKE_STATUS}; trace upload remains blocked unless it reports enabled`,
       `After a local byte/digest disclosure, authenticate with GitHub and permanently upload the inspected trace through ${TRACE_AUTHORITY} under ${TRACE_PRIVACY_CONTRACT}`,
     ],
@@ -2132,6 +2169,9 @@ function previewRun(options) {
     ],
     consentFlag: "--allow-local-usage",
     packageExecutionConsentFlag: "--allow-package-execution",
+    usageUnavailableFlag: "--usage-unavailable",
+    usageReadDisclosure:
+      "--usage-unavailable invokes no package manager and reads no usage logs, but policy checks and trace networking remain; it records signed zero/unavailable usage and forfeits the usage evidence bonus.",
     localStateDisclosure:
       "Active baselines retain aggregate counters and SHA-256 session identifiers until finish.",
     linkabilityDisclosure:
@@ -2147,8 +2187,8 @@ function previewRun(options) {
         `Local usage reads: ${result.localReads.join(", ") || "none; this client has no usage adapter"}`,
         `Local state: ${stateRoot}`,
         "Automatic uploads: none.",
-        `Doctor only after consent with ${result.packageExecutionConsentFlag}.`,
-        `Start only after consent with ${result.consentFlag}.`,
+        `For configured adapters, choose ${result.packageExecutionConsentFlag} or ${result.usageUnavailableFlag}.`,
+        `Measured starts require ${result.consentFlag}; unavailable starts omit it.`,
       ].join("\n"),
     },
     options.json,
@@ -2158,12 +2198,16 @@ function previewRun(options) {
 function doctorRun(options) {
   const provenance = resolveSkillProvenance();
   const repositoryRoot = requireRepository(options.repoRoot);
-  const usageAdapter = PROJECT.usageAdapters[options.client] ?? null;
-  const probe = usageAdapter
-    ? inspectCcusageRunner()
-    : { runner: null, status: "unsupported", version: null };
+  const usageAdapter = usageAdapterFor(options.client);
+  const probe = options.usageUnavailable
+    ? { runner: null, status: "intentional-unavailable", version: null }
+    : usageAdapter
+      ? inspectCcusageRunner()
+      : { runner: null, status: "unsupported", version: null };
   const result = {
-    ok: probe.status === "available" || probe.status === "unsupported",
+    ok: ["available", "intentional-unavailable", "unsupported"].includes(
+      probe.status,
+    ),
     projectId: PROJECT.projectId,
     repositoryId: PROJECT.repositoryId,
     repositoryRoot,
@@ -2186,7 +2230,9 @@ function doctorRun(options) {
     {
       ...result,
       message: result.ok
-        ? `Slop receipt doctor passed for ${result.repositoryId}; no usage logs were read${usageAdapter ? "." : "; this client has no usage adapter, so usage will be unavailable."}`
+        ? options.usageUnavailable
+          ? `Slop receipt doctor passed for ${result.repositoryId}; package execution and local usage-log reads are disabled, so usage will be unavailable.`
+          : `Slop receipt doctor passed for ${result.repositoryId}; no usage logs were read${usageAdapter ? "." : "; this client has no usage adapter, so usage will be unavailable."}`
         : `Slop receipt doctor failed: exact ccusage@${CCUSAGE_VERSION} could not be executed.`,
     },
     options.json,
@@ -2225,7 +2271,7 @@ function statusRun(options) {
 function startRun(options, testOptions) {
   const provenance = resolveSkillProvenance();
   const repositoryRoot = requireRepository(options.repoRoot);
-  const usageAdapter = PROJECT.usageAdapters[options.client] ?? null;
+  const usageAdapter = usageAdapterFor(options.client);
   const runId = createRunId();
   const state = validateActiveRecord({
     schemaVersion: "2",
@@ -2238,7 +2284,9 @@ function startRun(options, testOptions) {
     model: options.model,
     lane: options.lane,
     startedAt: canonicalIso(),
-    baseline: collectUsage(options.client, repositoryRoot),
+    baseline: options.usageUnavailable
+      ? null
+      : collectUsage(options.client, repositoryRoot),
     policyAcknowledgement: projectPolicyPreflight(testOptions),
     ...provenance,
   });
@@ -2249,7 +2297,9 @@ function startRun(options, testOptions) {
       runId,
       message: `Project run started. Keep this id: ${runId}`,
       usageStatus:
-        usageAdapter === null
+        options.usageUnavailable
+          ? "unavailable"
+          : usageAdapter === null
           ? "unsupported"
           : state.baseline === null
             ? "unavailable"
@@ -2363,13 +2413,15 @@ function finishRun(options, testOptions) {
   if (Date.parse(completedAt) + CLOCK_SKEW_MS < Date.parse(state.startedAt)) {
     fail("system clock moved backward during the run");
   }
-  const usage = PROJECT.usageAdapters[options.client]
-    ? usageDelta(
-        state.baseline,
-        collectUsage(options.client, repositoryRoot),
-        options.client,
-      )
-    : unavailableUsage("none");
+  const usage = options.usageUnavailable
+    ? unavailableUsage()
+    : usageAdapterFor(options.client)
+      ? usageDelta(
+          state.baseline,
+          collectUsage(options.client, repositoryRoot),
+          options.client,
+        )
+      : unavailableUsage("none");
   const key = deviceKey();
   const trajectorySha256 = trajectoryDigest(options.trajectory);
   const currentPolicy = projectPolicyPreflight(testOptions);

--- a/skills/contribute-to-eliza/SKILL.md
+++ b/skills/contribute-to-eliza/SKILL.md
@@ -97,8 +97,9 @@ creates a local Ed25519 device key only when the run finishes.
 If the operator does not authorize package execution, use
 `--usage-unavailable` instead of `--allow-package-execution` for `doctor`,
 `start`, and `finish`; also omit `--allow-local-usage` from `start`. This mode
-invokes no package manager, reads no usage logs, records signed
-zero/unavailable usage, and forfeits the usage evidence bonus. Policy preflight
+invokes no package manager, reads no usage logs, and records signed
+zero/unavailable usage. Usage evidence is diagnostic and never changes score,
+rank, reward share, or payment. Policy preflight
 and trace networking still run. Because receipts bind the exact skill revision,
 restart any active run created before this option was installed.
 

--- a/skills/contribute-to-eliza/SKILL.md
+++ b/skills/contribute-to-eliza/SKILL.md
@@ -94,6 +94,14 @@ clients continue with usage marked unavailable and omit
 `--allow-package-execution`. The receipt records a non-secret baseline and
 creates a local Ed25519 device key only when the run finishes.
 
+If the operator does not authorize package execution, use
+`--usage-unavailable` instead of `--allow-package-execution` for `doctor`,
+`start`, and `finish`; also omit `--allow-local-usage` from `start`. This mode
+invokes no package manager, reads no usage logs, records signed
+zero/unavailable usage, and forfeits the usage evidence bonus. Policy preflight
+and trace networking still run. Because receipts bind the exact skill revision,
+restart any active run created before this option was installed.
+
 ## Choose one mission-critical outcome
 
 Use the read-only live report as a filter, then inspect GitHub immediately
@@ -272,6 +280,9 @@ node <skill-directory>/scripts/run-receipt.mjs finish \
   --run <run-id> --allow-package-execution --trajectory <path> \
   --trace-server-run <server-run-id> --trace-object-id sha256:<digest>
 ```
+
+For an unavailable-mode run, replace `--allow-package-execution` with
+`--usage-unavailable`.
 
 The command prints the exact native Slop footer. Preserve it unchanged when
 using the native marker. Do not hand-edit token counts, identifiers, timestamps,

--- a/skills/contribute-to-eliza/scripts/run-receipt.mjs
+++ b/skills/contribute-to-eliza/scripts/run-receipt.mjs
@@ -2065,9 +2065,7 @@ function parseArguments(args) {
       "finish requires finalized --trace-server-run and --trace-object-id evidence",
     );
   }
-  const measuredAction = ["doctor", "finish", "start"].includes(
-    options.action,
-  );
+  const measuredAction = ["doctor", "finish", "start"].includes(options.action);
   const usageAdapter = usageAdapterFor(options.client);
   if (options.allowPackageExecution && options.usageUnavailable) {
     fail(
@@ -2296,10 +2294,9 @@ function startRun(options, testOptions) {
     {
       runId,
       message: `Project run started. Keep this id: ${runId}`,
-      usageStatus:
-        options.usageUnavailable
-          ? "unavailable"
-          : usageAdapter === null
+      usageStatus: options.usageUnavailable
+        ? "unavailable"
+        : usageAdapter === null
           ? "unsupported"
           : state.baseline === null
             ? "unavailable"

--- a/skills/contribute-to-eliza/scripts/run-receipt.mjs
+++ b/skills/contribute-to-eliza/scripts/run-receipt.mjs
@@ -113,7 +113,7 @@ For a configured usage adapter, doctor, start, and finish require exactly one:
   --usage-unavailable       Skip package execution and all usage-log reads
 
 Measured starts also require --allow-local-usage after preview. Unavailable
-starts omit it and produce a signed zero-usage receipt without the usage bonus.
+starts omit it and produce a signed zero-usage receipt; usage never affects scoring.
 `;
 
 function fail(message) {
@@ -2169,7 +2169,7 @@ function previewRun(options) {
     packageExecutionConsentFlag: "--allow-package-execution",
     usageUnavailableFlag: "--usage-unavailable",
     usageReadDisclosure:
-      "--usage-unavailable invokes no package manager and reads no usage logs, but policy checks and trace networking remain; it records signed zero/unavailable usage and forfeits the usage evidence bonus.",
+      "--usage-unavailable invokes no package manager and reads no usage logs, but policy checks and trace networking remain; it records signed zero/unavailable usage, and usage never affects scoring.",
     localStateDisclosure:
       "Active baselines retain aggregate counters and SHA-256 session identifiers until finish.",
     linkabilityDisclosure:

--- a/skills/contribute-to-eliza/scripts/run-receipt.mjs
+++ b/skills/contribute-to-eliza/scripts/run-receipt.mjs
@@ -91,7 +91,7 @@ Commands:
   preview  Show local reads, writes, network access, and public receipt fields
   doctor   Verify repository, skill provenance, declarations, and local runners
   status   List this project's local active and completed measured runs
-  start    Capture a local ccusage baseline after explicit usage consent
+  start    Capture a local ccusage baseline or record usage as unavailable
   trace    Permanently upload this run's private trace and finalize it
   finish   Close a measured run and print its device-signed GitHub footer
 
@@ -103,13 +103,17 @@ Common options:
   --client-version <version>  Exact declared agent/client version
   --json              Emit machine-readable JSON
 
-Start and finish also require --lane <public-lane>. Start requires
---allow-local-usage after preview. Finish requires --run <run-id> and accepts
-a required --trajectory <path>, --trace-server-run <id>, and
---trace-object-id sha256:<digest> returned by the finalized private Slop trace
-upload. Publish only this upload evidence and digest. Supported usage adapters
-also require --allow-package-execution after preview because package-manager
-resolution may fetch code and write caches.
+Start and finish also require --lane <public-lane>. Finish requires --run
+<run-id> and accepts a required --trajectory <path>, --trace-server-run <id>,
+and --trace-object-id sha256:<digest> returned by the finalized private Slop
+trace upload. Publish only this upload evidence and digest.
+
+For a configured usage adapter, doctor, start, and finish require exactly one:
+  --allow-package-execution  Resolve the pinned adapter and measure usage
+  --usage-unavailable       Skip package execution and all usage-log reads
+
+Measured starts also require --allow-local-usage after preview. Unavailable
+starts omit it and produce a signed zero-usage receipt without the usage bonus.
 `;
 
 function fail(message) {
@@ -432,6 +436,12 @@ function unavailableUsage(source = "ccusage-session-v20") {
   };
 }
 
+function usageAdapterFor(client) {
+  return Object.hasOwn(PROJECT.usageAdapters, client)
+    ? PROJECT.usageAdapters[client]
+    : null;
+}
+
 function commandExists(command, executionRoot) {
   return (
     spawnSync(command, ["--version"], {
@@ -548,7 +558,7 @@ function inspectCcusageRunner() {
 }
 
 function collectUsage(client, repositoryRoot) {
-  const ccusageSource = PROJECT.usageAdapters[client];
+  const ccusageSource = usageAdapterFor(client);
   if (!ccusageSource) return null;
   return withPackageExecution((executionRoot) => {
     for (const runner of ccusageRunners(executionRoot)) {
@@ -1904,6 +1914,7 @@ function parseArguments(args) {
     traceObjectId: null,
     traceServerRun: null,
     trajectory: null,
+    usageUnavailable: false,
   };
   for (let index = 1; index < args.length; index += 1) {
     const argument = args[index];
@@ -1912,6 +1923,8 @@ function parseArguments(args) {
     if (argument === "--json") options.json = true;
     else if (argument === "--allow-package-execution") {
       options.allowPackageExecution = true;
+    } else if (argument === "--usage-unavailable") {
+      options.usageUnavailable = true;
     } else if (argument === "--allow-local-usage") {
       options.allowLocalUsage = true;
     } else if (
@@ -1964,6 +1977,7 @@ function parseArguments(args) {
       "--model",
       "--provider",
       "--repo-root",
+      "--usage-unavailable",
     ]),
     finish: new Set([
       "--allow-package-execution",
@@ -1977,6 +1991,7 @@ function parseArguments(args) {
       "--trace-object-id",
       "--trace-server-run",
       "--trajectory",
+      "--usage-unavailable",
     ]),
     help: new Set(),
     preview: new Set(["--client", "--json", "--repo-root"]),
@@ -1989,6 +2004,7 @@ function parseArguments(args) {
       "--model",
       "--provider",
       "--repo-root",
+      "--usage-unavailable",
     ]),
     status: new Set(["--json"]),
     trace: new Set([
@@ -2049,31 +2065,51 @@ function parseArguments(args) {
       "finish requires finalized --trace-server-run and --trace-object-id evidence",
     );
   }
-  if (options.action === "start" && !options.allowLocalUsage) {
+  const measuredAction = ["doctor", "finish", "start"].includes(
+    options.action,
+  );
+  const usageAdapter = usageAdapterFor(options.client);
+  if (options.allowPackageExecution && options.usageUnavailable) {
+    fail(
+      "choose exactly one of --allow-package-execution or --usage-unavailable",
+    );
+  }
+  if (
+    measuredAction &&
+    usageAdapter &&
+    !options.allowPackageExecution &&
+    !options.usageUnavailable
+  ) {
+    fail(
+      `${options.action} requires exactly one of --allow-package-execution or --usage-unavailable after reviewing the preview output`,
+    );
+  }
+  if ((!measuredAction || !usageAdapter) && options.allowPackageExecution) {
+    fail(
+      "--allow-package-execution is valid only for a supported usage adapter",
+    );
+  }
+  if ((!measuredAction || !usageAdapter) && options.usageUnavailable) {
+    fail("--usage-unavailable is valid only for a supported usage adapter");
+  }
+  if (
+    options.action === "start" &&
+    !options.usageUnavailable &&
+    !options.allowLocalUsage
+  ) {
     fail(
       "start requires --allow-local-usage after reviewing the preview output",
     );
   }
+  if (
+    options.action === "start" &&
+    options.usageUnavailable &&
+    options.allowLocalUsage
+  ) {
+    fail("--allow-local-usage is not valid with --usage-unavailable");
+  }
   if (options.action !== "start" && options.allowLocalUsage) {
     fail("--allow-local-usage is valid only with start");
-  }
-  if (
-    ["doctor", "finish", "start"].includes(options.action) &&
-    PROJECT.usageAdapters[options.client] &&
-    !options.allowPackageExecution
-  ) {
-    fail(
-      `${options.action} requires --allow-package-execution after reviewing the preview output`,
-    );
-  }
-  if (
-    (!["doctor", "finish", "start"].includes(options.action) ||
-      !PROJECT.usageAdapters[options.client]) &&
-    options.allowPackageExecution
-  ) {
-    fail(
-      "--allow-package-execution is valid only for a supported usage adapter",
-    );
   }
   return options;
 }
@@ -2088,7 +2124,7 @@ function previewRun(options) {
   const provenance = resolveSkillProvenance();
   const repositoryRoot = requireRepository(options.repoRoot);
   const stateRoot = configurationRoot();
-  const usageAdapter = PROJECT.usageAdapters[options.client] ?? null;
+  const usageAdapter = usageAdapterFor(options.client);
   const result = {
     projectId: PROJECT.projectId,
     repositoryId: PROJECT.repositoryId,
@@ -2106,10 +2142,11 @@ function previewRun(options) {
       join(stateRoot, "device-ed25519.pem"),
     ],
     packageManagerCacheWrites: [
-      "Bun or npm package cache and diagnostic logs during doctor/start/finish",
+      "Bun or npm package cache and diagnostic logs only with --allow-package-execution; none with --usage-unavailable",
     ],
     network: [
-      `Resolve exact ccusage@${CCUSAGE_VERSION} during doctor and measured runs; fetch it from the package registry only when it is not already cached`,
+      `With --allow-package-execution, resolve exact ccusage@${CCUSAGE_VERSION} during doctor and measured runs; fetch it from the package registry only when it is not already cached`,
+      `On start and finish, fetch current project terms from https://slop.cash/projects/${PROJECT.projectId}/terms.json and any digest-bound LICENSE, inbound terms, or prize rules from github.com, raw.githubusercontent.com, or proximityprize.org as named by that policy`,
       `Verify the public private-request intake gate at ${PRIVATE_REQUEST_INTAKE_STATUS}; trace upload remains blocked unless it reports enabled`,
       `After a local byte/digest disclosure, authenticate with GitHub and permanently upload the inspected trace through ${TRACE_AUTHORITY} under ${TRACE_PRIVACY_CONTRACT}`,
     ],
@@ -2132,6 +2169,9 @@ function previewRun(options) {
     ],
     consentFlag: "--allow-local-usage",
     packageExecutionConsentFlag: "--allow-package-execution",
+    usageUnavailableFlag: "--usage-unavailable",
+    usageReadDisclosure:
+      "--usage-unavailable invokes no package manager and reads no usage logs, but policy checks and trace networking remain; it records signed zero/unavailable usage and forfeits the usage evidence bonus.",
     localStateDisclosure:
       "Active baselines retain aggregate counters and SHA-256 session identifiers until finish.",
     linkabilityDisclosure:
@@ -2147,8 +2187,8 @@ function previewRun(options) {
         `Local usage reads: ${result.localReads.join(", ") || "none; this client has no usage adapter"}`,
         `Local state: ${stateRoot}`,
         "Automatic uploads: none.",
-        `Doctor only after consent with ${result.packageExecutionConsentFlag}.`,
-        `Start only after consent with ${result.consentFlag}.`,
+        `For configured adapters, choose ${result.packageExecutionConsentFlag} or ${result.usageUnavailableFlag}.`,
+        `Measured starts require ${result.consentFlag}; unavailable starts omit it.`,
       ].join("\n"),
     },
     options.json,
@@ -2158,12 +2198,16 @@ function previewRun(options) {
 function doctorRun(options) {
   const provenance = resolveSkillProvenance();
   const repositoryRoot = requireRepository(options.repoRoot);
-  const usageAdapter = PROJECT.usageAdapters[options.client] ?? null;
-  const probe = usageAdapter
-    ? inspectCcusageRunner()
-    : { runner: null, status: "unsupported", version: null };
+  const usageAdapter = usageAdapterFor(options.client);
+  const probe = options.usageUnavailable
+    ? { runner: null, status: "intentional-unavailable", version: null }
+    : usageAdapter
+      ? inspectCcusageRunner()
+      : { runner: null, status: "unsupported", version: null };
   const result = {
-    ok: probe.status === "available" || probe.status === "unsupported",
+    ok: ["available", "intentional-unavailable", "unsupported"].includes(
+      probe.status,
+    ),
     projectId: PROJECT.projectId,
     repositoryId: PROJECT.repositoryId,
     repositoryRoot,
@@ -2186,7 +2230,9 @@ function doctorRun(options) {
     {
       ...result,
       message: result.ok
-        ? `Slop receipt doctor passed for ${result.repositoryId}; no usage logs were read${usageAdapter ? "." : "; this client has no usage adapter, so usage will be unavailable."}`
+        ? options.usageUnavailable
+          ? `Slop receipt doctor passed for ${result.repositoryId}; package execution and local usage-log reads are disabled, so usage will be unavailable.`
+          : `Slop receipt doctor passed for ${result.repositoryId}; no usage logs were read${usageAdapter ? "." : "; this client has no usage adapter, so usage will be unavailable."}`
         : `Slop receipt doctor failed: exact ccusage@${CCUSAGE_VERSION} could not be executed.`,
     },
     options.json,
@@ -2225,7 +2271,7 @@ function statusRun(options) {
 function startRun(options, testOptions) {
   const provenance = resolveSkillProvenance();
   const repositoryRoot = requireRepository(options.repoRoot);
-  const usageAdapter = PROJECT.usageAdapters[options.client] ?? null;
+  const usageAdapter = usageAdapterFor(options.client);
   const runId = createRunId();
   const state = validateActiveRecord({
     schemaVersion: "2",
@@ -2238,7 +2284,9 @@ function startRun(options, testOptions) {
     model: options.model,
     lane: options.lane,
     startedAt: canonicalIso(),
-    baseline: collectUsage(options.client, repositoryRoot),
+    baseline: options.usageUnavailable
+      ? null
+      : collectUsage(options.client, repositoryRoot),
     policyAcknowledgement: projectPolicyPreflight(testOptions),
     ...provenance,
   });
@@ -2249,7 +2297,9 @@ function startRun(options, testOptions) {
       runId,
       message: `Project run started. Keep this id: ${runId}`,
       usageStatus:
-        usageAdapter === null
+        options.usageUnavailable
+          ? "unavailable"
+          : usageAdapter === null
           ? "unsupported"
           : state.baseline === null
             ? "unavailable"
@@ -2363,13 +2413,15 @@ function finishRun(options, testOptions) {
   if (Date.parse(completedAt) + CLOCK_SKEW_MS < Date.parse(state.startedAt)) {
     fail("system clock moved backward during the run");
   }
-  const usage = PROJECT.usageAdapters[options.client]
-    ? usageDelta(
-        state.baseline,
-        collectUsage(options.client, repositoryRoot),
-        options.client,
-      )
-    : unavailableUsage("none");
+  const usage = options.usageUnavailable
+    ? unavailableUsage()
+    : usageAdapterFor(options.client)
+      ? usageDelta(
+          state.baseline,
+          collectUsage(options.client, repositoryRoot),
+          options.client,
+        )
+      : unavailableUsage("none");
   const key = deviceKey();
   const trajectorySha256 = trajectoryDigest(options.trajectory);
   const currentPolicy = projectPolicyPreflight(testOptions);

--- a/skills/contribute-to-heir-elements-sdk/SKILL.md
+++ b/skills/contribute-to-heir-elements-sdk/SKILL.md
@@ -87,6 +87,14 @@ clients continue with usage marked unavailable and omit
 `--allow-package-execution`. The receipt records a non-secret baseline and
 creates a local Ed25519 device key only when the run finishes.
 
+If the operator does not authorize package execution, use
+`--usage-unavailable` instead of `--allow-package-execution` for `doctor`,
+`start`, and `finish`; also omit `--allow-local-usage` from `start`. This mode
+invokes no package manager, reads no usage logs, records signed
+zero/unavailable usage, and forfeits the usage evidence bonus. Policy preflight
+and trace networking still run. Because receipts bind the exact skill revision,
+restart any active run created before this option was installed.
+
 6. Build the bounded, read-only inventory of live work before choosing:
 
 ```bash
@@ -218,6 +226,9 @@ node <skill-directory>/scripts/run-receipt.mjs finish \
   --run <run-id> --allow-package-execution --trajectory <path> \
   --trace-server-run <server-run-id> --trace-object-id sha256:<digest>
 ```
+
+For an unavailable-mode run, replace `--allow-package-execution` with
+`--usage-unavailable`.
 
 The command prints the exact footer. Append it unchanged to the final PR body,
 review, or issue comment that carries the contribution. The hidden Slop marker

--- a/skills/contribute-to-heir-elements-sdk/SKILL.md
+++ b/skills/contribute-to-heir-elements-sdk/SKILL.md
@@ -90,8 +90,9 @@ creates a local Ed25519 device key only when the run finishes.
 If the operator does not authorize package execution, use
 `--usage-unavailable` instead of `--allow-package-execution` for `doctor`,
 `start`, and `finish`; also omit `--allow-local-usage` from `start`. This mode
-invokes no package manager, reads no usage logs, records signed
-zero/unavailable usage, and forfeits the usage evidence bonus. Policy preflight
+invokes no package manager, reads no usage logs, and records signed
+zero/unavailable usage. Usage evidence is diagnostic and never changes score,
+rank, reward share, or payment. Policy preflight
 and trace networking still run. Because receipts bind the exact skill revision,
 restart any active run created before this option was installed.
 

--- a/skills/contribute-to-heir-elements-sdk/scripts/run-receipt.mjs
+++ b/skills/contribute-to-heir-elements-sdk/scripts/run-receipt.mjs
@@ -2065,9 +2065,7 @@ function parseArguments(args) {
       "finish requires finalized --trace-server-run and --trace-object-id evidence",
     );
   }
-  const measuredAction = ["doctor", "finish", "start"].includes(
-    options.action,
-  );
+  const measuredAction = ["doctor", "finish", "start"].includes(options.action);
   const usageAdapter = usageAdapterFor(options.client);
   if (options.allowPackageExecution && options.usageUnavailable) {
     fail(
@@ -2296,10 +2294,9 @@ function startRun(options, testOptions) {
     {
       runId,
       message: `Project run started. Keep this id: ${runId}`,
-      usageStatus:
-        options.usageUnavailable
-          ? "unavailable"
-          : usageAdapter === null
+      usageStatus: options.usageUnavailable
+        ? "unavailable"
+        : usageAdapter === null
           ? "unsupported"
           : state.baseline === null
             ? "unavailable"

--- a/skills/contribute-to-heir-elements-sdk/scripts/run-receipt.mjs
+++ b/skills/contribute-to-heir-elements-sdk/scripts/run-receipt.mjs
@@ -113,7 +113,7 @@ For a configured usage adapter, doctor, start, and finish require exactly one:
   --usage-unavailable       Skip package execution and all usage-log reads
 
 Measured starts also require --allow-local-usage after preview. Unavailable
-starts omit it and produce a signed zero-usage receipt without the usage bonus.
+starts omit it and produce a signed zero-usage receipt; usage never affects scoring.
 `;
 
 function fail(message) {
@@ -2169,7 +2169,7 @@ function previewRun(options) {
     packageExecutionConsentFlag: "--allow-package-execution",
     usageUnavailableFlag: "--usage-unavailable",
     usageReadDisclosure:
-      "--usage-unavailable invokes no package manager and reads no usage logs, but policy checks and trace networking remain; it records signed zero/unavailable usage and forfeits the usage evidence bonus.",
+      "--usage-unavailable invokes no package manager and reads no usage logs, but policy checks and trace networking remain; it records signed zero/unavailable usage, and usage never affects scoring.",
     localStateDisclosure:
       "Active baselines retain aggregate counters and SHA-256 session identifiers until finish.",
     linkabilityDisclosure:

--- a/skills/contribute-to-heir-elements-sdk/scripts/run-receipt.mjs
+++ b/skills/contribute-to-heir-elements-sdk/scripts/run-receipt.mjs
@@ -91,7 +91,7 @@ Commands:
   preview  Show local reads, writes, network access, and public receipt fields
   doctor   Verify repository, skill provenance, declarations, and local runners
   status   List this project's local active and completed measured runs
-  start    Capture a local ccusage baseline after explicit usage consent
+  start    Capture a local ccusage baseline or record usage as unavailable
   trace    Permanently upload this run's private trace and finalize it
   finish   Close a measured run and print its device-signed GitHub footer
 
@@ -103,13 +103,17 @@ Common options:
   --client-version <version>  Exact declared agent/client version
   --json              Emit machine-readable JSON
 
-Start and finish also require --lane <public-lane>. Start requires
---allow-local-usage after preview. Finish requires --run <run-id> and accepts
-a required --trajectory <path>, --trace-server-run <id>, and
---trace-object-id sha256:<digest> returned by the finalized private Slop trace
-upload. Publish only this upload evidence and digest. Supported usage adapters
-also require --allow-package-execution after preview because package-manager
-resolution may fetch code and write caches.
+Start and finish also require --lane <public-lane>. Finish requires --run
+<run-id> and accepts a required --trajectory <path>, --trace-server-run <id>,
+and --trace-object-id sha256:<digest> returned by the finalized private Slop
+trace upload. Publish only this upload evidence and digest.
+
+For a configured usage adapter, doctor, start, and finish require exactly one:
+  --allow-package-execution  Resolve the pinned adapter and measure usage
+  --usage-unavailable       Skip package execution and all usage-log reads
+
+Measured starts also require --allow-local-usage after preview. Unavailable
+starts omit it and produce a signed zero-usage receipt without the usage bonus.
 `;
 
 function fail(message) {
@@ -432,6 +436,12 @@ function unavailableUsage(source = "ccusage-session-v20") {
   };
 }
 
+function usageAdapterFor(client) {
+  return Object.hasOwn(PROJECT.usageAdapters, client)
+    ? PROJECT.usageAdapters[client]
+    : null;
+}
+
 function commandExists(command, executionRoot) {
   return (
     spawnSync(command, ["--version"], {
@@ -548,7 +558,7 @@ function inspectCcusageRunner() {
 }
 
 function collectUsage(client, repositoryRoot) {
-  const ccusageSource = PROJECT.usageAdapters[client];
+  const ccusageSource = usageAdapterFor(client);
   if (!ccusageSource) return null;
   return withPackageExecution((executionRoot) => {
     for (const runner of ccusageRunners(executionRoot)) {
@@ -1904,6 +1914,7 @@ function parseArguments(args) {
     traceObjectId: null,
     traceServerRun: null,
     trajectory: null,
+    usageUnavailable: false,
   };
   for (let index = 1; index < args.length; index += 1) {
     const argument = args[index];
@@ -1912,6 +1923,8 @@ function parseArguments(args) {
     if (argument === "--json") options.json = true;
     else if (argument === "--allow-package-execution") {
       options.allowPackageExecution = true;
+    } else if (argument === "--usage-unavailable") {
+      options.usageUnavailable = true;
     } else if (argument === "--allow-local-usage") {
       options.allowLocalUsage = true;
     } else if (
@@ -1964,6 +1977,7 @@ function parseArguments(args) {
       "--model",
       "--provider",
       "--repo-root",
+      "--usage-unavailable",
     ]),
     finish: new Set([
       "--allow-package-execution",
@@ -1977,6 +1991,7 @@ function parseArguments(args) {
       "--trace-object-id",
       "--trace-server-run",
       "--trajectory",
+      "--usage-unavailable",
     ]),
     help: new Set(),
     preview: new Set(["--client", "--json", "--repo-root"]),
@@ -1989,6 +2004,7 @@ function parseArguments(args) {
       "--model",
       "--provider",
       "--repo-root",
+      "--usage-unavailable",
     ]),
     status: new Set(["--json"]),
     trace: new Set([
@@ -2049,31 +2065,51 @@ function parseArguments(args) {
       "finish requires finalized --trace-server-run and --trace-object-id evidence",
     );
   }
-  if (options.action === "start" && !options.allowLocalUsage) {
+  const measuredAction = ["doctor", "finish", "start"].includes(
+    options.action,
+  );
+  const usageAdapter = usageAdapterFor(options.client);
+  if (options.allowPackageExecution && options.usageUnavailable) {
+    fail(
+      "choose exactly one of --allow-package-execution or --usage-unavailable",
+    );
+  }
+  if (
+    measuredAction &&
+    usageAdapter &&
+    !options.allowPackageExecution &&
+    !options.usageUnavailable
+  ) {
+    fail(
+      `${options.action} requires exactly one of --allow-package-execution or --usage-unavailable after reviewing the preview output`,
+    );
+  }
+  if ((!measuredAction || !usageAdapter) && options.allowPackageExecution) {
+    fail(
+      "--allow-package-execution is valid only for a supported usage adapter",
+    );
+  }
+  if ((!measuredAction || !usageAdapter) && options.usageUnavailable) {
+    fail("--usage-unavailable is valid only for a supported usage adapter");
+  }
+  if (
+    options.action === "start" &&
+    !options.usageUnavailable &&
+    !options.allowLocalUsage
+  ) {
     fail(
       "start requires --allow-local-usage after reviewing the preview output",
     );
   }
+  if (
+    options.action === "start" &&
+    options.usageUnavailable &&
+    options.allowLocalUsage
+  ) {
+    fail("--allow-local-usage is not valid with --usage-unavailable");
+  }
   if (options.action !== "start" && options.allowLocalUsage) {
     fail("--allow-local-usage is valid only with start");
-  }
-  if (
-    ["doctor", "finish", "start"].includes(options.action) &&
-    PROJECT.usageAdapters[options.client] &&
-    !options.allowPackageExecution
-  ) {
-    fail(
-      `${options.action} requires --allow-package-execution after reviewing the preview output`,
-    );
-  }
-  if (
-    (!["doctor", "finish", "start"].includes(options.action) ||
-      !PROJECT.usageAdapters[options.client]) &&
-    options.allowPackageExecution
-  ) {
-    fail(
-      "--allow-package-execution is valid only for a supported usage adapter",
-    );
   }
   return options;
 }
@@ -2088,7 +2124,7 @@ function previewRun(options) {
   const provenance = resolveSkillProvenance();
   const repositoryRoot = requireRepository(options.repoRoot);
   const stateRoot = configurationRoot();
-  const usageAdapter = PROJECT.usageAdapters[options.client] ?? null;
+  const usageAdapter = usageAdapterFor(options.client);
   const result = {
     projectId: PROJECT.projectId,
     repositoryId: PROJECT.repositoryId,
@@ -2106,10 +2142,11 @@ function previewRun(options) {
       join(stateRoot, "device-ed25519.pem"),
     ],
     packageManagerCacheWrites: [
-      "Bun or npm package cache and diagnostic logs during doctor/start/finish",
+      "Bun or npm package cache and diagnostic logs only with --allow-package-execution; none with --usage-unavailable",
     ],
     network: [
-      `Resolve exact ccusage@${CCUSAGE_VERSION} during doctor and measured runs; fetch it from the package registry only when it is not already cached`,
+      `With --allow-package-execution, resolve exact ccusage@${CCUSAGE_VERSION} during doctor and measured runs; fetch it from the package registry only when it is not already cached`,
+      `On start and finish, fetch current project terms from https://slop.cash/projects/${PROJECT.projectId}/terms.json and any digest-bound LICENSE, inbound terms, or prize rules from github.com, raw.githubusercontent.com, or proximityprize.org as named by that policy`,
       `Verify the public private-request intake gate at ${PRIVATE_REQUEST_INTAKE_STATUS}; trace upload remains blocked unless it reports enabled`,
       `After a local byte/digest disclosure, authenticate with GitHub and permanently upload the inspected trace through ${TRACE_AUTHORITY} under ${TRACE_PRIVACY_CONTRACT}`,
     ],
@@ -2132,6 +2169,9 @@ function previewRun(options) {
     ],
     consentFlag: "--allow-local-usage",
     packageExecutionConsentFlag: "--allow-package-execution",
+    usageUnavailableFlag: "--usage-unavailable",
+    usageReadDisclosure:
+      "--usage-unavailable invokes no package manager and reads no usage logs, but policy checks and trace networking remain; it records signed zero/unavailable usage and forfeits the usage evidence bonus.",
     localStateDisclosure:
       "Active baselines retain aggregate counters and SHA-256 session identifiers until finish.",
     linkabilityDisclosure:
@@ -2147,8 +2187,8 @@ function previewRun(options) {
         `Local usage reads: ${result.localReads.join(", ") || "none; this client has no usage adapter"}`,
         `Local state: ${stateRoot}`,
         "Automatic uploads: none.",
-        `Doctor only after consent with ${result.packageExecutionConsentFlag}.`,
-        `Start only after consent with ${result.consentFlag}.`,
+        `For configured adapters, choose ${result.packageExecutionConsentFlag} or ${result.usageUnavailableFlag}.`,
+        `Measured starts require ${result.consentFlag}; unavailable starts omit it.`,
       ].join("\n"),
     },
     options.json,
@@ -2158,12 +2198,16 @@ function previewRun(options) {
 function doctorRun(options) {
   const provenance = resolveSkillProvenance();
   const repositoryRoot = requireRepository(options.repoRoot);
-  const usageAdapter = PROJECT.usageAdapters[options.client] ?? null;
-  const probe = usageAdapter
-    ? inspectCcusageRunner()
-    : { runner: null, status: "unsupported", version: null };
+  const usageAdapter = usageAdapterFor(options.client);
+  const probe = options.usageUnavailable
+    ? { runner: null, status: "intentional-unavailable", version: null }
+    : usageAdapter
+      ? inspectCcusageRunner()
+      : { runner: null, status: "unsupported", version: null };
   const result = {
-    ok: probe.status === "available" || probe.status === "unsupported",
+    ok: ["available", "intentional-unavailable", "unsupported"].includes(
+      probe.status,
+    ),
     projectId: PROJECT.projectId,
     repositoryId: PROJECT.repositoryId,
     repositoryRoot,
@@ -2186,7 +2230,9 @@ function doctorRun(options) {
     {
       ...result,
       message: result.ok
-        ? `Slop receipt doctor passed for ${result.repositoryId}; no usage logs were read${usageAdapter ? "." : "; this client has no usage adapter, so usage will be unavailable."}`
+        ? options.usageUnavailable
+          ? `Slop receipt doctor passed for ${result.repositoryId}; package execution and local usage-log reads are disabled, so usage will be unavailable.`
+          : `Slop receipt doctor passed for ${result.repositoryId}; no usage logs were read${usageAdapter ? "." : "; this client has no usage adapter, so usage will be unavailable."}`
         : `Slop receipt doctor failed: exact ccusage@${CCUSAGE_VERSION} could not be executed.`,
     },
     options.json,
@@ -2225,7 +2271,7 @@ function statusRun(options) {
 function startRun(options, testOptions) {
   const provenance = resolveSkillProvenance();
   const repositoryRoot = requireRepository(options.repoRoot);
-  const usageAdapter = PROJECT.usageAdapters[options.client] ?? null;
+  const usageAdapter = usageAdapterFor(options.client);
   const runId = createRunId();
   const state = validateActiveRecord({
     schemaVersion: "2",
@@ -2238,7 +2284,9 @@ function startRun(options, testOptions) {
     model: options.model,
     lane: options.lane,
     startedAt: canonicalIso(),
-    baseline: collectUsage(options.client, repositoryRoot),
+    baseline: options.usageUnavailable
+      ? null
+      : collectUsage(options.client, repositoryRoot),
     policyAcknowledgement: projectPolicyPreflight(testOptions),
     ...provenance,
   });
@@ -2249,7 +2297,9 @@ function startRun(options, testOptions) {
       runId,
       message: `Project run started. Keep this id: ${runId}`,
       usageStatus:
-        usageAdapter === null
+        options.usageUnavailable
+          ? "unavailable"
+          : usageAdapter === null
           ? "unsupported"
           : state.baseline === null
             ? "unavailable"
@@ -2363,13 +2413,15 @@ function finishRun(options, testOptions) {
   if (Date.parse(completedAt) + CLOCK_SKEW_MS < Date.parse(state.startedAt)) {
     fail("system clock moved backward during the run");
   }
-  const usage = PROJECT.usageAdapters[options.client]
-    ? usageDelta(
-        state.baseline,
-        collectUsage(options.client, repositoryRoot),
-        options.client,
-      )
-    : unavailableUsage("none");
+  const usage = options.usageUnavailable
+    ? unavailableUsage()
+    : usageAdapterFor(options.client)
+      ? usageDelta(
+          state.baseline,
+          collectUsage(options.client, repositoryRoot),
+          options.client,
+        )
+      : unavailableUsage("none");
   const key = deviceKey();
   const trajectorySha256 = trajectoryDigest(options.trajectory);
   const currentPolicy = projectPolicyPreflight(testOptions);


### PR DESCRIPTION
## Summary

- add an explicit `--usage-unavailable` mode for `doctor`, `start`, and
  `finish` when a client has a configured usage adapter
- skip package-runner probes and usage-log reads in that mode, then sign an
  honest zero/unavailable usage record without the usage evidence bonus
- disclose that policy checks and trace networking still apply, and document
  that runs created under an older skill revision must be restarted
- reject inherited object keys as adapter names and keep all four packaged
  receipt CLIs byte-identical

This gives operators a supported path when they do not authorize external
package execution. It does not weaken receipt provenance or retroactively
rescue runs started under an older skill revision.

Closes #188.

## Validation

- `bun test ./skill-tests` — 82 passed, 0 failed in an already-local,
  read-only, capability-dropped Docker image with networking disabled
- `node --check skills/contribute-to-asi/scripts/run-receipt.mjs` — passed
- `git diff --check` — passed
- `shasum -a 256 skills/contribute-to-{asi,eliza,delta-star,heir-elements-sdk}/scripts/run-receipt.mjs`
  — all four files produced the same SHA-256

The adversarial receipt fixture logs every `bun` and `npx` invocation. It
proves that unavailable-mode doctor/start/finish and a conservative finish from
a non-null baseline leave both runner logs unchanged.

## Evidence

- Before screenshots: N/A - command-line receipt behavior has no visual UI.
- After screenshots: N/A - command-line receipt behavior has no visual UI.
- Walkthrough video: N/A - deterministic tests cover the complete changed path.
- Backend logs: N/A - no deployed backend changed.
- Frontend console/network logs: N/A - no frontend changed.
- Real-LLM trajectory: N/A - no model-behavior claim is made.
- Domain artifacts: N/A - deterministic receipt and contract tests are the
  relevant proof and are listed under Validation.

## Contribution provenance

- AI assistance: Yes - implementation, test drafting, and review under human
  direction.
- AI provider/model: OpenAI / gpt-5.6-sol
- Client / agent tooling: Codex
- Contribution skill revision: N/A - direct repository maintenance; no project
  contribution skill was used.
- Attribution status: self-reported

## Slop protocol changes

- Contributor skill (`skills/contribute-to-<id>/`): updates the four registered
  contributor skills and their byte-identical receipt CLIs.

## Safety review

- [x] No private key, seed phrase, API token, raw private trajectory, or secret was added.
- [x] Untrusted project code is not executed with repository or deployment credentials.
- [x] New telemetry is bounded, disclosed, project-attributed, and covered by adversarial tests.
- [x] Money state is derived from validated manifests and finalized on-chain evidence, not a transaction signature alone.
