### PR TITLE
Stage protected external-prize fee migration

### DIFF
--- a/src/lib/project-schema.mjs
+++ b/src/lib/project-schema.mjs
@@ -798,7 +798,11 @@ function validateReward(value, field) {
   }
   text(reward.monthlyCapDisplay, `${field}.monthlyCapDisplay`, { max: 80 });
   timestamp(reward.rewardStartAt, `${field}.rewardStartAt`);
-  if (reward.cycle !== "calendar-month-utc" || reward.feeBasisPoints !== 100) {
+  const validFeeBasisPoints =
+    reward.kind === "external-prize-share"
+      ? reward.feeBasisPoints === 100 || reward.feeBasisPoints === 1000
+      : reward.feeBasisPoints === 100;
+  if (reward.cycle !== "calendar-month-utc" || !validFeeBasisPoints) {
     throw new TypeError(`${field} cycle or fee policy is invalid`);
   }
   if (reward.kind === "monthly-pool") {

--- a/src/lib/project-schema.test.ts
+++ b/src/lib/project-schema.test.ts
@@ -500,6 +500,22 @@ describe("project proposal schema", () => {
 
   it("keeps external prize rules outside platform settlement", () => {
     expect(deltaStar.reward.paymentMode).toBe("disabled");
+    const migratedFee = structuredClone(deltaStar) as unknown as {
+      reward: { feeBasisPoints: number };
+    };
+    migratedFee.reward.feeBasisPoints = 1000;
+    expect(assertProjectDefinition(migratedFee).reward.feeBasisPoints).toBe(
+      1000,
+    );
+    migratedFee.reward.feeBasisPoints = 999;
+    expect(() => assertProjectDefinition(migratedFee)).toThrow(/fee policy/u);
+    const invalidPoolFee = structuredClone(eliza) as unknown as {
+      reward: { feeBasisPoints: number };
+    };
+    invalidPoolFee.reward.feeBasisPoints = 1000;
+    expect(() => assertProjectDefinition(invalidPoolFee)).toThrow(
+      /fee policy/u,
+    );
     expect(deltaStar.terms.externalPrize?.allocationAuthority).toMatch(
       /author-approved/u,
     );


### PR DESCRIPTION
## Summary

Stage the protected two-phase Delta Star fee migration. The trusted transition gate executes the immutable base schema, so the base must temporarily admit both the historical 1% external-prize allocation and the new 10% allocation before the manifest can move.

- monthly pools remain fixed at 1%
- external-prize manifests admit exactly 1% or 10% during migration
- regression tests reject 9.99% and reject 10% on monthly pools
- no project manifest or public policy changes in this PR

After this merges, #237 changes Delta Star to 10% and hardens the current schema back to 10%, retaining 1% only in the historical transition reader.

## Verification

- focused project schema and transition tests (19/19)
- projects check
- typecheck
- format and lint checks
- diff check

Prerequisite for #237.