### PR TITLE
Bound release verification stalls

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -158,7 +158,18 @@ jobs:
         run: bun run build
 
       - name: Install Playwright Chromium
-        run: ./node_modules/.bin/playwright install --with-deps chromium
+        run: |
+          set -euo pipefail
+          for attempt in 1 2; do
+            if timeout --signal=TERM 10m ./node_modules/.bin/playwright install --with-deps chromium; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 2 ]; then
+              echo "::error::Playwright Chromium installation failed twice."
+              exit 1
+            fi
+            echo "::warning::Playwright Chromium installation stalled or failed; retrying once."
+          done
 
       - name: Run desktop and mobile browser tests
         run: bun run test:e2e

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,7 +21,7 @@ const localServerCommand =
 
 export default defineConfig({
   testDir: "./tests/e2e",
-  timeout: 0,
+  timeout: 300_000,
   expect: { timeout: 10_000 },
   fullyParallel: true,
   // Wrangler's Pages proxy can terminate while serving concurrent browser

--- a/protocol/scoring-v2.md
+++ b/protocol/scoring-v2.md
@@ -54,6 +54,10 @@ successor records capture higher tiers, holds, exclusions, and work-unit
 grouping. The frozen August snapshot binds this rule version and then enters
 the ordinary 14-day public allocation review.
 
+Usage-derived bonuses shown in provisional snapshots before the
+2026-08-19 00:00:00 UTC cutover are void when August is frozen for settlement;
+the underlying accepted outcome and any finalized private-trace bonus remain.
+
 No KYC is required. Abuse resistance comes from immutable GitHub actor and
 artifact IDs, work-unit grouping, exact-head decisions, public human authority,
 and append-only corrections—not identity documents.

--- a/scripts/deployment-contract.test.mjs
+++ b/scripts/deployment-contract.test.mjs
@@ -287,7 +287,11 @@ describe("slop.cash deployment contract", () => {
     expect(e2eRunner).toContain('"--grep",\n    artifactContract');
     expect(qualityJob).toContain("run: bun run test:e2e");
     expect(qualityJob).toContain(
-      "run: ./node_modules/.bin/playwright install --with-deps chromium",
+      "timeout --signal=TERM 10m ./node_modules/.bin/playwright install --with-deps chromium",
+    );
+    expect(qualityJob).toContain("for attempt in 1 2; do");
+    expect(qualityJob).toContain(
+      "Playwright Chromium installation failed twice.",
     );
     expect(qualityJob).not.toContain("bunx playwright install");
     expect(qualityJob).toContain("bun test ./skill-tests");

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
     // those integration checks contend with one another and hit Vitest's
     // per-test timeout despite passing in isolation.
     fileParallelism: false,
-    hookTimeout: 0,
+    hookTimeout: 300_000,
     setupFiles: ["./tests/setup.ts"],
     testTimeout: 0,
     include: [


### PR DESCRIPTION
## Summary

- cap Playwright tests and Vitest hooks at five minutes instead of consuming the complete 90-minute quality lane on a hang
- bound the Playwright Chromium download to ten minutes per attempt and retry it once
- document that provisional pre-cutover usage bonuses are void at August settlement while accepted outcomes and private-trace bonuses remain

## Why this is separate

PR #196 merged concurrently at `6d9b9dc27945e6278e12aa97e55e03cd92c7fcb3` before these review fixes reached its branch. The immediately preceding trusted `develop` deployment run `32305554128` spent 84 minutes in `Install Playwright Chromium` and was canceled at the job ceiling without producing a browser-tested bundle.

## Verification

- `bun run typecheck`
- `bun run format:check`
- `bun run lint:check`
- `bun test src/lib/leaderboard.test.ts src/lib/project-schema.test.ts src/lib/project-view.test.ts` (111 passed)
- exact-head protected CI required before merge
