### PR TITLE
feat(projects): accept reviewed listing tiers

### DIFF
--- a/src/lib/project-schema.mjs
+++ b/src/lib/project-schema.mjs
@@ -18,6 +18,7 @@ const PROJECT_KEYS = [
   "headline",
   "id",
   "links",
+  "listingTier",
   "modelPolicy",
   "name",
   "repositories",
@@ -880,7 +881,14 @@ function validateProjectDefinition(
   } = {},
 ) {
   const project = record(value, "project");
-  exactKeys(project, PROJECT_KEYS, "project");
+  const hasListingTier = Object.hasOwn(project, "listingTier");
+  exactKeys(
+    project,
+    hasListingTier
+      ? PROJECT_KEYS
+      : PROJECT_KEYS.filter((key) => key !== "listingTier"),
+    "project",
+  );
   if (project.schemaVersion !== "1")
     throw new TypeError("project schemaVersion is unsupported");
   const id = text(project.id, "project.id", {
@@ -893,6 +901,13 @@ function validateProjectDefinition(
   text(project.eyebrow, "project.eyebrow", { max: 80, min: 3 });
   text(project.headline, "project.headline", { max: 120, min: 8 });
   text(project.description, "project.description", { max: 600, min: 24 });
+  if (
+    hasListingTier &&
+    project.listingTier !== "featured" &&
+    project.listingTier !== "community"
+  ) {
+    throw new TypeError("project.listingTier is invalid");
+  }
   if (project.status !== "active" && project.status !== "paused") {
     throw new TypeError("project.status is invalid");
   }

--- a/src/lib/project-schema.test.ts
+++ b/src/lib/project-schema.test.ts
@@ -100,6 +100,12 @@ describe("project proposal schema", () => {
     expect(assertProjectDefinition(eliza).reviewSkill.id).toBe(
       "review-eliza-contributions",
     );
+    expect(assertProjectDefinition(eliza).listingTier).toBeUndefined();
+    const featured = { ...structuredClone(eliza), listingTier: "featured" };
+    expect(assertProjectDefinition(featured).listingTier).toBe("featured");
+    expect(() =>
+      assertProjectDefinition({ ...featured, listingTier: "sponsored" }),
+    ).toThrow(/listingTier/u);
     expect(assertProjectDefinition(deltaStar).repositories[0]).toMatchObject({
       id: "elizaOS/proximityprize",
       aliases: ["SlopDotCash/proximityprize"],

--- a/src/lib/projects.d.mts
+++ b/src/lib/projects.d.mts
@@ -48,6 +48,7 @@ export interface ProjectDefinition {
   readonly eyebrow: string;
   readonly headline: string;
   readonly description: string;
+  readonly listingTier?: "featured" | "community";
   readonly status: ProjectStatus;
   readonly steward: {
     readonly displayName: string;


### PR DESCRIPTION
## Summary
- allow current project manifests to opt into a validated featured or community listing tier
- preserve compatibility with existing manifests that do not yet carry the field
- add schema and typing coverage for valid, absent, and invalid tiers

This is the trusted-schema prerequisite for PR #207. It intentionally changes no manifest, UI, reward, or authority state.

## Verification
- project schema and policy tests: 23 passed
- TypeScript, Biome lint/format, diff check: pass
- exact base-to-head project transition gate: pass