### PR TITLE
fix: canonicalize actor avatar URLs so avatar changes cannot break snapshots

### DIFF
--- a/scripts/generate-leaderboard.ts
+++ b/scripts/generate-leaderboard.ts
@@ -11,6 +11,7 @@ import { fileURLToPath } from "node:url";
 import { loadEvaluatorAwardEvents } from "../src/lib/evaluator-awards";
 import {
   assertPublishableLeaderboardSnapshot,
+  canonicalActorAvatarUrl,
   createLeaderboardSnapshot,
   DETAILED_MERGED_PULL_REQUESTS_PER_MONTH,
   dedupeByNodeId,
@@ -680,7 +681,9 @@ function parseActor(value: unknown, path: string): GitHubActor | null {
   return {
     id: asString(actor.id, `${path}.id`),
     login: asString(actor.login, `${path}.login`),
-    avatarUrl: asString(actor.avatarUrl, `${path}.avatarUrl`),
+    avatarUrl: canonicalActorAvatarUrl(
+      asString(actor.avatarUrl, `${path}.avatarUrl`),
+    ),
     url: asString(actor.url, `${path}.url`),
     kind: actorKind(asString(actor.__typename, `${path}.__typename`)),
   };

--- a/src/lib/evaluator-awards.ts
+++ b/src/lib/evaluator-awards.ts
@@ -7,7 +7,11 @@
 import { createHash } from "node:crypto";
 import { lstatSync, readdirSync, readFileSync } from "node:fs";
 import { basename, join, relative, resolve, sep } from "node:path";
-import type { GitHubActor, ScoreEvent } from "./leaderboard";
+import {
+  canonicalActorAvatarUrl,
+  type GitHubActor,
+  type ScoreEvent,
+} from "./leaderboard";
 import { findProject } from "./projects.mjs";
 
 export const EVALUATOR_AWARD_SCHEMA_VERSION = "1" as const;
@@ -153,7 +157,7 @@ function actor(value: unknown, field: string): GitHubActor {
   return {
     id,
     login,
-    avatarUrl,
+    avatarUrl: canonicalActorAvatarUrl(avatarUrl),
     url: githubUrl(candidate.url, `${field}.url`, `/${login}`),
     kind: "User",
   };

--- a/src/lib/leaderboard.test.ts
+++ b/src/lib/leaderboard.test.ts
@@ -13,6 +13,7 @@ import {
   assertPublishableLeaderboardSnapshot,
   assessEvidence,
   assessModelAttribution,
+  canonicalActorAvatarUrl,
   createLeaderboardSnapshot,
   dedupeByNodeId,
   type EvidenceCategory,
@@ -4042,5 +4043,29 @@ describe("deduplication and public schema", () => {
     expect(() => assertLeaderboardSnapshot(actionable)).toThrow(
       "actionability does not match its labels",
     );
+  });
+});
+
+describe("canonical actor avatar URLs", () => {
+  it("strips the mutable u cache key and keeps the stable v parameter", () => {
+    expect(
+      canonicalActorAvatarUrl(
+        "https://avatars.githubusercontent.com/u/38991243?u=5884a38e5f489400941246854be4d9b7c51a1030&v=4",
+      ),
+    ).toBe("https://avatars.githubusercontent.com/u/38991243?v=4");
+  });
+
+  it("leaves an already-canonical URL unchanged", () => {
+    expect(
+      canonicalActorAvatarUrl("https://avatars.githubusercontent.com/u/1?v=4"),
+    ).toBe("https://avatars.githubusercontent.com/u/1?v=4");
+  });
+
+  it("drops every parameter when no version is present", () => {
+    expect(
+      canonicalActorAvatarUrl(
+        "https://avatars.githubusercontent.com/u/1?u=abc&s=96",
+      ),
+    ).toBe("https://avatars.githubusercontent.com/u/1");
   });
 });

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -98,6 +98,17 @@ export interface GitHubActor {
   kind: GitHubActorKind;
 }
 
+// GitHub appends a mutable ?u= cache key to avatar URLs whenever a user
+// changes their avatar, so the same actor can carry different avatarUrl bytes
+// in live data and in reviewed manifests. Only the stable v parameter may
+// survive into a snapshot, or actor coherence fails on a cosmetic change.
+export function canonicalActorAvatarUrl(value: string): string {
+  const url = new URL(value);
+  const version = url.searchParams.get("v");
+  url.search = version === null ? "" : `v=${version}`;
+  return url.toString();
+}
+
 export interface GitHubLabel {
   id: string;
   name: string;


### PR DESCRIPTION
Fixes #242.

**Environment Variables**

No environment variable changes.

**Overview**

Scheduled production run [32659348420](https://github.com/SlopDotCash/slopdotcash/actions/runs/32659348420) fails in `leaderboard:generate` with `GitHub actor MDQ6VXNlcjM4OTkxMjQz changes identity inside the snapshot`, skipping the deploy and pinning the already-merged #224 and #230 fixes out of production. The actor is pinned at `?v=4` in the four reviewed `evaluations/eliza/award-neutize-review-*.json` manifests, while live GraphQL now returns the same actor with a mutable `?u=<cache-key>&v=4` avatar URL after an avatar change. `assertActorCoherence` correctly fails closed, but on a cosmetic field: any avatar change by any actor who appears in a committed award manifest re-triggers the outage.

**Change Summary**

- **Fixes:** `canonicalActorAvatarUrl()` (exported from `src/lib/leaderboard.ts`) keeps only the stable `v` query parameter of an avatar URL. Applied at both ingestion boundaries: live GraphQL `parseActor` in `scripts/generate-leaderboard.ts` and the award-manifest `actor()` parser in `src/lib/evaluator-awards.ts`.
- **Deliberately unchanged:** `assertActorValue` / `assertActorCoherence` and every validator. Historical `cycles/` source snapshots legitimately contain `?u=` avatar URLs (e.g. `cycles/eliza/2026-07/source-snapshot.json`) and must keep validating byte-for-byte. Coherence still catches genuine login/url/kind divergence.
- **Tests:** three unit tests proving the canonical form — strips `u`, preserves `v`, drops all parameters when no `v` exists.

**Technical Impact**

- **Affected surfaces:** snapshot generation and award-manifest ingestion only. Published snapshots now always carry the canonical `?v=` avatar form; `avatars.githubusercontent.com/u/<id>?v=4` serves the actor's current avatar, so rendering is unaffected.
- **Database/schema changes:** none.
- **API/contract changes:** none.

**Testing Evidence**

- `vitest run src/lib/leaderboard.test.ts` — 93 pass (3 new).
- `vitest run src/lib/evaluator-awards.test.ts` — 7 pass.
- `bun run typecheck` — clean. `bun run format:check`, `bun run lint:check` — clean.
- `bun run projects:check`, `evaluations:check`, `funding:check`, `cycles:check`, `protocol:check`, `audit:dependencies` — pass.
- `bun run build` — clean (`dist/deployment-manifest.json` written, 173 public files).
- Root cause independently reproducible without this branch: `gh api graphql` for the pinned actor returns the `?u=…&v=4` form; the last good public snapshot (generated `2026-08-22T20:15:12.389Z`) holds five records for that actor, all `?v=4`.
- Known local-environment failures, present on unmodified `develop` (macOS): 5 `scripts/skill-validation.test.ts` cases (`os.tmpdir()` resolves under the `/var → /private/var` symlink, tripping the symlink-refusal checks) and 1 `skill-tests/contribute-to-eliza.test.ts` ccusage case. Both reproduce with this branch's changes stashed; hosted CI is authoritative.
- Browser E2E: N/A — data-ingestion change with no UI surface; CI runs the browser suite on this head.

**Migration / Deployment Notes**

No special deployment steps. The next scheduled or manual production run from `develop` should complete generation and publish, unblocking the live states tracked in #224 and #230.

**Provenance**

Authored by `wbaxterh` using Claude Code (model `claude-fable-5`, client `claude-code`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
