### PR TITLE
Fix live leaderboard compound model identities

### DIFF
--- a/src/lib/leaderboard.test.ts
+++ b/src/lib/leaderboard.test.ts
@@ -2636,6 +2636,24 @@ describe("scoring and limits", () => {
 });
 
 describe("work queue claims and prioritization", () => {
+  it("publishes exact compound model identifiers accepted by attribution parsing", () => {
+    const openPullRequest = pullRequest({
+      id: "PR_NESTED_MODEL_IDENTITY",
+      number: 99,
+      mergedAt: null,
+      body: machineAttribution("xAI", "grok-4.6+zai/glm-5.2"),
+    });
+
+    const snapshot = createLeaderboardSnapshot(
+      input({ openPullRequests: [openPullRequest] }),
+    );
+
+    expect(snapshot.workQueue.pullRequests[0].model).toMatchObject({
+      status: "complete",
+      identifiers: ["xai/grok-4.6+zai/glm-5.2"],
+    });
+  });
+
   it("marks only safe, unclaimed issue and review candidates", () => {
     const issueCandidate = issue({
       id: "ISSUE_CANDIDATE",

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -8,6 +8,7 @@ import {
   isExactClientIdentifier,
   isExactModelIdentifier,
   isExactProviderIdentifier,
+  isExactProviderModelIdentifier,
 } from "./model-identity";
 import { findProject } from "./projects.mjs";
 import {
@@ -4085,11 +4086,7 @@ function assertLeaderValue(
     `${path}.reportedModels`,
   );
   models.forEach((identifier, index) => {
-    if (
-      !/^[a-z0-9][a-z0-9._-]{0,63}\/[a-z0-9][a-z0-9._:/-]{0,127}$/i.test(
-        identifier,
-      )
-    ) {
+    if (!isExactProviderModelIdentifier(identifier)) {
       throw new Error(
         `${path}.reportedModels[${index}] must be an exact provider/model identifier`,
       );
@@ -4380,11 +4377,7 @@ function assertWorkItemValue(
     `${path}.model.identifiers`,
   );
   identifiers.forEach((identifier, index) => {
-    if (
-      !/^[a-z0-9][a-z0-9._-]{0,63}\/[a-z0-9][a-z0-9._:/-]{0,127}$/i.test(
-        identifier,
-      )
-    ) {
+    if (!isExactProviderModelIdentifier(identifier)) {
       throw new Error(
         `${path}.model.identifiers[${index}] must be an exact provider/model identifier`,
       );

--- a/src/lib/model-identity.test.ts
+++ b/src/lib/model-identity.test.ts
@@ -5,6 +5,7 @@ import {
   isExactClientVersion,
   isExactModelIdentifier,
   isExactProviderIdentifier,
+  isExactProviderModelIdentifier,
 } from "./model-identity";
 import { MODEL_IDENTITY_CONFORMANCE_CASES } from "./model-identity-corpus";
 
@@ -36,6 +37,20 @@ describe("exact model identity", () => {
         client: "kimi-cli",
       }),
     ).not.toThrow();
+  });
+
+  it("validates combined identities across nested slash boundaries", () => {
+    expect(
+      isExactProviderModelIdentifier(
+        "x-ai/hosted+edge/accounts/x/models/grok-4.5+reasoning",
+      ),
+    ).toBe(true);
+    expect(isExactProviderModelIdentifier("~local/@scope/model+fast")).toBe(
+      true,
+    );
+    expect(isExactProviderModelIdentifier("provider/model")).toBe(false);
+    expect(isExactProviderModelIdentifier("OpenAI/unknown")).toBe(false);
+    expect(isExactProviderModelIdentifier("missing-separator")).toBe(false);
   });
 
   it.each([

--- a/src/lib/model-identity.ts
+++ b/src/lib/model-identity.ts
@@ -59,6 +59,30 @@ export function isExactModelIdentifier(value: unknown): value is string {
   return exactIdentity(value, 128, MODEL_PLACEHOLDERS);
 }
 
+/**
+ * Validates the public `provider/model` form without assuming that the first
+ * slash is the separator. Exact provider and model identifiers may themselves
+ * contain slashes, so every possible boundary must be considered.
+ */
+export function isExactProviderModelIdentifier(
+  value: unknown,
+): value is string {
+  if (typeof value !== "string") return false;
+  for (
+    let index = value.indexOf("/");
+    index >= 0;
+    index = value.indexOf("/", index + 1)
+  ) {
+    if (
+      isExactProviderIdentifier(value.slice(0, index)) &&
+      isExactModelIdentifier(value.slice(index + 1))
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
 export function isExactClientIdentifier(value: unknown): value is string {
   return exactIdentity(value, 64, CLIENT_PLACEHOLDERS);
 }


### PR DESCRIPTION
## Summary
- validate published `provider/model` identities through the shared exact-identity contract instead of a narrower duplicate regex
- preserve providers and models that legitimately contain nested paths, scopes, `+`, or `~`
- keep generic placeholders, missing separators, and malformed identifiers fail-closed

## Production reproduction
Develop run 32406680772 failed while publishing work-queue model identity `xai/grok-4.6+zai/glm-5.2`. Attribution parsing accepts that exact model syntax, but the final snapshot assertion rejected `+`, creating an internal contract contradiction.

## Exact-head evidence
- `bun x vitest run src/lib/model-identity.test.ts src/lib/leaderboard.test.ts` — 110/110 passed
- `bun run typecheck`
- `bun run format:check`
- `bun run lint:check`
- `git diff --check`
- `AGENTS.md` and `CLAUDE.md` byte-identical
- real authenticated `bun run leaderboard:generate` completed: schema 6, 104 leaders, 4,671 score events, 197 GraphQL requests; the resulting live snapshot contains both `xAI/grok-4.6+zai/glm-5.2` and `xai/grok-4.6+zai/glm-5.2` without weakening placeholder validation

No scoring, points, ranking, selection, or payment rule changes.