### PR TITLE
fix(skills): fall back when GraphQL budget is low

### DIFF
--- a/skill-tests/contribute-to-eliza.test.ts
+++ b/skill-tests/contribute-to-eliza.test.ts
@@ -629,6 +629,150 @@ describe("live report parsing", () => {
     assert.ok(activity.pulls.has(1_097));
   });
 
+  it("uses bounded REST activity when GraphQL cannot afford the scan", () => {
+    const issueComment = {
+      ...comment(10, "reviewer", "Issue comment"),
+      issue_url: "https://api.github.com/repos/elizaOS/eliza/issues/1",
+    };
+    const pullComment = {
+      ...comment(20, "reviewer", "Pull comment"),
+      issue_url: "https://api.github.com/repos/elizaOS/eliza/issues/2",
+    };
+    const inlineComment = {
+      ...comment(30, "reviewer", "Inline comment"),
+      pull_request_url: "https://api.github.com/repos/elizaOS/eliza/pulls/2",
+      commit_id: HEAD_SHA,
+    };
+    const calls: string[][] = [];
+
+    const activity = readGhOpenActivity(
+      "elizaOS/eliza",
+      (_command, args) => {
+        calls.push(args);
+        if (args.at(-1) === "rate_limit") {
+          return {
+            status: 0,
+            stderr: "",
+            stdout: JSON.stringify({
+              resources: {
+                graphql: {
+                  limit: 5_000,
+                  remaining: 999,
+                  reset: 1_800_000_000,
+                },
+                core: {
+                  limit: 5_000,
+                  remaining: 4_943,
+                  reset: 1_800_000_000,
+                },
+                search: { limit: 30, remaining: 30, reset: 1_800_000_000 },
+              },
+            }),
+          };
+        }
+        if (args.includes("graphql")) {
+          return {
+            status: 1,
+            stderr: "gh: API rate limit already exceeded",
+            stdout: "",
+          };
+        }
+        const endpoint = args.at(-1) ?? "";
+        if (endpoint.includes("/issues?state=open")) {
+          return {
+            status: 0,
+            stderr: "",
+            stdout: `${JSON.stringify({ number: 1, created_at: "2026-01-18T12:00:00.000Z" })}\n${JSON.stringify({ number: 2, created_at: "2026-01-19T12:00:00.000Z", pull_request: {} })}\n`,
+          };
+        }
+        if (endpoint.includes("/pulls?state=open")) {
+          return {
+            status: 0,
+            stderr: "",
+            stdout: `${JSON.stringify({ number: 2, created_at: "2026-01-19T12:00:00.000Z" })}\n`,
+          };
+        }
+        if (endpoint.includes("/issues/comments?")) {
+          return {
+            status: 0,
+            stderr: "",
+            stdout: `${JSON.stringify(issueComment)}\n${JSON.stringify(pullComment)}\n`,
+          };
+        }
+        if (endpoint.includes("/pulls/comments?")) {
+          return {
+            status: 0,
+            stderr: "",
+            stdout: `${JSON.stringify(inlineComment)}\n`,
+          };
+        }
+        if (
+          args.includes("q=repo:elizaOS/eliza is:pr is:open review:approved")
+        ) {
+          return {
+            status: 0,
+            stderr: "",
+            stdout: `${JSON.stringify({ number: 2 })}\n`,
+          };
+        }
+        if (
+          args.includes(
+            "q=repo:elizaOS/eliza is:pr is:open review:changes_requested",
+          )
+        ) {
+          return { status: 0, stderr: "", stdout: "" };
+        }
+        assert.fail(`unexpected GitHub command: ${args.join(" ")}`);
+      },
+      { preflight: true },
+    );
+
+    assert.strictEqual(calls[0].at(-1), "rate_limit");
+    assert.ok(calls.every((args) => !args.includes("graphql")));
+    assert.ok(
+      calls
+        .filter((args) => args.at(-1)?.includes("/comments?"))
+        .every((args) =>
+          args.at(-1)?.includes("since=2026-01-18T12%3A00%3A00.000Z"),
+        ),
+    );
+    assert.strictEqual(activity.issues.get(1)?.[0].id, 10);
+    assert.strictEqual(activity.pulls.get(2)?.issueComments[0].id, 20);
+    assert.strictEqual(activity.pulls.get(2)?.inlineComments[0].id, 30);
+    assert.strictEqual(activity.pulls.get(2)?.reviewStatus, "approved");
+
+    const report = collectLiveReport(
+      "elizaOS/eliza",
+      (endpoint) => {
+        if (endpoint.includes("/issues?state=open")) {
+          return [
+            {
+              number: 1,
+              title: "Issue 1",
+              html_url: "https://github.com/elizaOS/eliza/issues/1",
+              user: account("issue-author"),
+              labels: [{ name: MISSION_READY_LABEL }],
+              assignees: [],
+              comments: 1,
+            },
+          ];
+        }
+        if (endpoint.includes("/pulls?state=open")) return [pullRequest(2)];
+        assert.fail(`unexpected endpoint: ${endpoint}`);
+      },
+      NOW,
+      () => {},
+      activity,
+      [MISSION_READY_LABEL],
+    );
+
+    assert.strictEqual(report.reviewablePullRequests.length, 0);
+    assert.deepStrictEqual(
+      report.filtered.reviewedPullRequests.map((pull) => pull.number),
+      [2],
+    );
+  });
+
   it("paginates overflowing issue activity through bounded GET-only REST", () => {
     const actor = {
       __typename: "User",

--- a/skills/contribute-to-asi/scripts/live-report.mjs
+++ b/skills/contribute-to-asi/scripts/live-report.mjs
@@ -25,6 +25,9 @@ export const MISSION_READY_LABEL = "mission-ready";
 export const MAX_OPEN_ITEMS = 10_000;
 export const MAX_API_READS = 16;
 export const MAX_ACTIVITY_CONNECTION_ITEMS = 1_000;
+export const MIN_GRAPHQL_ACTIVITY_POINTS = 1_000;
+export const MIN_REST_ACTIVITY_REQUESTS = 100;
+export const MIN_SEARCH_ACTIVITY_REQUESTS = 2;
 
 const REPOSITORY_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const PLACEHOLDER_RE =
@@ -627,6 +630,196 @@ function readOverflowActivity(endpoint, expectedCount, context, spawn) {
   return records;
 }
 
+function activityItemNumber(record, field, context) {
+  const url = asStringField(record, field, context);
+  const match = url.match(/\/(?:issues|pulls)\/([1-9]\d*)$/);
+  if (!match) {
+    throw new TypeError(`${context}.${field} must end with an item number`);
+  }
+  return Number(match[1]);
+}
+
+function appendBoundedActivity(target, value, context) {
+  if (target.length >= MAX_ACTIVITY_CONNECTION_ITEMS) {
+    throw new RangeError(
+      `${context} exceeds the complete ${MAX_ACTIVITY_CONNECTION_ITEMS}-record activity bound`,
+    );
+  }
+  target.push(value);
+}
+
+function readGhSearchPullNumbers(repo, qualifier, spawn) {
+  const query = `repo:${repo} is:pr is:open review:${qualifier}`;
+  const result = spawn(
+    "gh",
+    [
+      "api",
+      "--method",
+      "GET",
+      "--paginate",
+      "-f",
+      `q=${query}`,
+      "-f",
+      "per_page=100",
+      "--jq",
+      ".items[]",
+      "search/issues",
+    ],
+    {
+      encoding: "utf8",
+      maxBuffer: 64 * 1024 * 1024,
+      windowsHide: true,
+    },
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const detail =
+      result.stderr.trim().length > 0 ? `: ${result.stderr.trim()}` : "";
+    throw new Error(`gh api failed for review:${qualifier}${detail}`);
+  }
+  const records = parsePaginatedJson(result.stdout, `review:${qualifier}`);
+  if (records.length >= 1_000) {
+    throw new RangeError(
+      `review:${qualifier} reaches GitHub's 1000-result search bound`,
+    );
+  }
+  const numbers = new Set();
+  for (const [index, value] of records.entries()) {
+    const number = asNumberField(
+      asRecord(value, `review:${qualifier}[${index}]`),
+      "number",
+      `review:${qualifier}[${index}]`,
+    );
+    if (numbers.has(number)) {
+      throw new TypeError(
+        `duplicate review:${qualifier} result for #${number}`,
+      );
+    }
+    numbers.add(number);
+  }
+  return numbers;
+}
+
+function readGhRestOpenActivity(repo, spawn) {
+  const issueItems = readGhPages(
+    `repos/${repo}/issues?state=open&per_page=100&sort=created&direction=asc`,
+    spawn,
+  )
+    .map((value, index) => asRecord(value, `REST issues[${index}]`))
+    .filter((item) => item.pull_request === undefined);
+  const pullItems = readGhPages(
+    `repos/${repo}/pulls?state=open&per_page=100&sort=created&direction=asc`,
+    spawn,
+  ).map((value, index) => asRecord(value, `REST pulls[${index}]`));
+  if (issueItems.length > MAX_OPEN_ITEMS || pullItems.length > MAX_OPEN_ITEMS) {
+    throw new RangeError(
+      `Live discovery exceeds the ${MAX_OPEN_ITEMS}-item per-kind safety bound`,
+    );
+  }
+  const oldestCreatedAt = [...issueItems, ...pullItems]
+    .map((item, index) =>
+      isoTime(item.created_at, `REST open items[${index}].created_at`),
+    )
+    .sort((left, right) => Date.parse(left) - Date.parse(right))[0];
+  const since =
+    oldestCreatedAt === undefined
+      ? null
+      : `since=${encodeURIComponent(oldestCreatedAt)}`;
+  const issues = new Map();
+  for (const item of issueItems) {
+    const number = asNumberField(item, "number", "REST issue");
+    if (issues.has(number))
+      throw new TypeError(`duplicate issue activity for #${number}`);
+    issues.set(number, []);
+  }
+  const pulls = new Map();
+  for (const item of pullItems) {
+    const number = asNumberField(item, "number", "REST pull request");
+    if (pulls.has(number))
+      throw new TypeError(`duplicate pull activity for #${number}`);
+    pulls.set(number, {
+      issueComments: [],
+      inlineComments: [],
+      reviews: [],
+      reviewStatus: "none",
+    });
+  }
+  const issueComments =
+    since === null
+      ? []
+      : readGhPages(
+          `repos/${repo}/issues/comments?per_page=100&sort=created&direction=asc&${since}`,
+          spawn,
+        );
+  for (const [index, value] of issueComments.entries()) {
+    const record = asRecord(value, `REST issue comments[${index}]`);
+    const number = activityItemNumber(
+      record,
+      "issue_url",
+      `REST issue comments[${index}]`,
+    );
+    if (issues.has(number)) {
+      appendBoundedActivity(
+        issues.get(number),
+        record,
+        `issue #${number}.comments`,
+      );
+    } else if (pulls.has(number)) {
+      appendBoundedActivity(
+        pulls.get(number).issueComments,
+        record,
+        `pull request #${number}.comments`,
+      );
+    }
+  }
+  const inlineComments =
+    since === null || pulls.size === 0
+      ? []
+      : readGhPages(
+          `repos/${repo}/pulls/comments?per_page=100&sort=created&direction=asc&${since}`,
+          spawn,
+        );
+  for (const [index, value] of inlineComments.entries()) {
+    const record = asRecord(value, `REST review comments[${index}]`);
+    const number = activityItemNumber(
+      record,
+      "pull_request_url",
+      `REST review comments[${index}]`,
+    );
+    if (pulls.has(number)) {
+      appendBoundedActivity(
+        pulls.get(number).inlineComments,
+        record,
+        `pull request #${number}.review comments`,
+      );
+    }
+  }
+  const approved = readGhSearchPullNumbers(repo, "approved", spawn);
+  const changesRequested = readGhSearchPullNumbers(
+    repo,
+    "changes_requested",
+    spawn,
+  );
+  for (const number of approved) {
+    if (!pulls.has(number)) {
+      throw new TypeError(`review:approved returned non-open pull #${number}`);
+    }
+    pulls.get(number).reviewStatus = "approved";
+  }
+  for (const number of changesRequested) {
+    if (!pulls.has(number)) {
+      throw new TypeError(
+        `review:changes_requested returned non-open pull #${number}`,
+      );
+    }
+    if (approved.has(number)) {
+      throw new TypeError(`conflicting REST review status for pull #${number}`);
+    }
+    pulls.get(number).reviewStatus = "changes_requested";
+  }
+  return { issues, pulls };
+}
+
 function graphqlAccount(value, context) {
   if (value === null) return null;
   const actor = asRecord(value, context);
@@ -728,10 +921,112 @@ export function createGhCommandBudget(spawn = spawnSync) {
   };
 }
 
+function rateResource(value, context) {
+  const resource = asRecord(value, context);
+  const limit = asNumberField(resource, "limit", context);
+  const remaining = asNumberField(resource, "remaining", context);
+  const reset = asNumberField(resource, "reset", context);
+  if (limit <= 0 || remaining < 0 || remaining > limit || reset <= 0) {
+    throw new RangeError(`${context} contains an invalid rate budget`);
+  }
+  return { limit, remaining, reset };
+}
+
+export function readGhRateLimits(spawn = spawnSync) {
+  const result = spawn(
+    "gh",
+    [
+      "api",
+      "--method",
+      "GET",
+      "--jq",
+      "{resources: .resources | {core, graphql, search}}",
+      "rate_limit",
+    ],
+    {
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024,
+      windowsHide: true,
+    },
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const detail =
+      result.stderr.trim().length > 0 ? `: ${result.stderr.trim()}` : "";
+    throw new Error(`gh api failed for rate_limit${detail}`);
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(result.stdout);
+  } catch (cause) {
+    throw new SyntaxError("gh api returned malformed JSON for rate_limit", {
+      cause,
+    });
+  }
+  const resources = asRecord(
+    asRecord(parsed, "GitHub rate limit response").resources,
+    "GitHub rate limit resources",
+  );
+  const graphql = rateResource(resources.graphql, "GitHub GraphQL rate limit");
+  const rest = rateResource(resources.core, "GitHub REST rate limit");
+  const search = rateResource(resources.search, "GitHub Search rate limit");
+  return {
+    graphqlLimit: graphql.limit,
+    graphqlRemaining: graphql.remaining,
+    graphqlReset: graphql.reset,
+    restLimit: rest.limit,
+    restRemaining: rest.remaining,
+    restReset: rest.reset,
+    searchLimit: search.limit,
+    searchRemaining: search.remaining,
+    searchReset: search.reset,
+  };
+}
+
 /** Reads open activity in two batches plus bounded overflow pagination. */
-export function readGhOpenActivity(repo, spawn = spawnSync) {
+export function readGhOpenActivity(repo, spawn = spawnSync, rateLimits = null) {
   if (!REPOSITORY_RE.test(repo)) {
     throw new TypeError("Repository must use the owner/name form");
+  }
+  let limits = rateLimits;
+  if (limits !== null) {
+    const options = asRecord(limits, "GitHub rate limits");
+    if (options.preflight === true) {
+      limits = readGhRateLimits(spawn);
+    }
+  }
+  if (limits !== null) {
+    limits = asRecord(limits, "GitHub rate limits");
+    const graphqlRemaining = asNumberField(
+      limits,
+      "graphqlRemaining",
+      "GitHub rate limits",
+    );
+    const restRemaining = asNumberField(
+      limits,
+      "restRemaining",
+      "GitHub rate limits",
+    );
+    const searchRemaining = asNumberField(
+      limits,
+      "searchRemaining",
+      "GitHub rate limits",
+    );
+    if (graphqlRemaining < MIN_GRAPHQL_ACTIVITY_POINTS) {
+      if (
+        restRemaining < MIN_REST_ACTIVITY_REQUESTS ||
+        searchRemaining < MIN_SEARCH_ACTIVITY_REQUESTS
+      ) {
+        throw new RangeError(
+          "GitHub budgets cannot afford either complete GraphQL or REST activity discovery",
+        );
+      }
+      return {
+        ...readGhRestOpenActivity(repo, spawn),
+        rateLimits: limits,
+        source: "rest",
+      };
+    }
   }
   const issueNodes = readGraphqlActivityNodes(
     repo,
@@ -846,7 +1141,12 @@ export function readGhOpenActivity(repo, spawn = spawnSync) {
     }
     pulls.set(number, { issueComments, inlineComments, reviews });
   }
-  return { issues, pulls };
+  return {
+    issues,
+    pulls,
+    ...(limits === null ? {} : { rateLimits: limits }),
+    source: "graphql",
+  };
 }
 
 export function parseModelDisclosure(text) {
@@ -1646,7 +1946,24 @@ export function collectLiveReport(
     const body = nullableText(item.body, `${context}.body`);
     const requestedTargets = requestedReviewTargets(item, context);
     const requestStatus = reviewRequestStatus(requestedTargets);
-    const currentReviews = currentHeadReviewStatus(item, reviews, context);
+    const fallbackReviewStatus = pullActivity?.reviewStatus ?? null;
+    if (
+      fallbackReviewStatus !== null &&
+      !new Set(["none", "approved", "changes_requested"]).has(
+        fallbackReviewStatus,
+      )
+    ) {
+      throw new TypeError(`${context} has an invalid REST review status`);
+    }
+    const currentReviews =
+      fallbackReviewStatus === "approved"
+        ? { approved: ["GitHub REST review status"], changesRequested: [] }
+        : fallbackReviewStatus === "changes_requested"
+          ? {
+              approved: [],
+              changesRequested: ["GitHub REST review status"],
+            }
+          : currentHeadReviewStatus(item, reviews, context);
     const reviewState = {
       activeRequests: requestStatus.active,
       staleRequests: requestStatus.stale,
@@ -1874,7 +2191,13 @@ export function main(args = process.argv.slice(2)) {
   const boundedRead = (endpoint) => {
     return readGhPages(endpoint, commandBudget.run);
   };
-  const openActivity = readGhOpenActivity(options.repo, commandBudget.run);
+  const openActivity = readGhOpenActivity(options.repo, commandBudget.run, {
+    preflight: true,
+  });
+  const limits = asRecord(openActivity.rateLimits, "GitHub rate limits");
+  process.stderr.write(
+    `[Slop] GitHub budgets: GraphQL ${limits.graphqlRemaining}/${limits.graphqlLimit}; REST ${limits.restRemaining}/${limits.restLimit}; Search ${limits.searchRemaining}/${limits.searchLimit}; activity source ${openActivity.source}\n`,
+  );
   const report = collectLiveReport(
     options.repo,
     boundedRead,

--- a/skills/contribute-to-delta-star/scripts/live-report.mjs
+++ b/skills/contribute-to-delta-star/scripts/live-report.mjs
@@ -25,6 +25,9 @@ export const MISSION_READY_LABEL = "mission-ready";
 export const MAX_OPEN_ITEMS = 10_000;
 export const MAX_API_READS = 16;
 export const MAX_ACTIVITY_CONNECTION_ITEMS = 1_000;
+export const MIN_GRAPHQL_ACTIVITY_POINTS = 1_000;
+export const MIN_REST_ACTIVITY_REQUESTS = 100;
+export const MIN_SEARCH_ACTIVITY_REQUESTS = 2;
 
 const REPOSITORY_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const PLACEHOLDER_RE =
@@ -627,6 +630,196 @@ function readOverflowActivity(endpoint, expectedCount, context, spawn) {
   return records;
 }
 
+function activityItemNumber(record, field, context) {
+  const url = asStringField(record, field, context);
+  const match = url.match(/\/(?:issues|pulls)\/([1-9]\d*)$/);
+  if (!match) {
+    throw new TypeError(`${context}.${field} must end with an item number`);
+  }
+  return Number(match[1]);
+}
+
+function appendBoundedActivity(target, value, context) {
+  if (target.length >= MAX_ACTIVITY_CONNECTION_ITEMS) {
+    throw new RangeError(
+      `${context} exceeds the complete ${MAX_ACTIVITY_CONNECTION_ITEMS}-record activity bound`,
+    );
+  }
+  target.push(value);
+}
+
+function readGhSearchPullNumbers(repo, qualifier, spawn) {
+  const query = `repo:${repo} is:pr is:open review:${qualifier}`;
+  const result = spawn(
+    "gh",
+    [
+      "api",
+      "--method",
+      "GET",
+      "--paginate",
+      "-f",
+      `q=${query}`,
+      "-f",
+      "per_page=100",
+      "--jq",
+      ".items[]",
+      "search/issues",
+    ],
+    {
+      encoding: "utf8",
+      maxBuffer: 64 * 1024 * 1024,
+      windowsHide: true,
+    },
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const detail =
+      result.stderr.trim().length > 0 ? `: ${result.stderr.trim()}` : "";
+    throw new Error(`gh api failed for review:${qualifier}${detail}`);
+  }
+  const records = parsePaginatedJson(result.stdout, `review:${qualifier}`);
+  if (records.length >= 1_000) {
+    throw new RangeError(
+      `review:${qualifier} reaches GitHub's 1000-result search bound`,
+    );
+  }
+  const numbers = new Set();
+  for (const [index, value] of records.entries()) {
+    const number = asNumberField(
+      asRecord(value, `review:${qualifier}[${index}]`),
+      "number",
+      `review:${qualifier}[${index}]`,
+    );
+    if (numbers.has(number)) {
+      throw new TypeError(
+        `duplicate review:${qualifier} result for #${number}`,
+      );
+    }
+    numbers.add(number);
+  }
+  return numbers;
+}
+
+function readGhRestOpenActivity(repo, spawn) {
+  const issueItems = readGhPages(
+    `repos/${repo}/issues?state=open&per_page=100&sort=created&direction=asc`,
+    spawn,
+  )
+    .map((value, index) => asRecord(value, `REST issues[${index}]`))
+    .filter((item) => item.pull_request === undefined);
+  const pullItems = readGhPages(
+    `repos/${repo}/pulls?state=open&per_page=100&sort=created&direction=asc`,
+    spawn,
+  ).map((value, index) => asRecord(value, `REST pulls[${index}]`));
+  if (issueItems.length > MAX_OPEN_ITEMS || pullItems.length > MAX_OPEN_ITEMS) {
+    throw new RangeError(
+      `Live discovery exceeds the ${MAX_OPEN_ITEMS}-item per-kind safety bound`,
+    );
+  }
+  const oldestCreatedAt = [...issueItems, ...pullItems]
+    .map((item, index) =>
+      isoTime(item.created_at, `REST open items[${index}].created_at`),
+    )
+    .sort((left, right) => Date.parse(left) - Date.parse(right))[0];
+  const since =
+    oldestCreatedAt === undefined
+      ? null
+      : `since=${encodeURIComponent(oldestCreatedAt)}`;
+  const issues = new Map();
+  for (const item of issueItems) {
+    const number = asNumberField(item, "number", "REST issue");
+    if (issues.has(number))
+      throw new TypeError(`duplicate issue activity for #${number}`);
+    issues.set(number, []);
+  }
+  const pulls = new Map();
+  for (const item of pullItems) {
+    const number = asNumberField(item, "number", "REST pull request");
+    if (pulls.has(number))
+      throw new TypeError(`duplicate pull activity for #${number}`);
+    pulls.set(number, {
+      issueComments: [],
+      inlineComments: [],
+      reviews: [],
+      reviewStatus: "none",
+    });
+  }
+  const issueComments =
+    since === null
+      ? []
+      : readGhPages(
+          `repos/${repo}/issues/comments?per_page=100&sort=created&direction=asc&${since}`,
+          spawn,
+        );
+  for (const [index, value] of issueComments.entries()) {
+    const record = asRecord(value, `REST issue comments[${index}]`);
+    const number = activityItemNumber(
+      record,
+      "issue_url",
+      `REST issue comments[${index}]`,
+    );
+    if (issues.has(number)) {
+      appendBoundedActivity(
+        issues.get(number),
+        record,
+        `issue #${number}.comments`,
+      );
+    } else if (pulls.has(number)) {
+      appendBoundedActivity(
+        pulls.get(number).issueComments,
+        record,
+        `pull request #${number}.comments`,
+      );
+    }
+  }
+  const inlineComments =
+    since === null || pulls.size === 0
+      ? []
+      : readGhPages(
+          `repos/${repo}/pulls/comments?per_page=100&sort=created&direction=asc&${since}`,
+          spawn,
+        );
+  for (const [index, value] of inlineComments.entries()) {
+    const record = asRecord(value, `REST review comments[${index}]`);
+    const number = activityItemNumber(
+      record,
+      "pull_request_url",
+      `REST review comments[${index}]`,
+    );
+    if (pulls.has(number)) {
+      appendBoundedActivity(
+        pulls.get(number).inlineComments,
+        record,
+        `pull request #${number}.review comments`,
+      );
+    }
+  }
+  const approved = readGhSearchPullNumbers(repo, "approved", spawn);
+  const changesRequested = readGhSearchPullNumbers(
+    repo,
+    "changes_requested",
+    spawn,
+  );
+  for (const number of approved) {
+    if (!pulls.has(number)) {
+      throw new TypeError(`review:approved returned non-open pull #${number}`);
+    }
+    pulls.get(number).reviewStatus = "approved";
+  }
+  for (const number of changesRequested) {
+    if (!pulls.has(number)) {
+      throw new TypeError(
+        `review:changes_requested returned non-open pull #${number}`,
+      );
+    }
+    if (approved.has(number)) {
+      throw new TypeError(`conflicting REST review status for pull #${number}`);
+    }
+    pulls.get(number).reviewStatus = "changes_requested";
+  }
+  return { issues, pulls };
+}
+
 function graphqlAccount(value, context) {
   if (value === null) return null;
   const actor = asRecord(value, context);
@@ -728,10 +921,112 @@ export function createGhCommandBudget(spawn = spawnSync) {
   };
 }
 
+function rateResource(value, context) {
+  const resource = asRecord(value, context);
+  const limit = asNumberField(resource, "limit", context);
+  const remaining = asNumberField(resource, "remaining", context);
+  const reset = asNumberField(resource, "reset", context);
+  if (limit <= 0 || remaining < 0 || remaining > limit || reset <= 0) {
+    throw new RangeError(`${context} contains an invalid rate budget`);
+  }
+  return { limit, remaining, reset };
+}
+
+export function readGhRateLimits(spawn = spawnSync) {
+  const result = spawn(
+    "gh",
+    [
+      "api",
+      "--method",
+      "GET",
+      "--jq",
+      "{resources: .resources | {core, graphql, search}}",
+      "rate_limit",
+    ],
+    {
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024,
+      windowsHide: true,
+    },
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const detail =
+      result.stderr.trim().length > 0 ? `: ${result.stderr.trim()}` : "";
+    throw new Error(`gh api failed for rate_limit${detail}`);
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(result.stdout);
+  } catch (cause) {
+    throw new SyntaxError("gh api returned malformed JSON for rate_limit", {
+      cause,
+    });
+  }
+  const resources = asRecord(
+    asRecord(parsed, "GitHub rate limit response").resources,
+    "GitHub rate limit resources",
+  );
+  const graphql = rateResource(resources.graphql, "GitHub GraphQL rate limit");
+  const rest = rateResource(resources.core, "GitHub REST rate limit");
+  const search = rateResource(resources.search, "GitHub Search rate limit");
+  return {
+    graphqlLimit: graphql.limit,
+    graphqlRemaining: graphql.remaining,
+    graphqlReset: graphql.reset,
+    restLimit: rest.limit,
+    restRemaining: rest.remaining,
+    restReset: rest.reset,
+    searchLimit: search.limit,
+    searchRemaining: search.remaining,
+    searchReset: search.reset,
+  };
+}
+
 /** Reads open activity in two batches plus bounded overflow pagination. */
-export function readGhOpenActivity(repo, spawn = spawnSync) {
+export function readGhOpenActivity(repo, spawn = spawnSync, rateLimits = null) {
   if (!REPOSITORY_RE.test(repo)) {
     throw new TypeError("Repository must use the owner/name form");
+  }
+  let limits = rateLimits;
+  if (limits !== null) {
+    const options = asRecord(limits, "GitHub rate limits");
+    if (options.preflight === true) {
+      limits = readGhRateLimits(spawn);
+    }
+  }
+  if (limits !== null) {
+    limits = asRecord(limits, "GitHub rate limits");
+    const graphqlRemaining = asNumberField(
+      limits,
+      "graphqlRemaining",
+      "GitHub rate limits",
+    );
+    const restRemaining = asNumberField(
+      limits,
+      "restRemaining",
+      "GitHub rate limits",
+    );
+    const searchRemaining = asNumberField(
+      limits,
+      "searchRemaining",
+      "GitHub rate limits",
+    );
+    if (graphqlRemaining < MIN_GRAPHQL_ACTIVITY_POINTS) {
+      if (
+        restRemaining < MIN_REST_ACTIVITY_REQUESTS ||
+        searchRemaining < MIN_SEARCH_ACTIVITY_REQUESTS
+      ) {
+        throw new RangeError(
+          "GitHub budgets cannot afford either complete GraphQL or REST activity discovery",
+        );
+      }
+      return {
+        ...readGhRestOpenActivity(repo, spawn),
+        rateLimits: limits,
+        source: "rest",
+      };
+    }
   }
   const issueNodes = readGraphqlActivityNodes(
     repo,
@@ -846,7 +1141,12 @@ export function readGhOpenActivity(repo, spawn = spawnSync) {
     }
     pulls.set(number, { issueComments, inlineComments, reviews });
   }
-  return { issues, pulls };
+  return {
+    issues,
+    pulls,
+    ...(limits === null ? {} : { rateLimits: limits }),
+    source: "graphql",
+  };
 }
 
 export function parseModelDisclosure(text) {
@@ -1646,7 +1946,24 @@ export function collectLiveReport(
     const body = nullableText(item.body, `${context}.body`);
     const requestedTargets = requestedReviewTargets(item, context);
     const requestStatus = reviewRequestStatus(requestedTargets);
-    const currentReviews = currentHeadReviewStatus(item, reviews, context);
+    const fallbackReviewStatus = pullActivity?.reviewStatus ?? null;
+    if (
+      fallbackReviewStatus !== null &&
+      !new Set(["none", "approved", "changes_requested"]).has(
+        fallbackReviewStatus,
+      )
+    ) {
+      throw new TypeError(`${context} has an invalid REST review status`);
+    }
+    const currentReviews =
+      fallbackReviewStatus === "approved"
+        ? { approved: ["GitHub REST review status"], changesRequested: [] }
+        : fallbackReviewStatus === "changes_requested"
+          ? {
+              approved: [],
+              changesRequested: ["GitHub REST review status"],
+            }
+          : currentHeadReviewStatus(item, reviews, context);
     const reviewState = {
       activeRequests: requestStatus.active,
       staleRequests: requestStatus.stale,
@@ -1874,7 +2191,13 @@ export function main(args = process.argv.slice(2)) {
   const boundedRead = (endpoint) => {
     return readGhPages(endpoint, commandBudget.run);
   };
-  const openActivity = readGhOpenActivity(options.repo, commandBudget.run);
+  const openActivity = readGhOpenActivity(options.repo, commandBudget.run, {
+    preflight: true,
+  });
+  const limits = asRecord(openActivity.rateLimits, "GitHub rate limits");
+  process.stderr.write(
+    `[Slop] GitHub budgets: GraphQL ${limits.graphqlRemaining}/${limits.graphqlLimit}; REST ${limits.restRemaining}/${limits.restLimit}; Search ${limits.searchRemaining}/${limits.searchLimit}; activity source ${openActivity.source}\n`,
+  );
   const report = collectLiveReport(
     options.repo,
     boundedRead,

--- a/skills/contribute-to-eliza/scripts/live-report.mjs
+++ b/skills/contribute-to-eliza/scripts/live-report.mjs
@@ -25,6 +25,9 @@ export const MISSION_READY_LABEL = "mission-ready";
 export const MAX_OPEN_ITEMS = 10_000;
 export const MAX_API_READS = 16;
 export const MAX_ACTIVITY_CONNECTION_ITEMS = 1_000;
+export const MIN_GRAPHQL_ACTIVITY_POINTS = 1_000;
+export const MIN_REST_ACTIVITY_REQUESTS = 100;
+export const MIN_SEARCH_ACTIVITY_REQUESTS = 2;
 
 const REPOSITORY_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const PLACEHOLDER_RE =
@@ -627,6 +630,196 @@ function readOverflowActivity(endpoint, expectedCount, context, spawn) {
   return records;
 }
 
+function activityItemNumber(record, field, context) {
+  const url = asStringField(record, field, context);
+  const match = url.match(/\/(?:issues|pulls)\/([1-9]\d*)$/);
+  if (!match) {
+    throw new TypeError(`${context}.${field} must end with an item number`);
+  }
+  return Number(match[1]);
+}
+
+function appendBoundedActivity(target, value, context) {
+  if (target.length >= MAX_ACTIVITY_CONNECTION_ITEMS) {
+    throw new RangeError(
+      `${context} exceeds the complete ${MAX_ACTIVITY_CONNECTION_ITEMS}-record activity bound`,
+    );
+  }
+  target.push(value);
+}
+
+function readGhSearchPullNumbers(repo, qualifier, spawn) {
+  const query = `repo:${repo} is:pr is:open review:${qualifier}`;
+  const result = spawn(
+    "gh",
+    [
+      "api",
+      "--method",
+      "GET",
+      "--paginate",
+      "-f",
+      `q=${query}`,
+      "-f",
+      "per_page=100",
+      "--jq",
+      ".items[]",
+      "search/issues",
+    ],
+    {
+      encoding: "utf8",
+      maxBuffer: 64 * 1024 * 1024,
+      windowsHide: true,
+    },
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const detail =
+      result.stderr.trim().length > 0 ? `: ${result.stderr.trim()}` : "";
+    throw new Error(`gh api failed for review:${qualifier}${detail}`);
+  }
+  const records = parsePaginatedJson(result.stdout, `review:${qualifier}`);
+  if (records.length >= 1_000) {
+    throw new RangeError(
+      `review:${qualifier} reaches GitHub's 1000-result search bound`,
+    );
+  }
+  const numbers = new Set();
+  for (const [index, value] of records.entries()) {
+    const number = asNumberField(
+      asRecord(value, `review:${qualifier}[${index}]`),
+      "number",
+      `review:${qualifier}[${index}]`,
+    );
+    if (numbers.has(number)) {
+      throw new TypeError(
+        `duplicate review:${qualifier} result for #${number}`,
+      );
+    }
+    numbers.add(number);
+  }
+  return numbers;
+}
+
+function readGhRestOpenActivity(repo, spawn) {
+  const issueItems = readGhPages(
+    `repos/${repo}/issues?state=open&per_page=100&sort=created&direction=asc`,
+    spawn,
+  )
+    .map((value, index) => asRecord(value, `REST issues[${index}]`))
+    .filter((item) => item.pull_request === undefined);
+  const pullItems = readGhPages(
+    `repos/${repo}/pulls?state=open&per_page=100&sort=created&direction=asc`,
+    spawn,
+  ).map((value, index) => asRecord(value, `REST pulls[${index}]`));
+  if (issueItems.length > MAX_OPEN_ITEMS || pullItems.length > MAX_OPEN_ITEMS) {
+    throw new RangeError(
+      `Live discovery exceeds the ${MAX_OPEN_ITEMS}-item per-kind safety bound`,
+    );
+  }
+  const oldestCreatedAt = [...issueItems, ...pullItems]
+    .map((item, index) =>
+      isoTime(item.created_at, `REST open items[${index}].created_at`),
+    )
+    .sort((left, right) => Date.parse(left) - Date.parse(right))[0];
+  const since =
+    oldestCreatedAt === undefined
+      ? null
+      : `since=${encodeURIComponent(oldestCreatedAt)}`;
+  const issues = new Map();
+  for (const item of issueItems) {
+    const number = asNumberField(item, "number", "REST issue");
+    if (issues.has(number))
+      throw new TypeError(`duplicate issue activity for #${number}`);
+    issues.set(number, []);
+  }
+  const pulls = new Map();
+  for (const item of pullItems) {
+    const number = asNumberField(item, "number", "REST pull request");
+    if (pulls.has(number))
+      throw new TypeError(`duplicate pull activity for #${number}`);
+    pulls.set(number, {
+      issueComments: [],
+      inlineComments: [],
+      reviews: [],
+      reviewStatus: "none",
+    });
+  }
+  const issueComments =
+    since === null
+      ? []
+      : readGhPages(
+          `repos/${repo}/issues/comments?per_page=100&sort=created&direction=asc&${since}`,
+          spawn,
+        );
+  for (const [index, value] of issueComments.entries()) {
+    const record = asRecord(value, `REST issue comments[${index}]`);
+    const number = activityItemNumber(
+      record,
+      "issue_url",
+      `REST issue comments[${index}]`,
+    );
+    if (issues.has(number)) {
+      appendBoundedActivity(
+        issues.get(number),
+        record,
+        `issue #${number}.comments`,
+      );
+    } else if (pulls.has(number)) {
+      appendBoundedActivity(
+        pulls.get(number).issueComments,
+        record,
+        `pull request #${number}.comments`,
+      );
+    }
+  }
+  const inlineComments =
+    since === null || pulls.size === 0
+      ? []
+      : readGhPages(
+          `repos/${repo}/pulls/comments?per_page=100&sort=created&direction=asc&${since}`,
+          spawn,
+        );
+  for (const [index, value] of inlineComments.entries()) {
+    const record = asRecord(value, `REST review comments[${index}]`);
+    const number = activityItemNumber(
+      record,
+      "pull_request_url",
+      `REST review comments[${index}]`,
+    );
+    if (pulls.has(number)) {
+      appendBoundedActivity(
+        pulls.get(number).inlineComments,
+        record,
+        `pull request #${number}.review comments`,
+      );
+    }
+  }
+  const approved = readGhSearchPullNumbers(repo, "approved", spawn);
+  const changesRequested = readGhSearchPullNumbers(
+    repo,
+    "changes_requested",
+    spawn,
+  );
+  for (const number of approved) {
+    if (!pulls.has(number)) {
+      throw new TypeError(`review:approved returned non-open pull #${number}`);
+    }
+    pulls.get(number).reviewStatus = "approved";
+  }
+  for (const number of changesRequested) {
+    if (!pulls.has(number)) {
+      throw new TypeError(
+        `review:changes_requested returned non-open pull #${number}`,
+      );
+    }
+    if (approved.has(number)) {
+      throw new TypeError(`conflicting REST review status for pull #${number}`);
+    }
+    pulls.get(number).reviewStatus = "changes_requested";
+  }
+  return { issues, pulls };
+}
+
 function graphqlAccount(value, context) {
   if (value === null) return null;
   const actor = asRecord(value, context);
@@ -728,10 +921,112 @@ export function createGhCommandBudget(spawn = spawnSync) {
   };
 }
 
+function rateResource(value, context) {
+  const resource = asRecord(value, context);
+  const limit = asNumberField(resource, "limit", context);
+  const remaining = asNumberField(resource, "remaining", context);
+  const reset = asNumberField(resource, "reset", context);
+  if (limit <= 0 || remaining < 0 || remaining > limit || reset <= 0) {
+    throw new RangeError(`${context} contains an invalid rate budget`);
+  }
+  return { limit, remaining, reset };
+}
+
+export function readGhRateLimits(spawn = spawnSync) {
+  const result = spawn(
+    "gh",
+    [
+      "api",
+      "--method",
+      "GET",
+      "--jq",
+      "{resources: .resources | {core, graphql, search}}",
+      "rate_limit",
+    ],
+    {
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024,
+      windowsHide: true,
+    },
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const detail =
+      result.stderr.trim().length > 0 ? `: ${result.stderr.trim()}` : "";
+    throw new Error(`gh api failed for rate_limit${detail}`);
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(result.stdout);
+  } catch (cause) {
+    throw new SyntaxError("gh api returned malformed JSON for rate_limit", {
+      cause,
+    });
+  }
+  const resources = asRecord(
+    asRecord(parsed, "GitHub rate limit response").resources,
+    "GitHub rate limit resources",
+  );
+  const graphql = rateResource(resources.graphql, "GitHub GraphQL rate limit");
+  const rest = rateResource(resources.core, "GitHub REST rate limit");
+  const search = rateResource(resources.search, "GitHub Search rate limit");
+  return {
+    graphqlLimit: graphql.limit,
+    graphqlRemaining: graphql.remaining,
+    graphqlReset: graphql.reset,
+    restLimit: rest.limit,
+    restRemaining: rest.remaining,
+    restReset: rest.reset,
+    searchLimit: search.limit,
+    searchRemaining: search.remaining,
+    searchReset: search.reset,
+  };
+}
+
 /** Reads open activity in two batches plus bounded overflow pagination. */
-export function readGhOpenActivity(repo, spawn = spawnSync) {
+export function readGhOpenActivity(repo, spawn = spawnSync, rateLimits = null) {
   if (!REPOSITORY_RE.test(repo)) {
     throw new TypeError("Repository must use the owner/name form");
+  }
+  let limits = rateLimits;
+  if (limits !== null) {
+    const options = asRecord(limits, "GitHub rate limits");
+    if (options.preflight === true) {
+      limits = readGhRateLimits(spawn);
+    }
+  }
+  if (limits !== null) {
+    limits = asRecord(limits, "GitHub rate limits");
+    const graphqlRemaining = asNumberField(
+      limits,
+      "graphqlRemaining",
+      "GitHub rate limits",
+    );
+    const restRemaining = asNumberField(
+      limits,
+      "restRemaining",
+      "GitHub rate limits",
+    );
+    const searchRemaining = asNumberField(
+      limits,
+      "searchRemaining",
+      "GitHub rate limits",
+    );
+    if (graphqlRemaining < MIN_GRAPHQL_ACTIVITY_POINTS) {
+      if (
+        restRemaining < MIN_REST_ACTIVITY_REQUESTS ||
+        searchRemaining < MIN_SEARCH_ACTIVITY_REQUESTS
+      ) {
+        throw new RangeError(
+          "GitHub budgets cannot afford either complete GraphQL or REST activity discovery",
+        );
+      }
+      return {
+        ...readGhRestOpenActivity(repo, spawn),
+        rateLimits: limits,
+        source: "rest",
+      };
+    }
   }
   const issueNodes = readGraphqlActivityNodes(
     repo,
@@ -846,7 +1141,12 @@ export function readGhOpenActivity(repo, spawn = spawnSync) {
     }
     pulls.set(number, { issueComments, inlineComments, reviews });
   }
-  return { issues, pulls };
+  return {
+    issues,
+    pulls,
+    ...(limits === null ? {} : { rateLimits: limits }),
+    source: "graphql",
+  };
 }
 
 export function parseModelDisclosure(text) {
@@ -1646,7 +1946,24 @@ export function collectLiveReport(
     const body = nullableText(item.body, `${context}.body`);
     const requestedTargets = requestedReviewTargets(item, context);
     const requestStatus = reviewRequestStatus(requestedTargets);
-    const currentReviews = currentHeadReviewStatus(item, reviews, context);
+    const fallbackReviewStatus = pullActivity?.reviewStatus ?? null;
+    if (
+      fallbackReviewStatus !== null &&
+      !new Set(["none", "approved", "changes_requested"]).has(
+        fallbackReviewStatus,
+      )
+    ) {
+      throw new TypeError(`${context} has an invalid REST review status`);
+    }
+    const currentReviews =
+      fallbackReviewStatus === "approved"
+        ? { approved: ["GitHub REST review status"], changesRequested: [] }
+        : fallbackReviewStatus === "changes_requested"
+          ? {
+              approved: [],
+              changesRequested: ["GitHub REST review status"],
+            }
+          : currentHeadReviewStatus(item, reviews, context);
     const reviewState = {
       activeRequests: requestStatus.active,
       staleRequests: requestStatus.stale,
@@ -1874,7 +2191,13 @@ export function main(args = process.argv.slice(2)) {
   const boundedRead = (endpoint) => {
     return readGhPages(endpoint, commandBudget.run);
   };
-  const openActivity = readGhOpenActivity(options.repo, commandBudget.run);
+  const openActivity = readGhOpenActivity(options.repo, commandBudget.run, {
+    preflight: true,
+  });
+  const limits = asRecord(openActivity.rateLimits, "GitHub rate limits");
+  process.stderr.write(
+    `[Slop] GitHub budgets: GraphQL ${limits.graphqlRemaining}/${limits.graphqlLimit}; REST ${limits.restRemaining}/${limits.restLimit}; Search ${limits.searchRemaining}/${limits.searchLimit}; activity source ${openActivity.source}\n`,
+  );
   const report = collectLiveReport(
     options.repo,
     boundedRead,

--- a/skills/contribute-to-heir-elements-sdk/scripts/live-report.mjs
+++ b/skills/contribute-to-heir-elements-sdk/scripts/live-report.mjs
@@ -25,6 +25,9 @@ export const MISSION_READY_LABEL = "mission-ready";
 export const MAX_OPEN_ITEMS = 10_000;
 export const MAX_API_READS = 16;
 export const MAX_ACTIVITY_CONNECTION_ITEMS = 1_000;
+export const MIN_GRAPHQL_ACTIVITY_POINTS = 1_000;
+export const MIN_REST_ACTIVITY_REQUESTS = 100;
+export const MIN_SEARCH_ACTIVITY_REQUESTS = 2;
 
 const REPOSITORY_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const PLACEHOLDER_RE =
@@ -627,6 +630,196 @@ function readOverflowActivity(endpoint, expectedCount, context, spawn) {
   return records;
 }
 
+function activityItemNumber(record, field, context) {
+  const url = asStringField(record, field, context);
+  const match = url.match(/\/(?:issues|pulls)\/([1-9]\d*)$/);
+  if (!match) {
+    throw new TypeError(`${context}.${field} must end with an item number`);
+  }
+  return Number(match[1]);
+}
+
+function appendBoundedActivity(target, value, context) {
+  if (target.length >= MAX_ACTIVITY_CONNECTION_ITEMS) {
+    throw new RangeError(
+      `${context} exceeds the complete ${MAX_ACTIVITY_CONNECTION_ITEMS}-record activity bound`,
+    );
+  }
+  target.push(value);
+}
+
+function readGhSearchPullNumbers(repo, qualifier, spawn) {
+  const query = `repo:${repo} is:pr is:open review:${qualifier}`;
+  const result = spawn(
+    "gh",
+    [
+      "api",
+      "--method",
+      "GET",
+      "--paginate",
+      "-f",
+      `q=${query}`,
+      "-f",
+      "per_page=100",
+      "--jq",
+      ".items[]",
+      "search/issues",
+    ],
+    {
+      encoding: "utf8",
+      maxBuffer: 64 * 1024 * 1024,
+      windowsHide: true,
+    },
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const detail =
+      result.stderr.trim().length > 0 ? `: ${result.stderr.trim()}` : "";
+    throw new Error(`gh api failed for review:${qualifier}${detail}`);
+  }
+  const records = parsePaginatedJson(result.stdout, `review:${qualifier}`);
+  if (records.length >= 1_000) {
+    throw new RangeError(
+      `review:${qualifier} reaches GitHub's 1000-result search bound`,
+    );
+  }
+  const numbers = new Set();
+  for (const [index, value] of records.entries()) {
+    const number = asNumberField(
+      asRecord(value, `review:${qualifier}[${index}]`),
+      "number",
+      `review:${qualifier}[${index}]`,
+    );
+    if (numbers.has(number)) {
+      throw new TypeError(
+        `duplicate review:${qualifier} result for #${number}`,
+      );
+    }
+    numbers.add(number);
+  }
+  return numbers;
+}
+
+function readGhRestOpenActivity(repo, spawn) {
+  const issueItems = readGhPages(
+    `repos/${repo}/issues?state=open&per_page=100&sort=created&direction=asc`,
+    spawn,
+  )
+    .map((value, index) => asRecord(value, `REST issues[${index}]`))
+    .filter((item) => item.pull_request === undefined);
+  const pullItems = readGhPages(
+    `repos/${repo}/pulls?state=open&per_page=100&sort=created&direction=asc`,
+    spawn,
+  ).map((value, index) => asRecord(value, `REST pulls[${index}]`));
+  if (issueItems.length > MAX_OPEN_ITEMS || pullItems.length > MAX_OPEN_ITEMS) {
+    throw new RangeError(
+      `Live discovery exceeds the ${MAX_OPEN_ITEMS}-item per-kind safety bound`,
+    );
+  }
+  const oldestCreatedAt = [...issueItems, ...pullItems]
+    .map((item, index) =>
+      isoTime(item.created_at, `REST open items[${index}].created_at`),
+    )
+    .sort((left, right) => Date.parse(left) - Date.parse(right))[0];
+  const since =
+    oldestCreatedAt === undefined
+      ? null
+      : `since=${encodeURIComponent(oldestCreatedAt)}`;
+  const issues = new Map();
+  for (const item of issueItems) {
+    const number = asNumberField(item, "number", "REST issue");
+    if (issues.has(number))
+      throw new TypeError(`duplicate issue activity for #${number}`);
+    issues.set(number, []);
+  }
+  const pulls = new Map();
+  for (const item of pullItems) {
+    const number = asNumberField(item, "number", "REST pull request");
+    if (pulls.has(number))
+      throw new TypeError(`duplicate pull activity for #${number}`);
+    pulls.set(number, {
+      issueComments: [],
+      inlineComments: [],
+      reviews: [],
+      reviewStatus: "none",
+    });
+  }
+  const issueComments =
+    since === null
+      ? []
+      : readGhPages(
+          `repos/${repo}/issues/comments?per_page=100&sort=created&direction=asc&${since}`,
+          spawn,
+        );
+  for (const [index, value] of issueComments.entries()) {
+    const record = asRecord(value, `REST issue comments[${index}]`);
+    const number = activityItemNumber(
+      record,
+      "issue_url",
+      `REST issue comments[${index}]`,
+    );
+    if (issues.has(number)) {
+      appendBoundedActivity(
+        issues.get(number),
+        record,
+        `issue #${number}.comments`,
+      );
+    } else if (pulls.has(number)) {
+      appendBoundedActivity(
+        pulls.get(number).issueComments,
+        record,
+        `pull request #${number}.comments`,
+      );
+    }
+  }
+  const inlineComments =
+    since === null || pulls.size === 0
+      ? []
+      : readGhPages(
+          `repos/${repo}/pulls/comments?per_page=100&sort=created&direction=asc&${since}`,
+          spawn,
+        );
+  for (const [index, value] of inlineComments.entries()) {
+    const record = asRecord(value, `REST review comments[${index}]`);
+    const number = activityItemNumber(
+      record,
+      "pull_request_url",
+      `REST review comments[${index}]`,
+    );
+    if (pulls.has(number)) {
+      appendBoundedActivity(
+        pulls.get(number).inlineComments,
+        record,
+        `pull request #${number}.review comments`,
+      );
+    }
+  }
+  const approved = readGhSearchPullNumbers(repo, "approved", spawn);
+  const changesRequested = readGhSearchPullNumbers(
+    repo,
+    "changes_requested",
+    spawn,
+  );
+  for (const number of approved) {
+    if (!pulls.has(number)) {
+      throw new TypeError(`review:approved returned non-open pull #${number}`);
+    }
+    pulls.get(number).reviewStatus = "approved";
+  }
+  for (const number of changesRequested) {
+    if (!pulls.has(number)) {
+      throw new TypeError(
+        `review:changes_requested returned non-open pull #${number}`,
+      );
+    }
+    if (approved.has(number)) {
+      throw new TypeError(`conflicting REST review status for pull #${number}`);
+    }
+    pulls.get(number).reviewStatus = "changes_requested";
+  }
+  return { issues, pulls };
+}
+
 function graphqlAccount(value, context) {
   if (value === null) return null;
   const actor = asRecord(value, context);
@@ -728,10 +921,112 @@ export function createGhCommandBudget(spawn = spawnSync) {
   };
 }
 
+function rateResource(value, context) {
+  const resource = asRecord(value, context);
+  const limit = asNumberField(resource, "limit", context);
+  const remaining = asNumberField(resource, "remaining", context);
+  const reset = asNumberField(resource, "reset", context);
+  if (limit <= 0 || remaining < 0 || remaining > limit || reset <= 0) {
+    throw new RangeError(`${context} contains an invalid rate budget`);
+  }
+  return { limit, remaining, reset };
+}
+
+export function readGhRateLimits(spawn = spawnSync) {
+  const result = spawn(
+    "gh",
+    [
+      "api",
+      "--method",
+      "GET",
+      "--jq",
+      "{resources: .resources | {core, graphql, search}}",
+      "rate_limit",
+    ],
+    {
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024,
+      windowsHide: true,
+    },
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const detail =
+      result.stderr.trim().length > 0 ? `: ${result.stderr.trim()}` : "";
+    throw new Error(`gh api failed for rate_limit${detail}`);
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(result.stdout);
+  } catch (cause) {
+    throw new SyntaxError("gh api returned malformed JSON for rate_limit", {
+      cause,
+    });
+  }
+  const resources = asRecord(
+    asRecord(parsed, "GitHub rate limit response").resources,
+    "GitHub rate limit resources",
+  );
+  const graphql = rateResource(resources.graphql, "GitHub GraphQL rate limit");
+  const rest = rateResource(resources.core, "GitHub REST rate limit");
+  const search = rateResource(resources.search, "GitHub Search rate limit");
+  return {
+    graphqlLimit: graphql.limit,
+    graphqlRemaining: graphql.remaining,
+    graphqlReset: graphql.reset,
+    restLimit: rest.limit,
+    restRemaining: rest.remaining,
+    restReset: rest.reset,
+    searchLimit: search.limit,
+    searchRemaining: search.remaining,
+    searchReset: search.reset,
+  };
+}
+
 /** Reads open activity in two batches plus bounded overflow pagination. */
-export function readGhOpenActivity(repo, spawn = spawnSync) {
+export function readGhOpenActivity(repo, spawn = spawnSync, rateLimits = null) {
   if (!REPOSITORY_RE.test(repo)) {
     throw new TypeError("Repository must use the owner/name form");
+  }
+  let limits = rateLimits;
+  if (limits !== null) {
+    const options = asRecord(limits, "GitHub rate limits");
+    if (options.preflight === true) {
+      limits = readGhRateLimits(spawn);
+    }
+  }
+  if (limits !== null) {
+    limits = asRecord(limits, "GitHub rate limits");
+    const graphqlRemaining = asNumberField(
+      limits,
+      "graphqlRemaining",
+      "GitHub rate limits",
+    );
+    const restRemaining = asNumberField(
+      limits,
+      "restRemaining",
+      "GitHub rate limits",
+    );
+    const searchRemaining = asNumberField(
+      limits,
+      "searchRemaining",
+      "GitHub rate limits",
+    );
+    if (graphqlRemaining < MIN_GRAPHQL_ACTIVITY_POINTS) {
+      if (
+        restRemaining < MIN_REST_ACTIVITY_REQUESTS ||
+        searchRemaining < MIN_SEARCH_ACTIVITY_REQUESTS
+      ) {
+        throw new RangeError(
+          "GitHub budgets cannot afford either complete GraphQL or REST activity discovery",
+        );
+      }
+      return {
+        ...readGhRestOpenActivity(repo, spawn),
+        rateLimits: limits,
+        source: "rest",
+      };
+    }
   }
   const issueNodes = readGraphqlActivityNodes(
     repo,
@@ -846,7 +1141,12 @@ export function readGhOpenActivity(repo, spawn = spawnSync) {
     }
     pulls.set(number, { issueComments, inlineComments, reviews });
   }
-  return { issues, pulls };
+  return {
+    issues,
+    pulls,
+    ...(limits === null ? {} : { rateLimits: limits }),
+    source: "graphql",
+  };
 }
 
 export function parseModelDisclosure(text) {
@@ -1646,7 +1946,24 @@ export function collectLiveReport(
     const body = nullableText(item.body, `${context}.body`);
     const requestedTargets = requestedReviewTargets(item, context);
     const requestStatus = reviewRequestStatus(requestedTargets);
-    const currentReviews = currentHeadReviewStatus(item, reviews, context);
+    const fallbackReviewStatus = pullActivity?.reviewStatus ?? null;
+    if (
+      fallbackReviewStatus !== null &&
+      !new Set(["none", "approved", "changes_requested"]).has(
+        fallbackReviewStatus,
+      )
+    ) {
+      throw new TypeError(`${context} has an invalid REST review status`);
+    }
+    const currentReviews =
+      fallbackReviewStatus === "approved"
+        ? { approved: ["GitHub REST review status"], changesRequested: [] }
+        : fallbackReviewStatus === "changes_requested"
+          ? {
+              approved: [],
+              changesRequested: ["GitHub REST review status"],
+            }
+          : currentHeadReviewStatus(item, reviews, context);
     const reviewState = {
       activeRequests: requestStatus.active,
       staleRequests: requestStatus.stale,
@@ -1874,7 +2191,13 @@ export function main(args = process.argv.slice(2)) {
   const boundedRead = (endpoint) => {
     return readGhPages(endpoint, commandBudget.run);
   };
-  const openActivity = readGhOpenActivity(options.repo, commandBudget.run);
+  const openActivity = readGhOpenActivity(options.repo, commandBudget.run, {
+    preflight: true,
+  });
+  const limits = asRecord(openActivity.rateLimits, "GitHub rate limits");
+  process.stderr.write(
+    `[Slop] GitHub budgets: GraphQL ${limits.graphqlRemaining}/${limits.graphqlLimit}; REST ${limits.restRemaining}/${limits.restLimit}; Search ${limits.searchRemaining}/${limits.searchLimit}; activity source ${openActivity.source}\n`,
+  );
   const report = collectLiveReport(
     options.repo,
     boundedRead,


### PR DESCRIPTION
## Summary

- Preflight authenticated GitHub GraphQL, REST, and Search budgets before activity discovery.
- Fall back to a six-command, fully paginated REST inventory when GraphQL cannot afford the scan.
- Preserve bounded activity collection, hostile-input validation, conservative review filtering, and fail-closed behavior when neither route has enough budget.
- Keep the shared contributor CLIs byte-identical across Eliza, ASI, Delta Star, and Heir Elements SDK.

Fixes #256.

## Validation

- Regression RED: the new low-GraphQL fixture initially invoked `gh api graphql` and failed with `API rate limit already exceeded`.
- `bun test ./skill-tests --timeout 30000` — 90 passed, 0 failed.
- `bun run test:e2e` — 36 responsive browser tests plus 1 artifact-consistency test passed.
- `bun run build` — passed.
- `git diff --check` — passed.
- Byte parity: canonical `live-report.mjs` matches all three shared copies with `cmp`.
- Live forced fallback: `{"source":"rest","issues":9,"pulls":1,"commands":6}` with GraphQL remaining set to 0 and healthy REST/Search budgets.
- Live normal preflight: GraphQL 5000/5000, REST 4759/5000, Search 30/30; selected GraphQL and completed in 5 bounded commands.
- `bun run verify` reaches 611/611 Vitest tests and all changed skill tests, but the stock aggregate command is not green: the unrelated measured-run fixture intermittently exceeds Bun's default per-test timeout and is terminated with `status: null`. That same fixture passes in isolation and the complete skill lane passes with the explicit 30-second timeout above.

## Evidence

- Before screenshots: N/A - backend CLI behavior only; no UI changed.
- After screenshots: N/A - backend CLI behavior only; no UI changed.
- Walkthrough video: N/A - no user-facing interaction changed.
- Backend logs: Live fallback and budget/source outputs are included in Validation.
- Frontend console/network logs: N/A - no frontend changed.
- Real-LLM trajectory: N/A - no model behavior changed.
- Domain artifacts: N/A - no domain artifact changed.

## Contribution provenance

- AI assistance: Yes
- AI provider/model: OpenAI / GPT-5.6
- Client / agent tooling: Codex desktop agent
- Contribution skill revision: `1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42`
- Attribution status: self-reported

## Safety review

- [x] No private key, seed phrase, API token, raw private trajectory, or secret was added.
- [x] Untrusted project code is not executed with repository or deployment credentials.
- [x] New telemetry is bounded, disclosed, project-attributed, and covered by adversarial tests.
- [x] Money state is derived from validated manifests and finalized on-chain evidence, not a transaction signature alone.
