### PR TITLE
fix: use Bun portable package runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,10 +37,10 @@
     "test:e2e": "node scripts/run-e2e.mjs",
     "test:e2e:record": "node scripts/record-evidence.mjs --local",
     "test:e2e:record:production": "node scripts/record-evidence.mjs --production",
-    "lint": "bunx @biomejs/biome check --write --unsafe .",
-    "lint:check": "bunx @biomejs/biome check .",
-    "format": "bunx @biomejs/biome format --write .",
-    "format:check": "bunx @biomejs/biome format .",
+    "lint": "bun x @biomejs/biome check --write --unsafe .",
+    "lint:check": "bun x @biomejs/biome check .",
+    "format": "bun x @biomejs/biome format --write .",
+    "format:check": "bun x @biomejs/biome format .",
     "clean": "node scripts/rm-path-recursive.mjs dist"
   },
   "dependencies": {

--- a/scripts/tooling-contract.test.mjs
+++ b/scripts/tooling-contract.test.mjs
@@ -1,8 +1,9 @@
-import { describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
 
-const packageRoot = join(import.meta.dir, "..");
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 const packageJson = JSON.parse(
   readFileSync(join(packageRoot, "package.json"), "utf8"),
 );

--- a/scripts/tooling-contract.test.mjs
+++ b/scripts/tooling-contract.test.mjs
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const packageRoot = join(import.meta.dir, "..");
+const packageJson = JSON.parse(
+  readFileSync(join(packageRoot, "package.json"), "utf8"),
+);
+
+describe("repository tooling contract", () => {
+  it("runs Biome through Bun's portable package runner", () => {
+    for (const scriptName of ["format", "format:check", "lint", "lint:check"]) {
+      const command = packageJson.scripts[scriptName];
+      expect(command).toMatch(/^bun x @biomejs\/biome\b/);
+      expect(command).not.toMatch(/\bbunx\b/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- replace the standalone `bunx` shim in formatting and lint scripts with Bun’s portable `bun x` form
- add a repository tooling contract test covering all four scripts

Closes #187.

## Validation

- `bun test scripts/tooling-contract.test.mjs`
- `bun run format:check`
- `bun run lint:check`
- `bun run typecheck`
- `git diff --check`

## Evidence

- UI/browser evidence: N/A - package-runner commands only; no product UI changed.
- AI assistance: OpenAI / GPT-5 / Codex.
- Contribution skill: N/A - direct repository maintenance.