### PR TITLE
Prioritize substantive issue completion across skills

### DIFF
--- a/skill-tests/project-skills.test.ts
+++ b/skill-tests/project-skills.test.ts
@@ -122,6 +122,72 @@ describe("project skill contracts", () => {
     assert.match(delta, /does not.*guarantee.*dollar/is);
   });
 
+  it("finishes valid issue queues before new work and rejects trivial output", {
+    timeout: 15_000,
+  }, () => {
+    for (const { project, contributorRoot, reviewerRoot } of projectPackages) {
+      const contributor = readFileSync(
+        join(contributorRoot, "SKILL.md"),
+        "utf8",
+      );
+      const reviewer = readFileSync(join(reviewerRoot, "SKILL.md"), "utf8");
+      const issuePriority = contributor.search(
+        /(?:implement|finish) an existing issue with no PR|finish the oldest[\s\S]{0,180}open issue[\s\S]{0,180}no open PR/iu,
+      );
+      const reviewPriority = contributor.search(
+        /review an existing PR with no review|only when no such issue remains[\s\S]{0,180}review the oldest/iu,
+      );
+
+      assert.ok(
+        issuePriority >= 0,
+        `${project.skill.id} must prioritize an existing issue without a PR`,
+      );
+      assert.ok(
+        reviewPriority > issuePriority,
+        `${project.skill.id} must place unreviewed PRs after uncovered issues`,
+      );
+      assert.match(
+        contributor,
+        /(?:after )?reconciling the old queue|old queue (?:is|has been) reconciled|every older issue and PR is reconciled/iu,
+      );
+      assert.match(
+        contributor,
+        /trivial fixes|trivial work|trivial requests/iu,
+      );
+      assert.match(
+        contributor,
+        /generic ["-]?improvements?|generic-improvement/iu,
+      );
+      assert.match(reviewer, /recommend `reject`[\s\S]{0,220}trivial/iu);
+      assert.match(
+        reviewer,
+        /tests with no\s+demonstrated\s+behavioral risk|tests that prove no meaningful/iu,
+      );
+    }
+
+    const asi = readFileSync(
+      join(root, "skills", "contribute-to-asi", "SKILL.md"),
+      "utf8",
+    );
+    const asiReview = readFileSync(
+      join(root, "skills", "review-asi-contributions", "SKILL.md"),
+      "utf8",
+    );
+    assert.match(
+      asi,
+      /benchmark hill climb[\s\S]*measured port or decisive experimental[\s\S]*actual reproduced/iu,
+    );
+    assert.match(asi, /Do not make random\s+improvements/iu);
+    assert.match(
+      asi,
+      /test that merely looks weak, stale, or flaky is\s+not enough without a reproduced behavioral failure/iu,
+    );
+    assert.match(
+      asiReview,
+      /reproducible benchmark hill climb[\s\S]*actual reproduced/iu,
+    );
+  });
+
   it("ships byte-identical receipt logic with policy derived from the project inventory", () => {
     const [canonicalPackage] = projectPackages;
     const receiptSource = readFileSync(

--- a/skill-tests/project-skills.test.ts
+++ b/skill-tests/project-skills.test.ts
@@ -122,9 +122,7 @@ describe("project skill contracts", () => {
     assert.match(delta, /does not.*guarantee.*dollar/is);
   });
 
-  it("finishes valid issue queues before new work and rejects trivial output", {
-    timeout: 15_000,
-  }, () => {
+  it("finishes valid issue queues before new work and rejects trivial output", () => {
     for (const { project, contributorRoot, reviewerRoot } of projectPackages) {
       const contributor = readFileSync(
         join(contributorRoot, "SKILL.md"),

--- a/skills/contribute-to-asi/SKILL.md
+++ b/skills/contribute-to-asi/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: contribute-to-asi
-description: "Hill-climb the benchmarks in elizaOS/asi, a JAX continual-reinforcement-learning framework, with optional public payout registration. Use when an agent is asked to improve a measured result, port a method from the literature, fix something that corrupts measurement, decisively close a research direction with paired evidence, or register a public Solana payout address."
+description: "Finish mission-aligned open issues in elizaOS/asi, then hill-climb its continual-RL benchmarks, produce measured research advancement, or fix a reproduced bug that corrupts execution or measurement, with optional public payout registration. Do not use for generic improvements, cleanup, or speculative polish."
 ---
 
 # Contribute to ASI
@@ -104,6 +104,40 @@ node <skill-directory>/scripts/live-report.mjs --repo elizaOS/asi
 Re-read the chosen issue, discussion, or pull request immediately before
 acting — someone may already be running your experiment.
 
+## Finish the existing queue before inventing work
+
+Use the live report as a filter, then inspect GitHub directly. Follow this
+priority order without skipping a nonempty higher tier for easier, newer, or
+more interesting work:
+
+1. **Finish an existing issue with no PR.** Choose the oldest bounded,
+   unblocked, unclaimed open issue that fits the measured ASI mission. Confirm
+   no open PR has a closing reference or substantively implements it, then
+   resolve the issue completely with the required paired evidence. An issue
+   asking for cleanup, generic improvement, or unmeasured polish is not made
+   valid merely because it is old; give it an explicit out-of-scope
+   disposition instead of implementing it.
+2. **Review an existing PR with no review.** Only when no qualifying issue is
+   available, independently reproduce the oldest non-draft, unblocked,
+   non-sensitive PR you did not author that lacks a substantive current-head
+   human review and active reviewer. Approve, request changes, repair only when
+   authorized, or recommend closure.
+3. **Advance the research only after the old queue is reconciled.** New work
+   must be a benchmark hill climb, a measured port or decisive experimental
+   advancement/refutation, or a fix for an actual reproduced runtime,
+   harness, metric, validator, or test-system bug. Do not make random
+   improvements, opportunistic refactors, speculative abstractions, cosmetic
+   or trivial fixes, documentation-only edits, or tests with no demonstrated
+   behavioral risk.
+
+The closing-reference check is only a deduplication aid. Re-read linked PRs,
+issue timelines, reviews, and current heads before declaring an issue
+uncovered or a PR unreviewed. Treat incomplete queue data as unknown and stop.
+Do not create an issue or discussion during a self-directed run. A new one
+requires the operator to request that exact write after the existing issue and
+PR queue has been reconciled and the measured mission gate has passed. Route
+security findings privately under repository policy.
+
 ## What counts as work here
 
 Exactly four outcomes. Pick one:
@@ -111,9 +145,11 @@ Exactly four outcomes. Pick one:
 1. **Climb** — beat a recorded baseline on a named benchmark metric.
 2. **Port** — implement a method from the literature and measure it against
    that baseline on this repository's lanes.
-3. **Fix** — repair something that blocks or corrupts measurement: a broken
-   harness, an unsound metric, a failing or flaky test, a validator that
-   accepts what it should reject.
+3. **Fix** — repair an actual reproduced defect that blocks or corrupts
+   execution or measurement: a broken harness, an unsound metric, a validator
+   that accepts what it should reject, or test infrastructure that demonstrably
+   produces false results. A test that merely looks weak, stale, or flaky is
+   not enough without a reproduced behavioral failure.
 4. **Close** — refute a direction decisively enough that nobody spends compute
    on it again, and record it in `NEGATIVE_RESULTS_LEDGER.md`.
 
@@ -199,19 +235,21 @@ Plan line of work itself.
   rather than quietly tuning until it does.
 - A published claim is not evidence for this repository. Nothing enters
   `RESEARCH_STATUS.md` on a citation; it enters on a measurement made here.
-- Bring the idea even when you cannot finish it: open a discussion with the
-  paper, the mechanism, and how it would be measured on a named lane.
+- Do not create a speculative discussion merely because you cannot finish an
+  idea. After the old queue is reconciled, the operator may explicitly
+  authorize a discussion that names the paper, mechanism, and measurement lane.
 
 ## Collaborate in the open
 
-Novel research direction is a conversation, not a surprise pull request.
+Novel research direction is a conversation, not a surprise pull request, but
+it comes only after existing issues and unreviewed PRs are reconciled.
 
-- **Discussions** (`Ideas` category) — propose a direction, a paper worth
-  porting, a benchmark that seems mismeasured, or a result you cannot explain.
-  Use this before large or speculative work so someone else does not spend the
-  same compute.
-- **Issues** — one bounded, measurable piece of work with a named lane, metric,
-  and baseline. This is where a pre-registration lives.
+- **Discussions** (`Ideas` category) — when explicitly authorized after queue
+  reconciliation, propose a direction, a paper worth porting, a benchmark that
+  seems mismeasured, or a result you cannot explain before spending compute.
+- **Issues** — only when explicitly authorized after queue reconciliation, one
+  bounded, measurable piece of work with a named lane, metric, and baseline.
+  This is where a pre-registration lives.
 - **Pull requests** — the change plus its evidence. Link the issue or
   discussion it came from.
 

--- a/skills/contribute-to-asi/agents/openai.yaml
+++ b/skills/contribute-to-asi/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Contribute to ASI"
-  short_description: "Advance and prove accepted continual-RL work in ASI"
-  default_prompt: "Use $contribute-to-asi to deliver and prove one bounded contribution to the ASI continual-reinforcement-learning framework."
+  short_description: "Finish ASI issues, then advance measured research"
+  default_prompt: "Use $contribute-to-asi to finish a mission-aligned open issue first, then pursue a proven hill climb, measured advancement or refutation, or an actual reproduced bug fix—never a random improvement."

--- a/skills/contribute-to-delta-star/SKILL.md
+++ b/skills/contribute-to-delta-star/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: contribute-to-delta-star
-description: "Advance, test, refute, or independently review machine-checked work in elizaOS/proximityprize's Delta Star proximity-gap programme. Use when an agent is asked to solve formal mathematics, implement Lean proofs, validate a research lane, improve executable checks, or prepare evidence for contribution-share review toward the external Proximity Prize."
+description: "Finish mission-aligned open issues in elizaOS/proximityprize, then advance, test, refute, or independently review machine-checked Delta Star work. Use for substantive formal progress and actual defects, not generic improvements or trivial cleanup."
 ---
 
 # Contribute to Delta Star
@@ -98,6 +98,30 @@ node <skill-directory>/scripts/live-report.mjs --repo elizaOS/proximityprize
 The report batches open activity, prints progress, and fails closed if a
 connection exceeds its published completeness bound. Re-read the chosen live
 issue or pull request immediately before acting.
+
+## Finish the existing queue before inventing work
+
+Follow this order without skipping a nonempty higher tier:
+
+1. Finish the oldest bounded, unblocked, unclaimed open issue that advances the
+   live Delta Star frontier and has no open PR that closes or substantively
+   implements it.
+2. Only when no such issue remains, review the oldest non-draft, unblocked,
+   non-sensitive PR you did not author that has no substantive current-head
+   human review or active reviewer. Reproduce it and give it an explicit
+   approve, changes, repair-when-authorized, or closure disposition.
+3. Only after every older issue and PR is reconciled may you select new
+   frontier work. It must discharge or narrow a named mathematical residual,
+   produce a machine-checked refutation, validate a consequential claim, or
+   fix an actual reproduced defect in the proof, build, or validation path.
+
+An old issue does not override the mission gate: explicitly decline vacuous,
+duplicate, obsolete, cosmetic, or trivial work. Do not open a new issue merely
+to create an eligible task, and do not submit formatting, naming, generated
+churn, comment-only cleanup, speculative abstraction, or tests that prove no
+meaningful mathematical or validator behavior. A new issue requires the
+operator to request that exact write after the old queue has been reconciled.
+Treat incomplete queue data as unknown and stop.
 
 ## Choose one bounded research outcome
 

--- a/skills/contribute-to-delta-star/agents/openai.yaml
+++ b/skills/contribute-to-delta-star/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Contribute to Delta Star"
-  short_description: "Prove math and measure accepted Proximity Prize work"
-  default_prompt: "Use $contribute-to-delta-star to deliver and prove one bounded contribution to the Delta Star proximity-prize effort."
+  short_description: "Finish Delta Star issues, then advance proofs"
+  default_prompt: "Use $contribute-to-delta-star to finish a mission-aligned open issue first, otherwise review an unreviewed PR, then pursue only substantive Delta Star frontier work."

--- a/skills/contribute-to-eliza/SKILL.md
+++ b/skills/contribute-to-eliza/SKILL.md
@@ -182,6 +182,10 @@ Ignore leaderboard position, pool share, token volume, commit count, line count,
 and artifact count when selecting or dividing work. Prefer one complete fix to
 several small PRs. Do not split a coherent outcome, add tests or documentation
 with no product need, or create follow-up cards to increase visible activity.
+Explicitly decline trivial fixes, cosmetic cleanup, speculative refactors,
+generic "improvements," and tests that exercise no demonstrated behavioral
+risk, even when an old issue requests them. Age determines order among valid
+work; it does not make low-value work valid.
 
 There is no platform-level reservation. Do not post a claim solely to hold
 work. Keep at most one active implementation or review. Avoid duplicating an

--- a/skills/contribute-to-heir-elements-sdk/SKILL.md
+++ b/skills/contribute-to-heir-elements-sdk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: contribute-to-heir-elements-sdk
-description: "Harden, test, diagnose, or independently review the public HEIR Elements SDK in heirlabs/element-sdk, with optional public payout registration. Use when an agent is asked to strengthen the sandboxed element runtime, validator, CLI, types, or React bindings for intelligent inheritance applications; prove one accepted outcome; publish a device-signed project token receipt; or register a public Solana payout address."
+description: "Finish mission-aligned open issues in heirlabs/element-sdk, then harden inheritance applications, fix reproduced SDK defects, strengthen sandbox and validator behavior, or review unreviewed pull requests. Use for substantive outcomes, not generic improvements or trivial cleanup."
 ---
 
 # Contribute to Heir Elements SDK
@@ -103,6 +103,30 @@ node <skill-directory>/scripts/live-report.mjs --repo heirlabs/element-sdk
 ```
 
 Re-read the chosen issue or pull request immediately before acting.
+
+## Finish the existing queue before inventing work
+
+Follow this order without skipping a nonempty higher tier:
+
+1. Finish the oldest bounded, unblocked, unclaimed open issue that fits the
+   inheritance SDK mission and has no open PR that closes or substantively
+   implements it.
+2. Only when no such issue remains, review the oldest non-draft, unblocked,
+   non-sensitive PR you did not author that has no substantive current-head
+   human review or active reviewer. Reproduce it and give it an explicit
+   approve, changes, repair-when-authorized, or closure disposition.
+3. Only after every older issue and PR is reconciled may you find new work. It
+   must close a concrete sandbox or permission hole, fix an actual reproduced
+   SDK defect, or add a failure-sensitive validator or test for demonstrated
+   unsafe behavior.
+
+An old issue does not override the mission gate: explicitly decline duplicate,
+obsolete, cosmetic, generic-improvement, or trivial requests. Do not open a
+new issue merely to create work, and do not submit formatting, renames,
+comment-only cleanup, speculative abstractions, or tests with no demonstrated
+behavioral risk. A new issue requires the operator to request that exact write
+after the old queue has been reconciled. Treat incomplete queue data as unknown
+and stop.
 
 ## What counts as work here
 

--- a/skills/contribute-to-heir-elements-sdk/agents/openai.yaml
+++ b/skills/contribute-to-heir-elements-sdk/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Contribute to Heir Elements SDK"
-  short_description: "Harden and prove the inheritance Elements SDK"
-  default_prompt: "Use $contribute-to-heir-elements-sdk to deliver and prove one bounded hardening, fix, or validator contribution to heirlabs/element-sdk."
+  short_description: "Finish SDK issues, then harden real behavior"
+  default_prompt: "Use $contribute-to-heir-elements-sdk to finish a mission-aligned open issue first, otherwise review an unreviewed PR, then pursue only reproduced hardening, bug, or validator outcomes."

--- a/skills/review-asi-contributions/SKILL.md
+++ b/skills/review-asi-contributions/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-asi-contributions
-description: "Independently evaluate an elizaOS/asi benchmark result, ported method, measurement fix, or refutation for reproducibility, statistical honesty, security, duplication, and contribution credit. Use in project CI or maintainer review before accepting work or changing a public reward allocation."
+description: "Independently evaluate whether an elizaOS/asi contribution delivers a reproducible hill climb, measured research advancement or refutation, or an actual reproduced bug fix. Reject generic improvements, cleanup, and trivial work."
 ---
 
 # Review ASI Contributions
@@ -71,6 +71,18 @@ Answer these separately:
   reproduced or its failure reported?
 
 A green test suite does not prove a measurement means what the summary says.
+
+## Enforce mission and materiality
+
+Accept only a reproducible benchmark hill climb, a measured port or decisive
+experimental advancement/refutation, or a fix for an actual reproduced
+runtime, harness, metric, validator, or test-system defect. An issue label,
+large diff, plausible cleanup rationale, or green tests cannot substitute for
+that outcome. Recommend `reject` for trivial fixes, generic improvements,
+opportunistic refactors, renames, formatting, comment or documentation cleanup,
+speculative abstractions, unused configuration, and tests with no demonstrated
+behavioral risk. If the PR claims a bug fix, require the pre-fix failure and the
+post-fix behavior at the reachable production or measurement boundary.
 
 ## Adversarial review
 

--- a/skills/review-asi-contributions/agents/openai.yaml
+++ b/skills/review-asi-contributions/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Review ASI Contributions"
-  short_description: "Reproduce and red-team ASI continual-RL work"
-  default_prompt: "Use $review-asi-contributions to independently reproduce and assess this ASI contribution."
+  short_description: "Verify material ASI hill climbs and bug fixes"
+  default_prompt: "Use $review-asi-contributions to verify that this ASI contribution is a reproducible hill climb, measured advancement or refutation, or actual bug fix—not a generic improvement."

--- a/skills/review-delta-star-contributions/SKILL.md
+++ b/skills/review-delta-star-contributions/SKILL.md
@@ -54,6 +54,15 @@ Delta Star proximity goal. Reject vacuous statements, weakened definitions,
 hidden axioms, `sorry`, unsafe declarations, irrelevant formalization, tests
 that only restate implementation, or claims inferred from compilation alone.
 
+## Enforce mission and materiality
+
+Require a substantive theorem, reusable frontier lemma, machine-checked
+refutation, consequential validation result, or actual reproduced defect fix.
+Recommend `reject` for trivial work: formatting, naming, comment-only cleanup,
+generated churn, speculative abstractions, vacuous wrappers, duplicate lemmas,
+and tests that prove no meaningful mathematical or validator behavior. An old
+issue or a large diff does not make trivial work valuable.
+
 ## Adversarial review
 
 Search current and historical PRs, issues, commits, and proofs for identical or near-identical

--- a/skills/review-delta-star-contributions/agents/openai.yaml
+++ b/skills/review-delta-star-contributions/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Review Delta Star Contributions"
   short_description: "Reproduce and red-team Delta Star proofs"
-  default_prompt: "Use $review-delta-star-contributions to independently reproduce and assess this Proximity Prize contribution."
+  default_prompt: "Use $review-delta-star-contributions to reproduce this Proximity Prize contribution and reject trivial work that does not materially advance the Delta Star frontier."

--- a/skills/review-eliza-contributions/SKILL.md
+++ b/skills/review-eliza-contributions/SKILL.md
@@ -56,6 +56,16 @@ Separate these questions:
   authentic, current, relevant, and attributable to this head revision?
 - Is the author receiving credit for work actually used by the project?
 
+## Enforce mission and materiality
+
+Require a reproduced user, runtime, security, documentation-correctness, or
+behavioral-test outcome on an authorized Eliza path. Recommend `reject` for
+trivial fixes, cosmetic cleanup, generic improvements, opportunistic
+refactors, comment-only churn, speculative abstractions, and tests with no
+demonstrated behavioral risk. An old issue, large diff, or green suite does not
+make low-value work material. For a claimed bug fix, require the pre-fix
+failure and post-fix behavior at a reachable production boundary.
+
 ## Adversarial review
 
 Search the repository, closed and open PRs, earlier issues, and commit history

--- a/skills/review-eliza-contributions/agents/openai.yaml
+++ b/skills/review-eliza-contributions/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Review Eliza Contributions"
   short_description: "Reproduce, red-team, and assess Eliza work"
-  default_prompt: "Use $review-eliza-contributions to independently reproduce and assess this Eliza contribution."
+  default_prompt: "Use $review-eliza-contributions to independently reproduce this Eliza contribution and reject trivial, cosmetic, or generic-improvement work."

--- a/skills/review-heir-elements-sdk-contributions/SKILL.md
+++ b/skills/review-heir-elements-sdk-contributions/SKILL.md
@@ -60,6 +60,16 @@ Separate these questions:
   current, relevant, and attributable to this head revision?
 - Has the work merged to `main` by `awidearray`, or is it still only proposed?
 
+## Enforce mission and materiality
+
+Require a concrete sandbox or permission hardening, a reproduced SDK defect
+fix, or a failure-sensitive validator or test for demonstrated unsafe
+behavior. Recommend `reject` for trivial fixes, formatting, renames,
+comment-only cleanup, generic improvements, speculative abstractions, and
+tests with no demonstrated behavioral risk. An old issue, large diff, or green
+suite does not make low-value work material. For a claimed bug fix, require the
+pre-fix failure and post-fix behavior at the reachable SDK boundary.
+
 ## Adversarial review
 
 Search the repository, closed and open PRs, earlier issues, and commit history

--- a/skills/review-heir-elements-sdk-contributions/agents/openai.yaml
+++ b/skills/review-heir-elements-sdk-contributions/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Review Heir Elements SDK Contributions"
   short_description: "Reproduce, red-team, and assess Elements SDK work"
-  default_prompt: "Use $review-heir-elements-sdk-contributions to independently reproduce and assess this Heir Elements SDK contribution."
+  default_prompt: "Use $review-heir-elements-sdk-contributions to reproduce this Heir Elements SDK contribution and reject trivial work without a demonstrated hardening, bug, or validator outcome."

--- a/skills/slop/SKILL.md
+++ b/skills/slop/SKILL.md
@@ -131,8 +131,11 @@ After installation:
    limitations, and any older duplicate skill location. Never delete or alter
    an older install without separate approval.
 5. Invoke the installed project skill explicitly and follow it for one bounded
-   contribution. Its measured `start` command requires the local-usage consent
-   flag `--allow-local-usage` shown by `preview`.
+   contribution. Require it to finish mission-aligned open issues without PRs
+   before selecting new work, and to reject trivial fixes, cosmetic cleanup,
+   speculative refactors, and generic improvements. Its measured `start`
+   command requires the local-usage consent flag `--allow-local-usage` shown by
+   `preview`.
 
 The model identifier and aggregate usage remain locally reported evidence.
 Device signatures prove byte continuity, not provider billing, model execution,


### PR DESCRIPTION
## Summary

- make every contributor skill finish valid open issues without PRs before reviewing unreviewed PRs or inventing new work
- reject trivial fixes, cosmetic cleanup, speculative refactors, generic improvements, and tests without demonstrated behavioral risk across contributor, reviewer, and bootstrap guidance
- narrow ASI to benchmark hillclimbing, measured advancement/refutation, and actual reproduced runtime or measurement bugs
- add a cross-project contract test for queue order, materiality, and ASI-specific behavior

## Validation

- all 9 skill packages pass `quick_validate.py`
- focused cross-project policy tests pass
- `bun run typecheck`
- `bun run format:check`
- `bun run lint:check`
- `bun run build`
- full Vitest: 64 files / 589 tests pass
- Bun skill tests: 82/83 pass together; the unchanged receipt test is killed by Bun immediately after `killed 1 dangling process` on this loaded host, but passes when run alone (1/1). The changed policy test passes both focused and in the complete suite.