### PR TITLE
Admit bounded SPDX license expressions

### DIFF
--- a/src/lib/project-schema.mjs
+++ b/src/lib/project-schema.mjs
@@ -418,7 +418,7 @@ function validateTerms(
   } else if (license.state === "verified") {
     text(license.spdx, `${field}.repositoryLicense.spdx`, {
       max: 80,
-      pattern: /^[A-Za-z0-9-.+]+$/u,
+      pattern: /^[A-Za-z0-9-.+]+(?: (?:AND|OR|WITH) [A-Za-z0-9-.+]+)*$/u,
     });
     const licenseCommit = commit(
       license.commitSha,

--- a/src/lib/project-schema.test.ts
+++ b/src/lib/project-schema.test.ts
@@ -484,6 +484,22 @@ describe("project proposal schema", () => {
     }
   });
 
+  it("accepts bounded SPDX license expressions and rejects prose", () => {
+    const dualLicensed = mutablePolicyFixture(eliza);
+    const repositoryLicense = (
+      dualLicensed.terms as unknown as {
+        repositoryLicense: { spdx: string };
+      }
+    ).repositoryLicense;
+    repositoryLicense.spdx = "Apache-2.0 AND MIT";
+    expect(
+      assertProjectDefinition(dualLicensed).terms.repositoryLicense.spdx,
+    ).toBe("Apache-2.0 AND MIT");
+
+    repositoryLicense.spdx = "MIT or anything else";
+    expect(() => assertProjectDefinition(dualLicensed)).toThrow(/spdx/u);
+  });
+
   it("permits a legacy unsupported holder only on the historical transition side", () => {
     const legacy = mutablePolicyFixture(eliza);
     legacy.terms.copyright.model = "mixed";


### PR DESCRIPTION
## Summary

Stage the second protected Delta Star policy migration prerequisite. The current manifest schema accepts only a single SPDX identifier, but the legally accurate repository state is a bounded expression (`Apache-2.0 AND MIT`) because historical Apache grants remain intact while new accepted contributions are dual licensed.

This PR:
- admits canonical identifier sequences joined only by uppercase `AND`, `OR`, or `WITH`
- keeps the existing 80-character bound
- rejects prose such as `MIT or anything else`
- changes no project manifest or public policy

After merge, #237 can publish the exact dual-license state through the trusted base-schema transition gate.

## Verification
- project schema and transition tests (20/20)
- projects check
- typecheck
- format and lint checks
- diff check

Prerequisite for #237.