### PR TITLE
fix(skills): enforce review-first work queues

### DIFF
--- a/skill-tests/contribute-to-eliza.test.ts
+++ b/skill-tests/contribute-to-eliza.test.ts
@@ -169,8 +169,9 @@ describe("contribute-to-eliza skill structure", () => {
   it("encodes outcome modes, measured runs, security, sync, proof, and authority", () => {
     const source = readFileSync(skillPath, "utf8");
 
-    assert.match(source, /\*\*Implement an existing issue with no PR\*\*/);
-    assert.match(source, /\*\*Review an existing PR with no review\*\*/);
+    assert.match(source, /\*\*Review and test every current PR\*\*/);
+    assert.match(source, /\*\*Finish every existing issue without a PR\*\*/);
+    assert.match(source, /\*\*Restore `develop` workflow health\*\*/);
     assert.match(source, /\*\*Validate\*\*/);
     assert.match(source, /run-receipt\.mjs start/);
     assert.match(source, /run-receipt\.mjs finish/);
@@ -224,29 +225,36 @@ describe("contribute-to-eliza skill structure", () => {
       source,
       /Never apply, request, suggest applying, or automate/i,
     );
-    assert.match(source, /exact repository label\s+`mission-ready`/i);
-    assert.match(source, /issue explicitly selected by the operator/i);
+    assert.match(source, /exact\s+repository label `mission-ready`/i);
+    assert.match(source, /issue explicitly selected by the\s+operator/i);
     assert.match(source, /Keep at most one active implementation or review/i);
     assert.match(source, /Never\s+mirror a PR title into an issue/i);
     assert.match(source, /Prefer one complete fix to\s+several small PRs/i);
     assert.match(source, /Ignore leaderboard position/i);
-    const implementPriority = source.indexOf(
-      "**Implement an existing issue with no PR**",
-    );
     const reviewPriority = source.indexOf(
-      "**Review an existing PR with no review**",
+      "**Review and test every current PR**",
+    );
+    const implementPriority = source.indexOf(
+      "**Finish every existing issue without a PR**",
+    );
+    const workflowPriority = source.indexOf(
+      "**Restore `develop` workflow health**",
     );
     const auditPriority = source.indexOf(
-      "**Audit only after reconciling the old queue**",
+      "**Audit only after the three gates are clear**",
     );
-    assert.ok(implementPriority >= 0);
-    assert.ok(reviewPriority > implementPriority);
-    assert.ok(auditPriority > reviewPriority);
+    assert.ok(reviewPriority >= 0);
+    assert.ok(implementPriority > reviewPriority);
+    assert.ok(workflowPriority > implementPriority);
+    assert.ok(auditPriority > workflowPriority);
     assert.match(
       source,
       /\*\*security weaknesses\*\*.*\*\*reproducible bugs\*\*.*\*\*incorrect or stale\s+documentation and code comments\*\*.*\*\*important behavior that lacks real\s+tests\*\*/is,
     );
-    assert.match(source, /entire old issue and PR queue has been reconciled/i);
+    assert.match(
+      source,
+      /every current PR has a current-head review and disposition[\s\S]*every existing issue[\s\S]*every required `develop` workflow/iu,
+    );
     assert.match(mission, /Eliza app/);
     assert.match(mission, /Eliza Cloud/);
     assert.match(mission, /Core agent runtime/);
@@ -396,8 +404,9 @@ writeFileSync(
     );
     assert.match(openaiYaml, /display_name: "Contribute to Eliza"/);
     assert.match(openaiYaml, /default_prompt: "Use \$contribute-to-eliza/);
-    assert.match(openaiYaml, /finish an existing issue with no PR/);
-    assert.match(openaiYaml, /review an unreviewed PR/);
+    assert.match(openaiYaml, /review and test every current PR first/);
+    assert.match(openaiYaml, /existing issues through PRs second/);
+    assert.match(openaiYaml, /develop workflows third/);
     assert.match(openaiYaml, /elizaOS\/eliza/);
   });
 });

--- a/skill-tests/project-skills.test.ts
+++ b/skill-tests/project-skills.test.ts
@@ -140,31 +140,64 @@ describe("project skill contracts", () => {
     assert.match(delta, /does not.*guarantee.*dollar/is);
   });
 
-  it("finishes valid issue queues before new work and rejects trivial output", () => {
+  it("clears PRs, issues, and workflows before new work", {
+    timeout: 30_000,
+  }, () => {
     for (const { project, contributorRoot, reviewerRoot } of projectPackages) {
       const contributor = readFileSync(
         join(contributorRoot, "SKILL.md"),
         "utf8",
       );
       const reviewer = readFileSync(join(reviewerRoot, "SKILL.md"), "utf8");
+      const contributorLauncher = readFileSync(
+        join(contributorRoot, "agents", "openai.yaml"),
+        "utf8",
+      );
+      const reviewerLauncher = readFileSync(
+        join(reviewerRoot, "agents", "openai.yaml"),
+        "utf8",
+      );
       const issuePriority = contributor.search(
-        /(?:implement|finish) an existing issue with no PR|finish the oldest[\s\S]{0,180}open issue[\s\S]{0,180}no open PR/iu,
+        /finish every existing issue without a PR|finish the oldest[\s\S]{0,220}open issue/iu,
       );
       const reviewPriority = contributor.search(
-        /review an existing PR with no review|only when no such issue remains[\s\S]{0,180}review the oldest/iu,
+        /review and test every current PR/iu,
+      );
+      const workflowPriority = contributor.search(
+        /restore (?:`develop`|integration-branch) workflow health|inspect every required GitHub Actions\s+workflow/iu,
       );
 
       assert.ok(
-        issuePriority >= 0,
-        `${project.skill.id} must prioritize an existing issue without a PR`,
+        reviewPriority >= 0,
+        `${project.skill.id} must prioritize current-head PR review`,
       );
       assert.ok(
-        reviewPriority > issuePriority,
-        `${project.skill.id} must place unreviewed PRs after uncovered issues`,
+        issuePriority > reviewPriority,
+        `${project.skill.id} must place uncovered issues after PR review`,
+      );
+      assert.ok(
+        workflowPriority > issuePriority,
+        `${project.skill.id} must place workflow repair after the issue queue`,
       );
       assert.match(
         contributor,
-        /(?:after )?reconciling the old queue|old queue (?:is|has been) reconciled|every older issue and PR is reconciled/iu,
+        /\*\*merge\*\*, \*\*fix\*\*, or \*\*close\*\*/iu,
+      );
+      assert.match(contributor, /exact current head|exact-head/iu);
+      const newIssueGate = contributor.search(
+        /(?:a new (?:issue|one)\s+requires|open a new\s+issue only)/iu,
+      );
+      assert.ok(newIssueGate >= 0);
+      const gateText = contributor.slice(newIssueGate, newIssueGate + 900);
+      assert.match(gateText, /every current PR/iu);
+      assert.match(gateText, /every existing\s+issue/iu);
+      assert.match(
+        gateText,
+        /workflow[\s\S]{0,100}green[\s\S]{0,100}current\s+integration head/iu,
+      );
+      assert.match(
+        gateText,
+        /external[\s\S]{0,80}blocker\s+keeps[\s\S]{0,80}gate closed/iu,
       );
       assert.match(
         contributor,
@@ -179,6 +212,18 @@ describe("project skill contracts", () => {
         reviewer,
         /tests with no\s+demonstrated\s+behavioral risk|tests that prove no meaningful/iu,
       );
+      assert.match(reviewer, /## Clear the review queue first/iu);
+      assert.match(reviewer, /\*\*merge\*\*, \*\*fix\*\*, or \*\*close\*\*/iu);
+      assert.match(
+        reviewer,
+        /Do not open new issues[\s\S]{0,320}reviewable PR remains[\s\S]{0,320}existing issue lacks a PR[\s\S]{0,320}workflow/iu,
+      );
+      assert.match(
+        contributorLauncher,
+        /review and test every current PR first[\s\S]*existing issues through PRs second[\s\S]*workflows third/iu,
+      );
+      assert.match(reviewerLauncher, /current-head PR reviews first/iu);
+      assert.match(reviewerLauncher, /merge, fix, or close recommendation/iu);
     }
 
     const asi = readFileSync(

--- a/skill-tests/slop-bootstrap.test.ts
+++ b/skill-tests/slop-bootstrap.test.ts
@@ -35,4 +35,22 @@ describe("Slop bootstrap revision authorization", () => {
     assert.match(source, /any missing or extra path/u);
     assert.match(source, /any byte difference/u);
   });
+
+  it("bootstraps the universal queue-first priority gates", () => {
+    const reviews = source.search(
+      /review, test, and[\s\S]{0,80}recommendation/iu,
+    );
+    const issues = source.search(/finish every valid existing issue/iu);
+    const workflows = source.search(
+      /repair every reproducible[\s\S]{0,80}failure/iu,
+    );
+    assert.ok(reviews >= 0);
+    assert.ok(issues > reviews);
+    assert.ok(workflows > issues);
+    assert.match(source, /only after all three\s+gates are clear/iu);
+    assert.match(
+      source,
+      /operator explicitly authorizes that exact issue\s+write/iu,
+    );
+  });
 });

--- a/skills/contribute-to-asi/SKILL.md
+++ b/skills/contribute-to-asi/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: contribute-to-asi
-description: "Finish mission-aligned open issues in SlopDotCash/asi, then hill-climb its continual-RL benchmarks, produce measured research advancement, or fix a reproduced bug that corrupts execution or measurement, with optional public payout registration. Do not use for generic improvements, cleanup, or speculative polish."
+description: "Review and test current SlopDotCash/asi pull requests, finish mission-aligned open issues through pull requests, restore main workflow health, then hill-climb continual-RL benchmarks, produce measured research advancement, or fix a reproduced bug. Do not use for generic improvements, cleanup, or speculative polish."
 ---
 
 # Contribute to ASI
@@ -104,25 +104,35 @@ node <skill-directory>/scripts/live-report.mjs --repo SlopDotCash/asi
 Re-read the chosen issue, discussion, or pull request immediately before
 acting — someone may already be running your experiment.
 
-## Finish the existing queue before inventing work
+## Finish the existing queue and workflows before inventing work
 
 Use the live report as a filter, then inspect GitHub directly. Follow this
 priority order without skipping a nonempty higher tier for easier, newer, or
 more interesting work:
 
-1. **Finish an existing issue with no PR.** Choose the oldest bounded,
-   unblocked, unclaimed open issue that fits the measured ASI mission. Confirm
-   no open PR has a closing reference or substantively implements it, then
-   resolve the issue completely with the required paired evidence. An issue
-   asking for cleanup, generic improvement, or unmeasured polish is not made
-   valid merely because it is old; give it an explicit out-of-scope
-   disposition instead of implementing it.
-2. **Review an existing PR with no review.** Only when no qualifying issue is
-   available, independently reproduce the oldest non-draft, unblocked,
-   non-sensitive PR you did not author that lacks a substantive current-head
-   human review and active reviewer. Approve, request changes, repair only when
-   authorized, or recommend closure.
-3. **Advance the research only after the old queue is reconciled.** New work
+1. **Review and test every current PR.** Start with the oldest non-draft,
+   unblocked, non-sensitive PR lacking a substantive independent review of its
+   exact current head. Inspect every open PR, including previously reviewed PRs
+   whose head changed. Independently reproduce the claimed outcome and give an
+   explicit **merge**, **fix**, or **close** recommendation. When authorized,
+   make an existing PR completely solid by repairing real defects, strengthening
+   failure-sensitive tests, and rerunning exact-head checks; never approve your
+   own work. Do not leave any reviewable PR without a current-head test and
+   disposition merely because its premise is weak or its author is inactive.
+2. **Finish every existing issue without a PR.** Only after tier one is empty,
+   choose the oldest bounded, unblocked, unclaimed open issue that fits the
+   measured ASI mission. Confirm no open PR has a closing reference or
+   substantively implements it, then resolve it completely through a focused PR
+   with the required paired evidence. Give duplicate, obsolete, invalid, or
+   out-of-scope issues an explicit closure recommendation instead of turning
+   them into cleanup work.
+3. **Restore integration-branch workflow health.** Only after tiers one and two
+   are empty, inspect every required GitHub Actions workflow on `main`. Repair
+   every reproducible repository-caused failure and rerun it at the exact head.
+   A queued run, missing runner, credential/environment gate, or external outage
+   is not green and not a code bug; record the precise blocker instead of
+   weakening checks or inventing unrelated work.
+4. **Advance the research only after all three gates are clear.** New work
    must be a benchmark hill climb, a measured port or decisive experimental
    advancement/refutation, or a fix for an actual reproduced runtime,
    harness, metric, validator, or test-system bug. Do not make random
@@ -130,12 +140,19 @@ more interesting work:
    or trivial fixes, documentation-only edits, or tests with no demonstrated
    behavioral risk.
 
+Before declaring tier three clear, query Actions directly and establish the
+latest required `main` result at the current integration head; do not infer
+workflow health from a PR check summary or an older green run.
+
 The closing-reference check is only a deduplication aid. Re-read linked PRs,
 issue timelines, reviews, and current heads before declaring an issue
 uncovered or a PR unreviewed. Treat incomplete queue data as unknown and stop.
 Do not create an issue or discussion during a self-directed run. A new one
-requires the operator to request that exact write after the existing issue and
-PR queue has been reconciled and the measured mission gate has passed. Route
+requires the operator to request that exact write after every current PR has a
+current-head review and disposition, every existing issue is covered by a PR
+or explicit disposition, all required `main` workflows are green at the current
+integration head, and the measured mission gate has passed. An external blocker
+keeps this gate closed. Route
 security findings privately under repository policy.
 
 ## What counts as work here
@@ -236,18 +253,19 @@ Plan line of work itself.
 - A published claim is not evidence for this repository. Nothing enters
   `RESEARCH_STATUS.md` on a citation; it enters on a measurement made here.
 - Do not create a speculative discussion merely because you cannot finish an
-  idea. After the old queue is reconciled, the operator may explicitly
+  idea. After the PR, issue, and workflow gates are clear, the operator may explicitly
   authorize a discussion that names the paper, mechanism, and measurement lane.
 
 ## Collaborate in the open
 
 Novel research direction is a conversation, not a surprise pull request, but
-it comes only after existing issues and unreviewed PRs are reconciled.
+it comes only after current-head PR reviews, uncovered issues, and required
+`main` workflows are reconciled.
 
-- **Discussions** (`Ideas` category) — when explicitly authorized after queue
+- **Discussions** (`Ideas` category) — when explicitly authorized after all gate
   reconciliation, propose a direction, a paper worth porting, a benchmark that
   seems mismeasured, or a result you cannot explain before spending compute.
-- **Issues** — only when explicitly authorized after queue reconciliation, one
+- **Issues** — only when explicitly authorized after all gate reconciliation, one
   bounded, measurable piece of work with a named lane, metric, and baseline.
   This is where a pre-registration lives.
 - **Pull requests** — the change plus its evidence. Link the issue or

--- a/skills/contribute-to-asi/agents/openai.yaml
+++ b/skills/contribute-to-asi/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Contribute to ASI"
-  short_description: "Finish ASI issues, then advance measured research"
-  default_prompt: "Use $contribute-to-asi to finish a mission-aligned open issue first, then pursue a proven hill climb, measured advancement or refutation, or an actual reproduced bug fix—never a random improvement."
+  short_description: "Clear ASI queues, then advance measured research"
+  default_prompt: "Use $contribute-to-asi to review and test every current PR first, finish valid existing issues through PRs second, restore main workflows third, then pursue a proven hill climb, measured advancement or refutation, or an actual reproduced bug fix—never a random improvement."

--- a/skills/contribute-to-delta-star/SKILL.md
+++ b/skills/contribute-to-delta-star/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: contribute-to-delta-star
-description: "Finish mission-aligned open issues in SlopDotCash/proximityprize, then advance, test, refute, or independently review machine-checked Delta Star work. Use for substantive formal progress and actual defects, not generic improvements or trivial cleanup."
+description: "Review and test current SlopDotCash/proximityprize pull requests, finish mission-aligned issues through pull requests, restore main workflow health, then advance, test, or refute machine-checked Delta Star work. Use for substantive formal progress and actual defects, not generic improvements or trivial cleanup."
 ---
 
 # Contribute to Delta Star
@@ -99,28 +99,45 @@ The report batches open activity, prints progress, and fails closed if a
 connection exceeds its published completeness bound. Re-read the chosen live
 issue or pull request immediately before acting.
 
-## Finish the existing queue before inventing work
+## Finish the existing queue and workflows before inventing work
 
 Follow this order without skipping a nonempty higher tier:
 
-1. Finish the oldest bounded, unblocked, unclaimed open issue that advances the
-   live Delta Star frontier and has no open PR that closes or substantively
-   implements it.
-2. Only when no such issue remains, review the oldest non-draft, unblocked,
-   non-sensitive PR you did not author that has no substantive current-head
-   human review or active reviewer. Reproduce it and give it an explicit
-   approve, changes, repair-when-authorized, or closure disposition.
-3. Only after every older issue and PR is reconciled may you select new
+1. Review and test every current PR, starting with the oldest non-draft,
+   unblocked, non-sensitive PR lacking a substantive independent review of its
+   exact current head. Reproduce the proof or claim and give an explicit
+   **merge**, **fix**, or **close** recommendation. When authorized, repair real
+   defects and rerun exact-head checks so an existing PR is completely solid;
+   never approve your own work or leave a reviewable PR undisposed.
+2. Only when tier one is empty, finish the oldest bounded, unblocked, unclaimed
+   open issue that advances the live Delta Star frontier and has no open PR that
+   closes or substantively implements it. Complete it through a focused PR, or
+   give duplicate, obsolete, invalid, and out-of-scope issues an explicit
+   closure recommendation.
+3. Only when tiers one and two are empty, inspect every required GitHub Actions
+   workflow on `main`. Repair every reproducible repository-caused failure and
+   rerun it at the exact head. Treat queued runs, missing runners,
+   credential/environment gates, and external outages as precise blockers, not
+   green results or reasons to weaken validation.
+4. Only after every PR, issue, and fixable workflow failure is reconciled may
+   you select new
    frontier work. It must discharge or narrow a named mathematical residual,
    produce a machine-checked refutation, validate a consequential claim, or
    fix an actual reproduced defect in the proof, build, or validation path.
+
+Before declaring tier three clear, query Actions directly and establish the
+latest required `main` result at the current integration head; an older green
+run or aggregate PR check is insufficient.
 
 An old issue does not override the mission gate: explicitly decline vacuous,
 duplicate, obsolete, cosmetic, or trivial work. Do not open a new issue merely
 to create an eligible task, and do not submit formatting, naming, generated
 churn, comment-only cleanup, speculative abstraction, or tests that prove no
-meaningful mathematical or validator behavior. A new issue requires the
-operator to request that exact write after the old queue has been reconciled.
+   meaningful mathematical or validator behavior. A new issue requires the
+   operator to request that exact write after every current PR has a current-head
+   review and disposition, every existing issue is covered by a PR or explicit
+   disposition, and all required `main` workflows are green at the current
+   integration head. An external blocker keeps this gate closed.
 Treat incomplete queue data as unknown and stop.
 
 ## Choose one bounded research outcome

--- a/skills/contribute-to-delta-star/agents/openai.yaml
+++ b/skills/contribute-to-delta-star/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Contribute to Delta Star"
-  short_description: "Finish Delta Star issues, then advance proofs"
-  default_prompt: "Use $contribute-to-delta-star to finish a mission-aligned open issue first, otherwise review an unreviewed PR, then pursue only substantive Delta Star frontier work."
+  short_description: "Clear Delta Star queues, then advance proofs"
+  default_prompt: "Use $contribute-to-delta-star to review and test every current PR first, finish valid existing issues through PRs second, restore main workflows third, then pursue only substantive Delta Star frontier work."

--- a/skills/contribute-to-eliza/SKILL.md
+++ b/skills/contribute-to-eliza/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: contribute-to-eliza
-description: "Finish existing issues without pull requests, review unreviewed pull requests, or audit mission-critical security, bugs, stale documentation and comments, and missing behavioral tests in elizaOS/eliza, with optional public payout registration. Use when an agent is asked to improve the shipped Eliza app, Eliza Cloud, the core agent runtime, or a primary capability on an existing product path; prove one authorized outcome; publish a device-signed project token receipt; or register a public Solana payout address."
+description: "Review and test current elizaOS/eliza pull requests, finish existing issues through pull requests, restore develop workflow health, then audit mission-critical security, bugs, stale documentation and comments, and missing behavioral tests, with optional public payout registration. Use for one material outcome on an existing shipped product path, not generic improvements or trivial cleanup."
 ---
 
 # Contribute to Eliza
@@ -133,24 +133,35 @@ post this note merely to reserve work. Stop when any field is unknown.
 Follow this priority ladder. Do not skip a nonempty higher tier for newer,
 easier, or more interesting work:
 
-1. **Implement an existing issue with no PR**: choose the oldest bounded,
-   unblocked, unclaimed open issue carrying the exact repository label
-   `mission-ready`, or an issue explicitly selected by the operator. Confirm
-   that no open PR has a GitHub closing reference or substantively implements
-   it, then resolve it completely with acceptance criteria, tests, and proof.
-   Other labels, Project membership, and text that merely says
-   "mission-ready" do not qualify.
-2. **Review an existing PR with no review**: only when no tier-one issue is
-   available, independently inspect the oldest non-draft, unblocked,
-   non-sensitive PR you did not author that has no substantive current-head
-   human review and no active reviewer. Reproduce the changed path and decide
-   whether to approve, request changes, repair when authorized, or recommend
-   closure. A low-value or invalid premise still needs an explicit review
-   disposition; it is not a reason to ignore the PR and invent new work.
-3. **Audit only after reconciling the old queue**: only when no tier-one issue
-   and no tier-two PR remain, reconcile every other open issue and PR as
-   linked, actively owned, already reviewed, draft, blocked, human-gated, or
-   security-sensitive. Then inspect one fallback category in this exact order:
+1. **Review and test every current PR**: start with the oldest non-draft,
+   unblocked, non-sensitive PR lacking a substantive independent review of its
+   exact current head. Inspect every open PR, including previously reviewed PRs
+   whose head changed. Reproduce the affected product path and give an explicit
+   **merge**, **fix**, or **close** recommendation. When authorized, make an
+   existing PR completely solid by repairing real defects, strengthening
+   failure-sensitive tests, and rerunning exact-head checks; never approve your
+   own work. A low-value or invalid premise still needs a disposition, not
+   neglect while new work is invented.
+2. **Finish every existing issue without a PR**: only when tier one is empty,
+   choose the oldest bounded, unblocked, unclaimed open issue carrying the exact
+   repository label `mission-ready`, or an issue explicitly selected by the
+   operator. Confirm that no open PR has a GitHub closing reference or
+   substantively implements it, then resolve it completely through a focused PR
+   with acceptance criteria, tests, and proof. Give duplicate, obsolete,
+   invalid, low-value, or out-of-scope issues an explicit closure recommendation.
+   Other labels, Project membership, and text that merely says "mission-ready"
+   do not qualify for implementation.
+3. **Restore `develop` workflow health**: only when tiers one and two are empty,
+   inspect every required GitHub Actions workflow on the current `develop`
+   head. Repair every reproducible repository-caused failure and rerun it at the
+   exact head. A queued run, missing runner, credential/environment gate, or
+   external outage is not green and not a code bug; record the precise blocker
+   instead of weakening checks or inventing unrelated work.
+4. **Audit only after the three gates are clear**: reconcile all excluded queue
+   items as draft, blocked, human-gated, or security-sensitive, and establish
+   the latest required workflow results directly from Actions. An older green
+   run or aggregate PR check is insufficient. Then inspect one fallback
+   category in this exact order:
    **security weaknesses**, **reproducible bugs**, **incorrect or stale
    documentation and code comments**, then **important behavior that lacks real
    tests**. Do not advance while a higher fallback category has a concrete,
@@ -166,12 +177,15 @@ declaring the queue empty.
 
 Do not create an issue during a self-directed contribution run. Open a new
 issue only when the operator explicitly asks for that exact GitHub write after
-the entire old issue and PR queue has been reconciled, a local reproduction and
-duplicate search are complete, and the mission and evidence plan pass. Fix a
+every current PR has a current-head review and disposition, every existing issue
+is covered by a PR or explicit disposition, every required `develop` workflow
+is green at the current integration head, a local reproduction and duplicate
+search are complete, and the mission and evidence plan pass. Fix a
 newly discovered bounded defect directly in one PR when authorized; route
 security findings privately under `SECURITY.md`. An issue report alone is not
 an accepted outcome. Never mirror a PR title into an issue, generate
 speculative backlog, or open issues to make work eligible for score.
+An external workflow blocker keeps the new-issue gate closed.
 
 Never apply, request, suggest applying, or automate the `mission-ready` label.
 Only a separate maintainer promotion action may add it. A Discussion remains a

--- a/skills/contribute-to-eliza/agents/openai.yaml
+++ b/skills/contribute-to-eliza/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Contribute to Eliza"
-  short_description: "Finish Eliza queues, then audit by risk"
-  default_prompt: "Use $contribute-to-eliza to finish an existing issue with no PR, otherwise review an unreviewed PR, and only after the old queue is reconciled audit security, bugs, stale docs or comments, then missing real tests in elizaOS/eliza."
+  short_description: "Clear Eliza queues, then audit by risk"
+  default_prompt: "Use $contribute-to-eliza to review and test every current PR first, finish valid existing issues through PRs second, restore develop workflows third, then audit security, bugs, stale docs or comments, and missing real tests in elizaOS/eliza."

--- a/skills/contribute-to-heir-elements-sdk/SKILL.md
+++ b/skills/contribute-to-heir-elements-sdk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: contribute-to-heir-elements-sdk
-description: "Finish mission-aligned open issues in heirlabs/element-sdk, then harden inheritance applications, fix reproduced SDK defects, strengthen sandbox and validator behavior, or review unreviewed pull requests. Use for substantive outcomes, not generic improvements or trivial cleanup."
+description: "Review and test current heirlabs/element-sdk pull requests, finish mission-aligned issues through pull requests, restore main workflow health, then harden inheritance applications or fix reproduced SDK defects. Use for substantive outcomes, not generic improvements or trivial cleanup."
 ---
 
 # Contribute to Heir Elements SDK
@@ -104,29 +104,45 @@ node <skill-directory>/scripts/live-report.mjs --repo heirlabs/element-sdk
 
 Re-read the chosen issue or pull request immediately before acting.
 
-## Finish the existing queue before inventing work
+## Finish the existing queue and workflows before inventing work
 
 Follow this order without skipping a nonempty higher tier:
 
-1. Finish the oldest bounded, unblocked, unclaimed open issue that fits the
-   inheritance SDK mission and has no open PR that closes or substantively
-   implements it.
-2. Only when no such issue remains, review the oldest non-draft, unblocked,
-   non-sensitive PR you did not author that has no substantive current-head
-   human review or active reviewer. Reproduce it and give it an explicit
-   approve, changes, repair-when-authorized, or closure disposition.
-3. Only after every older issue and PR is reconciled may you find new work. It
+1. Review and test every current PR, starting with the oldest non-draft,
+   unblocked, non-sensitive PR lacking a substantive independent review of its
+   exact current head. Reproduce the SDK behavior and give an explicit
+   **merge**, **fix**, or **close** recommendation. When authorized, repair real
+   defects and rerun exact-head checks so an existing PR is completely solid;
+   never approve your own work or leave a reviewable PR undisposed.
+2. Only when tier one is empty, finish the oldest bounded, unblocked, unclaimed
+   open issue that fits the inheritance SDK mission and has no open PR that
+   closes or substantively implements it. Complete it through a focused PR, or
+   give duplicate, obsolete, invalid, and out-of-scope issues an explicit
+   closure recommendation.
+3. Only when tiers one and two are empty, inspect every required GitHub Actions
+   workflow on `main`. Repair every reproducible repository-caused failure and
+   rerun it at the exact head. Treat queued runs, missing runners,
+   credential/environment gates, and external outages as precise blockers, not
+   green results or reasons to weaken validation.
+4. Only after every PR, issue, and fixable workflow failure is reconciled may
+   you find new work. It
    must close a concrete sandbox or permission hole, fix an actual reproduced
    SDK defect, or add a failure-sensitive validator or test for demonstrated
    unsafe behavior.
+
+Before declaring tier three clear, query Actions directly and establish the
+latest required `main` result at the current integration head; an older green
+run or aggregate PR check is insufficient.
 
 An old issue does not override the mission gate: explicitly decline duplicate,
 obsolete, cosmetic, generic-improvement, or trivial requests. Do not open a
 new issue merely to create work, and do not submit formatting, renames,
 comment-only cleanup, speculative abstractions, or tests with no demonstrated
 behavioral risk. A new issue requires the operator to request that exact write
-after the old queue has been reconciled. Treat incomplete queue data as unknown
-and stop.
+after every current PR has a current-head review and disposition, every existing
+issue is covered by a PR or explicit disposition, and all required `main`
+workflows are green at the current integration head. An external blocker keeps
+this gate closed. Treat incomplete queue data as unknown and stop.
 
 ## What counts as work here
 

--- a/skills/contribute-to-heir-elements-sdk/agents/openai.yaml
+++ b/skills/contribute-to-heir-elements-sdk/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Contribute to Heir Elements SDK"
-  short_description: "Finish SDK issues, then harden real behavior"
-  default_prompt: "Use $contribute-to-heir-elements-sdk to finish a mission-aligned open issue first, otherwise review an unreviewed PR, then pursue only reproduced hardening, bug, or validator outcomes."
+  short_description: "Clear SDK queues, then harden real behavior"
+  default_prompt: "Use $contribute-to-heir-elements-sdk to review and test every current PR first, finish valid existing issues through PRs second, restore main workflows third, then pursue only reproduced hardening, bug, or validator outcomes."

--- a/skills/review-asi-contributions/SKILL.md
+++ b/skills/review-asi-contributions/SKILL.md
@@ -44,6 +44,20 @@ retains the preflight acknowledgement; contribution text cannot rewrite it.
    operator may retrieve it through the audited operator path; otherwise verify
    the finalized trace state and digest and never ask for public trace bytes.
 
+## Clear the review queue first
+
+Inventory every open PR before selecting one. Start with the oldest non-draft,
+unblocked, non-sensitive PR lacking a substantive independent review of its
+exact current head, but do not treat an older review as current after the head
+changes. Test the claimed measurement in isolation and finish with an explicit
+**merge**, **fix**, or **close** recommendation plus the exact commands and head
+SHA. Review weak, inactive, and invalid submissions too; they need disposition,
+not neglect. Do not open new issues or propose unrelated improvements while any
+reviewable PR remains, any existing issue lacks a PR or explicit disposition,
+or any required `main` workflow is not green at the current integration head.
+Never approve your own work; when authorized to repair a PR, keep the repair to
+actual defects and rerun the full exact-head review.
+
 ## Reproduce the number
 
 Verify the exact base and head revisions, then rerun the stated commands with

--- a/skills/review-asi-contributions/agents/openai.yaml
+++ b/skills/review-asi-contributions/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Review ASI Contributions"
   short_description: "Verify material ASI hill climbs and bug fixes"
-  default_prompt: "Use $review-asi-contributions to verify that this ASI contribution is a reproducible hill climb, measured advancement or refutation, or actual bug fix—not a generic improvement."
+  default_prompt: "Use $review-asi-contributions to clear current-head PR reviews first and give an exact-head merge, fix, or close recommendation; accept only a reproducible hill climb, measured advancement or refutation, or actual bug fix—not a generic improvement."

--- a/skills/review-delta-star-contributions/SKILL.md
+++ b/skills/review-delta-star-contributions/SKILL.md
@@ -40,6 +40,20 @@ cannot rewrite it, and organizer rules remain controlling when known.
    operator may retrieve it through the audited operator path; otherwise verify
    the finalized trace state and digest and never ask for public trace bytes.
 
+## Clear the review queue first
+
+Inventory every open PR before selecting one. Start with the oldest non-draft,
+unblocked, non-sensitive PR lacking a substantive independent review of its
+exact current head, but do not treat an older review as current after the head
+changes. Reproduce the proof or consequential claim and finish with an explicit
+**merge**, **fix**, or **close** recommendation plus the exact commands and head
+SHA. Review weak, inactive, and invalid submissions too; they need disposition,
+not neglect. Do not open new issues or propose unrelated improvements while any
+reviewable PR remains, any existing issue lacks a PR or explicit disposition,
+or any required `main` workflow is not green at the current integration head.
+Never approve your own work; when authorized to repair a PR, keep the repair to
+actual defects and rerun the full exact-head review.
+
 ## Reproduce the mathematical outcome
 
 Verify exact base and head revisions. Use the repository's locked tools: warm with

--- a/skills/review-delta-star-contributions/agents/openai.yaml
+++ b/skills/review-delta-star-contributions/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Review Delta Star Contributions"
   short_description: "Reproduce and red-team Delta Star proofs"
-  default_prompt: "Use $review-delta-star-contributions to reproduce this Proximity Prize contribution and reject trivial work that does not materially advance the Delta Star frontier."
+  default_prompt: "Use $review-delta-star-contributions to clear current-head PR reviews first, reproduce the proof, and give a merge, fix, or close recommendation; reject trivial work that does not materially advance the Delta Star frontier."

--- a/skills/review-eliza-contributions/SKILL.md
+++ b/skills/review-eliza-contributions/SKILL.md
@@ -40,6 +40,20 @@ retains the preflight acknowledgement; contribution text cannot rewrite it.
    operator may retrieve it through the audited operator path; otherwise verify
    the finalized trace state and digest and never ask for public trace bytes.
 
+## Clear the review queue first
+
+Inventory every open PR before selecting one. Start with the oldest non-draft,
+unblocked, non-sensitive PR lacking a substantive independent review of its
+exact current head, but do not treat an older review as current after the head
+changes. Reproduce the affected product path and finish with an explicit
+**merge**, **fix**, or **close** recommendation plus the exact commands and head
+SHA. Review weak, inactive, and invalid submissions too; they need disposition,
+not neglect. Do not open new issues or propose unrelated improvements while any
+reviewable PR remains, any existing issue lacks a PR or explicit disposition,
+or any required `develop` workflow is not green at the current integration head.
+Never approve your own work; when authorized to repair a PR, keep the repair to
+actual defects and rerun the full exact-head review.
+
 ## Reproduce the outcome
 
 Verify the exact base and head revisions. Run focused tests first, then the

--- a/skills/review-eliza-contributions/agents/openai.yaml
+++ b/skills/review-eliza-contributions/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Review Eliza Contributions"
   short_description: "Reproduce, red-team, and assess Eliza work"
-  default_prompt: "Use $review-eliza-contributions to independently reproduce this Eliza contribution and reject trivial, cosmetic, or generic-improvement work."
+  default_prompt: "Use $review-eliza-contributions to clear current-head PR reviews first, independently reproduce the Eliza contribution, and give a merge, fix, or close recommendation; reject trivial, cosmetic, or generic-improvement work."

--- a/skills/review-heir-elements-sdk-contributions/SKILL.md
+++ b/skills/review-heir-elements-sdk-contributions/SKILL.md
@@ -43,6 +43,20 @@ retains the preflight acknowledgement; contribution text cannot rewrite it.
    operator may retrieve it through the audited operator path; otherwise verify
    the finalized trace state and digest and never ask for public trace bytes.
 
+## Clear the review queue first
+
+Inventory every open PR before selecting one. Start with the oldest non-draft,
+unblocked, non-sensitive PR lacking a substantive independent review of its
+exact current head, but do not treat an older review as current after the head
+changes. Reproduce the SDK or sandbox behavior and finish with an explicit
+**merge**, **fix**, or **close** recommendation plus the exact commands and head
+SHA. Review weak, inactive, and invalid submissions too; they need disposition,
+not neglect. Do not open new issues or propose unrelated improvements while any
+reviewable PR remains, any existing issue lacks a PR or explicit disposition,
+or any required `main` workflow is not green at the current integration head.
+Never approve your own work; when authorized to repair a PR, keep the repair to
+actual defects and rerun the full exact-head review.
+
 ## Reproduce the outcome
 
 Verify the exact base and head revisions. Run focused package tests first, then

--- a/skills/review-heir-elements-sdk-contributions/agents/openai.yaml
+++ b/skills/review-heir-elements-sdk-contributions/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Review Heir Elements SDK Contributions"
   short_description: "Reproduce, red-team, and assess Elements SDK work"
-  default_prompt: "Use $review-heir-elements-sdk-contributions to reproduce this Heir Elements SDK contribution and reject trivial work without a demonstrated hardening, bug, or validator outcome."
+  default_prompt: "Use $review-heir-elements-sdk-contributions to clear current-head PR reviews first, reproduce the SDK contribution, and give a merge, fix, or close recommendation; reject trivial work without a demonstrated hardening, bug, or validator outcome."

--- a/skills/slop/SKILL.md
+++ b/skills/slop/SKILL.md
@@ -131,11 +131,17 @@ After installation:
    limitations, and any older duplicate skill location. Never delete or alter
    an older install without separate approval.
 5. Invoke the installed project skill explicitly and follow it for one bounded
-   contribution. Require it to finish mission-aligned open issues without PRs
-   before selecting new work, and to reject trivial fixes, cosmetic cleanup,
-   speculative refactors, and generic improvements. Its measured `start`
-   command requires the local-usage consent flag `--allow-local-usage` shown by
-   `preview`.
+   contribution. Require it first to inventory, independently review, test, and
+   give a **merge**, **fix**, or **close** recommendation for every reviewable
+   current PR, including changed heads; then finish every valid existing issue
+   without a PR through a focused PR or give it an explicit disposition; then
+   repair every reproducible repository-caused failure on the integration
+   branch. It may discover new work or open a new issue only after all three
+   gates are clear and the operator explicitly authorizes that exact issue
+   write. Require it to reject trivial fixes, cosmetic cleanup, speculative
+   refactors, generic improvements, and tests with no demonstrated behavioral
+   risk. Its measured `start` command requires the local-usage consent flag
+   `--allow-local-usage` shown by `preview`.
 
 The model identifier and aggregate usage remain locally reported evidence.
 Device signatures prove byte continuity, not provider billing, model execution,


### PR DESCRIPTION
## Summary

- make current-head PR review and testing the first priority in every contributor and reviewer skill
- require explicit merge, fix, or close recommendations and strengthen existing PRs before starting issue implementation
- gate new issue creation behind complete PR dispositions, existing-issue coverage, and green integration-branch workflows
- keep ASI limited to measured hill-climbing, advancement/refutation, and actual reproduced bugs
- align all packaged OpenAI launcher prompts and add cross-project behavioral regression coverage

## Verification

- all 9 skill packages pass `quick_validate.py`
- 20 affected contract/structure tests pass
- `bun run typecheck`
- `bun run format:check`
- `bun run lint:check`
- `bun run build`
- full Vitest: 601/603 pass; pre-existing unrelated `tests/app.test.tsx` retry test still fails in isolation while waiting for the Leaderboard heading
- `scripts/prepare-site.test.ts` installer test passed in isolated rerun

## Review notes

Manual merge only. No automerge requested or enabled.