### PR TITLE
Add fail-closed repository transfer aliases

### DIFF
--- a/scripts/generate-leaderboard.test.ts
+++ b/scripts/generate-leaderboard.test.ts
@@ -1671,7 +1671,13 @@ describe("current-head review selection", () => {
       },
     ]);
     expect(snapshot.repositories).toEqual(
-      TARGET_REPOSITORIES.map((repository) => ({ ...repository })),
+      TARGET_REPOSITORIES.map(
+        ({
+          aliases: _aliases,
+          expectedNodeId: _expectedNodeId,
+          ...repository
+        }) => repository,
+      ),
     );
     const staleItem = snapshot.workQueue.pullRequests.find(
       (item) => item.id === "PR_STALE",

--- a/scripts/generate-leaderboard.ts
+++ b/scripts/generate-leaderboard.ts
@@ -1419,6 +1419,15 @@ async function preflightRepository(
     name: targetRepository.name,
   });
   const repository = child(data, "repository", "data");
+  const repositoryNodeId = asString(repository.id, "data.repository.id");
+  if (
+    targetRepository.expectedNodeId !== null &&
+    repositoryNodeId !== targetRepository.expectedNodeId
+  ) {
+    throw new Error(
+      `Repository alias ${targetRepository.owner}/${targetRepository.name} resolved to ${repositoryNodeId}, expected immutable node ${targetRepository.expectedNodeId}`,
+    );
+  }
   if (options.requireStartingBudget) {
     const rateLimit = client.getRateLimit();
     const requiredRemaining = Math.min(
@@ -1432,7 +1441,7 @@ async function preflightRepository(
     }
   }
   return {
-    id: asString(repository.id, "data.repository.id"),
+    id: repositoryNodeId,
     updatedAt: asString(repository.updatedAt, "data.repository.updatedAt"),
   };
 }
@@ -1447,7 +1456,7 @@ export async function collectSearchReferences(
   expectedKind: NodeReference["kind"],
   stats: { searchSliceCount: number },
 ): Promise<NodeReference[]> {
-  const searchQuery = `repo:${repository.id} ${kindQualifier} ${qualifier}:${searchRange(from, to)}`;
+  const searchQuery = `repo:${repository.owner}/${repository.name} ${kindQualifier} ${qualifier}:${searchRange(from, to)}`;
   stats.searchSliceCount += 1;
   const firstData = await client.execute(SEARCH_REFERENCES_QUERY, {
     searchQuery,
@@ -1530,7 +1539,7 @@ async function countSearchResults(
   expectedKind: NodeReference["kind"],
   stats: { searchSliceCount: number },
 ): Promise<number> {
-  const searchQuery = `repo:${repository.id} ${kindQualifier} ${qualifier}:${searchRange(from, to)}`;
+  const searchQuery = `repo:${repository.owner}/${repository.name} ${kindQualifier} ${qualifier}:${searchRange(from, to)}`;
   stats.searchSliceCount += 1;
   const data = await client.execute(SEARCH_REFERENCES_QUERY, {
     searchQuery,

--- a/src/lib/evaluator-awards.ts
+++ b/src/lib/evaluator-awards.ts
@@ -94,7 +94,7 @@ function iso(value: unknown, field: string): string {
 function githubUrl(
   value: unknown,
   field: string,
-  expectedPath: string,
+  expectedPath: string | readonly string[],
   expectedHash?: RegExp,
 ): string {
   const result = text(value, field, { max: 512 });
@@ -107,7 +107,9 @@ function githubUrl(
   if (
     parsed.protocol !== "https:" ||
     parsed.hostname !== "github.com" ||
-    parsed.pathname.toLowerCase() !== expectedPath.toLowerCase() ||
+    !(Array.isArray(expectedPath) ? expectedPath : [expectedPath]).some(
+      (path) => parsed.pathname.toLowerCase() === path.toLowerCase(),
+    ) ||
     parsed.search ||
     (expectedHash ? !expectedHash.test(parsed.hash) : parsed.hash !== "") ||
     parsed.username ||
@@ -176,14 +178,14 @@ function review(value: unknown, field: string): EvaluatorAwardReview {
   if (
     parsed.protocol !== "https:" ||
     parsed.hostname !== "github.com" ||
-    !/^\/elizaOS\/(?:slopdotcash|army)\/pull\/[1-9]\d*$/iu.test(
+    !/^\/(?:elizaOS\/(?:slopdotcash|army)|SlopDotCash\/slopdotcash)\/pull\/[1-9]\d*$/iu.test(
       parsed.pathname,
     ) ||
     parsed.search ||
     parsed.hash
   ) {
     throw new TypeError(
-      `${field}.decisionUrl must be an elizaOS/slopdotcash pull request`,
+      `${field}.decisionUrl must be a Slop review pull request`,
     );
   }
   return {
@@ -259,11 +261,16 @@ export function assertEvaluatorAwardManifest(
   const sourceKind = source.kind as ScoreEvent["source"]["kind"];
   const pathKind =
     sourceKind === "issue" || sourceKind === "comment" ? "issues" : "pull";
-  const normalizedRepository = repository.split("/");
+  const repositoryIdentities = [
+    registeredRepository.id,
+    ...(registeredRepository.aliases ?? []),
+  ];
   const sourceUrl = githubUrl(
     source.url,
     "evaluator award.source.url",
-    `/${normalizedRepository[0]}/${normalizedRepository[1]}/${pathKind}/${number}`,
+    repositoryIdentities.map(
+      (repositoryIdentity) => `/${repositoryIdentity}/${pathKind}/${number}`,
+    ),
     sourceKind === "review"
       ? /^#(?:pullrequestreview-|discussion_r)\d+$/iu
       : sourceKind === "comment"

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -532,7 +532,7 @@ export interface LeaderboardSourceMetadata {
 export interface LeaderboardSnapshot {
   schemaVersion: typeof LEADERBOARD_SCHEMA_VERSION;
   repository: typeof LEADERBOARD_REPOSITORY;
-  repositories: TargetRepository[];
+  repositories: Omit<TargetRepository, "aliases" | "expectedNodeId">[];
   ruleVersion: typeof SCORE_RULE_VERSION;
   generatedAt: string;
   sourceUpdatedAt: string;
@@ -3438,7 +3438,10 @@ export function createLeaderboardSnapshot(
   const snapshot: LeaderboardSnapshot = {
     schemaVersion: LEADERBOARD_SCHEMA_VERSION,
     repository: LEADERBOARD_REPOSITORY,
-    repositories: TARGET_REPOSITORIES.map((repository) => ({ ...repository })),
+    repositories: TARGET_REPOSITORIES.map(
+      ({ aliases: _aliases, expectedNodeId: _expectedNodeId, ...repository }) =>
+        repository,
+    ),
     ruleVersion: SCORE_RULE_VERSION,
     generatedAt: input.generatedAt,
     sourceUpdatedAt: latestSourceUpdate(input),
@@ -4548,14 +4551,14 @@ function assertLedgerValue(
   );
   if (
     decisionUrl.hostname !== "github.com" ||
-    !/^\/elizaOS\/(?:slopdotcash|army)\/pull\/[1-9]\d*$/iu.test(
+    !/^\/(?:elizaOS\/(?:slopdotcash|army)|SlopDotCash\/slopdotcash)\/pull\/[1-9]\d*$/iu.test(
       decisionUrl.pathname,
     ) ||
     decisionUrl.search ||
     decisionUrl.hash
   ) {
     throw new Error(
-      `${path}.evaluation.decisionUrl must be an elizaOS/slopdotcash pull request`,
+      `${path}.evaluation.decisionUrl must be a Slop review pull request`,
     );
   }
   assertString(evaluation.manifestSha256, `${path}.evaluation.manifestSha256`);

--- a/src/lib/project-policy.mjs
+++ b/src/lib/project-policy.mjs
@@ -87,6 +87,59 @@ function canonical(value) {
   return JSON.stringify(value);
 }
 
+function assertRepositoryTransition(previousRepositories, nextRepositories) {
+  if (previousRepositories.length !== nextRepositories.length) {
+    throw new TypeError("repository inventory cannot change");
+  }
+  for (let index = 0; index < previousRepositories.length; index += 1) {
+    const previous = previousRepositories[index];
+    const next = nextRepositories[index];
+    const previousAliases = previous.aliases ?? [];
+    const nextAliases = next.aliases ?? [];
+    if (
+      previous.id !== next.id ||
+      previous.integrationBranch !== next.integrationBranch ||
+      previous.description !== next.description
+    ) {
+      throw new TypeError(
+        "repository transfer, rename, or integration-branch drift requires a new project review",
+      );
+    }
+    if (
+      nextAliases.length < previousAliases.length ||
+      nextAliases.length > previousAliases.length + 1 ||
+      previousAliases.some(
+        (alias, aliasIndex) =>
+          alias.toLowerCase() !== nextAliases[aliasIndex]?.toLowerCase(),
+      )
+    ) {
+      throw new TypeError(
+        "repository aliases must remain an append-only prefix with at most one transfer per review",
+      );
+    }
+    if (nextAliases.length === previousAliases.length) {
+      if (canonical(previous) !== canonical(next)) {
+        throw new TypeError(
+          "repository metadata may change only with an appended transfer alias",
+        );
+      }
+      continue;
+    }
+    const alias = nextAliases.at(-1);
+    const currentPath = new URL(next.githubUrl).pathname
+      .replace(/^\//u, "")
+      .replace(/\/$/u, "");
+    if (
+      alias.toLowerCase() !== currentPath.toLowerCase() ||
+      next.displayName.toLowerCase() !== alias.toLowerCase()
+    ) {
+      throw new TypeError(
+        "a repository transfer must publish its appended alias as the current repository identity",
+      );
+    }
+  }
+}
+
 /**
  * Refuses identity drift and silent material-policy edits. Historical records
  * remain valid because callers receive a new revision rather than mutating an
@@ -102,13 +155,13 @@ export function assertProjectPolicyTransition(previousValue, nextValue) {
   );
   if (
     previous.authority.repositoryId !== next.authority.repositoryId ||
-    previous.authority.repositoryNodeId !== next.authority.repositoryNodeId ||
-    canonical(previous.repositories) !== canonical(next.repositories)
+    previous.authority.repositoryNodeId !== next.authority.repositoryNodeId
   ) {
     throw new TypeError(
       "repository transfer, rename, or integration-branch drift requires a new project review",
     );
   }
+  assertRepositoryTransition(previous.repositories, next.repositories);
   const previousReceiptPolicy = previous.terms.receiptPolicy;
   const nextReceiptPolicy = next.terms.receiptPolicy;
   const initialReceiptActivation =

--- a/src/lib/project-policy.test.ts
+++ b/src/lib/project-policy.test.ts
@@ -130,6 +130,39 @@ describe("project policy transitions", () => {
     );
   });
 
+  it("allows one identity-preserving transfer alias and rejects alias drift", () => {
+    const previous = structuredClone(eliza);
+    const transferred = structuredClone(eliza);
+    const transferredRepository = transferred
+      .repositories[0] as (typeof transferred.repositories)[number] & {
+      aliases: string[];
+    };
+    transferredRepository.aliases = ["SlopDotCash/eliza"];
+    transferredRepository.githubUrl = "https://github.com/SlopDotCash/eliza";
+    transferredRepository.displayName = "SlopDotCash/eliza";
+    expect(assertProjectPolicyTransition(previous, transferred)).toEqual(
+      transferred,
+    );
+
+    const rewritten = structuredClone(transferred);
+    const rewrittenRepository = rewritten
+      .repositories[0] as (typeof rewritten.repositories)[number] & {
+      aliases: string[];
+    };
+    rewrittenRepository.aliases[0] = "attacker/eliza";
+    rewritten.repositories[0].githubUrl = "https://github.com/attacker/eliza";
+    rewritten.repositories[0].displayName = "attacker/eliza";
+    expect(() => assertProjectPolicyTransition(transferred, rewritten)).toThrow(
+      /append-only/u,
+    );
+
+    const branch = structuredClone(transferred);
+    branch.repositories[0].integrationBranch = "main";
+    expect(() => assertProjectPolicyTransition(transferred, branch)).toThrow(
+      /drift/u,
+    );
+  });
+
   it("keeps payment transitions from rewriting IP state", () => {
     const payment = structuredClone(eliza);
     payment.reward.monthlyCapMinor = "20000000000";

--- a/src/lib/project-schema.mjs
+++ b/src/lib/project-schema.mjs
@@ -651,25 +651,58 @@ function timestamp(value, field) {
 function validateRepository(value, index) {
   const field = `project.repositories[${index}]`;
   const repository = record(value, field);
-  exactKeys(
-    repository,
-    ["description", "displayName", "githubUrl", "id", "integrationBranch"],
-    field,
-  );
+  const requiredKeys = [
+    "description",
+    "displayName",
+    "githubUrl",
+    "id",
+    "integrationBranch",
+  ];
+  const actualKeys = Object.keys(repository).sort().join("\0");
+  if (
+    actualKeys !== [...requiredKeys].sort().join("\0") &&
+    actualKeys !== [...requiredKeys, "aliases"].sort().join("\0")
+  ) {
+    throw new TypeError(`${field} has unexpected or missing fields`);
+  }
   const id = text(repository.id, `${field}.id`, {
     max: 201,
     pattern: /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u,
   });
+  const aliases = repository.aliases ?? [];
+  if (!Array.isArray(aliases) || aliases.length > 10) {
+    throw new TypeError(`${field}.aliases must contain at most 10 entries`);
+  }
+  const repositoryIds = [
+    id,
+    ...aliases.map((alias, aliasIndex) =>
+      text(alias, `${field}.aliases[${aliasIndex}]`, {
+        max: 201,
+        pattern: /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u,
+      }),
+    ),
+  ];
+  if (
+    new Set(repositoryIds.map((repositoryId) => repositoryId.toLowerCase()))
+      .size !== repositoryIds.length
+  ) {
+    throw new TypeError(`${field} contains duplicate repository identities`);
+  }
   const githubUrl = url(
     repository.githubUrl,
     `${field}.githubUrl`,
     "https://github.com",
   );
   if (
-    new URL(githubUrl).pathname.replace(/\/$/u, "").toLowerCase() !==
-    `/${id}`.toLowerCase()
+    !repositoryIds.some(
+      (repositoryId) =>
+        new URL(githubUrl).pathname.replace(/\/$/u, "").toLowerCase() ===
+        `/${repositoryId}`.toLowerCase(),
+    )
   ) {
-    throw new TypeError(`${field}.githubUrl does not match its repository id`);
+    throw new TypeError(
+      `${field}.githubUrl does not match a registered repository identity`,
+    );
   }
   text(repository.displayName, `${field}.displayName`, { max: 201 });
   text(repository.description, `${field}.description`, { max: 500, min: 12 });
@@ -994,7 +1027,11 @@ export function assertProjectRegistry(values) {
     [
       "repositories",
       projects.flatMap((project) =>
-        project.repositories.map((repository) => repository.id.toLowerCase()),
+        project.repositories.flatMap((repository) =>
+          [repository.id, ...(repository.aliases ?? [])].map((repositoryId) =>
+            repositoryId.toLowerCase(),
+          ),
+        ),
       ),
     ],
   ]) {

--- a/src/lib/project-schema.test.ts
+++ b/src/lib/project-schema.test.ts
@@ -113,6 +113,26 @@ describe("project proposal schema", () => {
       /does not match/u,
     );
 
+    const duplicateAlias = structuredClone(deltaStar);
+    const duplicateRepository = duplicateAlias
+      .repositories[0] as (typeof duplicateAlias.repositories)[number] & {
+      aliases: string[];
+    };
+    duplicateRepository.aliases = ["elizaOS/proximityprize"];
+    expect(() => assertProjectDefinition(duplicateAlias)).toThrow(
+      /duplicate repository identities/u,
+    );
+
+    const crossProjectAlias = structuredClone(deltaStar);
+    const collidingRepository = crossProjectAlias
+      .repositories[0] as (typeof crossProjectAlias.repositories)[number] & {
+      aliases: string[];
+    };
+    collidingRepository.aliases = ["elizaOS/eliza"];
+    expect(() => assertProjectRegistry([eliza, crossProjectAlias])).toThrow(
+      /duplicate repositories/u,
+    );
+
     const fakeCommitment = structuredClone(eliza);
     fakeCommitment.reward.committedMinor = "1000000";
     expect(() => assertProjectDefinition(fakeCommitment)).toThrow(

--- a/src/lib/projects.d.mts
+++ b/src/lib/projects.d.mts
@@ -175,6 +175,7 @@ export interface ProjectDefinition {
   };
   readonly repositories: readonly {
     readonly id: string;
+    readonly aliases?: readonly string[];
     readonly displayName: string;
     readonly githubUrl: string;
     readonly description: string;

--- a/src/lib/projects.mjs
+++ b/src/lib/projects.mjs
@@ -43,10 +43,12 @@ const PROJECTS_BY_ID = new Map(
 );
 const PROJECTS_BY_REPOSITORY = new Map(
   PROJECTS.flatMap((project) =>
-    project.repositories.map(({ id: repositoryId }) => [
-      repositoryId.toLowerCase(),
-      project,
-    ]),
+    project.repositories.flatMap((repository) =>
+      [repository.id, ...(repository.aliases ?? [])].map((repositoryId) => [
+        repositoryId.toLowerCase(),
+        project,
+      ]),
+    ),
   ),
 );
 

--- a/src/lib/repositories.d.mts
+++ b/src/lib/repositories.d.mts
@@ -8,6 +8,8 @@ export interface TargetRepository {
   readonly id: RepositoryId;
   readonly owner: string;
   readonly name: string;
+  readonly aliases: readonly RepositoryId[];
+  readonly expectedNodeId: string | null;
   readonly displayName: string;
   readonly githubUrl: string;
   readonly description: string;

--- a/src/lib/repositories.mjs
+++ b/src/lib/repositories.mjs
@@ -9,11 +9,18 @@ import { PROJECTS } from "./projects.mjs";
 export const TARGET_REPOSITORIES = Object.freeze(
   PROJECTS.flatMap((project, projectIndex) =>
     project.repositories.map((metadata, repositoryIndex) => {
-      const [owner, name] = metadata.id.split("/");
+      const canonicalUrl = new URL(metadata.githubUrl);
+      const [owner, name] = canonicalUrl.pathname.split("/").filter(Boolean);
+      const currentIdentity = `${owner}/${name}`;
       return Object.freeze({
         ...metadata,
+        aliases: metadata.aliases ?? [],
         owner,
         name,
+        expectedNodeId:
+          currentIdentity.toLowerCase() === metadata.id.toLowerCase()
+            ? null
+            : project.authority.repositoryNodeId,
         projectId: project.id,
         role:
           projectIndex === 0 && repositoryIndex === 0 ? "primary" : "member",
@@ -25,10 +32,12 @@ export const TARGET_REPOSITORIES = Object.freeze(
 export const PRIMARY_REPOSITORY = TARGET_REPOSITORIES[0];
 
 const REPOSITORIES_BY_LOWERCASE_ID = new Map(
-  TARGET_REPOSITORIES.map((repository) => [
-    repository.id.toLowerCase(),
-    repository,
-  ]),
+  TARGET_REPOSITORIES.flatMap((repository) =>
+    [repository.id, ...(repository.aliases ?? [])].map((repositoryId) => [
+      repositoryId.toLowerCase(),
+      repository,
+    ]),
+  ),
 );
 
 /**

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -31,7 +31,10 @@ export function snapshotFixture(): LeaderboardSnapshot {
   return {
     schemaVersion: "6",
     repository: "elizaOS/eliza",
-    repositories: TARGET_REPOSITORIES.map((repository) => ({ ...repository })),
+    repositories: TARGET_REPOSITORIES.map(
+      ({ aliases: _aliases, expectedNodeId: _expectedNodeId, ...repository }) =>
+        repository,
+    ),
     ruleVersion: SCORE_RULE_VERSION,
     generatedAt,
     sourceUpdatedAt: generatedAt,


### PR DESCRIPTION
## Summary
- add optional, collision-checked repository aliases while preserving stable receipt and snapshot IDs
- require aliases to be append-only, one transfer per review, with immutable repository authority and integration branch
- bind live ingestion of a current alias to the project's already-pinned GitHub node ID before accepting source data
- query the current owner/name while keeping internal alias metadata out of the public leaderboard schema
- accept exact review decisions under the transferred `SlopDotCash/slopdotcash` path

This bootstrap intentionally does **not** change any project manifest. The trusted transition workflow executes code from immutable base `develop`; landing the generic schema first lets a successor PR register the actual Delta Star alias under the newly trusted gate.

## Transfer evidence motivating the successor
- `SlopDotCash/proximityprize`: repository ID `1334780197`, node `R_kgDOT48hJQ`, default branch `main`
- `SlopDotCash/slopdotcash`: repository ID `1319812413`, node `R_kgDOTqq9PQ`, default branch `develop`
- failed trusted deployment: run `32338688182`
- base: `3d3c07cf6c4ec47ec749cf402f9141c292c47278`

## Verification
- `bun run typecheck`
- `bun run format:check`
- `bun run lint:check`
- `bun run projects:check`
- `bun run evaluations:check`
- `node scripts/check-project-transitions.mjs 3d3c07cf6c4ec47ec749cf402f9141c292c47278`
- focused transition/schema suite: 23 passed
- broader transfer/security matrix before split: 194 passed
- full Vitest matrix: 64 files / 591 tests passed
- `bun run build`

The aggregate skill runner experienced a host-level spawned-process kill under concurrent load; its exact interrupted test passed in isolation. Protected exact-head CI remains authoritative.
