### PR TITLE
chore: recognize GG100-eng review on 23961

### DIFF
--- a/evaluations/eliza/award-gg100-review-23961.json
+++ b/evaluations/eliza/award-gg100-review-23961.json
@@ -1,0 +1,29 @@
+{
+  "schemaVersion": "1",
+  "kind": "evaluated-contribution",
+  "id": "award_gg100_review_23961",
+  "projectId": "eliza",
+  "repository": "elizaOS/eliza",
+  "actor": {
+    "id": "U_kgDOCzOt4w",
+    "login": "GG100-eng",
+    "avatarUrl": "https://avatars.githubusercontent.com/u/187936227?v=4",
+    "url": "https://github.com/GG100-eng",
+    "kind": "User"
+  },
+  "occurredAt": "2026-08-22T08:34:13.000Z",
+  "points": 4,
+  "source": {
+    "id": "PRR_kwDOMT5cIs8AAAABKgIsmw",
+    "kind": "review",
+    "number": 23961,
+    "title": "fix(cloud): bound payout alerting Slack/PagerDuty hops",
+    "url": "https://github.com/elizaOS/eliza/pull/23961#pullrequestreview-4999752859"
+  },
+  "reason": "The exact-head review correctly showed that the attempted alert hardening bounded only request bytes: it returned an open response after headers, cleared the deadline before body consumption, and lacked declared-length, chunked-body, stalled-body, and channel-isolation regressions. Commit 2989806ddbf3dcc09505d421f45594e894a2bd83 directly implemented those requested boundaries and tests, and a maintainer independently verified the repair on the final head. The award is bounded because an earlier maintainer had already requested a response cap and a later review found a deeper adapter-level backpressure gap outside this repair.",
+  "review": {
+    "reviewer": "lalalune",
+    "reviewedAt": "2026-08-23T16:45:00.000Z",
+    "decisionUrl": "https://github.com/SlopDotCash/slopdotcash/pull/241"
+  }
+}


### PR DESCRIPTION
## Decision

Award 4 evaluated-contribution points for the otherwise-unscored exact-head review on elizaOS/eliza#23961. It materially proved that the attempted response cap still bounded only requests and supplied the missing response/deadline/isolation test boundary adopted in `2989806ddbf3dcc09505d421f45594e894a2bd83`. The award is intentionally below the maximum because an earlier maintainer had already requested the general response cap and a later review found a deeper adapter-level gap.

This PR contains exactly one evaluation manifest, as required. Resolves #235 after merge and ledger publication.

## Verification
- independently inspected the immutable review and exact reviewed head
- verified the repair commit and final-head maintainer approval
- checked the limitation from the later adapter backpressure repair
- confirmed the live ledger and existing manifests do not contain the immutable source
- `bun run evaluations:check`
- `git diff --check`