### PR TITLE
Repair protected release gates after repository transfer

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -258,7 +258,7 @@ jobs:
             --max-filesize 65536 \
             --header "Accept: application/vnd.github+json" \
             --header "User-Agent: slop-release-intake-check" \
-            https://api.github.com/repos/elizaOS/slopdotcash/private-vulnerability-reporting |
+            https://api.github.com/repos/SlopDotCash/slopdotcash/private-vulnerability-reporting |
             node -e '
               let source = "";
               process.stdin.setEncoding("utf8");
@@ -295,7 +295,7 @@ jobs:
           set -euo pipefail
           live_develop="$(
             git -C "$GITHUB_WORKSPACE" ls-remote --exit-code --refs \
-              https://github.com/elizaOS/slopdotcash.git refs/heads/develop |
+              https://github.com/SlopDotCash/slopdotcash.git refs/heads/develop |
               awk 'NR == 1 { print $1 }'
           )"
           if ! [[ "$live_develop" =~ ^[0-9a-f]{40}$ ]]; then
@@ -394,7 +394,7 @@ jobs:
           set -euo pipefail
           live_develop="$(
             git -C "$GITHUB_WORKSPACE" ls-remote --exit-code --refs \
-              https://github.com/elizaOS/slopdotcash.git refs/heads/develop |
+              https://github.com/SlopDotCash/slopdotcash.git refs/heads/develop |
               awk 'NR == 1 { print $1 }'
           )"
           if ! [[ "$live_develop" =~ ^[0-9a-f]{40}$ ]]; then
@@ -707,7 +707,7 @@ jobs:
 
           live_develop="$(
             git -C "$GITHUB_WORKSPACE" ls-remote --exit-code --refs \
-              https://github.com/elizaOS/slopdotcash.git refs/heads/develop |
+              https://github.com/SlopDotCash/slopdotcash.git refs/heads/develop |
               awk 'NR == 1 { print $1 }'
           )"
           if ! [[ "$live_develop" =~ ^[0-9a-f]{40}$ ]]; then

--- a/scripts/deployment-contract.test.mjs
+++ b/scripts/deployment-contract.test.mjs
@@ -106,7 +106,7 @@ describe("slop.cash deployment contract", () => {
       "- name: Require public private-request intake",
     );
     expect(deployJob).toContain(
-      "https://api.github.com/repos/elizaOS/slopdotcash/private-vulnerability-reporting",
+      "https://api.github.com/repos/SlopDotCash/slopdotcash/private-vulnerability-reporting",
     );
     expect(deployJob).toContain("value?.enabled !== true");
     expect(
@@ -237,7 +237,15 @@ describe("slop.cash deployment contract", () => {
     expect(
       deployJob.match(/diff --quiet "\$GITHUB_SHA" "\$live_develop" -- \./g),
     ).toHaveLength(3);
-    expect(deployJob).toContain("https://github.com/elizaOS/slopdotcash.git");
+    expect(deployJob).toContain(
+      "https://github.com/SlopDotCash/slopdotcash.git",
+    );
+    expect(deployJob).not.toContain(
+      "https://api.github.com/repos/elizaOS/slopdotcash",
+    );
+    expect(deployJob).not.toContain(
+      "https://github.com/elizaOS/slopdotcash.git",
+    );
     expect(wranglerConfiguration).toContain(
       'pages_build_output_dir = "./dist"',
     );


### PR DESCRIPTION
## Summary
- query private vulnerability reporting from the transferred canonical repository
- bind all three live-develop release checks to the transferred canonical Git URL
- prevent the retired owner paths from returning in the deployment contract

## Evidence
- failed production run 32343279014 stopped at the old-owner private-request gate
- `https://api.github.com/repos/SlopDotCash/slopdotcash/private-vulnerability-reporting` returns `{"enabled":true}`
- `bun test scripts/deployment-contract.test.mjs` (15 pass, 246 assertions)
- `git diff --check`
- `AGENTS.md` and `CLAUDE.md` remain byte-identical

No Cloudflare configuration, credentials, or deployment state is changed by this PR.