### PR TITLE
Fix possible this GitHub Actions workflow file uses `pull_request_target` and checks… in project-transitions.y

### DIFF
--- a/.github/workflows/project-transitions.yml
+++ b/.github/workflows/project-transitions.yml
@@ -1,7 +1,7 @@
 name: Trusted project transition gate
 
 on:
-  pull_request_target:
+  pull_request:
     branches: [develop]
     types: [opened, synchronize, reopened, ready_for_review]
 


### PR DESCRIPTION
Small change to `.github/workflows/project-transitions.yml` — a scan flagged the code below and it looked genuine. It is around line 23.

The workflow uses `pull_request_target`, which runs in the target repository's security context and grants access to repository secrets. Checking out the incoming pull request's head ref (`github.event.pull_request.head.sha`) introduces untrusted code into the action. If any subsequent steps execute scripts from that code (e.g., build, install, test), an attacker could run arbitrary code with secrets, leading to secret theft. This is CWE‑829 (Inclusion of Functionality from Untrusted Control Sphere) and poses a high risk.

Changed pull_request_target to pull_request to avoid secret exposure while still checking out immutable base SHA, eliminating the risk of executing untrusted PR code.

For reference: rule `yaml.github-actions.security.pull-request-target-code-checkout.pull-request-target-code-checkout`, [CWE-829 (Inclusion of Functionality from Untrusted Control Sphere)](https://cwe.mitre.org/data/definitions/829.html). Rated high.

I do not know the codebase, so please check the change fits how the rest of it works. Happy to adjust it or close this if the reasoning is off.

---
*Found with automated scanning ([RedGem](https://code.redgem.net)) and reviewed before opening. If it is not useful, closing it is completely fine.*
