### PR TITLE
fix(leaderboard): validate combined model identities consistently

### DIFF
--- a/src/lib/leaderboard.test.ts
+++ b/src/lib/leaderboard.test.ts
@@ -3631,6 +3631,32 @@ describe("work queue claims and prioritization", () => {
     });
     expect(snapshot.leaders).toEqual([]);
   });
+
+  it("uses the canonical field validators for combined queue model identifiers", () => {
+    const snapshot = createLeaderboardSnapshot(
+      input({
+        mergedPullRequests: [
+          pullRequest({
+            body: machineAttribution("OpenAI", "@gpt-5.6-sol"),
+          }),
+        ],
+        openIssues: [
+          issue({
+            id: "ISSUE_PREFIXED_MODEL",
+            closedAt: null,
+            stateReason: null,
+            body: "AI provider/model: OpenAI / @gpt-5.6-sol",
+            labels: [],
+          }),
+        ],
+      }),
+    );
+
+    expect(snapshot.workQueue.issues[0].model.identifiers).toEqual([
+      "OpenAI/@gpt-5.6-sol",
+    ]);
+    expect(snapshot.leaders[0].reportedModels).toEqual(["openai/@gpt-5.6-sol"]);
+  });
 });
 
 describe("deduplication and public schema", () => {

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -1170,6 +1170,22 @@ function exactIdentifier(provider: string, model: string): string {
     : `${provider}/${model}`;
 }
 
+function isExactProviderModelIdentifier(identifier: string): boolean {
+  for (
+    let index = identifier.indexOf("/");
+    index !== -1;
+    index = identifier.indexOf("/", index + 1)
+  ) {
+    if (
+      isExactProviderIdentifier(identifier.slice(0, index)) &&
+      isExactModelIdentifier(identifier.slice(index + 1))
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function attributionLineValues(body: string, label: string): string[] {
   const expression = new RegExp(`^${label}\\s*:\\s*(.+?)\\s*$`, "i");
   return attributionDeclarationLines(body)
@@ -4085,11 +4101,7 @@ function assertLeaderValue(
     `${path}.reportedModels`,
   );
   models.forEach((identifier, index) => {
-    if (
-      !/^[a-z0-9][a-z0-9._-]{0,63}\/[a-z0-9][a-z0-9._:/-]{0,127}$/i.test(
-        identifier,
-      )
-    ) {
+    if (!isExactProviderModelIdentifier(identifier)) {
       throw new Error(
         `${path}.reportedModels[${index}] must be an exact provider/model identifier`,
       );
@@ -4380,11 +4392,7 @@ function assertWorkItemValue(
     `${path}.model.identifiers`,
   );
   identifiers.forEach((identifier, index) => {
-    if (
-      !/^[a-z0-9][a-z0-9._-]{0,63}\/[a-z0-9][a-z0-9._:/-]{0,127}$/i.test(
-        identifier,
-      )
-    ) {
+    if (!isExactProviderModelIdentifier(identifier)) {
       throw new Error(
         `${path}.model.identifiers[${index}] must be an exact provider/model identifier`,
       );


### PR DESCRIPTION
Fixes the scheduled live-ledger failure where canonical model identity fields accepted a prefixed identifier but the combined public snapshot validator used a narrower regex. The combined validator now tries every provider/model boundary with the canonical field validators, preserving fail-closed validation while accepting exactly the identities ingestion already recognizes. Adds a regression test for OpenAI/@gpt-5.6-sol. Verified with 87 leaderboard tests, typecheck, lint, format, and diff checks. Manual merge only; auto-merge is not enabled.