### PR TITLE
Keep test runners unlimited

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,7 +21,7 @@ const localServerCommand =
 
 export default defineConfig({
   testDir: "./tests/e2e",
-  timeout: 300_000,
+  timeout: 0,
   expect: { timeout: 10_000 },
   fullyParallel: true,
   // Wrangler's Pages proxy can terminate while serving concurrent browser

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
     // those integration checks contend with one another and hit Vitest's
     // per-test timeout despite passing in isolation.
     fileParallelism: false,
-    hookTimeout: 300_000,
+    hookTimeout: 0,
     setupFiles: ["./tests/setup.ts"],
     testTimeout: 0,
     include: [


### PR DESCRIPTION
## Summary
- restore unlimited Playwright per-test execution
- restore unlimited Vitest hook execution
- retain the bounded/retried Chromium download guard from #197; this change removes only test-runner ceilings

## Verification
- `bun run typecheck`
- `bun run format:check`
- `bun run lint:check`
- `bunx vitest run scripts/deployment-contract.test.mjs scripts/prepare-site.test.ts scripts/sync-funding-index.test.ts` — 26/26 passed in 94.99s

No 60-second or replacement five-minute test ceiling.