### PR TITLE
fix(skills): allow complete reports above 1,000 open PRs

### DIFF
--- a/skill-tests/contribute-to-eliza.test.ts
+++ b/skill-tests/contribute-to-eliza.test.ts
@@ -607,6 +607,28 @@ describe("live report parsing", () => {
     assert.strictEqual(activity.pulls.get(2)?.inlineComments.length, 1);
   });
 
+  it("audits the current 1,097-item pull queue without truncation", () => {
+    const pullNodes = Array.from({ length: 1_097 }, (_, index) => ({
+      number: index + 1,
+      comments: { totalCount: 0, nodes: [] },
+      reviews: { totalCount: 0, nodes: [] },
+      reviewThreads: { totalCount: 0, nodes: [] },
+    }));
+
+    const activity = readGhOpenActivity("elizaOS/eliza", (_command, args) => ({
+      status: 0,
+      stderr: "",
+      stdout: args.at(-1)?.includes(".pullRequests.")
+        ? `${pullNodes.map((node) => JSON.stringify(node)).join("\n")}\n`
+        : "",
+    }));
+
+    assert.strictEqual(activity.issues.size, 0);
+    assert.strictEqual(activity.pulls.size, 1_097);
+    assert.ok(activity.pulls.has(1));
+    assert.ok(activity.pulls.has(1_097));
+  });
+
   it("paginates overflowing issue activity through bounded GET-only REST", () => {
     const actor = {
       __typename: "User",

--- a/skills/contribute-to-asi/scripts/live-report.mjs
+++ b/skills/contribute-to-asi/scripts/live-report.mjs
@@ -22,7 +22,7 @@ export const REQUIRED_EVIDENCE_ROWS = [
 ];
 export const CLAIM_RECENCY_DAYS = 7;
 export const MISSION_READY_LABEL = "mission-ready";
-export const MAX_OPEN_ITEMS = 1_000;
+export const MAX_OPEN_ITEMS = 10_000;
 export const MAX_API_READS = 16;
 export const MAX_ACTIVITY_CONNECTION_ITEMS = 1_000;
 

--- a/skills/contribute-to-delta-star/scripts/live-report.mjs
+++ b/skills/contribute-to-delta-star/scripts/live-report.mjs
@@ -22,7 +22,7 @@ export const REQUIRED_EVIDENCE_ROWS = [
 ];
 export const CLAIM_RECENCY_DAYS = 7;
 export const MISSION_READY_LABEL = "mission-ready";
-export const MAX_OPEN_ITEMS = 1_000;
+export const MAX_OPEN_ITEMS = 10_000;
 export const MAX_API_READS = 16;
 export const MAX_ACTIVITY_CONNECTION_ITEMS = 1_000;
 

--- a/skills/contribute-to-eliza/scripts/live-report.mjs
+++ b/skills/contribute-to-eliza/scripts/live-report.mjs
@@ -22,7 +22,7 @@ export const REQUIRED_EVIDENCE_ROWS = [
 ];
 export const CLAIM_RECENCY_DAYS = 7;
 export const MISSION_READY_LABEL = "mission-ready";
-export const MAX_OPEN_ITEMS = 1_000;
+export const MAX_OPEN_ITEMS = 10_000;
 export const MAX_API_READS = 16;
 export const MAX_ACTIVITY_CONNECTION_ITEMS = 1_000;
 

--- a/skills/contribute-to-heir-elements-sdk/scripts/live-report.mjs
+++ b/skills/contribute-to-heir-elements-sdk/scripts/live-report.mjs
@@ -22,7 +22,7 @@ export const REQUIRED_EVIDENCE_ROWS = [
 ];
 export const CLAIM_RECENCY_DAYS = 7;
 export const MISSION_READY_LABEL = "mission-ready";
-export const MAX_OPEN_ITEMS = 1_000;
+export const MAX_OPEN_ITEMS = 10_000;
 export const MAX_API_READS = 16;
 export const MAX_ACTIVITY_CONNECTION_ITEMS = 1_000;
 


### PR DESCRIPTION
## Summary

- raise the finite per-kind open-item safety bound from 1,000 to 10,000
- preserve byte-identical discovery logic across every registered contributor skill
- add a regression that audits all 1,097 PR activity nodes without truncation

Fixes #257.

## Validation

- RED proof: focused regression failed on the prior code with `RangeError: Live discovery exceeds the 1000-item per-kind safety bound`
- `bun run verify` — 64 Vitest files / 611 tests, 90 Bun skill tests, packaging, and production build passed
- `bun run test:e2e` — 36 browser-matrix tests plus 1 Pages artifact-contract test passed using the deployed validated leaderboard snapshot
- `node skills/contribute-to-eliza/scripts/live-report.mjs --repo elizaOS/eliza` — exit 0; complete live report for 539 issues and 1,106 PRs using 4 bounded GitHub commands
- packaged archive SHA-256 matched its sidecar: `36c0686131983f24437be2d236b331bf2667766702e7e4952af31c757870b6fe`

A fresh local leaderboard generation was also attempted. It discovered 1,100 open Eliza PRs but correctly failed the separate 16 MiB deployment-manifest size bound. That unrelated data-volume issue is not changed here.

## Evidence

- Before screenshots: N/A - no UI behavior changed
- After screenshots: N/A - no UI behavior changed
- Walkthrough video: N/A - CLI-only bound change
- Backend logs: N/A - no backend runtime changed
- Frontend console/network logs: N/A - no frontend behavior changed
- Real-LLM trajectory: N/A - no model behavior changed
- Domain artifacts: live CLI output above and generated skill checksum

## Contribution provenance

- AI assistance: yes
- AI provider/model: OpenAI / GPT-5.6
- Client / agent tooling: Codex desktop agent
- Contribution skill revision: `1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42`
- Attribution status: self-reported

## Slop protocol changes

- Contributor skill (`skills/contribute-to-<id>/`): shared discovery ceiling only; no payout, identity, receipt, or authority policy change

## Safety review

- [x] No private key, seed phrase, API token, raw private trajectory, or secret was added.
- [x] Untrusted project code is not executed with repository or deployment credentials.
- [x] New telemetry is bounded, disclosed, project-attributed, and covered by adversarial tests.
- [x] Money state is derived from validated manifests and finalized on-chain evidence, not a transaction signature alone.