### PR TITLE
fix(leaderboard): tolerate GitHub avatar revision drift

### DIFF
--- a/src/lib/leaderboard.test.ts
+++ b/src/lib/leaderboard.test.ts
@@ -3812,6 +3812,35 @@ describe("deduplication and public schema", () => {
     );
   });
 
+  it("accepts GitHub avatar revision drift for the same actor ID", () => {
+    const snapshot = createLeaderboardSnapshot(
+      input({ mergedPullRequests: [pullRequest()] }),
+    );
+    snapshot.leaders[0].actor.avatarUrl =
+      "https://avatars.githubusercontent.com/u/38991243?v=4";
+    snapshot.ledger[0].actor = {
+      ...snapshot.leaders[0].actor,
+      avatarUrl:
+        "https://avatars.githubusercontent.com/u/38991243?u=5884a38e5f489400941246854be4d9b7c51a1030&v=4",
+    };
+
+    expect(() => assertLeaderboardSnapshot(snapshot)).not.toThrow();
+  });
+
+  it("rejects avatar resource drift for the same actor ID", () => {
+    const snapshot = createLeaderboardSnapshot(
+      input({ mergedPullRequests: [pullRequest()] }),
+    );
+    snapshot.ledger[0].actor = {
+      ...snapshot.leaders[0].actor,
+      avatarUrl: "https://avatars.githubusercontent.com/u/99999999?v=4",
+    };
+
+    expect(() => assertLeaderboardSnapshot(snapshot)).toThrow(
+      "changes identity inside the snapshot",
+    );
+  });
+
   it("rejects leader arrays whose ranks disguise the published ordering", () => {
     const snapshot = createLeaderboardSnapshot(
       input({

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -3704,6 +3704,13 @@ function assertNullableActor(
   }
 }
 
+function actorAvatarIdentity(avatarUrl: string): string {
+  const identity = new URL(avatarUrl);
+  identity.search = "";
+  identity.hash = "";
+  return identity.href;
+}
+
 function assertActorCoherence(actors: GitHubActor[]): void {
   const byId = new Map<string, GitHubActor>();
   const idByLogin = new Map<string, string>();
@@ -3712,7 +3719,8 @@ function assertActorCoherence(actors: GitHubActor[]): void {
     if (
       previous &&
       (previous.login !== actor.login ||
-        previous.avatarUrl !== actor.avatarUrl ||
+        actorAvatarIdentity(previous.avatarUrl) !==
+          actorAvatarIdentity(actor.avatarUrl) ||
         previous.url !== actor.url ||
         previous.kind !== actor.kind)
     ) {


### PR DESCRIPTION
## Summary

- treat GitHub avatar query and fragment parameters as mutable presentation metadata during actor-coherence validation
- continue requiring exact agreement on actor node ID, login, profile URL, kind, and avatar origin/path
- add regression coverage for the live `Neutize` avatar revision shape and for a different avatar resource under the same actor ID

## Why

Scheduled leaderboard generation on `develop` failed in runs `32624637312` and `32641270355` with:

```text
GitHub actor MDQ6VXNlcjM4OTkxMjQz changes identity inside the snapshot
```

The same actor is represented by two otherwise identical records:

- live GitHub: `https://avatars.githubusercontent.com/u/38991243?u=5884a38e5f489400941246854be4d9b7c51a1030&v=4`
- committed evaluated contributions: `https://avatars.githubusercontent.com/u/38991243?v=4`

The `u` parameter is GitHub avatar revision/cache metadata. Comparing the complete URL made a presentation revision look like an identity transition. This change removes only query and fragment components before comparing avatar resources; a different host/path still fails closed.

## Validation

- focused leaderboard/generator/evaluator suite — 151/151 tests passed
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=core.hooksPath GIT_CONFIG_VALUE_0=/dev/null bun run test` — 64 Vitest files / 605 tests and 87 skill tests passed; hook isolation applies only to synthetic test repositories whose public GitHub blob URLs trigger the user-global scanner
- `bun run typecheck`
- `bun run format:check`
- `bun run lint:check`
- `bun run build` — 173 deploy files emitted
- `bun run projects:check`
- `bun run evaluations:check`
- `bun run funding:check`
- `bun run cycles:check`
- `bun run protocol:check`
- `bun audit` — no vulnerabilities
- normal branch commit passed the machine-wide secret scanner without bypass

A full live generator rerun was attempted, but GitHub stopped hydration with a secondary rate limit before snapshot validation. The deterministic regression recreates the exact conflicting public avatar records without claiming that incomplete run passed.

## Evidence

- Before screenshots: N/A - non-visual validation contract
- After screenshots: N/A - non-visual validation contract
- Walkthrough video: N/A - no user interaction changed
- Backend logs: scheduled runs `32624637312` and `32641270355`; local live rerun recorded the secondary-rate-limit boundary
- Frontend console/network logs: N/A - no frontend behavior changed
- Real-LLM trajectory: N/A - runtime contains no LLM behavior
- Domain artifacts: positive avatar-revision and negative avatar-resource regression tests

## Contribution provenance

- AI assistance: Yes - diagnosis, implementation, tests, and verification
- AI provider/model: OpenAI / gpt-5.6-sol
- Client / agent tooling: Hermes Agent
- Contribution skill revision: N/A - no packaged contribution skill was invoked
- Attribution status: self-reported

## Slop protocol changes

N/A - no project, skill, evaluation, or reward-cycle artifact changed.

## Safety review

- [x] No private key, seed phrase, API token, raw private trajectory, or secret was added.
- [x] Untrusted project code is not executed with repository or deployment credentials.
- [x] New telemetry is bounded, disclosed, project-attributed, and covered by adversarial tests.
- [x] Money state is derived from validated manifests and finalized on-chain evidence, not a transaction signature alone.
