### PR TITLE
fix: accept the transferred canonical repository as bundled skill provenance

### DIFF
--- a/skill-tests/project-skills.test.ts
+++ b/skill-tests/project-skills.test.ts
@@ -337,6 +337,24 @@ describe("project skill contracts", () => {
     );
   });
 
+  it("accepts the transferred canonical repository as bundled skill provenance", () => {
+    const [canonicalPackage] = projectPackages;
+    const receiptSource = readFileSync(
+      join(canonicalPackage.contributorRoot, "scripts", "run-receipt.mjs"),
+      "utf8",
+    );
+    for (const remote of [
+      "https://github.com/elizaos/army",
+      "https://github.com/elizaos/slopdotcash",
+      "https://github.com/slopdotcash/slopdotcash",
+    ]) {
+      assert.ok(
+        receiptSource.includes(`"${remote}",`),
+        `bundled-source provenance must accept ${remote}`,
+      );
+    }
+  });
+
   it("accepts only exact signed Delta Star migration-era receipt identities", () => {
     const sha = "a".repeat(40);
     for (const [repositoryId, skillRepository] of [

--- a/skills/contribute-to-asi/scripts/run-receipt.mjs
+++ b/skills/contribute-to-asi/scripts/run-receipt.mjs
@@ -1015,6 +1015,7 @@ function resolveSkillProvenance() {
     ![
       "https://github.com/elizaos/army",
       "https://github.com/elizaos/slopdotcash",
+      "https://github.com/slopdotcash/slopdotcash",
     ].includes(sourceRemote)
   ) {
     fail("bundled skill source must come from the canonical Slop repository");

--- a/skills/contribute-to-delta-star/scripts/run-receipt.mjs
+++ b/skills/contribute-to-delta-star/scripts/run-receipt.mjs
@@ -1015,6 +1015,7 @@ function resolveSkillProvenance() {
     ![
       "https://github.com/elizaos/army",
       "https://github.com/elizaos/slopdotcash",
+      "https://github.com/slopdotcash/slopdotcash",
     ].includes(sourceRemote)
   ) {
     fail("bundled skill source must come from the canonical Slop repository");

--- a/skills/contribute-to-eliza/scripts/run-receipt.mjs
+++ b/skills/contribute-to-eliza/scripts/run-receipt.mjs
@@ -1015,6 +1015,7 @@ function resolveSkillProvenance() {
     ![
       "https://github.com/elizaos/army",
       "https://github.com/elizaos/slopdotcash",
+      "https://github.com/slopdotcash/slopdotcash",
     ].includes(sourceRemote)
   ) {
     fail("bundled skill source must come from the canonical Slop repository");

--- a/skills/contribute-to-heir-elements-sdk/scripts/run-receipt.mjs
+++ b/skills/contribute-to-heir-elements-sdk/scripts/run-receipt.mjs
@@ -1015,6 +1015,7 @@ function resolveSkillProvenance() {
     ![
       "https://github.com/elizaos/army",
       "https://github.com/elizaos/slopdotcash",
+      "https://github.com/slopdotcash/slopdotcash",
     ].includes(sourceRemote)
   ) {
     fail("bundled skill source must come from the canonical Slop repository");


### PR DESCRIPTION
Fixes #244.

**Environment Variables**

No environment variable changes.

**Overview**

Every project skill's `run-receipt.mjs` rejects a bundled-source run from a clone of the canonical `SlopDotCash/slopdotcash` repository: the provenance allowlist still holds only the pre-transfer names (`elizaos/army`, `elizaos/slopdotcash`), so `preview`, `doctor`, and `start` fail closed with `bundled skill source must come from the canonical Slop repository` before any receipted contribution can begin. Installed archives take the separate archive-provenance path and are unaffected. Same organization-transfer class as #230 and the legacy-identity half of #224, surfacing in the receipt CLI.

**Change Summary**

- **Fixes:** add `https://github.com/slopdotcash/slopdotcash` to the bundled-source provenance allowlist in all four skills' `run-receipt.mjs`, keeping the legacy names (both still redirect to the canonical repository). The four files remain byte-identical per the receipt contract.
- **Tests:** new cross-skill contract test in `skill-tests/project-skills.test.ts` pinning the three accepted remotes.

**Technical Impact**

- **Affected surfaces:** bundled-source provenance check only. The recorded `skillRevision` string is built independently as `SlopDotCash/slopdotcash@<HEAD>` and is unchanged. Archive provenance, digest verification, dirty-tree refusal, and the full-SHA check are untouched.
- **Database/schema/API changes:** none.

**Testing Evidence**

- `bun test ./skill-tests/project-skills.test.ts` — 24 pass (1 new).
- `bun test ./skill-tests` — 88 pass; the single failure (`contribute-to-eliza.test.ts` ccusage case) is present on unmodified `develop` in this environment and reproduces with these changes stashed.
- `bun run typecheck` — clean; `biome check` on touched files — clean.
- Live failure-path proof: on unmodified `develop`, `preview --repo-root <eliza clone> --client claude-code` from a canonical clone fails with the provenance message; with this change it advances to the next gate (dirty-tree refusal when the skill tree has uncommitted edits, and normal preview output on a committed revision).

**Migration / Deployment Notes**

No special deployment steps. Contributors on existing clones need no action; legacy remotes keep working.

**Provenance**

Authored by `wbaxterh` using Claude Code (model `claude-fable-5`, client `claude-code`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)