### PR TITLE
Fix reward cycle formatting workflow failure

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -9,7 +9,14 @@
   "files": {
     "ignoreUnknown": true,
     "maxSize": 1048576,
-    "includes": ["**", "!**/dist", "!**/node_modules", "!**/public", "!assets"]
+    "includes": [
+      "**",
+      "!**/dist",
+      "!**/node_modules",
+      "!**/public",
+      "!assets",
+      "!cycles"
+    ]
   },
   "formatter": {
     "enabled": true,


### PR DESCRIPTION
## Summary
- exclude append-only generated `cycles/` artifacts from the general Biome formatter/linter
- keep cycle validation under the purpose-built `cycles:check` contract
- prevent format checks from trying to rewrite canonical proposal bytes or process multi-megabyte immutable source snapshots

## Evidence
- reproduced PR #220 CI failure against the generated July proposal and 5.2 MiB snapshot
- `bun run format:check`
- `bun run lint:check`
- with this config applied to #220: `format:check` ignores the generated cycle tree; `cycles:check` validates the exact proposal/snapshot pair
- `git diff --check`; AGENTS/CLAUDE parity

This does not change scoring, allocations, review state, payment state, or generated cycle bytes.