### PR TITLE
fix(receipts): accept the Windows Git repository root

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -5,6 +5,8 @@ on:
     branches: [develop]
     paths:
       - ".github/workflows/windows-installer.yml"
+      - "skill-tests/contribute-to-eliza.test.ts"
+      - "skills/contribute-to-*/scripts/run-receipt.mjs"
       - "src/lib/install-command.ts"
       - "src/lib/install-command.test.ts"
   workflow_dispatch:
@@ -42,3 +44,10 @@ jobs:
         shell: bash
         # Bun's default is a five-second per-test ceiling; zero disables it.
         run: bun test src/lib/install-command.test.ts --timeout 0
+
+      - name: Exercise receipt repository-root canonicalization
+        shell: bash
+        run: >-
+          bun test skill-tests/contribute-to-eliza.test.ts
+          --test-name-pattern
+          "accepts the repository root without comparing path spellings"

--- a/skill-tests/contribute-to-eliza.test.ts
+++ b/skill-tests/contribute-to-eliza.test.ts
@@ -44,6 +44,7 @@ import {
   renderMarkdown,
 } from "../skills/contribute-to-eliza/scripts/live-report.mjs";
 import {
+  isRepositoryRoot,
   normalizeSessionReport,
   usageDelta,
 } from "../skills/contribute-to-eliza/scripts/run-receipt.mjs";
@@ -2211,6 +2212,18 @@ describe("live report behavior", () => {
 });
 
 describe("run receipt CLI", () => {
+  it("accepts the repository root without comparing path spellings", () => {
+    const fixtureRoot = mkdtempSync(join(tmpdir(), "slop-windows-repo-root-"));
+    const repositoryRoot = join(fixtureRoot, "repo");
+    try {
+      mkdirSync(repositoryRoot);
+      runGit(repositoryRoot, ["init", "--quiet"]);
+      assert.strictEqual(isRepositoryRoot(repositoryRoot), true);
+    } finally {
+      rmSync(fixtureRoot, { force: true, recursive: true });
+    }
+  });
+
   function runGit(cwd: string, args: string[]) {
     const result = spawnSync("git", args, { cwd, encoding: "utf8" });
     assert.strictEqual(result.status, 0, result.stderr);

--- a/skills/contribute-to-asi/scripts/run-receipt.mjs
+++ b/skills/contribute-to-asi/scripts/run-receipt.mjs
@@ -897,9 +897,14 @@ function git(repositoryRoot, args) {
   return result.stdout.trim();
 }
 
+export function isRepositoryRoot(repositoryRoot) {
+  const root = realpathSync(resolve(repositoryRoot));
+  return git(root, ["rev-parse", "--show-prefix"]) === "";
+}
+
 function requireRepository(repositoryRoot) {
   const root = realpathSync(resolve(repositoryRoot));
-  if (git(root, ["rev-parse", "--show-toplevel"]) !== root) {
+  if (!isRepositoryRoot(root)) {
     fail("--repo-root must be the Git repository root");
   }
   const remote = git(root, ["remote", "get-url", "origin"]);

--- a/skills/contribute-to-delta-star/scripts/run-receipt.mjs
+++ b/skills/contribute-to-delta-star/scripts/run-receipt.mjs
@@ -897,9 +897,14 @@ function git(repositoryRoot, args) {
   return result.stdout.trim();
 }
 
+export function isRepositoryRoot(repositoryRoot) {
+  const root = realpathSync(resolve(repositoryRoot));
+  return git(root, ["rev-parse", "--show-prefix"]) === "";
+}
+
 function requireRepository(repositoryRoot) {
   const root = realpathSync(resolve(repositoryRoot));
-  if (git(root, ["rev-parse", "--show-toplevel"]) !== root) {
+  if (!isRepositoryRoot(root)) {
     fail("--repo-root must be the Git repository root");
   }
   const remote = git(root, ["remote", "get-url", "origin"]);

--- a/skills/contribute-to-eliza/scripts/run-receipt.mjs
+++ b/skills/contribute-to-eliza/scripts/run-receipt.mjs
@@ -897,9 +897,14 @@ function git(repositoryRoot, args) {
   return result.stdout.trim();
 }
 
+export function isRepositoryRoot(repositoryRoot) {
+  const root = realpathSync(resolve(repositoryRoot));
+  return git(root, ["rev-parse", "--show-prefix"]) === "";
+}
+
 function requireRepository(repositoryRoot) {
   const root = realpathSync(resolve(repositoryRoot));
-  if (git(root, ["rev-parse", "--show-toplevel"]) !== root) {
+  if (!isRepositoryRoot(root)) {
     fail("--repo-root must be the Git repository root");
   }
   const remote = git(root, ["remote", "get-url", "origin"]);

--- a/skills/contribute-to-heir-elements-sdk/scripts/run-receipt.mjs
+++ b/skills/contribute-to-heir-elements-sdk/scripts/run-receipt.mjs
@@ -897,9 +897,14 @@ function git(repositoryRoot, args) {
   return result.stdout.trim();
 }
 
+export function isRepositoryRoot(repositoryRoot) {
+  const root = realpathSync(resolve(repositoryRoot));
+  return git(root, ["rev-parse", "--show-prefix"]) === "";
+}
+
 function requireRepository(repositoryRoot) {
   const root = realpathSync(resolve(repositoryRoot));
-  if (git(root, ["rev-parse", "--show-toplevel"]) !== root) {
+  if (!isRepositoryRoot(root)) {
     fail("--repo-root must be the Git repository root");
   }
   const remote = git(root, ["remote", "get-url", "origin"]);


### PR DESCRIPTION
## Summary

- verify the supplied repository is exactly its Git root without comparing platform-specific path strings
- keep the existing physical-path and origin checks fail-closed
- synchronize the receipt implementation across all four project skills
- run one focused native Windows regression in the existing bounded Windows workflow

## Root cause

On Windows, Node may represent a physical path as `C:\path\repo`, while Git for Windows may return the same root as `C:/path/repo`. The receipt CLI compared `realpathSync(resolve(repositoryRoot))` directly with `git rev-parse --show-toplevel`, so equivalent roots could compare unequal before `preview` completed.

The fix avoids path spelling entirely. Because Git already runs with `-C <physical-root>`, an empty `git rev-parse --show-prefix` proves that location is exactly the repository root. A subdirectory remains nonempty, Git failures remain fatal, and the independent origin check is unchanged.

Closes #208

## Regression evidence

Exact head: `f697ae0e9bbc3643b5fe057db11b9a7c1275de01`

The single focused test creates a real temporary Git repository and verifies its root through the production helper.

Before the fix, production `preview` at verified skill revision `792ba098a7590c293398446246a9d2bb3dd72f50` failed with:

```text
project run receipt failed: --repo-root must be the Git repository root
```

After the fix, the focused repository-root test passes locally. The exact native Windows workflow is the required CI authority.

## Validation

- focused repository-root regression: pass
- byte-identical receipt contract across all four project skills: pass
- scoped Biome format and lint: pass
- TypeScript: pass
- dependency audit: no vulnerabilities
- production build and skill packaging: pass
- `git diff --check`: pass
- browser E2E: N/A, no UI or browser behavior changed

## Scope

Exactly one regression test was added. The existing Windows workflow runs only that focused test when receipt code changes. No trace, scoring, reward, wallet, or settlement behavior changed.

## Provenance

No Slop receipt could be created because this bug blocks receipt `preview` on Windows.

- AI assistance: yes
- AI provider/model: openai / gpt-5.6-sol
- Client / agent tooling: Codex desktop
- Attribution status: self-reported