### PR TITLE
fix(skills): preserve transferred review proof identity

### DIFF
--- a/skill-tests/review-preflight.test.ts
+++ b/skill-tests/review-preflight.test.ts
@@ -7,11 +7,22 @@ import { assessReviewCompatibility } from "../skills/contribute-to-eliza/scripts
 
 const branchSha = "1".repeat(40);
 const commitId = "65455082b87f12ddf5ea4a40e4e8734dbae9e961";
+const configuration = JSON.parse(
+  readFileSync(
+    new URL(
+      "../skills/contribute-to-eliza/review-compatibility.json",
+      import.meta.url,
+    ),
+    "utf8",
+  ),
+);
+const proofSkillRevision =
+  "elizaOS/slopdotcash@1bde21d6d8229678f20bbd450f8e49f9fd95f989:skills/contribute-to-eliza";
 const marker = {
   provider: "openai",
   model: "gpt-5.6-sol",
   client: "codex",
-  skill_revision: `SlopDotCash/slopdotcash@${"2".repeat(40)}:skills/contribute-to-eliza`,
+  skill_revision: proofSkillRevision,
   run: {
     schema_version: "1",
     run_id: "run_01M001JJ3EJEXAR11GKPE15MXM",
@@ -171,6 +182,28 @@ describe("Eliza review compatibility preflight", () => {
     assert.equal(result.status, "unknown");
     assert.equal(result.safeToPublish, false);
     assert.equal(result.forwardProof.valid, false);
+  });
+
+  it("fails closed when the proof marker names a different skill revision", () => {
+    const input = fixture();
+    const mismatchedMarker = {
+      ...marker,
+      skill_revision: `elizaOS/slopdotcash@${"2".repeat(40)}:skills/contribute-to-eliza`,
+    };
+    input.proofReview.body = `Verified review\n<!-- slop-contribution-attribution:v1 ${JSON.stringify(mismatchedMarker)} -->`;
+    const result = assessReviewCompatibility(input);
+    assert.equal(result.status, "unknown");
+    assert.equal(result.safeToPublish, false);
+    assert.equal(result.forwardProof.valid, false);
+  });
+
+  it("rejects an unregistered repository identity in proof configuration", () => {
+    const invalidConfiguration = structuredClone(configuration);
+    invalidConfiguration.forwardProof.skillRevision = `example/slopdotcash@${"2".repeat(40)}:skills/contribute-to-eliza`;
+    assert.throws(
+      () => assessReviewCompatibility(fixture(), invalidConfiguration),
+      /forward proof has an invalid identity/u,
+    );
   });
 
   it("rejects unbounded or malformed workflow inventories", () => {

--- a/skills/contribute-to-eliza/review-compatibility.json
+++ b/skills/contribute-to-eliza/review-compatibility.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "1",
+  "schemaVersion": "2",
   "artifact": "pull-request-review",
   "repositoryId": "elizaOS/eliza",
   "integrationBranch": "develop",
@@ -11,6 +11,7 @@
     "pullRequest": 19560,
     "reviewId": 4936838769,
     "commitId": "65455082b87f12ddf5ea4a40e4e8734dbae9e961",
+    "skillRevision": "elizaOS/slopdotcash@1bde21d6d8229678f20bbd450f8e49f9fd95f989:skills/contribute-to-eliza",
     "url": "https://github.com/elizaOS/eliza/pull/19560#pullrequestreview-4936838769"
   }
 }

--- a/skills/contribute-to-eliza/scripts/review-preflight.mjs
+++ b/skills/contribute-to-eliza/scripts/review-preflight.mjs
@@ -73,7 +73,7 @@ function validateConfiguration(value = CONFIG) {
     "review compatibility configuration",
   );
   if (
-    config.schemaVersion !== "1" ||
+    config.schemaVersion !== "2" ||
     config.artifact !== "pull-request-review" ||
     config.repositoryId !== "elizaOS/eliza" ||
     config.integrationBranch !== "develop" ||
@@ -87,7 +87,7 @@ function validateConfiguration(value = CONFIG) {
   const proof = record(config.forwardProof, "forward proof");
   exactKeys(
     proof,
-    ["commitId", "pullRequest", "reviewId", "url"],
+    ["commitId", "pullRequest", "reviewId", "skillRevision", "url"],
     "forward proof",
   );
   if (
@@ -96,6 +96,9 @@ function validateConfiguration(value = CONFIG) {
     !Number.isSafeInteger(proof.reviewId) ||
     proof.reviewId <= 0 ||
     !SHA_RE.test(proof.commitId) ||
+    !/^(?:elizaOS|SlopDotCash)\/slopdotcash@[0-9a-f]{40}:skills\/contribute-to-eliza$/u.test(
+      proof.skillRevision,
+    ) ||
     proof.url !==
       `https://github.com/${config.repositoryId}/pull/${proof.pullRequest}#pullrequestreview-${proof.reviewId}`
   ) {
@@ -133,7 +136,7 @@ function validProofReview(review, config) {
     marker.run?.signature_algorithm === "ed25519" &&
     typeof marker.run?.device_public_key === "string" &&
     typeof marker.run?.device_signature === "string" &&
-    marker.skill_revision?.startsWith("SlopDotCash/slopdotcash@")
+    marker.skill_revision === config.forwardProof.skillRevision
   );
 }
 


### PR DESCRIPTION
## Summary

- bind the pinned Eliza review proof to its exact pre-transfer skill revision
- move the compatibility configuration to schema v2 for the new required identity field
- reject mismatched revisions and unregistered repository aliases with focused fail-closed regressions

Fixes #214.

## Root cause

Organization migration PR #211 changed `validProofReview()` from the historical `elizaOS/slopdotcash@` prefix to the current `SlopDotCash/slopdotcash@` prefix. The configured immutable proof was created before that transfer, so its signed terminal marker can never contain the new owner name.

This change does not generally accept the old prefix. It records the one exact historical revision in the pinned proof configuration and requires the public review marker to match it byte-for-byte. Configuration validation accepts only the registered old/current Slop repository identities and still rejects every other alias.

## Exact-head validation

Head: `4bcd24ee9c658ece8a8a7b2b079e10200c141cfe`

- `bun run verify` — passed; 64/64 Vitest files, 594/594 tests, 86/86 skill tests, dependency audit, project/evaluation/funding/cycle/protocol checks, typecheck, format, lint, and production build
- `bun run test:e2e` through the pull-request workflow's deployed-ledger preparation path — 36/36 desktop/tablet/mobile tests plus 1/1 Pages artifact contract passed
- `node skills/contribute-to-eliza/scripts/review-preflight.mjs --json` — `forwardProof.valid: true`, `safeToPublish: true`, `status: supported-with-documentation-drift`
- generated `contribute-to-eliza.skill` SHA-256: `aa556edaf785c1b677d155fc1df6062f7df9b31abf0d242df950002e94cd21bf`
- UI evidence: N/A — skill configuration, validation, and tests only; no rendered product behavior changed

## Additional observation

A separate local trusted-ledger generation attempt currently fails closed on a malformed live `provider/model` identifier in an open work-queue PR. Pull-request CI intentionally uses the deployed public ledger instead of executing untrusted PR code with a repository token, so the exact PR workflow path above was used for browser verification. No partial or fabricated ledger was retained.

## Contribution provenance

- AI assistance: yes
- AI provider/model: OpenAI / GPT-5.6
- Client / agent tooling: Codex desktop
- Attribution status: self-reported
