### PR TITLE
fix(leaderboard): remove duplicate model validator

### DIFF
--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -1171,22 +1171,6 @@ function exactIdentifier(provider: string, model: string): string {
     : `${provider}/${model}`;
 }
 
-function isExactProviderModelIdentifier(identifier: string): boolean {
-  for (
-    let index = identifier.indexOf("/");
-    index !== -1;
-    index = identifier.indexOf("/", index + 1)
-  ) {
-    if (
-      isExactProviderIdentifier(identifier.slice(0, index)) &&
-      isExactModelIdentifier(identifier.slice(index + 1))
-    ) {
-      return true;
-    }
-  }
-  return false;
-}
-
 function attributionLineValues(body: string, label: string): string[] {
   const expression = new RegExp(`^${label}\\s*:\\s*(.+?)\\s*$`, "i");
   return attributionDeclarationLines(body)


### PR DESCRIPTION
Repairs the merge race between #217 and #218. Both introduced the same validator; after #218 merged the later merge of #217 added a local declaration alongside the shared import, producing a duplicate binding. Keep the shared, independently tested helper and the additional focused regression test from #217; remove only the duplicate declaration.\n\nExact-head verification: `bun run typecheck`; 111 focused model-identity/leaderboard tests; format; lint; diff checks; AGENTS/CLAUDE parity.