### PR TITLE
test(skills): remove wording-only Eliza checks

### DIFF
--- a/skill-tests/contribute-to-eliza.test.ts
+++ b/skill-tests/contribute-to-eliza.test.ts
@@ -249,44 +249,11 @@ describe("contribute-to-eliza skill structure", () => {
     assert.ok(auditPriority > workflowPriority);
     assert.match(
       source,
-      /\*\*security weaknesses\*\*.*\*\*reproducible bugs\*\*.*\*\*incorrect or stale\s+documentation and code comments\*\*.*\*\*important behavior that lacks\s+real-system verification\*\*/is,
+      /\*\*security weaknesses\*\*.*\*\*reproducible bugs\*\*.*\*\*incorrect or stale\s+documentation and code comments\*\*.*\*\*important behavior that lacks real\s+tests\*\*/is,
     );
     assert.match(
       source,
       /every current PR has a current-head review and disposition[\s\S]*every existing issue[\s\S]*every required `develop` workflow/iu,
-    );
-    assert.match(
-      source,
-      /default is\s+to create no new issue at all[\s\S]*requires an absolutely necessary[\s\S]*falls out of that work/iu,
-    );
-    assert.match(
-      source,
-      /open a test-gap issue without a reproduced product failure/iu,
-    );
-    assert.match(source, /## Prove a real working system, not a unit/iu);
-    const endToEndPriority = source.indexOf(
-      "a real end-to-end run of the affected product path",
-    );
-    const scenarioPriority = source.indexOf(
-      "an Eliza scenario test that exercises the actual agent loop",
-    );
-    const benchmarkPriority = source.indexOf(
-      "a reproducible benchmark with a meaningful baseline",
-    );
-    assert.ok(endToEndPriority >= 0);
-    assert.ok(scenarioPriority > endToEndPriority);
-    assert.ok(benchmarkPriority > scenarioPriority);
-    assert.match(
-      source,
-      /Do not add a unit test by default[\s\S]*supplemental\s+regression guard[\s\S]*real working-system evidence/iu,
-    );
-    assert.match(
-      source,
-      /unit test that can pass while the real product path is broken is useless/iu,
-    );
-    assert.match(
-      source,
-      /Formatting, typecheck,\s+build, lint, and existing repository checks[\s\S]*do not demonstrate that Eliza works/iu,
     );
     assert.match(mission, /Eliza app/);
     assert.match(mission, /Eliza Cloud/);
@@ -298,37 +265,6 @@ describe("contribute-to-eliza skill structure", () => {
       /splitting one outcome into multiple issues or pull requests/i,
     );
     assert.match(mission, /Recommend closure rather than repairs/i);
-    assert.match(
-      mission,
-      /PRs without a\s+substantive review of their exact current head come first[\s\S]*existing\s+authorized issues without PRs/iu,
-    );
-    assert.match(
-      mission,
-      /Missing real-system verification[\s\S]*end-to-end, scenario, or benchmark evidence/iu,
-    );
-    const rubric = readFileSync(
-      join(skillDir, "references", "evidence-review-rubric.md"),
-      "utf8",
-    );
-    const reviewer = readFileSync(
-      join(skillDir, "..", "review-eliza-contributions", "SKILL.md"),
-      "utf8",
-    );
-    assert.match(rubric, /## Verification hierarchy/iu);
-    assert.match(rubric, /Unit tests are not acceptance evidence/iu);
-    assert.match(
-      rubric,
-      /E2E runs, Eliza scenarios, and applicable benchmarks drive the real system/iu,
-    );
-    assert.match(
-      reviewer,
-      /Reproduce the affected user or\s+operator path on a real operating system[\s\S]*end-to-end flow first[\s\S]*Eliza scenario/iu,
-    );
-    assert.match(reviewer, /Unit tests are not acceptance evidence/iu);
-    assert.match(
-      reviewer,
-      /Reject unit-test production, mock-only evidence,\s+coverage-only additions/iu,
-    );
     assert.deepStrictEqual(readProjectSelectionPolicy().eligibleIssueLabels, [
       "mission-ready",
     ]);
@@ -468,15 +404,7 @@ writeFileSync(
     );
     assert.match(openaiYaml, /display_name: "Contribute to Eliza"/);
     assert.match(openaiYaml, /default_prompt: "Use \$contribute-to-eliza/);
-    assert.match(
-      openaiYaml,
-      /review and test every current PR first on a real working system/,
-    );
-    assert.match(
-      openaiYaml,
-      /missing E2E, scenario, or benchmark verification/,
-    );
-    assert.match(openaiYaml, /Do not produce unit tests or new issues/);
+    assert.match(openaiYaml, /review and test every current PR first/);
     assert.match(openaiYaml, /existing issues through PRs second/);
     assert.match(openaiYaml, /develop workflows third/);
     assert.match(openaiYaml, /elizaOS\/eliza/);

--- a/skills/contribute-to-eliza/SKILL.md
+++ b/skills/contribute-to-eliza/SKILL.md
@@ -163,11 +163,12 @@ easier, or more interesting work:
    run or aggregate PR check is insufficient. Then inspect one fallback
    category in this exact order:
    **security weaknesses**, **reproducible bugs**, **incorrect or stale
-   documentation and code comments**, then **important behavior that lacks
-   real-system verification**. Do not advance while a higher fallback category
-   has a concrete, unowned finding. Prefer a bounded fix and proof; use
-   **Validate** only for a reproducible diagnosis, refutation, benchmark, test,
-   or research artifact that changes a concrete engineering decision.
+   documentation and code comments**, then **important behavior that lacks real
+   tests**. Here, real tests mean the real-system verification required below,
+   not unit-test coverage. Do not advance while a higher fallback category has
+   a concrete, unowned finding. Prefer a bounded fix and proof; use **Validate**
+   only for a reproducible diagnosis, refutation, benchmark, test, or research
+   artifact that changes a concrete engineering decision.
 
 The live report's closing-reference check is a conservative deduplication aid,
 not proof that a PR solves an issue. Inspect linked PRs, branches, issue


### PR DESCRIPTION
## Summary

- remove the wording-only regex assertions introduced in #249
- retain the actual contributor and reviewer policy requiring real E2E, scenario, benchmark, and operating-system evidence
- preserve the existing priority-order contract without adding tests whose only purpose is to match policy prose

## Validation

- `quick_validate.py skills/contribute-to-eliza`
- targeted existing skill structure checks: 2 passed
- `bun run format:check`

The fresh corrective worktree did not have locked TypeScript dependencies installed, so local typecheck could not resolve existing workspace packages; hosted exact-head CI is the acceptance gate.

Manual merge only; automerge was not enabled.