### PR TITLE
Follow current repository authority during deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -258,7 +258,7 @@ jobs:
             --max-filesize 65536 \
             --header "Accept: application/vnd.github+json" \
             --header "User-Agent: slop-release-intake-check" \
-            https://api.github.com/repos/elizaOS/slopdotcash/private-vulnerability-reporting |
+            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/private-vulnerability-reporting" |
             node -e '
               let source = "";
               process.stdin.setEncoding("utf8");
@@ -295,7 +295,7 @@ jobs:
           set -euo pipefail
           live_develop="$(
             git -C "$GITHUB_WORKSPACE" ls-remote --exit-code --refs \
-              https://github.com/elizaOS/slopdotcash.git refs/heads/develop |
+              "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git" refs/heads/develop |
               awk 'NR == 1 { print $1 }'
           )"
           if ! [[ "$live_develop" =~ ^[0-9a-f]{40}$ ]]; then
@@ -394,7 +394,7 @@ jobs:
           set -euo pipefail
           live_develop="$(
             git -C "$GITHUB_WORKSPACE" ls-remote --exit-code --refs \
-              https://github.com/elizaOS/slopdotcash.git refs/heads/develop |
+              "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git" refs/heads/develop |
               awk 'NR == 1 { print $1 }'
           )"
           if ! [[ "$live_develop" =~ ^[0-9a-f]{40}$ ]]; then
@@ -707,7 +707,7 @@ jobs:
 
           live_develop="$(
             git -C "$GITHUB_WORKSPACE" ls-remote --exit-code --refs \
-              https://github.com/elizaOS/slopdotcash.git refs/heads/develop |
+              "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git" refs/heads/develop |
               awk 'NR == 1 { print $1 }'
           )"
           if ! [[ "$live_develop" =~ ^[0-9a-f]{40}$ ]]; then

--- a/scripts/deployment-contract.test.mjs
+++ b/scripts/deployment-contract.test.mjs
@@ -106,7 +106,7 @@ describe("slop.cash deployment contract", () => {
       "- name: Require public private-request intake",
     );
     expect(deployJob).toContain(
-      "https://api.github.com/repos/elizaOS/slopdotcash/private-vulnerability-reporting",
+      `"\${GITHUB_API_URL}/repos/\${GITHUB_REPOSITORY}/private-vulnerability-reporting"`,
     );
     expect(deployJob).toContain("value?.enabled !== true");
     expect(
@@ -237,7 +237,11 @@ describe("slop.cash deployment contract", () => {
     expect(
       deployJob.match(/diff --quiet "\$GITHUB_SHA" "\$live_develop" -- \./g),
     ).toHaveLength(3);
-    expect(deployJob).toContain("https://github.com/elizaOS/slopdotcash.git");
+    expect(
+      deployJob.match(
+        /"\$\{GITHUB_SERVER_URL\}\/\$\{GITHUB_REPOSITORY\}\.git"/g,
+      ),
+    ).toHaveLength(3);
     expect(wranglerConfiguration).toContain(
       'pages_build_output_dir = "./dist"',
     );


### PR DESCRIPTION
Fixes the protected deployment gate after the repository transfer. The private-request intake and live-develop checks now derive the current repository from GitHub trusted runtime context instead of hardcoding the pre-transfer path. The current intake endpoint returns enabled=true. Verified with 15 deployment-contract tests, typecheck, formatting, lint, and unlimited Bun test timeout.