### PR TITLE
fix(skills): require real Eliza system proof

### DIFF
--- a/skill-tests/contribute-to-eliza.test.ts
+++ b/skill-tests/contribute-to-eliza.test.ts
@@ -249,11 +249,44 @@ describe("contribute-to-eliza skill structure", () => {
     assert.ok(auditPriority > workflowPriority);
     assert.match(
       source,
-      /\*\*security weaknesses\*\*.*\*\*reproducible bugs\*\*.*\*\*incorrect or stale\s+documentation and code comments\*\*.*\*\*important behavior that lacks real\s+tests\*\*/is,
+      /\*\*security weaknesses\*\*.*\*\*reproducible bugs\*\*.*\*\*incorrect or stale\s+documentation and code comments\*\*.*\*\*important behavior that lacks\s+real-system verification\*\*/is,
     );
     assert.match(
       source,
       /every current PR has a current-head review and disposition[\s\S]*every existing issue[\s\S]*every required `develop` workflow/iu,
+    );
+    assert.match(
+      source,
+      /default is\s+to create no new issue at all[\s\S]*requires an absolutely necessary[\s\S]*falls out of that work/iu,
+    );
+    assert.match(
+      source,
+      /open a test-gap issue without a reproduced product failure/iu,
+    );
+    assert.match(source, /## Prove a real working system, not a unit/iu);
+    const endToEndPriority = source.indexOf(
+      "a real end-to-end run of the affected product path",
+    );
+    const scenarioPriority = source.indexOf(
+      "an Eliza scenario test that exercises the actual agent loop",
+    );
+    const benchmarkPriority = source.indexOf(
+      "a reproducible benchmark with a meaningful baseline",
+    );
+    assert.ok(endToEndPriority >= 0);
+    assert.ok(scenarioPriority > endToEndPriority);
+    assert.ok(benchmarkPriority > scenarioPriority);
+    assert.match(
+      source,
+      /Do not add a unit test by default[\s\S]*supplemental\s+regression guard[\s\S]*real working-system evidence/iu,
+    );
+    assert.match(
+      source,
+      /unit test that can pass while the real product path is broken is useless/iu,
+    );
+    assert.match(
+      source,
+      /Formatting, typecheck,\s+build, lint, and existing repository checks[\s\S]*do not demonstrate that Eliza works/iu,
     );
     assert.match(mission, /Eliza app/);
     assert.match(mission, /Eliza Cloud/);
@@ -265,6 +298,37 @@ describe("contribute-to-eliza skill structure", () => {
       /splitting one outcome into multiple issues or pull requests/i,
     );
     assert.match(mission, /Recommend closure rather than repairs/i);
+    assert.match(
+      mission,
+      /PRs without a\s+substantive review of their exact current head come first[\s\S]*existing\s+authorized issues without PRs/iu,
+    );
+    assert.match(
+      mission,
+      /Missing real-system verification[\s\S]*end-to-end, scenario, or benchmark evidence/iu,
+    );
+    const rubric = readFileSync(
+      join(skillDir, "references", "evidence-review-rubric.md"),
+      "utf8",
+    );
+    const reviewer = readFileSync(
+      join(skillDir, "..", "review-eliza-contributions", "SKILL.md"),
+      "utf8",
+    );
+    assert.match(rubric, /## Verification hierarchy/iu);
+    assert.match(rubric, /Unit tests are not acceptance evidence/iu);
+    assert.match(
+      rubric,
+      /E2E runs, Eliza scenarios, and applicable benchmarks drive the real system/iu,
+    );
+    assert.match(
+      reviewer,
+      /Reproduce the affected user or\s+operator path on a real operating system[\s\S]*end-to-end flow first[\s\S]*Eliza scenario/iu,
+    );
+    assert.match(reviewer, /Unit tests are not acceptance evidence/iu);
+    assert.match(
+      reviewer,
+      /Reject unit-test production, mock-only evidence,\s+coverage-only additions/iu,
+    );
     assert.deepStrictEqual(readProjectSelectionPolicy().eligibleIssueLabels, [
       "mission-ready",
     ]);
@@ -404,7 +468,15 @@ writeFileSync(
     );
     assert.match(openaiYaml, /display_name: "Contribute to Eliza"/);
     assert.match(openaiYaml, /default_prompt: "Use \$contribute-to-eliza/);
-    assert.match(openaiYaml, /review and test every current PR first/);
+    assert.match(
+      openaiYaml,
+      /review and test every current PR first on a real working system/,
+    );
+    assert.match(
+      openaiYaml,
+      /missing E2E, scenario, or benchmark verification/,
+    );
+    assert.match(openaiYaml, /Do not produce unit tests or new issues/);
     assert.match(openaiYaml, /existing issues through PRs second/);
     assert.match(openaiYaml, /develop workflows third/);
     assert.match(openaiYaml, /elizaOS\/eliza/);

--- a/skills/contribute-to-eliza/SKILL.md
+++ b/skills/contribute-to-eliza/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: contribute-to-eliza
-description: "Review and test current elizaOS/eliza pull requests, finish existing issues through pull requests, restore develop workflow health, then audit mission-critical security, bugs, stale documentation and comments, and missing behavioral tests, with optional public payout registration. Use for one material outcome on an existing shipped product path, not generic improvements or trivial cleanup."
+description: "Review and prove current elizaOS/eliza pull requests on real working systems, finish existing issues through pull requests, restore develop workflow health, then audit mission-critical security, bugs, stale documentation and comments, and missing end-to-end verification, with optional public payout registration. Use for one material outcome on an existing shipped product path, not generic improvements, trivial cleanup, or unit-test production."
 ---
 
 # Contribute to Eliza
@@ -163,11 +163,11 @@ easier, or more interesting work:
    run or aggregate PR check is insufficient. Then inspect one fallback
    category in this exact order:
    **security weaknesses**, **reproducible bugs**, **incorrect or stale
-   documentation and code comments**, then **important behavior that lacks real
-   tests**. Do not advance while a higher fallback category has a concrete,
-   unowned finding. Prefer a bounded fix and proof; use **Validate** only for a
-   reproducible diagnosis, refutation, benchmark, test, or research artifact
-   that changes a concrete engineering decision.
+   documentation and code comments**, then **important behavior that lacks
+   real-system verification**. Do not advance while a higher fallback category
+   has a concrete, unowned finding. Prefer a bounded fix and proof; use
+   **Validate** only for a reproducible diagnosis, refutation, benchmark, test,
+   or research artifact that changes a concrete engineering decision.
 
 The live report's closing-reference check is a conservative deduplication aid,
 not proof that a PR solves an issue. Inspect linked PRs, branches, issue
@@ -175,17 +175,22 @@ timelines, current reviews, and newest comments immediately before selecting.
 Treat malformed or incomplete queue data as unknown and stop rather than
 declaring the queue empty.
 
-Do not create an issue during a self-directed contribution run. Open a new
-issue only when the operator explicitly asks for that exact GitHub write after
+Do not create an issue during a self-directed contribution run. The default is
+to create no new issue at all: finish the authorized work in the existing PR or
+issue. A new issue requires an absolutely necessary, separately actionable
+problem that falls out of that work, cannot safely or coherently be fixed in the
+current outcome, and would otherwise be lost. Even then, open it only when the
+operator explicitly asks for that exact GitHub write after
 every current PR has a current-head review and disposition, every existing issue
 is covered by a PR or explicit disposition, every required `develop` workflow
 is green at the current integration head, a local reproduction and duplicate
-search are complete, and the mission and evidence plan pass. Fix a
+search are complete, and the mission and evidence plan pass. An external
+workflow blocker keeps the new-issue gate closed. Fix a
 newly discovered bounded defect directly in one PR when authorized; route
 security findings privately under `SECURITY.md`. An issue report alone is not
 an accepted outcome. Never mirror a PR title into an issue, generate
-speculative backlog, or open issues to make work eligible for score.
-An external workflow blocker keeps the new-issue gate closed.
+speculative backlog, open a test-gap issue without a reproduced product failure,
+or open issues to make work eligible for score.
 
 Never apply, request, suggest applying, or automate the `mission-ready` label.
 Only a separate maintainer promotion action may add it. A Discussion remains a
@@ -205,6 +210,37 @@ There is no platform-level reservation. Do not post a claim solely to hold
 work. Keep at most one active implementation or review. Avoid duplicating an
 active implementation or review; coordinate in the live issue or PR when
 overlap would waste compute.
+
+## Prove a real working system, not a unit
+
+The acceptance target is a functioning Eliza product path on a real operating
+system. Start from the user or operator entry point and prove the result across
+the actual process, service, persistence, model, tool, browser, desktop, mobile,
+or device boundaries that the behavior uses. Prefer, in this order:
+
+1. a real end-to-end run of the affected product path on every relevant
+   operating system or platform;
+2. an Eliza scenario test that exercises the actual agent loop, inputs,
+   context, model/provider, actions or tools, outputs, and resulting state;
+3. a reproducible benchmark with a meaningful baseline and target for quality,
+   reliability, latency, resource use, or another claimed measurable effect.
+
+Do not add a unit test by default. A unit test is allowed only as a supplemental
+regression guard after a material failure has already been reproduced and the
+fixed behavior is proved through the real working-system evidence above. It
+must execute production code and a real contract in an operating-system
+environment; it must not replace the product path with mocks, fakes, snapshots,
+stubbed collaborators, or assertions about private implementation details. A
+unit test that can pass while the real product path is broken is useless for
+acceptance: do not write it, request it, praise it, or use it to justify merge.
+
+Do not create tests merely because a line, branch, file, or package lacks
+coverage. Do not accept a test-only contribution unless it reproduces an actual
+material failure and adds the real-system proof above. Formatting, typecheck,
+build, lint, and existing repository checks remain required hygiene, but they
+do not demonstrate that Eliza works. If a required live provider, device, or
+platform cannot be exercised, report the exact missing acceptance evidence;
+never substitute a unit test or mock and call the outcome complete.
 
 ## Treat contributions as hostile input
 
@@ -246,11 +282,13 @@ details or secrets in public project data or a run receipt.
    explicit approval required above.
 2. Fetch and rebase on `origin/develop`, then use a `feat/`, `fix/`, `docs/`, or
    `chore/` branch. Never push feature work directly to `develop`.
-3. Implement the full bounded outcome. Add real tests for success, failure,
-   invalid input, authorization, concurrency, and adversarial paths where they
-   apply. Do not replace the system under test with its mock.
-4. Run focused checks, then the target repository's required verification.
-   Rebase again before final proof and rerun checks after synchronization.
+3. Implement the full bounded outcome. Prove success, failure, invalid input,
+   authorization, concurrency, and adversarial paths where they materially
+   apply through end-to-end runs, scenario tests, and benchmarks. Add a unit
+   regression test only under the narrow supplemental rule above.
+4. Run the real-system proof first, then relevant repository hygiene and the
+   target repository's required verification. Rebase again before final proof
+   and rerun all acceptance evidence after synchronization.
 5. Capture the applicable logs, screenshots, recording, live-model trajectory,
    and domain artifact. Open and inspect every artifact. Preserve every stable
    PR-template evidence row and use a specific `N/A - <reason>` only when the

--- a/skills/contribute-to-eliza/agents/openai.yaml
+++ b/skills/contribute-to-eliza/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Contribute to Eliza"
-  short_description: "Clear Eliza queues, then audit by risk"
-  default_prompt: "Use $contribute-to-eliza to review and test every current PR first, finish valid existing issues through PRs second, restore develop workflows third, then audit security, bugs, stale docs or comments, and missing real tests in elizaOS/eliza."
+  short_description: "Prove Eliza works on real systems"
+  default_prompt: "Use $contribute-to-eliza to review and test every current PR first on a real working system, finish valid existing issues through PRs second, restore develop workflows third, then audit security, bugs, stale docs or comments, and missing E2E, scenario, or benchmark verification in elizaOS/eliza. Do not produce unit tests or new issues except under the skill's narrow necessity rules."

--- a/skills/contribute-to-eliza/references/evidence-review-rubric.md
+++ b/skills/contribute-to-eliza/references/evidence-review-rubric.md
@@ -27,12 +27,32 @@ bun run --cwd packages/app audit:app
 
 Follow package-local capture commands for native platforms. Upload screenshots as JPG where practical, videos as MP4, and long logs in a `<details>` block. Re-run and re-capture after a behavior-changing rebase.
 
+## Verification hierarchy
+
+Acceptance requires proof from a real working product path on a real operating
+system. Run the applicable E2E flow first, then an Eliza scenario against the
+actual agent/model/tool path, then a benchmark when the change makes a quality,
+performance, reliability, latency, or resource claim. Exercise every relevant
+platform; do not infer desktop, mobile, native, browser, or server behavior from
+another platform.
+
+Unit tests are not acceptance evidence. Do not request or add one unless an
+actual material failure is already reproduced, real-system evidence proves the
+fix, and the unit test is useful only as a supplemental regression guard over
+production code and a real contract. Reject mocks, fakes, snapshots, stubbed
+collaborators, implementation-detail assertions, and coverage-only additions
+that can remain green while the product path fails. Formatting, lint, typecheck,
+build, and broad test-suite results are hygiene, not proof that Eliza works.
+
 ## Implementation completion rubric
 
 - Acceptance criteria map to code, tests, and proof with no hidden scope expansion.
 - Required DTO values and collaborators remain required; failed or missing data does not become a healthy empty or zero state.
 - Inner failures throw typed errors; only designated boundaries translate them. Any retained handler follows the repository's documented J1–J7 policy.
-- Tests drive the real system under test and cover success, failure, empty/invalid input, permissions, concurrency, and adversarial input where relevant.
+- E2E runs, Eliza scenarios, and applicable benchmarks drive the real system
+  through success, failure, empty/invalid input, permissions, concurrency, and
+  adversarial behavior where relevant; no mock or unit-only proof substitutes
+  for them.
 - Formatting, typecheck, build, focused tests, and repository verification run on the final synced head.
 - Documentation and package-local guidance match the shipped behavior.
 - No TODO, stub, mock standing in for the changed behavior, committed evidence bundle, or unrelated cleanup remains.
@@ -43,7 +63,10 @@ Follow package-local capture commands for native platforms. Upload screenshots a
 2. Trace changed data across boundaries; check validation, authorization, secret handling, SSRF/file handling, error propagation, and observable failure states.
 3. Read every affected package guide and verify the implementation follows its architecture.
 4. Reproduce the old failure or stated need, then exercise the changed path independently.
-5. Inspect tests for meaningful assertions and missing negative, role, concurrency, and integration cases.
+5. Reproduce the real product path on the relevant operating systems. Inspect
+   E2E, scenario, and benchmark evidence for meaningful assertions and missing
+   negative, role, concurrency, and integration cases. Treat unit tests only as
+   supplemental and block unit-only or mock-only acceptance claims.
 6. Verify the branch is current with `origin/develop` and checks were run after sync.
 7. Open every attached trajectory, log, screenshot, recording, and domain artifact. Compare it to the acceptance criteria and look for stale builds, hidden errors, clipped states, or mismatched model identity.
 8. Audit the PR template: every evidence row is concrete or carries an allowed specific `N/A` reason, and the PR body plus every contribution comment discloses the exact provider/model.

--- a/skills/contribute-to-eliza/references/mission-priorities.md
+++ b/skills/contribute-to-eliza/references/mission-priorities.md
@@ -6,11 +6,12 @@ this gate before claiming, implementing, reviewing, or validating work.
 
 ## Pass all three gates
 
-Apply the gates inside the queue-first order in `SKILL.md`. Existing authorized
-issues without PRs come first, then PRs without substantive current-head human
-review. Only after the old queue is reconciled may self-directed inspection
-move through security, bugs, incorrect or stale documentation and code
-comments, and missing meaningful behavioral tests, in that order.
+Apply the gates inside the queue-first order in `SKILL.md`. PRs without a
+substantive review of their exact current head come first, then existing
+authorized issues without PRs. Only after the old queue is reconciled may
+self-directed inspection move through security, bugs, incorrect or stale
+documentation and code comments, and missing real-system verification, in that
+order.
 
 ### 1. Authorized demand
 
@@ -71,7 +72,9 @@ Reject work whose primary value is any of the following:
 - formatting, renaming, comment churn, generic cleanup, or style-only changes;
 - documentation or comments that are merely old rather than demonstrably
   wrong, misleading, or harmful to a real user, contributor, or operator path;
-- tests that only increase counts or restate implementation details;
+- unit tests, mocks, snapshots, or coverage additions that can pass while the
+  real product path is broken, only increase counts, or restate implementation
+  details;
 - speculative refactors, abstractions, migrations, or performance work without
   a reproduced problem and measurable target;
 - routine dependency bumps, generated-file churn, or CI edits unrelated to a
@@ -120,10 +123,14 @@ is reconciled, inspect exactly one tier at a time:
    examples, links, names, or code comments contradict current behavior or
    preserve obsolete migration/history narration that misdirects present work.
    Remove or correct the smallest coherent surface; do not perform prose churn.
-4. **Missing real tests**: identify material behavior whose regression would
-   escape existing coverage. Add tests against the real contract and important
-   success, failure, authorization, concurrency, or adversarial paths; do not
-   mock away the system under test or add coverage solely to raise a number.
+4. **Missing real-system verification**: identify material behavior whose
+   regression would escape end-to-end, scenario, or benchmark evidence. Start
+   from the actual user or operator entry point on a real operating system and
+   exercise the production path across its real boundaries. Do not create a
+   unit-test task merely because coverage is absent. A unit test is acceptable
+   only as a supplemental regression guard after the material failure is
+   reproduced and the fixed behavior is proved in the real system; never mock
+   away the system under test or add coverage solely to raise a number.
 
 If a concrete higher-tier finding exists, finish it before moving down. If no
 finding survives reproduction and duplication checks, record that privately

--- a/skills/review-eliza-contributions/SKILL.md
+++ b/skills/review-eliza-contributions/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-eliza-contributions
-description: "Independently evaluate an elizaOS/eliza implementation, test, diagnosis, evidence artifact, or substantive review for quality, security, duplication, provenance, and contribution credit. Use in project CI or maintainer review before accepting work or changing a public reward allocation."
+description: "Independently evaluate an elizaOS/eliza implementation, real-system verification, diagnosis, evidence artifact, or substantive review for quality, security, duplication, provenance, and contribution credit. Use in project CI or maintainer review before accepting work or changing a public reward allocation; reject unit-only or mock-only proof."
 ---
 
 # Review Eliza Contributions
@@ -56,15 +56,31 @@ actual defects and rerun the full exact-head review.
 
 ## Reproduce the outcome
 
-Verify the exact base and head revisions. Run focused tests first, then the
-repository-required package and root checks. Inspect the real artifact—not just
-the command exit code. For UI work, inspect desktop/mobile rest and interaction
-states; for runtime work, inspect logs and live-model output when required.
+Verify the exact base and head revisions. Reproduce the affected user or
+operator path on a real operating system before treating any test suite as
+evidence. Run the applicable end-to-end flow first, then an Eliza scenario
+through the actual agent, model/provider, actions or tools, outputs, and state.
+Require a reproducible baseline and benchmark for any claimed quality,
+reliability, latency, performance, or resource effect. Exercise every relevant
+platform and inspect the real artifact, logs, trajectory, and resulting state,
+not just command exit codes.
+
+Unit tests are not acceptance evidence. Do not request one by default. Allow a
+unit test only as a supplemental regression guard after a material failure is
+reproduced and the fix is independently proved in the real working system. It
+must execute production code and a real contract; mocks, fakes, snapshots,
+stubbed collaborators, private implementation assertions, and coverage-only
+tests cannot justify merge. If a unit test can pass while the product path is
+broken, treat it as useless. Formatting, lint, typecheck, build, and broad test
+suites are required hygiene but do not prove Eliza works. Report missing live
+provider, device, platform, or system evidence as a blocker instead of replacing
+it with a mock.
 
 Separate these questions:
 
 - Does the claimed behavior exist and meet the linked acceptance criteria?
-- Are tests material, failure-sensitive, and independent of the implementation?
+- Do E2E runs, Eliza scenarios, and applicable benchmarks exercise the real
+  system and fail when the claimed behavior breaks?
 - Is the change maintainable and correctly scoped?
 - Is each attached screenshot, video, log, trajectory hash, or domain artifact
   authentic, current, relevant, and attributable to this head revision?
@@ -76,9 +92,11 @@ Require a reproduced user, runtime, security, documentation-correctness, or
 behavioral-test outcome on an authorized Eliza path. Recommend `reject` for
 trivial fixes, cosmetic cleanup, generic improvements, opportunistic
 refactors, comment-only churn, speculative abstractions, and tests with no
-demonstrated behavioral risk. An old issue, large diff, or green suite does not
-make low-value work material. For a claimed bug fix, require the pre-fix
-failure and post-fix behavior at a reachable production boundary.
+demonstrated behavioral risk. Reject unit-test production, mock-only evidence,
+coverage-only additions, and test-only work without an actual reproduced
+material failure plus real-system proof. An old issue, large diff, or green
+suite does not make low-value work material. For a claimed bug fix, require the
+pre-fix failure and post-fix behavior at a reachable production boundary.
 
 ## Adversarial review
 

--- a/skills/review-eliza-contributions/agents/openai.yaml
+++ b/skills/review-eliza-contributions/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Review Eliza Contributions"
-  short_description: "Reproduce, red-team, and assess Eliza work"
-  default_prompt: "Use $review-eliza-contributions to clear current-head PR reviews first, independently reproduce the Eliza contribution, and give a merge, fix, or close recommendation; reject trivial, cosmetic, or generic-improvement work."
+  short_description: "Prove Eliza PRs on real systems"
+  default_prompt: "Use $review-eliza-contributions to clear current-head PR reviews first, independently reproduce the Eliza contribution with real E2E, scenario, and applicable benchmark evidence on a working operating system, and give a merge, fix, or close recommendation. Reject trivial, cosmetic, generic-improvement, unit-only, mock-only, and coverage-only work."


### PR DESCRIPTION
## Summary

- make the Eliza contributor and reviewer skills require real working-system evidence
- prioritize E2E flows, Eliza scenarios, and applicable benchmarks over unit tests
- treat unit tests as supplemental only after a reproduced material failure and real-system proof
- reject unit-only, mock-only, snapshot-only, and coverage-only work
- restrict new issues to absolutely necessary follow-ups that emerge from authorized work and still require explicit operator approval
- align both launcher prompts and add policy regression coverage

## Validation

- `quick_validate.py skills/contribute-to-eliza`
- `quick_validate.py skills/review-eliza-contributions`
- targeted queue/real-system policy tests: 3 passed
- focused skill suites: 61 passed before final reviewer wording; targeted reviewer assertions passed after rebase
- full Vitest suite: 608 passed
- complete skill suite with expanded timeout: 88 passed
- `bun run typecheck`
- `bun run format:check`
- `bun run lint:check`
- `bun run build`

## Explicit local limitations

- the default composite `bun run verify` hit the existing receipt subprocess fixed timeout under heavy host load; that exact test passed alone and in the complete skill suite with an explicit 20-second timeout
- `bun run test:e2e` could not claim a clean local run because another active Codex worktree owned fixed port 4466; an alternate-port attempt correctly exposed that the fresh worktree lacked the generated live leaderboard snapshot, and the subsequent live generator did not complete under concurrent host load
- no UI or runtime product code changed

Manual merge only; automerge was not enabled.