### PR TITLE
Keep usage diagnostic and harden receipt activation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,9 +114,9 @@ Every project-skill contribution carries a
 timestamps, exact provider/model/client, skill revision and digest, aggregate
 pinned-ccusage figures, the private trace digest and upload identity, and an
 Ed25519 device signature. A device signature proves byte continuity—not
-provider billing truth. Raw token volume never changes score. A finalized
-private trace adds a fixed 15% evidence bonus and outcome-matched exact or
-bounded usage adds 10%, capped at 25% combined.
+provider billing truth. Token evidence is diagnostic and never changes score,
+rank, share, or payment. A finalized private trace adds a fixed 15% evidence
+bonus.
 
 ## Private traces
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,9 +114,9 @@ Every project-skill contribution carries a
 timestamps, exact provider/model/client, skill revision and digest, aggregate
 pinned-ccusage figures, the private trace digest and upload identity, and an
 Ed25519 device signature. A device signature proves byte continuity—not
-provider billing truth. Raw token volume never changes score. A finalized
-private trace adds a fixed 15% evidence bonus and outcome-matched exact or
-bounded usage adds 10%, capped at 25% combined.
+provider billing truth. Token evidence is diagnostic and never changes score,
+rank, share, or payment. A finalized private trace adds a fixed 15% evidence
+bonus.
 
 ## Private traces
 

--- a/README.md
+++ b/README.md
@@ -88,9 +88,10 @@ full review checklist, see [CONTRIBUTING.md](CONTRIBUTING.md).
 Accepted work from August 2026 uses integer-thirds effort tiers instead of
 account caps or diminishing merge credit. Claude review agents propose effort,
 complexity, impact, review load, and logical work-unit grouping; maintainers
-ratify the score in an immutable exact-head GitHub record. Valid private traces
-and outcome-matched bounded usage receive fixed evidence bonuses, never a bonus
-proportional to raw tokens. See [the complete score contract](protocol/scoring-v2.md).
+ratify the score in an immutable exact-head GitHub record. A valid finalized
+private trace receives a fixed evidence bonus. Usage remains diagnostic and
+never changes score, rank, reward share, or payment. See
+[the complete score contract](protocol/scoring-v2.md).
 
 ## What the public record means
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,7 +21,7 @@ const localServerCommand =
 
 export default defineConfig({
   testDir: "./tests/e2e",
-  timeout: 45_000,
+  timeout: 0,
   expect: { timeout: 10_000 },
   fullyParallel: true,
   // Wrangler's Pages proxy can terminate while serving concurrent browser

--- a/protocol/scoring-v2.md
+++ b/protocol/scoring-v2.md
@@ -40,11 +40,11 @@ private trace. Maintainers remain the sole scoring authority.
 ## Evidence bonuses
 
 A valid signed receipt with an outcome-matched finalized private trace adds a
-fixed 15% weight. Outcome-matched exact or bounded usage adds 10%. The combined
-bonus is capped at 25%; raw tokens, cost, lines, commits, and account count
-never increase it. Missing pre-activation August traces do not reduce base
-credit. Runs after a project's receipt cutover must satisfy its active receipt
-policy or remain held.
+fixed 15% weight. Usage evidence remains diagnostic: token volume, confidence,
+cost, lines, commits, and account count never change score, rank, reward share,
+or payment. Missing pre-activation August traces do not reduce base credit. Runs
+after a project's receipt cutover must satisfy its active receipt policy or
+remain held.
 
 ## August migration
 

--- a/scripts/prepare-site.mjs
+++ b/scripts/prepare-site.mjs
@@ -591,7 +591,7 @@ const manifest = {
   telemetry: {
     source: "ccusage@20.0.20",
     policy:
-      "Every agent run permanently uploads its contributor-inspected, minimized run trace under https://slop.cash/protocol/private-trace-v1.md before submission; the uploader performs no automatic redaction. Public receipts contain aggregate locally reported usage, exact self-reported identity, the required trace digest and upload identity, and a device signature. Fixed evidence bonuses follow https://slop.cash/protocol/scoring-v2.md; raw token volume never changes weight. Unsupported usage adapters never block participation.",
+      "Every agent run permanently uploads its contributor-inspected, minimized run trace under https://slop.cash/protocol/private-trace-v1.md before submission; the uploader performs no automatic redaction. Public receipts contain aggregate locally reported usage, exact self-reported identity, the required trace digest and upload identity, and a device signature. The fixed private-trace evidence bonus follows https://slop.cash/protocol/scoring-v2.md; token usage is diagnostic and never changes score, rank, reward share, or payment. Unsupported usage adapters never block participation.",
   },
 };
 
@@ -866,7 +866,7 @@ function publishAdditionalProject({
     telemetry: {
       source: "ccusage@20.0.20",
       policy:
-        "Every agent run permanently uploads its contributor-inspected, minimized run trace under https://slop.cash/protocol/private-trace-v1.md before submission; the uploader performs no automatic redaction. Public receipts contain only aggregate locally reported usage, exact self-reported identity, the required trace digest and upload identity, and a device signature. Fixed evidence bonuses follow https://slop.cash/protocol/scoring-v2.md; raw token volume never changes weight. Unsupported usage adapters never block participation.",
+        "Every agent run permanently uploads its contributor-inspected, minimized run trace under https://slop.cash/protocol/private-trace-v1.md before submission; the uploader performs no automatic redaction. Public receipts contain only aggregate locally reported usage, exact self-reported identity, the required trace digest and upload identity, and a device signature. The fixed private-trace evidence bonus follows https://slop.cash/protocol/scoring-v2.md; token usage is diagnostic and never changes score, rank, reward share, or payment. Unsupported usage adapters never block participation.",
     },
     ...(publicationPrefix
       ? {

--- a/scripts/prepare-site.test.ts
+++ b/scripts/prepare-site.test.ts
@@ -362,7 +362,7 @@ beforeAll(() => {
       },
     },
   });
-}, 120_000);
+});
 
 afterAll(() => {
   if (authorityRoot) {
@@ -1154,7 +1154,7 @@ describe("contribution skill package", () => {
       rmSync(defaultRoot, { force: true, recursive: true });
       rmSync(claudeRoot, { force: true, recursive: true });
     }
-  }, 30_000);
+  });
 
   it("rejects unsafe archive paths, symlinks, and broken target symlinks", () => {
     const traversalRoot = mkdtempSync(

--- a/scripts/sync-funding-index.test.ts
+++ b/scripts/sync-funding-index.test.ts
@@ -61,7 +61,7 @@ describe("funding manifest history", () => {
     expect(() =>
       fundingAddressesAtRevision("eliza", "f".repeat(40), root),
     ).toThrow(/not an ancestor/u);
-  }, 15_000);
+  });
 
   it("publishes commitments separately and bounds committed claims", async () => {
     const root = mkdtempSync(join(tmpdir(), "slop-funding-commitment-"));
@@ -175,5 +175,5 @@ describe("funding manifest history", () => {
         projects: [withoutInstrument],
       }),
     ).rejects.toThrow(/not active/u);
-  }, 15_000);
+  });
 });

--- a/skills/contribute-to-asi/SKILL.md
+++ b/skills/contribute-to-asi/SKILL.md
@@ -17,8 +17,8 @@ maintainers review allocations and the projection is not a payment promise.
 Any model and agent client may contribute, including Grok and Kimi. Declare the
 exact provider, model, and client used; never infer or substitute them. Model
 choice and raw token volume never change score or payout. A valid finalized
-private trace earns a fixed 15% evidence bonus and outcome-matched exact or
-bounded usage earns 10%, capped at 25% combined.
+private trace earns a fixed 15% evidence bonus. Usage evidence is diagnostic
+and never changes score, rank, reward share, or payment.
 
 ## Start every run
 

--- a/skills/contribute-to-delta-star/SKILL.md
+++ b/skills/contribute-to-delta-star/SKILL.md
@@ -13,8 +13,8 @@ the prize, guarantee eligibility, or promise a dollar amount.
 Any model and agent client may contribute, including Grok and Kimi. Declare the
 exact provider, model, and client used; never infer or substitute them. Model
 choice and raw token volume never change score or share. A valid finalized
-private trace earns a fixed 15% evidence bonus and outcome-matched exact or
-bounded usage earns 10%, capped at 25% combined.
+private trace earns a fixed 15% evidence bonus. Usage evidence is diagnostic
+and never changes score, rank, reward share, or payment.
 
 ## Start every run
 
@@ -213,8 +213,8 @@ For an unavailable-mode run, replace `--allow-package-execution` with
 Append the emitted footer unchanged to the final PR body, review, or issue
 comment. The Slop marker must remain the final line. Its ccusage totals are
 diagnostic in amount: raw token volume cannot add weight. A valid finalized
-private trace earns a fixed 15% evidence bonus and outcome-matched exact or
-bounded usage earns 10%, capped at 25% combined. The
+private trace earns a fixed 15% evidence bonus. Usage evidence is diagnostic
+and never changes score, rank, reward share, or payment. The
 device signature proves byte integrity and device continuity, not mathematical
 correctness, log truth, account ownership, actual subscription cost, external
 prize eligibility, or payout.

--- a/skills/contribute-to-eliza/SKILL.md
+++ b/skills/contribute-to-eliza/SKILL.md
@@ -12,8 +12,8 @@ the projection is not a payment promise, and token volume alone never earns.
 Any model and agent client may contribute, including Grok and Kimi. Declare the
 exact provider, model, and client used; never infer or substitute them. Model
 choice and raw token volume never change score or payout. A valid finalized
-private trace earns a fixed 15% evidence bonus and outcome-matched exact or
-bounded usage earns 10%, capped at 25% combined.
+private trace earns a fixed 15% evidence bonus. Usage evidence is diagnostic
+and never changes score, rank, reward share, or payment.
 
 ## Start every run
 

--- a/skills/contribute-to-heir-elements-sdk/SKILL.md
+++ b/skills/contribute-to-heir-elements-sdk/SKILL.md
@@ -17,8 +17,8 @@ alone never earns. A receipt cannot create score.
 Any model and agent client may contribute, including Grok and Kimi. Declare the
 exact provider, model, and client used; never infer or substitute them. Model
 choice and raw token volume never change score or payout. A valid finalized
-private trace earns a fixed 15% evidence bonus and outcome-matched exact or
-bounded usage earns 10%, capped at 25% combined.
+private trace earns a fixed 15% evidence bonus. Usage evidence is diagnostic
+and never changes score, rank, reward share, or payment.
 
 ## Start every run
 

--- a/src/lib/leaderboard.test.ts
+++ b/src/lib/leaderboard.test.ts
@@ -600,6 +600,17 @@ describe("score v2 work units", () => {
         provider: "openai",
         model: "gpt-5.6-sol",
         client: "codex",
+        usage: {
+          source: "ccusage-session-v20",
+          confidence: "exact",
+          inputTokens: 900_000,
+          outputTokens: 100_000,
+          cacheCreationTokens: 0,
+          cacheReadTokens: 0,
+          totalTokens: 1_000_000,
+          costMicroUsd: "5000000",
+          sessionCount: 1,
+        },
       },
       {
         schemaVersion: "2",
@@ -676,8 +687,11 @@ describe("score v2 work units", () => {
       updatedAt: "2026-08-18T02:30:00.000Z",
       authorAssociation: "MEMBER",
     });
+    const postUsageBonusInput = v2Input([pr]);
+    postUsageBonusInput.generatedAt = "2026-08-19T00:01:00.000Z";
+    postUsageBonusInput.source.fetchedAt = postUsageBonusInput.generatedAt;
     const accepted = createLeaderboardSnapshot({
-      ...v2Input([pr]),
+      ...postUsageBonusInput,
       verifyRunReceipt: (value) => value as ProjectRunReceipt,
     });
     expect(
@@ -686,6 +700,16 @@ describe("score v2 work units", () => {
       scoreThirds: 3,
       evidenceBonusBasisPoints: 1_500,
     });
+    const legacy = structuredClone(accepted);
+    legacy.generatedAt = "2026-08-18T05:00:00.000Z";
+    legacy.source.fetchedAt = legacy.generatedAt;
+    const legacyReview = legacy.ledger.find(
+      (event) => event.category === "substantive-review",
+    );
+    if (!legacyReview) throw new Error("expected a legacy review fixture");
+    legacyReview.evidenceBonusBasisPoints = 2_500;
+    expect(() => assertLeaderboardSnapshot(legacy)).not.toThrow();
+
     const detached = structuredClone(accepted);
     const detachedReview = detached.ledger.find(
       (event) => event.category === "substantive-review",

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -51,6 +51,7 @@ export const LEADERBOARD_SCHEMA_VERSION = "6" as const;
 export const PROFILE_OPPORTUNITY_LIMIT = 5 as const;
 export const SCORE_RULE_VERSION = "slop-score-v2" as const;
 export const SCORE_V2_EFFECTIVE_AT = "2026-08-01T00:00:00.000Z" as const;
+const USAGE_NEUTRAL_EVIDENCE_POLICY_AT = "2026-08-19T00:00:00.000Z" as const;
 // A 35-day collection window guarantees a complete prior UTC calendar month;
 // project reward views still exclude everything before their reward start.
 export const SCORE_WINDOW_DAYS = 35;
@@ -2988,13 +2989,7 @@ export function createLeaderboardSnapshot(
               declaration.artifactId === pullRequest.id,
           )?.run
         : null;
-      const contributionBonus = contributionRun
-        ? (contributionRun.traceUpload ? 1_500 : 0) +
-          (["exact", "bounded"].includes(contributionRun.usage.confidence) &&
-          contributionRun.usage.totalTokens > 0
-            ? 1_000
-            : 0)
-        : 0;
+      const contributionBonus = contributionRun?.traceUpload ? 1_500 : 0;
       const scored = addScore(entries, ledger, {
         id: `${pullRequest.id}:merged`,
         actor: pullRequest.author,
@@ -3170,11 +3165,7 @@ export function createLeaderboardSnapshot(
           category: "substantive-review",
           points: reviewThirds / 3,
           scoreThirds: reviewThirds,
-          evidenceBonusBasisPoints: ((receipt.traceUpload ? 1_500 : 0) +
-            (["exact", "bounded"].includes(receipt.usage.confidence) &&
-            receipt.usage.totalTokens > 0
-              ? 1_000
-              : 0)) as 0 | 1_000 | 1_500 | 2_500,
+          evidenceBonusBasisPoints: receipt.traceUpload ? 1_500 : 0,
           workUnitId: `${record.workUnitId}_review_${source.author.id.toLowerCase().replace(/[^a-z0-9_-]+/gu, "_")}`,
           occurredAt: source.createdAt,
           repository: repositoryIdFromUrl(pullRequest.url),
@@ -5166,9 +5157,13 @@ export function assertLeaderboardSnapshot(
           attribution.sourceId === event.source.id) &&
         attribution.run !== null,
     )?.run;
+    const legacyUsageBonusPolicy =
+      Date.parse(snapshot.generatedAt) <
+      Date.parse(USAGE_NEUTRAL_EVIDENCE_POLICY_AT);
     const expectedBonus = matchingRun
       ? (matchingRun.traceUpload ? 1_500 : 0) +
-        (["exact", "bounded"].includes(matchingRun.usage.confidence) &&
+        (legacyUsageBonusPolicy &&
+        ["exact", "bounded"].includes(matchingRun.usage.confidence) &&
         matchingRun.usage.totalTokens > 0
           ? 1_000
           : 0)

--- a/src/lib/project-schema.mjs
+++ b/src/lib/project-schema.mjs
@@ -547,6 +547,26 @@ function validateTerms(
     );
   }
   if (receiptPolicy.state === "active") {
+    if (license.state !== "verified" || license.fileSha256 === null) {
+      throw new TypeError(
+        `${field}.receiptPolicy active state requires a verified repository license`,
+      );
+    }
+    if (inbound.mode === "unknown" || inbound.fileSha256 === null) {
+      throw new TypeError(
+        `${field}.receiptPolicy active state requires immutable inbound terms`,
+      );
+    }
+    if (
+      terms.externalPrize !== null &&
+      (terms.externalPrize.rulesSha256 === null ||
+        terms.externalPrize.rulesCapturedAt === null ||
+        terms.externalPrize.version === "unknown")
+    ) {
+      throw new TypeError(
+        `${field}.receiptPolicy active state requires immutable external prize rules`,
+      );
+    }
     const revisions = new Set();
     let previousActivation = -Infinity;
     const bindings = receiptPolicy.bindings.map((value, index) => {

--- a/src/lib/project-schema.test.ts
+++ b/src/lib/project-schema.test.ts
@@ -477,6 +477,85 @@ describe("project proposal schema", () => {
     );
   });
 
+  it("rejects receipt activation before every contributor term is immutable", () => {
+    const missingInbound = structuredClone(deltaStar) as unknown as {
+      terms: {
+        receiptPolicy: unknown;
+        inbound: {
+          acceptance: string | null;
+          commitSha: string | null;
+          fileSha256: string | null;
+          mode: string;
+          termsUrl: string | null;
+          version: string | null;
+        };
+        externalPrize: {
+          rulesCapturedAt: string | null;
+          rulesSha256: string | null;
+          version: string;
+        };
+        repositoryLicense: { fileSha256: string | null; state: string };
+        revision: string;
+      };
+    };
+    missingInbound.terms.receiptPolicy = {
+      state: "active",
+      activatedAt: "2026-08-19T00:00:00.000Z",
+      bindings: [
+        {
+          activatedAt: "2026-08-19T00:00:00.000Z",
+          policyRevision: missingInbound.terms.revision,
+          licenseSha256: missingInbound.terms.repositoryLicense.fileSha256,
+          inboundTermsSha256: null,
+          prizeRulesSha256: null,
+        },
+      ],
+    };
+    expect(() => assertProjectDefinition(missingInbound)).toThrow(
+      /requires immutable inbound terms/u,
+    );
+
+    const missingPrizeRules = structuredClone(missingInbound);
+    const inboundCommit = "e".repeat(40);
+    missingPrizeRules.terms.inbound = {
+      mode: "license",
+      termsUrl: `https://github.com/elizaOS/proximityprize/blob/${inboundCommit}/CONTRIBUTING.md`,
+      commitSha: inboundCommit,
+      fileSha256: "d".repeat(64),
+      version: "2026-08-19.1",
+      acceptance:
+        "Inbound contributions follow the immutable repository terms.",
+    };
+    (
+      missingPrizeRules.terms.receiptPolicy as {
+        bindings: Array<{ inboundTermsSha256: string | null }>;
+      }
+    ).bindings[0].inboundTermsSha256 = "d".repeat(64);
+    expect(() => assertProjectDefinition(missingPrizeRules)).toThrow(
+      /requires immutable external prize rules/u,
+    );
+
+    const missingLicense = structuredClone(heirElements) as unknown as {
+      terms: { receiptPolicy: unknown; revision: string };
+    };
+    missingLicense.terms.receiptPolicy = {
+      state: "active",
+      activatedAt: "2026-08-19T00:00:00.000Z",
+      bindings: [
+        {
+          activatedAt: "2026-08-19T00:00:00.000Z",
+          policyRevision: missingLicense.terms.revision,
+          licenseSha256: "a".repeat(64),
+          inboundTermsSha256: null,
+          prizeRulesSha256: null,
+        },
+      ],
+    };
+    expect(() => assertProjectDefinition(missingLicense)).toThrow(
+      /requires a verified repository license/u,
+    );
+  });
+
   it("keeps a missing repository license explicit without blocking runs", () => {
     expect(assertProjectDefinition(heirElements).status).toBe("paused");
     expect(heirElements.terms.repositoryLicense).toEqual({

--- a/src/lib/project-view.test.ts
+++ b/src/lib/project-view.test.ts
@@ -251,20 +251,20 @@ describe("project views", () => {
     expect(view.leaders[0].adjustedWeight).toBe(240_000);
   });
 
-  it("binds a compute bonus to its exact scored outcome", () => {
+  it("binds a private-trace evidence bonus to its exact scored outcome", () => {
     const snapshot = snapshotFixture();
     const event = snapshot.ledger[0];
     const baseline = createProjectView(snapshot, "eliza", "2026-07");
     event.scoreThirds = event.points * 3;
     event.workUnitId = "wu_eliza_exact_bonus_outcome";
-    event.evidenceBonusBasisPoints = 2_500;
+    event.evidenceBonusBasisPoints = 1_500;
 
     const view = createProjectView(snapshot, "eliza", "2026-07");
     expect(view.leaders[0].adjustedWeight).toBe(
-      baseline.leaders[0].adjustedWeight + event.points * 2_500,
+      baseline.leaders[0].adjustedWeight + event.points * 1_500,
     );
     expect(view.leaders[0].computeBonusBasisPoints).toBe(
-      Math.floor((event.points * 3 * 2_500) / (baseline.leaders[0].score * 3)),
+      Math.floor((event.points * 3 * 1_500) / (baseline.leaders[0].score * 3)),
     );
     expect(view.leaders[0].score).toBe(baseline.leaders[0].score);
     expect(view.leaders[0].adjustedWeight).not.toBe(

--- a/src/lib/project-view.ts
+++ b/src/lib/project-view.ts
@@ -1,8 +1,7 @@
 /**
- * Derives one project's cycle leaderboard, bounded compute evidence, and reward
- * simulation from the canonical GitHub snapshot. Finalized private traces and
- * outcome-matched bounded usage earn a fixed evidence bonus; raw token volume
- * never changes the bonus.
+ * Derives one project's cycle leaderboard, diagnostic compute evidence, and
+ * reward simulation from the canonical GitHub snapshot. A finalized private
+ * trace can earn a fixed evidence bonus; token usage never changes scoring.
  */
 
 import type {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
     // those integration checks contend with one another and hit Vitest's
     // per-test timeout despite passing in isolation.
     fileParallelism: false,
-    hookTimeout: 30_000,
+    hookTimeout: 0,
     setupFiles: ["./tests/setup.ts"],
     testTimeout: 0,
     include: [


### PR DESCRIPTION
## Summary
- remove token-usage bonuses from Score v2 while retaining the fixed 15% finalized private-trace evidence weight
- preserve read compatibility for the already-published pre-cutover August snapshot, while new snapshots reject usage-derived bonuses
- reject contribution-receipt activation until repository license, inbound terms, and any external-prize rules are immutable
- remove finite per-test runner ceilings from Vitest and Playwright; bounded network/assertion waits and CI job runaway protection remain separate

## Verification
- `bun run typecheck`
- `bun run format:check`
- `bun run lint:check`
- 111 focused scoring/project-view/schema tests
- formerly capped archive installer test passes with no test timeout
- full `bun run verify` running on this exact head

## Policy
Automation proposes; maintainers ratify. Usage evidence is diagnostic and never changes score, rank, reward share, or payment. Receipt activation fails closed on unknown mutable contributor terms.