### PR TITLE
fix(trace): use authoritative intake preflight

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -261,6 +261,7 @@ jobs:
             --header "Accept: application/vnd.github+json" \
             --header "Authorization: Bearer $GITHUB_TOKEN" \
             --header "User-Agent: slop-release-intake-check" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/SlopDotCash/slopdotcash/private-vulnerability-reporting |
             node -e '
               let source = "";
@@ -957,6 +958,45 @@ jobs:
             sleep 5
           done
           echo "::error::Active private trace API did not reach its fail-closed unauthenticated boundary."
+          exit 1
+
+      - name: Verify authenticated private intake preflight
+        run: |
+          set -euo pipefail
+          response="$RUNNER_TEMP/slop-private-intake-preflight.json"
+          headers="$RUNNER_TEMP/slop-private-intake-preflight.headers"
+          for attempt in $(seq 1 18); do
+            status="$(
+              curl --silent --show-error \
+                --connect-timeout 10 \
+                --max-time 30 \
+                --max-filesize 65536 \
+                --output "$response" \
+                --dump-header "$headers" \
+                --write-out "%{http_code}" \
+                --header "Cache-Control: no-cache" \
+                "https://api.slop.cash/api/v1/private-request-intake?verify=$GITHUB_SHA-$GITHUB_RUN_ATTEMPT-intake-$attempt"
+            )"
+            if [ "$status" = "200" ] && node - "$response" "$headers" <<'NODE'
+          const { readFileSync } = require("node:fs");
+          const value = JSON.parse(readFileSync(process.argv[2], "utf8"));
+          const headers = readFileSync(process.argv[3], "utf8");
+          const contract = headers.match(/^x-slop-trace-api-contract:\s*([^\r\n]+)$/imu)?.[1]?.trim();
+          if (
+            JSON.stringify(Object.keys(value).sort()) !== JSON.stringify(["enabled", "source", "verifiedAt"]) ||
+            value?.enabled !== true ||
+            value?.source !== "github-authenticated" ||
+            !Number.isFinite(Date.parse(value?.verifiedAt)) ||
+            contract !== "private-trace-v1-opaque-hmac-v1"
+          ) process.exit(1);
+          NODE
+            then
+              exit 0
+            fi
+            echo "::warning::Authenticated private intake preflight returned HTTP $status (attempt $attempt/18)."
+            sleep 5
+          done
+          echo "::error::Authenticated private intake preflight did not become authoritative."
           exit 1
 
       - name: Require public identity OAuth app

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -250,6 +250,8 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Require public private-request intake
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           curl --fail --silent --show-error \
@@ -257,6 +259,7 @@ jobs:
             --max-time 30 \
             --max-filesize 65536 \
             --header "Accept: application/vnd.github+json" \
+            --header "Authorization: Bearer $GITHUB_TOKEN" \
             --header "User-Agent: slop-release-intake-check" \
             https://api.github.com/repos/SlopDotCash/slopdotcash/private-vulnerability-reporting |
             node -e '
@@ -433,7 +436,11 @@ jobs:
           node - "$pages_secrets" <<'NODE'
           const { readFileSync } = require("node:fs");
           const contents = readFileSync(process.argv[2], "utf8");
-          const expected = ["OPERATOR_GITHUB_IDS", "TRACE_AUTH_SECRET"];
+          const expected = [
+            "OPERATOR_GITHUB_IDS",
+            "PRIVATE_INTAKE_GITHUB_TOKEN",
+            "TRACE_AUTH_SECRET",
+          ];
           const actual = [...contents.matchAll(/^\s*-\s+([A-Z][A-Z0-9_]*):\s+Value Encrypted\s*$/gmu)]
             .map((match) => match[1])
             .sort();

--- a/backend/trace/README.md
+++ b/backend/trace/README.md
@@ -13,10 +13,11 @@ it. Backend integrity checks enforce the declared bytes; they do not replace
 the contributor's required pre-upload inspection.
 
 Trace upload and production activation require GitHub's public private
-vulnerability reporting status to return exactly `enabled: true`. The client
-and deploy workflow check that operator-controlled intake fail closed; an
-advisory URL alone is not evidence of availability, and a public issue is never
-a private intake.
+vulnerability reporting status to return exactly `enabled: true`. The deploy
+workflow verifies GitHub directly, while the client reads only the bounded
+server-authenticated Slop preflight. Both checks fail closed; an advisory URL
+alone is not evidence of availability, and a public issue is never a private
+intake.
 
 ## Storage contract
 
@@ -112,6 +113,7 @@ bunx wrangler d1 create slop-private
 bunx wrangler r2 bucket create slop-private-traces
 bunx wrangler d1 migrations apply slop-private --remote
 bunx wrangler pages secret put TRACE_AUTH_SECRET --project-name eliza-computer
+bunx wrangler pages secret put PRIVATE_INTAKE_GITHUB_TOKEN --project-name eliza-computer
 ```
 
 Then add the returned D1 ID and R2 binding to the production Pages project:
@@ -133,6 +135,13 @@ service = "slop-identity"
 ```
 
 Set `OPERATOR_GITHUB_IDS` to an explicit comma-separated list of numeric IDs.
+`PRIVATE_INTAKE_GITHUB_TOKEN` is a server-only GitHub credential scoped to
+`SlopDotCash/slopdotcash` with read access to the private-vulnerability-
+reporting status endpoint and no write permission. The public
+`GET /api/v1/private-request-intake` route exposes only the bounded verified
+boolean and timestamp, or a fail-closed error with rate-limit reset time. Its
+five-minute edge cache prevents each contributor from consuming a GitHub API
+request. The credential is never returned to the client or accepted from one.
 `TRACE_AUTH_SECRET` is opaque HMAC key material and must contain 32-128
 high-entropy printable ASCII characters. It must never be configured as a
 checked-in `[vars]` value. Generate a recommended 43-character base64url value

--- a/backend/trace/handler.ts
+++ b/backend/trace/handler.ts
@@ -36,6 +36,11 @@ export type TraceApiDependencies = {
   verifyIdentityAssertion: (
     assertion: string,
   ) => Promise<{ githubId: string; githubLogin: string } | null>;
+  privateIntakeStatus: () => Promise<
+    | { status: "verified"; enabled: boolean; verifiedAt: string }
+    | { status: "rate_limited"; resetAt: string }
+    | { status: "unavailable" }
+  >;
 };
 
 type ApiError = Error & { status?: number; code?: string };
@@ -60,6 +65,35 @@ function json(status: number, body: Record<string, unknown>): Response {
       "x-slop-trace-api-contract": TRACE_API_CONTRACT_VERSION,
     },
   });
+}
+
+async function readPrivateIntakeStatus(
+  deps: TraceApiDependencies,
+): Promise<Response> {
+  const status = await deps.privateIntakeStatus();
+  if (status.status === "verified") {
+    if (!validIsoTimestamp(status.verifiedAt)) {
+      return json(503, { error: "private_intake_unavailable" });
+    }
+    return json(200, {
+      enabled: status.enabled,
+      source: "github-authenticated",
+      verifiedAt: status.verifiedAt,
+    });
+  }
+  if (status.status === "rate_limited") {
+    if (!validIsoTimestamp(status.resetAt)) {
+      return json(503, { error: "private_intake_unavailable" });
+    }
+    return json(503, {
+      error: "private_intake_rate_limited",
+      resetAt: status.resetAt,
+    });
+  }
+  if (status.status === "unavailable") {
+    return json(503, { error: "private_intake_unavailable" });
+  }
+  return json(503, { error: "private_intake_unavailable" });
 }
 
 function requiredString(
@@ -830,6 +864,13 @@ export async function handleTraceApi(
     return json(404, { error: "not_found" });
   }
   try {
+    if (
+      request.method === "GET" &&
+      parts.length === 1 &&
+      parts[0] === "private-request-intake"
+    ) {
+      return await readPrivateIntakeStatus(deps);
+    }
     if (
       request.method === "GET" &&
       parts.length === 4 &&

--- a/functions/api/v1/[[path]].ts
+++ b/functions/api/v1/[[path]].ts
@@ -9,6 +9,7 @@ type Env = {
   SLOP_DB: D1Database;
   PRIVATE_TRACES: R2Bucket;
   TRACE_AUTH_SECRET: string;
+  PRIVATE_INTAKE_GITHUB_TOKEN?: string;
   OPERATOR_GITHUB_IDS?: string;
   SLOP_IDENTITY: { fetch(request: Request): Promise<Response> };
 };
@@ -19,16 +20,35 @@ type PagesContext = {
 };
 
 export const MAX_IDENTITY_RESPONSE_BYTES = 16 * 1024;
+export const MAX_PRIVATE_INTAKE_RESPONSE_BYTES = 16 * 1024;
+const PRIVATE_INTAKE_CACHE_KEY = new Request(
+  "https://private-intake-cache.invalid/status-v1",
+);
+const PRIVATE_INTAKE_STATUS_URL =
+  "https://api.github.com/repos/SlopDotCash/slopdotcash/private-vulnerability-reporting";
 
-async function readIdentityResponse(response: Response): Promise<unknown> {
+type EdgeCache = {
+  match(request: Request): Promise<Response | undefined>;
+  put(request: Request, response: Response): Promise<void>;
+};
+
+type PrivateIntakeStatus =
+  | { status: "verified"; enabled: boolean; verifiedAt: string }
+  | { status: "rate_limited"; resetAt: string }
+  | { status: "unavailable" };
+
+async function readBoundedJson(
+  response: Response,
+  maximumBytes: number,
+): Promise<unknown> {
   const declared = response.headers.get("content-length");
   if (
     declared !== null &&
-    (!/^\d+$/u.test(declared) || Number(declared) > MAX_IDENTITY_RESPONSE_BYTES)
+    (!/^\d+$/u.test(declared) || Number(declared) > maximumBytes)
   ) {
-    throw new Error("Identity response exceeds the allowed size");
+    throw new Error("Response exceeds the allowed size");
   }
-  if (response.body === null) throw new Error("Identity response is empty");
+  if (response.body === null) throw new Error("Response is empty");
   const reader = response.body.getReader();
   const chunks: Uint8Array[] = [];
   let total = 0;
@@ -37,9 +57,9 @@ async function readIdentityResponse(response: Response): Promise<unknown> {
       const { done, value } = await reader.read();
       if (done) break;
       total += value.byteLength;
-      if (total > MAX_IDENTITY_RESPONSE_BYTES) {
-        await reader.cancel("identity response too large");
-        throw new Error("Identity response exceeds the allowed size");
+      if (total > maximumBytes) {
+        await reader.cancel("response too large");
+        throw new Error("Response exceeds the allowed size");
       }
       chunks.push(value);
     }
@@ -53,6 +73,139 @@ async function readIdentityResponse(response: Response): Promise<unknown> {
     offset += chunk.byteLength;
   }
   return JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(bytes));
+}
+
+function parsedPrivateIntakeStatus(value: unknown): PrivateIntakeStatus | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null;
+  }
+  const record = value as Record<string, unknown>;
+  if (
+    record.status === "verified" &&
+    typeof record.enabled === "boolean" &&
+    typeof record.verifiedAt === "string" &&
+    !Number.isNaN(Date.parse(record.verifiedAt)) &&
+    Object.keys(record).length === 3
+  ) {
+    return {
+      status: "verified",
+      enabled: record.enabled,
+      verifiedAt: record.verifiedAt,
+    };
+  }
+  if (
+    record.status === "rate_limited" &&
+    typeof record.resetAt === "string" &&
+    !Number.isNaN(Date.parse(record.resetAt)) &&
+    Object.keys(record).length === 2
+  ) {
+    return { status: "rate_limited", resetAt: record.resetAt };
+  }
+  return null;
+}
+
+async function privateIntakeStatus(
+  token: string | undefined,
+  cache: EdgeCache | undefined,
+  fetchImpl: typeof fetch,
+  now: () => Date,
+): Promise<PrivateIntakeStatus> {
+  if (cache !== undefined) {
+    try {
+      const cached = await cache.match(PRIVATE_INTAKE_CACHE_KEY);
+      if (cached !== undefined) {
+        const status = parsedPrivateIntakeStatus(
+          await readBoundedJson(cached, MAX_PRIVATE_INTAKE_RESPONSE_BYTES),
+        );
+        if (status !== null) return status;
+      }
+    } catch {
+      return { status: "unavailable" };
+    }
+  }
+  if (
+    typeof token !== "string" ||
+    token.length < 20 ||
+    token.length > 2048 ||
+    /\s/u.test(token)
+  ) {
+    return { status: "unavailable" };
+  }
+  let response: Response;
+  try {
+    response = await fetchImpl(PRIVATE_INTAKE_STATUS_URL, {
+      method: "GET",
+      redirect: "error",
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "User-Agent": "slop-private-intake-verifier",
+      },
+      signal: AbortSignal.timeout(30_000),
+    });
+  } catch {
+    return { status: "unavailable" };
+  }
+  let status: PrivateIntakeStatus;
+  if (
+    (response.status === 403 || response.status === 429) &&
+    response.headers.get("x-ratelimit-remaining") === "0"
+  ) {
+    const reset = response.headers.get("x-ratelimit-reset");
+    if (reset === null || !/^\d{9,12}$/u.test(reset)) {
+      return { status: "unavailable" };
+    }
+    status = {
+      status: "rate_limited",
+      resetAt: new Date(Number(reset) * 1000).toISOString(),
+    };
+  } else if (response.ok) {
+    let value: unknown;
+    try {
+      value = await readBoundedJson(
+        response,
+        MAX_PRIVATE_INTAKE_RESPONSE_BYTES,
+      );
+    } catch {
+      return { status: "unavailable" };
+    }
+    if (
+      typeof value !== "object" ||
+      value === null ||
+      Array.isArray(value) ||
+      Object.keys(value).length !== 1 ||
+      typeof (value as { enabled?: unknown }).enabled !== "boolean"
+    ) {
+      return { status: "unavailable" };
+    }
+    status = {
+      status: "verified",
+      enabled: (value as { enabled: boolean }).enabled,
+      verifiedAt: now().toISOString(),
+    };
+  } else {
+    return { status: "unavailable" };
+  }
+  if (cache !== undefined) {
+    try {
+      await cache.put(
+        PRIVATE_INTAKE_CACHE_KEY,
+        new Response(JSON.stringify(status), {
+          headers: {
+            "cache-control": "public, max-age=300",
+            "content-type": "application/json; charset=utf-8",
+          },
+        }),
+      );
+    } catch {
+      return { status: "unavailable" };
+    }
+  }
+  return status;
+}
+
+async function readIdentityResponse(response: Response): Promise<unknown> {
+  return readBoundedJson(response, MAX_IDENTITY_RESPONSE_BYTES);
 }
 
 async function verifyIdentityAssertion(
@@ -86,6 +239,9 @@ async function verifyIdentityAssertion(
 }
 
 export async function onRequest(context: PagesContext): Promise<Response> {
+  const cache = (
+    globalThis as typeof globalThis & { caches?: { default?: EdgeCache } }
+  ).caches?.default;
   return handleTraceApi(context.request, {
     persistence: new CloudflareTracePersistence(
       context.env.SLOP_DB,
@@ -102,5 +258,12 @@ export async function onRequest(context: PagesContext): Promise<Response> {
     randomId: () => crypto.randomUUID(),
     verifyIdentityAssertion: (assertion) =>
       verifyIdentityAssertion(context.env.SLOP_IDENTITY, assertion),
+    privateIntakeStatus: () =>
+      privateIntakeStatus(
+        context.env.PRIVATE_INTAKE_GITHUB_TOKEN,
+        cache,
+        globalThis.fetch,
+        () => new Date(),
+      ),
   });
 }

--- a/functions/api/v1/[[path]].ts
+++ b/functions/api/v1/[[path]].ts
@@ -110,6 +110,14 @@ async function privateIntakeStatus(
   fetchImpl: typeof fetch,
   now: () => Date,
 ): Promise<PrivateIntakeStatus> {
+  if (
+    typeof token !== "string" ||
+    token.length < 20 ||
+    token.length > 2048 ||
+    /\s/u.test(token)
+  ) {
+    return { status: "unavailable" };
+  }
   if (cache !== undefined) {
     try {
       const cached = await cache.match(PRIVATE_INTAKE_CACHE_KEY);
@@ -123,14 +131,6 @@ async function privateIntakeStatus(
       return { status: "unavailable" };
     }
   }
-  if (
-    typeof token !== "string" ||
-    token.length < 20 ||
-    token.length > 2048 ||
-    /\s/u.test(token)
-  ) {
-    return { status: "unavailable" };
-  }
   let response: Response;
   try {
     response = await fetchImpl(PRIVATE_INTAKE_STATUS_URL, {
@@ -140,6 +140,7 @@ async function privateIntakeStatus(
         Accept: "application/vnd.github+json",
         Authorization: `Bearer ${token}`,
         "User-Agent": "slop-private-intake-verifier",
+        "X-GitHub-Api-Version": "2022-11-28",
       },
       signal: AbortSignal.timeout(30_000),
     });

--- a/functions/api/v1/trace-api.test.ts
+++ b/functions/api/v1/trace-api.test.ts
@@ -323,6 +323,11 @@ function dependencies(
       assertion === "valid_slop_identity_assertion_value"
         ? { githubId: "42", githubLogin: "octocat" }
         : null,
+    privateIntakeStatus: async () => ({
+      status: "verified",
+      enabled: true,
+      verifiedAt: NOW.toISOString(),
+    }),
   };
 }
 
@@ -427,6 +432,179 @@ async function uploadTrace(
 }
 
 describe("private trace API", () => {
+  it("serves a cached server-authenticated private intake verification", async () => {
+    const originalFetch = globalThis.fetch;
+    const originalCaches = Object.getOwnPropertyDescriptor(
+      globalThis,
+      "caches",
+    );
+    const cache = new Map<string, Response>();
+    const requests: Array<{ url: string; init: RequestInit }> = [];
+    try {
+      globalThis.fetch = (async (input, init = {}) => {
+        requests.push({ url: String(input), init });
+        return new Response(JSON.stringify({ enabled: true }), { status: 200 });
+      }) as typeof fetch;
+      Object.defineProperty(globalThis, "caches", {
+        configurable: true,
+        value: {
+          default: {
+            match: async (request: Request) => cache.get(request.url)?.clone(),
+            put: async (request: Request, response: Response) => {
+              cache.set(request.url, response.clone());
+            },
+          },
+        },
+      });
+      const context = {
+        request: new Request(
+          "https://api.slop.cash/api/v1/private-request-intake",
+        ),
+        env: {
+          SLOP_DB: {} as never,
+          PRIVATE_TRACES: {} as never,
+          TRACE_AUTH_SECRET: SECRET,
+          PRIVATE_INTAKE_GITHUB_TOKEN: "github_server_token_value",
+          SLOP_IDENTITY: {
+            fetch: async () => new Response(null, { status: 401 }),
+          },
+        },
+      };
+      const first = await onPagesRequest(context);
+      const second = await onPagesRequest(context);
+
+      expect(first.status).toBe(200);
+      expect(second.status).toBe(200);
+      await expect(first.json()).resolves.toEqual({
+        enabled: true,
+        source: "github-authenticated",
+        verifiedAt: expect.any(String),
+      });
+      expect(requests).toHaveLength(1);
+      expect(requests[0]?.url).toBe(
+        "https://api.github.com/repos/SlopDotCash/slopdotcash/private-vulnerability-reporting",
+      );
+      expect(requests[0]?.init).toMatchObject({
+        method: "GET",
+        redirect: "error",
+        headers: {
+          Accept: "application/vnd.github+json",
+          Authorization: "Bearer github_server_token_value",
+          "User-Agent": "slop-private-intake-verifier",
+        },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (originalCaches === undefined) {
+        Reflect.deleteProperty(globalThis, "caches");
+      } else {
+        Object.defineProperty(globalThis, "caches", originalCaches);
+      }
+    }
+  });
+
+  it("reports bounded reset diagnostics for an upstream GitHub rate limit", async () => {
+    const originalFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = (async () =>
+        new Response(JSON.stringify({ message: "API rate limit exceeded" }), {
+          status: 403,
+          headers: {
+            "x-ratelimit-remaining": "0",
+            "x-ratelimit-reset": "1800000000",
+          },
+        })) as unknown as typeof fetch;
+      const response = await onPagesRequest({
+        request: new Request(
+          "https://api.slop.cash/api/v1/private-request-intake",
+        ),
+        env: {
+          SLOP_DB: {} as never,
+          PRIVATE_TRACES: {} as never,
+          TRACE_AUTH_SECRET: SECRET,
+          PRIVATE_INTAKE_GITHUB_TOKEN: "github_server_token_value",
+          SLOP_IDENTITY: {
+            fetch: async () => new Response(null, { status: 401 }),
+          },
+        },
+      });
+
+      expect(response.status).toBe(503);
+      await expect(response.json()).resolves.toEqual({
+        error: "private_intake_rate_limited",
+        resetAt: "2027-01-15T08:00:00.000Z",
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("fails closed when GitHub returns an invalid rate-limit reset", async () => {
+    const originalFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = (async () =>
+        new Response(JSON.stringify({ message: "API rate limit exceeded" }), {
+          status: 403,
+          headers: {
+            "x-ratelimit-remaining": "0",
+            "x-ratelimit-reset": "999999999999",
+          },
+        })) as unknown as typeof fetch;
+      const response = await onPagesRequest({
+        request: new Request(
+          "https://api.slop.cash/api/v1/private-request-intake",
+        ),
+        env: {
+          SLOP_DB: {} as never,
+          PRIVATE_TRACES: {} as never,
+          TRACE_AUTH_SECRET: SECRET,
+          PRIVATE_INTAKE_GITHUB_TOKEN: "github_server_token_value",
+          SLOP_IDENTITY: {
+            fetch: async () => new Response(null, { status: 401 }),
+          },
+        },
+      });
+
+      expect(response.status).toBe(503);
+      await expect(response.json()).resolves.toEqual({
+        error: "private_intake_unavailable",
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("fails closed on a malformed authenticated GitHub response", async () => {
+    const originalFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = (async () =>
+        new Response(JSON.stringify({ enabled: "yes" }), {
+          status: 200,
+        })) as unknown as typeof fetch;
+      const response = await onPagesRequest({
+        request: new Request(
+          "https://api.slop.cash/api/v1/private-request-intake",
+        ),
+        env: {
+          SLOP_DB: {} as never,
+          PRIVATE_TRACES: {} as never,
+          TRACE_AUTH_SECRET: SECRET,
+          PRIVATE_INTAKE_GITHUB_TOKEN: "github_server_token_value",
+          SLOP_IDENTITY: {
+            fetch: async () => new Response(null, { status: 401 }),
+          },
+        },
+      });
+
+      expect(response.status).toBe(503);
+      await expect(response.json()).resolves.toEqual({
+        error: "private_intake_unavailable",
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it("accepts arbitrary exact model identities and rejects placeholders", async () => {
     const deps = dependencies();
     const contributor = await token("42", "octocat", ["contributor"]);

--- a/functions/api/v1/trace-api.test.ts
+++ b/functions/api/v1/trace-api.test.ts
@@ -440,6 +440,7 @@ describe("private trace API", () => {
     );
     const cache = new Map<string, Response>();
     const requests: Array<{ url: string; init: RequestInit }> = [];
+    let cachedControl: string | null = null;
     try {
       globalThis.fetch = (async (input, init = {}) => {
         requests.push({ url: String(input), init });
@@ -451,6 +452,7 @@ describe("private trace API", () => {
           default: {
             match: async (request: Request) => cache.get(request.url)?.clone(),
             put: async (request: Request, response: Response) => {
+              cachedControl = response.headers.get("cache-control");
               cache.set(request.url, response.clone());
             },
           },
@@ -491,8 +493,68 @@ describe("private trace API", () => {
           Accept: "application/vnd.github+json",
           Authorization: "Bearer github_server_token_value",
           "User-Agent": "slop-private-intake-verifier",
+          "X-GitHub-Api-Version": "2022-11-28",
         },
       });
+      expect(cachedControl).toBe("public, max-age=300");
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (originalCaches === undefined) {
+        Reflect.deleteProperty(globalThis, "caches");
+      } else {
+        Object.defineProperty(globalThis, "caches", originalCaches);
+      }
+    }
+  });
+
+  it("rejects cached enabled status when the server credential is absent", async () => {
+    const originalFetch = globalThis.fetch;
+    const originalCaches = Object.getOwnPropertyDescriptor(
+      globalThis,
+      "caches",
+    );
+    let upstreamRequested = false;
+    try {
+      globalThis.fetch = (async () => {
+        upstreamRequested = true;
+        return new Response(JSON.stringify({ enabled: true }), { status: 200 });
+      }) as unknown as typeof fetch;
+      Object.defineProperty(globalThis, "caches", {
+        configurable: true,
+        value: {
+          default: {
+            match: async () =>
+              new Response(
+                JSON.stringify({
+                  status: "verified",
+                  enabled: true,
+                  verifiedAt: "2026-08-25T00:00:00.000Z",
+                }),
+              ),
+            put: async () => undefined,
+          },
+        },
+      });
+
+      const response = await onPagesRequest({
+        request: new Request(
+          "https://api.slop.cash/api/v1/private-request-intake",
+        ),
+        env: {
+          SLOP_DB: {} as never,
+          PRIVATE_TRACES: {} as never,
+          TRACE_AUTH_SECRET: SECRET,
+          SLOP_IDENTITY: {
+            fetch: async () => new Response(null, { status: 401 }),
+          },
+        },
+      });
+
+      expect(response.status).toBe(503);
+      await expect(response.json()).resolves.toEqual({
+        error: "private_intake_unavailable",
+      });
+      expect(upstreamRequested).toBe(false);
     } finally {
       globalThis.fetch = originalFetch;
       if (originalCaches === undefined) {

--- a/protocol/private-trace-v1.md
+++ b/protocol/private-trace-v1.md
@@ -97,10 +97,14 @@ private report from a signed-in GitHub user without publishing the report as an
 issue. Do not put private data, trace contents, or request details in a public
 issue.
 
-The uploader and production workflow independently query GitHub's public
-private-vulnerability-reporting status before activating this path. Trace
-upload and production activation fail closed if it does not report exactly
-`enabled: true`; the advisory URL alone is not evidence that intake is usable.
+The production workflow queries GitHub's private-vulnerability-reporting status
+with its trusted repository credential. The uploader queries only Slop's
+bounded server-authoritative preflight, whose server-held credential and
+five-minute cache keep GitHub authentication out of the client. Trace upload
+and production activation fail closed if the authoritative state does not
+report exactly `enabled: true`; a rate limit reports its bounded reset time and
+never becomes an enabled result. The advisory URL alone is not evidence that
+intake is usable.
 Operators must authenticate the requester and handle any action required by
 applicable law outside the contributor API with an audit record. This channel
 does not create a voluntary deletion or contributor-read right that conflicts

--- a/scripts/deployment-contract.test.mjs
+++ b/scripts/deployment-contract.test.mjs
@@ -208,6 +208,25 @@ describe("slop.cash deployment contract", () => {
       deployJob.indexOf("Verify active private trace API boundary"),
     ).toBeLessThan(deployJob.indexOf("Require public identity OAuth app"));
     expect(deployJob).toContain(
+      "Verify authenticated private intake preflight",
+    );
+    expect(deployJob).toContain(
+      "https://api.slop.cash/api/v1/private-request-intake?verify=",
+    );
+    expect(deployJob).toContain('value?.source !== "github-authenticated"');
+    expect(deployJob).toContain("value?.enabled !== true");
+    expect(deployJob).toContain(
+      "Authenticated private intake preflight did not become authoritative.",
+    );
+    expect(
+      deployJob.indexOf("Verify active private trace API boundary"),
+    ).toBeLessThan(
+      deployJob.indexOf("Verify authenticated private intake preflight"),
+    );
+    expect(
+      deployJob.indexOf("Verify authenticated private intake preflight"),
+    ).toBeLessThan(deployJob.indexOf("Require public identity OAuth app"));
+    expect(deployJob).toContain(
       "Active private trace API did not reach its fail-closed unauthenticated boundary.",
     );
     expect(deployJob).toContain('--dump-header "$headers"');
@@ -501,7 +520,7 @@ describe("slop.cash deployment contract", () => {
   it("bounds every trusted external response before buffering it", () => {
     const curlCommands = workflow.match(/^\s*(?:if )?curl /gmu) ?? [];
     const responseBounds = workflow.match(/^\s*--max-filesize /gmu) ?? [];
-    expect(curlCommands).toHaveLength(14);
+    expect(curlCommands).toHaveLength(15);
     expect(responseBounds).toHaveLength(curlCommands.length);
     expect(workflow).toContain('--max-filesize "$(wc -c < dist/index.html)"');
     expect(workflow).toContain('--max-filesize "$expected_bytes"');

--- a/scripts/deployment-contract.test.mjs
+++ b/scripts/deployment-contract.test.mjs
@@ -108,6 +108,10 @@ describe("slop.cash deployment contract", () => {
     expect(deployJob).toContain(
       "https://api.github.com/repos/SlopDotCash/slopdotcash/private-vulnerability-reporting",
     );
+    expect(deployJob).toContain(`GITHUB_TOKEN: ${"$"}{{ github.token }}`);
+    expect(deployJob).toContain(
+      '--header "Authorization: Bearer $GITHUB_TOKEN"',
+    );
     expect(deployJob).toContain("value?.enabled !== true");
     expect(
       deployJob.indexOf("Require public private-request intake"),
@@ -125,6 +129,7 @@ describe("slop.cash deployment contract", () => {
     expect(deployJob).toContain(
       "./node_modules/.bin/wrangler pages secret list \\\n            --project-name eliza-computer",
     );
+    expect(deployJob).toContain('"PRIVATE_INTAKE_GITHUB_TOKEN",');
     expect(deployJob).toContain(
       "./node_modules/.bin/wrangler d1 migrations apply slop-private \\",
     );

--- a/skill-tests/project-skills.test.ts
+++ b/skill-tests/project-skills.test.ts
@@ -867,7 +867,11 @@ describe("project run usage", () => {
       const sequence: string[] = [];
       let disclosure: Record<string, unknown> | null = null;
       const responses = [
-        { enabled: true },
+        {
+          enabled: true,
+          source: "github-authenticated",
+          verifiedAt: "2026-08-25T12:00:00.000Z",
+        },
         {
           token: "s".repeat(32),
           tokenType: "Bearer",
@@ -959,7 +963,7 @@ describe("project run usage", () => {
       );
       assert.strictEqual(
         calls[0].url,
-        "https://api.github.com/repos/SlopDotCash/slopdotcash/private-vulnerability-reporting",
+        "https://api.slop.cash/api/v1/private-request-intake",
       );
       assert.strictEqual(calls[0].options.method, "GET");
       assert.strictEqual(
@@ -1008,9 +1012,14 @@ describe("project run usage", () => {
             },
             fetchImpl: async (url) => {
               requests.push(String(url));
-              return new Response(JSON.stringify({ enabled: false }), {
-                status: 200,
-              });
+              return new Response(
+                JSON.stringify({
+                  enabled: false,
+                  source: "github-authenticated",
+                  verifiedAt: "2026-08-25T12:00:00.000Z",
+                }),
+                { status: 200 },
+              );
             },
           },
         ),
@@ -1018,8 +1027,51 @@ describe("project run usage", () => {
       );
       assert.strictEqual(authorizationStarted, false);
       assert.deepStrictEqual(requests, [
-        "https://api.github.com/repos/SlopDotCash/slopdotcash/private-vulnerability-reporting",
+        "https://api.slop.cash/api/v1/private-request-intake",
       ]);
+    } finally {
+      rmSync(fixtureRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("reports private intake rate-limit reset before authorization", async () => {
+    const fixtureRoot = mkdtempSync(join(tmpdir(), "slop-trace-intake-rate-"));
+    try {
+      const trajectory = join(fixtureRoot, "trace.ndjson");
+      writeFileSync(trajectory, '{"event":"complete"}\n');
+      let authorizationStarted = false;
+      await assert.rejects(
+        uploadPrivateTrace(
+          {
+            runId: "run_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+            projectId: "eliza",
+            repositoryId: "elizaOS/eliza",
+            revision: "a".repeat(40),
+            provider: "moonshot",
+            model: "kimi-k2",
+            client: "kimi-cli",
+          },
+          trajectory,
+          "1.2.3",
+          {
+            disclosure: () => {},
+            assertionProvider: () => {
+              authorizationStarted = true;
+              return "i".repeat(32);
+            },
+            fetchImpl: async () =>
+              new Response(
+                JSON.stringify({
+                  error: "private_intake_rate_limited",
+                  resetAt: "2027-01-15T08:00:00.000Z",
+                }),
+                { status: 503 },
+              ),
+          },
+        ),
+        /private request intake verification is rate limited until 2027-01-15T08:00:00.000Z/u,
+      );
+      assert.strictEqual(authorizationStarted, false);
     } finally {
       rmSync(fixtureRoot, { force: true, recursive: true });
     }

--- a/skills/contribute-to-asi/scripts/run-receipt.mjs
+++ b/skills/contribute-to-asi/scripts/run-receipt.mjs
@@ -82,8 +82,7 @@ const AUTHORIZATION_RECEIPT = ".slop-authorization.json";
 const TRACE_AUTHORITY = "https://api.slop.cash";
 const IDENTITY_AUTHORITY = "https://identity.slop.cash";
 const TRACE_PRIVACY_CONTRACT = "https://slop.cash/protocol/private-trace-v1.md";
-const PRIVATE_REQUEST_INTAKE_STATUS =
-  "https://api.github.com/repos/SlopDotCash/slopdotcash/private-vulnerability-reporting";
+const PRIVATE_REQUEST_INTAKE_STATUS = `${TRACE_AUTHORITY}/api/v1/private-request-intake`;
 const LEGACY_V1_RECEIPT_IDENTITIES = new Map([
   [
     "delta-star",
@@ -1245,6 +1244,57 @@ async function jsonRequest(fetchImpl, url, options, keys, field) {
   return exactObject(value, keys, field);
 }
 
+async function authoritativePrivateIntake(fetchImpl) {
+  let response;
+  try {
+    response = await fetchImpl(PRIVATE_REQUEST_INTAKE_STATUS, {
+      method: "GET",
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(30_000),
+    });
+  } catch {
+    fail("private request intake status request failed");
+  }
+  const source = await boundedResponseText(
+    response,
+    "private request intake status",
+  );
+  let value;
+  try {
+    value = JSON.parse(source);
+  } catch {
+    fail("private request intake status response was not JSON");
+  }
+  if (!response?.ok) {
+    if (
+      response?.status === 503 &&
+      hasExactKeys(value, ["error", "resetAt"]) &&
+      value.error === "private_intake_rate_limited" &&
+      canonicalIso(value.resetAt) === value.resetAt
+    ) {
+      fail(
+        `private request intake verification is rate limited until ${value.resetAt}`,
+      );
+    }
+    fail(
+      `private request intake status request returned HTTP ${response?.status}`,
+    );
+  }
+  const intake = exactObject(
+    value,
+    ["enabled", "source", "verifiedAt"],
+    "private request intake status",
+  );
+  if (
+    typeof intake.enabled !== "boolean" ||
+    intake.source !== "github-authenticated" ||
+    canonicalIso(intake.verifiedAt) !== intake.verifiedAt
+  ) {
+    fail("private request intake status returned invalid verification");
+  }
+  return intake;
+}
+
 export async function slopIdentityAssertion(
   fetchImpl = globalThis.fetch,
   delayImpl = (milliseconds) =>
@@ -1418,16 +1468,7 @@ export async function uploadPrivateTrace(
     automaticRedaction: "none",
     retention: "permanent",
   });
-  const intake = await jsonRequest(
-    fetchImpl,
-    PRIVATE_REQUEST_INTAKE_STATUS,
-    {
-      method: "GET",
-      headers: { Accept: "application/vnd.github+json" },
-    },
-    ["enabled"],
-    "private request intake status",
-  );
+  const intake = await authoritativePrivateIntake(fetchImpl);
   if (intake.enabled !== true) {
     fail(
       "private request intake is unavailable; private trace upload is blocked",
@@ -2179,7 +2220,7 @@ function previewRun(options) {
     network: [
       `With --allow-package-execution, resolve exact ccusage@${CCUSAGE_VERSION} during doctor and measured runs; fetch it from the package registry only when it is not already cached`,
       `On start and finish, fetch current project terms from https://slop.cash/projects/${PROJECT.projectId}/terms.json and any digest-bound LICENSE, inbound terms, or prize rules from github.com, raw.githubusercontent.com, or proximityprize.org as named by that policy`,
-      `Verify the public private-request intake gate at ${PRIVATE_REQUEST_INTAKE_STATUS}; trace upload remains blocked unless it reports enabled`,
+      `Verify the server-authenticated private-request intake gate at ${PRIVATE_REQUEST_INTAKE_STATUS}; trace upload remains blocked unless it reports enabled`,
       `After a local byte/digest disclosure, authenticate with GitHub and permanently upload the inspected trace through ${TRACE_AUTHORITY} under ${TRACE_PRIVACY_CONTRACT}`,
     ],
     automaticUploads: [],

--- a/skills/contribute-to-delta-star/scripts/run-receipt.mjs
+++ b/skills/contribute-to-delta-star/scripts/run-receipt.mjs
@@ -82,8 +82,7 @@ const AUTHORIZATION_RECEIPT = ".slop-authorization.json";
 const TRACE_AUTHORITY = "https://api.slop.cash";
 const IDENTITY_AUTHORITY = "https://identity.slop.cash";
 const TRACE_PRIVACY_CONTRACT = "https://slop.cash/protocol/private-trace-v1.md";
-const PRIVATE_REQUEST_INTAKE_STATUS =
-  "https://api.github.com/repos/SlopDotCash/slopdotcash/private-vulnerability-reporting";
+const PRIVATE_REQUEST_INTAKE_STATUS = `${TRACE_AUTHORITY}/api/v1/private-request-intake`;
 const LEGACY_V1_RECEIPT_IDENTITIES = new Map([
   [
     "delta-star",
@@ -1245,6 +1244,57 @@ async function jsonRequest(fetchImpl, url, options, keys, field) {
   return exactObject(value, keys, field);
 }
 
+async function authoritativePrivateIntake(fetchImpl) {
+  let response;
+  try {
+    response = await fetchImpl(PRIVATE_REQUEST_INTAKE_STATUS, {
+      method: "GET",
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(30_000),
+    });
+  } catch {
+    fail("private request intake status request failed");
+  }
+  const source = await boundedResponseText(
+    response,
+    "private request intake status",
+  );
+  let value;
+  try {
+    value = JSON.parse(source);
+  } catch {
+    fail("private request intake status response was not JSON");
+  }
+  if (!response?.ok) {
+    if (
+      response?.status === 503 &&
+      hasExactKeys(value, ["error", "resetAt"]) &&
+      value.error === "private_intake_rate_limited" &&
+      canonicalIso(value.resetAt) === value.resetAt
+    ) {
+      fail(
+        `private request intake verification is rate limited until ${value.resetAt}`,
+      );
+    }
+    fail(
+      `private request intake status request returned HTTP ${response?.status}`,
+    );
+  }
+  const intake = exactObject(
+    value,
+    ["enabled", "source", "verifiedAt"],
+    "private request intake status",
+  );
+  if (
+    typeof intake.enabled !== "boolean" ||
+    intake.source !== "github-authenticated" ||
+    canonicalIso(intake.verifiedAt) !== intake.verifiedAt
+  ) {
+    fail("private request intake status returned invalid verification");
+  }
+  return intake;
+}
+
 export async function slopIdentityAssertion(
   fetchImpl = globalThis.fetch,
   delayImpl = (milliseconds) =>
@@ -1418,16 +1468,7 @@ export async function uploadPrivateTrace(
     automaticRedaction: "none",
     retention: "permanent",
   });
-  const intake = await jsonRequest(
-    fetchImpl,
-    PRIVATE_REQUEST_INTAKE_STATUS,
-    {
-      method: "GET",
-      headers: { Accept: "application/vnd.github+json" },
-    },
-    ["enabled"],
-    "private request intake status",
-  );
+  const intake = await authoritativePrivateIntake(fetchImpl);
   if (intake.enabled !== true) {
     fail(
       "private request intake is unavailable; private trace upload is blocked",
@@ -2179,7 +2220,7 @@ function previewRun(options) {
     network: [
       `With --allow-package-execution, resolve exact ccusage@${CCUSAGE_VERSION} during doctor and measured runs; fetch it from the package registry only when it is not already cached`,
       `On start and finish, fetch current project terms from https://slop.cash/projects/${PROJECT.projectId}/terms.json and any digest-bound LICENSE, inbound terms, or prize rules from github.com, raw.githubusercontent.com, or proximityprize.org as named by that policy`,
-      `Verify the public private-request intake gate at ${PRIVATE_REQUEST_INTAKE_STATUS}; trace upload remains blocked unless it reports enabled`,
+      `Verify the server-authenticated private-request intake gate at ${PRIVATE_REQUEST_INTAKE_STATUS}; trace upload remains blocked unless it reports enabled`,
       `After a local byte/digest disclosure, authenticate with GitHub and permanently upload the inspected trace through ${TRACE_AUTHORITY} under ${TRACE_PRIVACY_CONTRACT}`,
     ],
     automaticUploads: [],

--- a/skills/contribute-to-eliza/scripts/run-receipt.mjs
+++ b/skills/contribute-to-eliza/scripts/run-receipt.mjs
@@ -82,8 +82,7 @@ const AUTHORIZATION_RECEIPT = ".slop-authorization.json";
 const TRACE_AUTHORITY = "https://api.slop.cash";
 const IDENTITY_AUTHORITY = "https://identity.slop.cash";
 const TRACE_PRIVACY_CONTRACT = "https://slop.cash/protocol/private-trace-v1.md";
-const PRIVATE_REQUEST_INTAKE_STATUS =
-  "https://api.github.com/repos/SlopDotCash/slopdotcash/private-vulnerability-reporting";
+const PRIVATE_REQUEST_INTAKE_STATUS = `${TRACE_AUTHORITY}/api/v1/private-request-intake`;
 const LEGACY_V1_RECEIPT_IDENTITIES = new Map([
   [
     "delta-star",
@@ -1245,6 +1244,57 @@ async function jsonRequest(fetchImpl, url, options, keys, field) {
   return exactObject(value, keys, field);
 }
 
+async function authoritativePrivateIntake(fetchImpl) {
+  let response;
+  try {
+    response = await fetchImpl(PRIVATE_REQUEST_INTAKE_STATUS, {
+      method: "GET",
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(30_000),
+    });
+  } catch {
+    fail("private request intake status request failed");
+  }
+  const source = await boundedResponseText(
+    response,
+    "private request intake status",
+  );
+  let value;
+  try {
+    value = JSON.parse(source);
+  } catch {
+    fail("private request intake status response was not JSON");
+  }
+  if (!response?.ok) {
+    if (
+      response?.status === 503 &&
+      hasExactKeys(value, ["error", "resetAt"]) &&
+      value.error === "private_intake_rate_limited" &&
+      canonicalIso(value.resetAt) === value.resetAt
+    ) {
+      fail(
+        `private request intake verification is rate limited until ${value.resetAt}`,
+      );
+    }
+    fail(
+      `private request intake status request returned HTTP ${response?.status}`,
+    );
+  }
+  const intake = exactObject(
+    value,
+    ["enabled", "source", "verifiedAt"],
+    "private request intake status",
+  );
+  if (
+    typeof intake.enabled !== "boolean" ||
+    intake.source !== "github-authenticated" ||
+    canonicalIso(intake.verifiedAt) !== intake.verifiedAt
+  ) {
+    fail("private request intake status returned invalid verification");
+  }
+  return intake;
+}
+
 export async function slopIdentityAssertion(
   fetchImpl = globalThis.fetch,
   delayImpl = (milliseconds) =>
@@ -1418,16 +1468,7 @@ export async function uploadPrivateTrace(
     automaticRedaction: "none",
     retention: "permanent",
   });
-  const intake = await jsonRequest(
-    fetchImpl,
-    PRIVATE_REQUEST_INTAKE_STATUS,
-    {
-      method: "GET",
-      headers: { Accept: "application/vnd.github+json" },
-    },
-    ["enabled"],
-    "private request intake status",
-  );
+  const intake = await authoritativePrivateIntake(fetchImpl);
   if (intake.enabled !== true) {
     fail(
       "private request intake is unavailable; private trace upload is blocked",
@@ -2179,7 +2220,7 @@ function previewRun(options) {
     network: [
       `With --allow-package-execution, resolve exact ccusage@${CCUSAGE_VERSION} during doctor and measured runs; fetch it from the package registry only when it is not already cached`,
       `On start and finish, fetch current project terms from https://slop.cash/projects/${PROJECT.projectId}/terms.json and any digest-bound LICENSE, inbound terms, or prize rules from github.com, raw.githubusercontent.com, or proximityprize.org as named by that policy`,
-      `Verify the public private-request intake gate at ${PRIVATE_REQUEST_INTAKE_STATUS}; trace upload remains blocked unless it reports enabled`,
+      `Verify the server-authenticated private-request intake gate at ${PRIVATE_REQUEST_INTAKE_STATUS}; trace upload remains blocked unless it reports enabled`,
       `After a local byte/digest disclosure, authenticate with GitHub and permanently upload the inspected trace through ${TRACE_AUTHORITY} under ${TRACE_PRIVACY_CONTRACT}`,
     ],
     automaticUploads: [],

--- a/skills/contribute-to-heir-elements-sdk/scripts/run-receipt.mjs
+++ b/skills/contribute-to-heir-elements-sdk/scripts/run-receipt.mjs
@@ -82,8 +82,7 @@ const AUTHORIZATION_RECEIPT = ".slop-authorization.json";
 const TRACE_AUTHORITY = "https://api.slop.cash";
 const IDENTITY_AUTHORITY = "https://identity.slop.cash";
 const TRACE_PRIVACY_CONTRACT = "https://slop.cash/protocol/private-trace-v1.md";
-const PRIVATE_REQUEST_INTAKE_STATUS =
-  "https://api.github.com/repos/SlopDotCash/slopdotcash/private-vulnerability-reporting";
+const PRIVATE_REQUEST_INTAKE_STATUS = `${TRACE_AUTHORITY}/api/v1/private-request-intake`;
 const LEGACY_V1_RECEIPT_IDENTITIES = new Map([
   [
     "delta-star",
@@ -1245,6 +1244,57 @@ async function jsonRequest(fetchImpl, url, options, keys, field) {
   return exactObject(value, keys, field);
 }
 
+async function authoritativePrivateIntake(fetchImpl) {
+  let response;
+  try {
+    response = await fetchImpl(PRIVATE_REQUEST_INTAKE_STATUS, {
+      method: "GET",
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(30_000),
+    });
+  } catch {
+    fail("private request intake status request failed");
+  }
+  const source = await boundedResponseText(
+    response,
+    "private request intake status",
+  );
+  let value;
+  try {
+    value = JSON.parse(source);
+  } catch {
+    fail("private request intake status response was not JSON");
+  }
+  if (!response?.ok) {
+    if (
+      response?.status === 503 &&
+      hasExactKeys(value, ["error", "resetAt"]) &&
+      value.error === "private_intake_rate_limited" &&
+      canonicalIso(value.resetAt) === value.resetAt
+    ) {
+      fail(
+        `private request intake verification is rate limited until ${value.resetAt}`,
+      );
+    }
+    fail(
+      `private request intake status request returned HTTP ${response?.status}`,
+    );
+  }
+  const intake = exactObject(
+    value,
+    ["enabled", "source", "verifiedAt"],
+    "private request intake status",
+  );
+  if (
+    typeof intake.enabled !== "boolean" ||
+    intake.source !== "github-authenticated" ||
+    canonicalIso(intake.verifiedAt) !== intake.verifiedAt
+  ) {
+    fail("private request intake status returned invalid verification");
+  }
+  return intake;
+}
+
 export async function slopIdentityAssertion(
   fetchImpl = globalThis.fetch,
   delayImpl = (milliseconds) =>
@@ -1418,16 +1468,7 @@ export async function uploadPrivateTrace(
     automaticRedaction: "none",
     retention: "permanent",
   });
-  const intake = await jsonRequest(
-    fetchImpl,
-    PRIVATE_REQUEST_INTAKE_STATUS,
-    {
-      method: "GET",
-      headers: { Accept: "application/vnd.github+json" },
-    },
-    ["enabled"],
-    "private request intake status",
-  );
+  const intake = await authoritativePrivateIntake(fetchImpl);
   if (intake.enabled !== true) {
     fail(
       "private request intake is unavailable; private trace upload is blocked",
@@ -2179,7 +2220,7 @@ function previewRun(options) {
     network: [
       `With --allow-package-execution, resolve exact ccusage@${CCUSAGE_VERSION} during doctor and measured runs; fetch it from the package registry only when it is not already cached`,
       `On start and finish, fetch current project terms from https://slop.cash/projects/${PROJECT.projectId}/terms.json and any digest-bound LICENSE, inbound terms, or prize rules from github.com, raw.githubusercontent.com, or proximityprize.org as named by that policy`,
-      `Verify the public private-request intake gate at ${PRIVATE_REQUEST_INTAKE_STATUS}; trace upload remains blocked unless it reports enabled`,
+      `Verify the server-authenticated private-request intake gate at ${PRIVATE_REQUEST_INTAKE_STATUS}; trace upload remains blocked unless it reports enabled`,
       `After a local byte/digest disclosure, authenticate with GitHub and permanently upload the inspected trace through ${TRACE_AUTHORITY} under ${TRACE_PRIVACY_CONTRACT}`,
     ],
     automaticUploads: [],


### PR DESCRIPTION
## Summary

- replace every contributor CLI's anonymous GitHub private-intake probe with a bounded Slop-authoritative preflight
- authenticate the canonical GitHub repository check only on the server, pin the GitHub API version, reject redirects, bound the response, and cache verified status for five minutes
- fail closed before cache access when the server credential is missing or malformed
- distinguish rate-limit reset diagnostics from generic intake unavailability before contributor identity authorization
- require the Pages secret inventory and verify the authenticated endpoint after deployment

Fixes #255.

## Validation

- TDD regression: cached `enabled: true` plus absent credential returns `503 private_intake_unavailable` and makes no upstream request
- focused backend and deployment contracts: 39/39 passed
- Vitest repository lane: 616/616 passed
- exact measured-run subprocess test: 1/1 passed in isolation
- production build: passed
- browser E2E: 36/36 passed across wide desktop, desktop, tablet, and narrow mobile
- published-artifact consistency E2E: 1/1 passed
- four packaged `run-receipt.mjs` copies: byte-identical
- typecheck, Biome format/lint, dependency audit, protocol/registry checks, and `git diff --check`: passed

`bun run verify` reached the aggregate skill lane twice with all prior gates and 616 Vitest tests green; Bun then killed one measured-run child process and reported a null subprocess status (89/90 skill tests). The exact same test passes in isolation. This change does not modify that test or its subprocess lifecycle.

## Evidence

- backend contract: covered by request/response tests for authenticated success, cached success, missing credential, malformed upstream response, and bounded rate-limit reset
- deployment evidence: workflow canary requires HTTP 200, exact response keys, `enabled: true`, authenticated source, valid timestamp, and the private-trace contract header
- screenshots/video: N/A — no UI behavior or pixels changed
- frontend console/network logs: N/A — contributor CLI and server/deployment boundary only

## Operational prerequisite

Before deployment, maintainers must provision the Pages secret `PRIVATE_INTAKE_GITHUB_TOKEN` with read-only access sufficient for the canonical repository's private-vulnerability-reporting status endpoint. No write permission is required. The deployment secret inventory and runtime preflight fail closed if this is absent.

GitHub permission reference: https://docs.github.com/en/rest/authentication/permissions-required-for-fine-grained-personal-access-tokens

## Contribution provenance

- AI-assisted: yes
- provider/model: OpenAI / GPT-5.6
- client/agent tooling: Codex desktop agent
- authorized Slop base revision: `1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42`
- implementation head: `f37867b9cc51a560cab241c60191fd14102a9520`
- attribution status: self-reported

## Safety

- [x] No secrets, tokens, private traces, or wallet material are committed or logged
- [x] No deployment, merge, approval, or fund movement was performed
- [x] Contributor identity authorization remains after the public fail-closed preflight
- [x] Independent exact-head review found no critical, important, or minor findings
