### PR TITLE
fix(scoring): decouple review hydration from author cap

### DIFF
--- a/protocol/scoring-v2.md
+++ b/protocol/scoring-v2.md
@@ -38,16 +38,24 @@ full-detail hydration cap. Before detail hydration, the generator performs a
 bounded scalar census across the complete merged-outcome window. Every pull
 request with at least one formal review enters complete review hydration even
 when it is older than the author's five newest merges. The generator preflights
-the census and detail cost against its fixed GitHub budget and aborts without a
-snapshot if any requested node, review page, or inline-comment page is missing
-or inconsistent.
+two full census passes plus the detail cost against its fixed GitHub budget,
+retains each pull request's review count and update timestamp, and repeats the
+census immediately before assembly. It aborts without a snapshot if any
+requested node, count, timestamp, review page, or inline-comment page is missing
+or inconsistent. Review-only hydration never enables author-detail bonuses.
 
 Each collected formal review that does not score appears in the public
 `reviewExclusions` array with immutable pull-request and review node IDs, its
 canonical public URL and repository, and one closed reason enum. This makes
 self-review, bot, post-merge, duplicate-reviewer, non-decision, insufficient-
-substance, external-prize-policy, and reviewer-cycle-cap exclusions auditable
-without publishing review bodies in a second surface.
+substance, pre-existing evaluated-contribution awards, external-prize-policy,
+and reviewer-cycle-cap exclusions auditable without publishing review bodies
+in a second surface.
+
+An existing evaluated-contribution review award remains authoritative for its
+reviewer and pull request. The same review cannot also receive ordinary formal
+review credit, and a second evaluator award for that reviewer/pull-request pair
+fails closed.
 
 The `slop-review` proposal records effort, complexity, impact, review load,
 split risk, confidence, exact provider/model/client, receipt, and finalized

--- a/protocol/scoring-v2.md
+++ b/protocol/scoring-v2.md
@@ -55,7 +55,8 @@ in a second surface.
 An existing evaluated-contribution review award remains authoritative for its
 reviewer and pull request. The same review cannot also receive ordinary formal
 review credit, and a second evaluator award for that reviewer/pull-request pair
-fails closed.
+fails closed. Historic awards whose closed-unmerged parent is outside the live
+collection window remain governed by their validated evaluator manifest.
 
 The `slop-review` proposal records effort, complexity, impact, review load,
 split risk, confidence, exact provider/model/client, receipt, and finalized

--- a/protocol/scoring-v2.md
+++ b/protocol/scoring-v2.md
@@ -33,6 +33,22 @@ reproduction 3, and specialist review 8. A separate maintainer ratification
 earns 1/3 unless that actor already received review credit on the artifact.
 Self-review, post-merge review, duplicate review, and bot activity do not score.
 
+Formal review collection is independent of the reviewed pull-request author's
+full-detail hydration cap. Before detail hydration, the generator performs a
+bounded scalar census across the complete merged-outcome window. Every pull
+request with at least one formal review enters complete review hydration even
+when it is older than the author's five newest merges. The generator preflights
+the census and detail cost against its fixed GitHub budget and aborts without a
+snapshot if any requested node, review page, or inline-comment page is missing
+or inconsistent.
+
+Each collected formal review that does not score appears in the public
+`reviewExclusions` array with immutable pull-request and review node IDs, its
+canonical public URL and repository, and one closed reason enum. This makes
+self-review, bot, post-merge, duplicate-reviewer, non-decision, insufficient-
+substance, external-prize-policy, and reviewer-cycle-cap exclusions auditable
+without publishing review bodies in a second surface.
+
 The `slop-review` proposal records effort, complexity, impact, review load,
 split risk, confidence, exact provider/model/client, receipt, and finalized
 private trace. Maintainers remain the sole scoring authority.

--- a/scripts/generate-leaderboard.test.ts
+++ b/scripts/generate-leaderboard.test.ts
@@ -17,6 +17,7 @@ import {
 } from "../src/lib/repositories.mjs";
 import {
   assertOpenEvidenceReferencesCurrent,
+  assertReviewCensusStable,
   collectReviewedPullRequestIds,
   collectSearchReferences,
   deriveCurrentHeadReviewDecision,
@@ -28,6 +29,7 @@ import {
   LEADERBOARD_QUERY_DOCUMENTS,
   OpenSetChangedError,
   parseGenerationArguments,
+  planMergedPullRequestHydration,
   resolveGitHubToken,
   retrySlopSnapshot,
   runGenerator,
@@ -35,7 +37,6 @@ import {
   sameReferenceSet,
   selectDetailedMergedPullRequestIds,
   selectEvaluatedContributionsForWindow,
-  selectHydratedMergedPullRequestIds,
   verifyPullRequestEvidence,
 } from "./generate-leaderboard";
 
@@ -1105,6 +1106,7 @@ describe("rate-efficient query plan", () => {
           nodes: ids.map((id) => ({
             __typename: "PullRequest",
             id,
+            updatedAt: "2026-08-25T18:00:00.000Z",
             reviews: { totalCount: id === "PR_REVIEWED" ? 2 : 0 },
           })),
         };
@@ -1148,6 +1150,33 @@ describe("rate-efficient query plan", () => {
     ).rejects.toThrow(
       "GitHub returned 0 review census nodes for 1 requested IDs",
     );
+  });
+
+  it("fails closed when review counts change before snapshot assembly", () => {
+    expect(() =>
+      assertReviewCensusStable(
+        new Map([
+          [
+            "PR_STABLE",
+            { reviewCount: 1, updatedAt: "2026-08-25T18:00:00.000Z" },
+          ],
+          [
+            "PR_CHANGED",
+            { reviewCount: 0, updatedAt: "2026-08-25T18:00:00.000Z" },
+          ],
+        ]),
+        new Map([
+          [
+            "PR_STABLE",
+            { reviewCount: 1, updatedAt: "2026-08-25T18:00:00.000Z" },
+          ],
+          [
+            "PR_CHANGED",
+            { reviewCount: 1, updatedAt: "2026-08-25T18:01:00.000Z" },
+          ],
+        ]),
+      ),
+    ).toThrow("Review census changed for PR_CHANGED");
   });
 
   it("parses every production GraphQL document", () => {
@@ -1355,6 +1384,7 @@ describe("rate-efficient query plan", () => {
         nodes: ((variables?.ids ?? []) as string[]).map((id) => ({
           __typename: "PullRequest",
           id,
+          updatedAt: mergedAt,
           reviews: { totalCount: id === "PR_101" ? 1 : 0 },
         })),
       }),
@@ -1368,16 +1398,17 @@ describe("rate-efficient query plan", () => {
       }),
     };
 
-    expect(
-      [
-        ...(await selectHydratedMergedPullRequestIds(
-          client,
-          candidates,
-          new Date("2026-06-01T00:00:00.000Z"),
-        )),
-      ].sort(),
-    ).toEqual(
+    const plan = await planMergedPullRequestHydration(
+      client,
+      candidates,
+      new Date("2026-06-01T00:00:00.000Z"),
+    );
+
+    expect([...plan.hydratedIds].sort()).toEqual(
       ["PR_101", "PR_102", "PR_103", "PR_104", "PR_105", "PR_106"].sort(),
+    );
+    expect([...plan.detailEligibleIds].sort()).toEqual(
+      ["PR_102", "PR_103", "PR_104", "PR_105", "PR_106"].sort(),
     );
   });
 

--- a/scripts/generate-leaderboard.test.ts
+++ b/scripts/generate-leaderboard.test.ts
@@ -17,6 +17,7 @@ import {
 } from "../src/lib/repositories.mjs";
 import {
   assertOpenEvidenceReferencesCurrent,
+  collectReviewedPullRequestIds,
   collectSearchReferences,
   deriveCurrentHeadReviewDecision,
   deriveSourceUpdatedAt,
@@ -34,6 +35,7 @@ import {
   sameReferenceSet,
   selectDetailedMergedPullRequestIds,
   selectEvaluatedContributionsForWindow,
+  selectHydratedMergedPullRequestIds,
   verifyPullRequestEvidence,
 } from "./generate-leaderboard";
 
@@ -1092,6 +1094,62 @@ describe("GitHub GraphQL boundary", () => {
 });
 
 describe("rate-efficient query plan", () => {
+  it("finds every reviewed merged pull request without hydrating unrelated detail", async () => {
+    const seenDocuments: string[] = [];
+    const client: GraphqlExecutor = {
+      execute: async (document, variables) => {
+        seenDocuments.push(document);
+        const ids = variables?.ids;
+        if (!Array.isArray(ids)) throw new Error("missing review census IDs");
+        return {
+          nodes: ids.map((id) => ({
+            __typename: "PullRequest",
+            id,
+            reviews: { totalCount: id === "PR_REVIEWED" ? 2 : 0 },
+          })),
+        };
+      },
+      getRequestCount: () => seenDocuments.length,
+      getRateLimit: () => ({
+        cost: 1,
+        consumedDuringRun: seenDocuments.length,
+        limit: 5_000,
+        remaining: 4_999,
+        resetAt: "2026-08-25T18:00:00.000Z",
+      }),
+    };
+
+    await expect(
+      collectReviewedPullRequestIds(client, [
+        { id: "PR_UNREVIEWED" },
+        { id: "PR_REVIEWED" },
+      ]),
+    ).resolves.toEqual(new Set(["PR_REVIEWED"]));
+    expect(seenDocuments).toHaveLength(1);
+    expect(seenDocuments[0]).toContain("reviews { totalCount }");
+    expect(seenDocuments[0]).not.toContain("reviews(first:");
+  });
+
+  it("fails closed when the review census is incomplete", async () => {
+    const client: GraphqlExecutor = {
+      execute: async () => ({ nodes: [] }),
+      getRequestCount: () => 1,
+      getRateLimit: () => ({
+        cost: 1,
+        consumedDuringRun: 1,
+        limit: 5_000,
+        remaining: 4_999,
+        resetAt: "2026-08-25T18:00:00.000Z",
+      }),
+    };
+
+    await expect(
+      collectReviewedPullRequestIds(client, [{ id: "PR_MISSING" }]),
+    ).rejects.toThrow(
+      "GitHub returned 0 review census nodes for 1 requested IDs",
+    );
+  });
+
   it("parses every production GraphQL document", () => {
     for (const [name, document] of Object.entries(
       LEADERBOARD_QUERY_DOCUMENTS,
@@ -1263,7 +1321,7 @@ describe("rate-efficient query plan", () => {
     ).toThrow("verificationWindowFrom must be a valid date");
   });
 
-  it("deep-inspects the newest budgeted outcomes when merge timestamps tie", () => {
+  it("hydrates reviewed outcomes independently of the author detail cap", async () => {
     const mergedAt = "2026-07-15T12:00:00.000Z";
     const outcome = (id: string): MergedPullRequestOutcome => ({
       id,
@@ -1292,14 +1350,35 @@ describe("rate-efficient query plan", () => {
       "PR_106",
     ].map((id) => ({ outcome: outcome(id), projectId: "eliza" }));
 
+    const client: GraphqlExecutor = {
+      execute: async (_document, variables) => ({
+        nodes: ((variables?.ids ?? []) as string[]).map((id) => ({
+          __typename: "PullRequest",
+          id,
+          reviews: { totalCount: id === "PR_101" ? 1 : 0 },
+        })),
+      }),
+      getRequestCount: () => 0,
+      getRateLimit: () => ({
+        cost: 0,
+        consumedDuringRun: 0,
+        limit: 5_000,
+        remaining: 5_000,
+        resetAt: "2026-08-25T18:00:00.000Z",
+      }),
+    };
+
     expect(
       [
-        ...selectDetailedMergedPullRequestIds(
+        ...(await selectHydratedMergedPullRequestIds(
+          client,
           candidates,
           new Date("2026-06-01T00:00:00.000Z"),
-        ),
+        )),
       ].sort(),
-    ).toEqual(["PR_102", "PR_103", "PR_104", "PR_105", "PR_106"].sort());
+    ).toEqual(
+      ["PR_101", "PR_102", "PR_103", "PR_104", "PR_105", "PR_106"].sort(),
+    );
   });
 
   it("recollects only typed concurrent changes to the non-scoring queue", async () => {

--- a/scripts/generate-leaderboard.ts
+++ b/scripts/generate-leaderboard.ts
@@ -412,6 +412,7 @@ const REVIEWED_PULL_REQUEST_REFERENCES_QUERY = `
       __typename
       ... on PullRequest {
         id
+        updatedAt
         reviews { totalCount }
       }
     }
@@ -1496,22 +1497,29 @@ function chunks<T>(values: T[], size: number): T[][] {
   return result;
 }
 
-export async function collectReviewedPullRequestIds(
+export interface ReviewCensusEntry {
+  reviewCount: number;
+  updatedAt: string;
+}
+
+export async function collectPullRequestReviewCounts(
   client: GraphqlExecutor,
   references: ReadonlyArray<{ id: string }>,
-): Promise<Set<string>> {
+  reservedPasses = 1,
+): Promise<Map<string, ReviewCensusEntry>> {
   const batches = chunks([...references], REVIEW_DETAIL_BATCH_SIZE);
   const rateLimit = client.getRateLimit();
   const available = Math.min(
     MAX_GENERATION_COST - rateLimit.consumedDuringRun,
     rateLimit.remaining - MINIMUM_RATE_LIMIT_RESERVE,
   );
-  if (batches.length > available) {
+  const estimatedCost = batches.length * reservedPasses;
+  if (estimatedCost > available) {
     throw new Error(
-      `Review census cost ${batches.length} exceeds the safe GraphQL budget ${available}; no partial snapshot will be written`,
+      `Review census cost ${estimatedCost} exceeds the safe GraphQL budget ${available}; no partial snapshot will be written`,
     );
   }
-  const reviewed = new Set<string>();
+  const reviewCounts = new Map<string, ReviewCensusEntry>();
   for (const batch of batches) {
     const data = await client.execute(REVIEWED_PULL_REQUEST_REFERENCES_QUERY, {
       ids: batch.map((reference) => reference.id),
@@ -1540,10 +1548,26 @@ export async function collectReviewedPullRequestIds(
           `${path}.reviews.totalCount must be a non-negative integer`,
         );
       }
-      if (totalCount > 0) reviewed.add(reference.id);
+      const updatedAt = asString(node.updatedAt, `${path}.updatedAt`);
+      if (!Number.isFinite(Date.parse(updatedAt))) {
+        throw new Error(`${path}.updatedAt must be an ISO timestamp`);
+      }
+      reviewCounts.set(reference.id, { reviewCount: totalCount, updatedAt });
     }
   }
-  return reviewed;
+  return reviewCounts;
+}
+
+export async function collectReviewedPullRequestIds(
+  client: GraphqlExecutor,
+  references: ReadonlyArray<{ id: string }>,
+): Promise<Set<string>> {
+  const reviewCounts = await collectPullRequestReviewCounts(client, references);
+  return new Set(
+    [...reviewCounts].flatMap(([id, entry]) =>
+      entry.reviewCount > 0 ? [id] : [],
+    ),
+  );
 }
 
 async function preflightRepository(
@@ -2307,15 +2331,70 @@ export async function selectHydratedMergedPullRequestIds(
   }>,
   verificationWindowFrom: Date,
 ): Promise<Set<string>> {
-  const reviewedPullRequestIds = await collectReviewedPullRequestIds(
+  return (
+    await planMergedPullRequestHydration(
+      client,
+      candidates,
+      verificationWindowFrom,
+    )
+  ).hydratedIds;
+}
+
+export interface MergedPullRequestHydrationPlan {
+  detailEligibleIds: Set<string>;
+  hydratedIds: Set<string>;
+  reviewCounts: Map<string, ReviewCensusEntry>;
+}
+
+export async function planMergedPullRequestHydration(
+  client: GraphqlExecutor,
+  candidates: ReadonlyArray<{
+    outcome: MergedPullRequestOutcome;
+    projectId: string;
+  }>,
+  verificationWindowFrom: Date,
+): Promise<MergedPullRequestHydrationPlan> {
+  const detailEligibleIds = selectDetailedMergedPullRequestIds(
+    candidates,
+    verificationWindowFrom,
+  );
+  const reviewCounts = await collectPullRequestReviewCounts(
     client,
     candidates.map(({ outcome }) => ({ id: outcome.id })),
+    2,
   );
-  return selectDetailedMergedPullRequestIds(
+  const reviewedPullRequestIds = new Set(
+    [...reviewCounts].flatMap(([id, entry]) =>
+      entry.reviewCount > 0 ? [id] : [],
+    ),
+  );
+  const hydratedIds = selectDetailedMergedPullRequestIds(
     candidates,
     verificationWindowFrom,
     reviewedPullRequestIds,
   );
+  return { detailEligibleIds, hydratedIds, reviewCounts };
+}
+
+export function assertReviewCensusStable(
+  before: ReadonlyMap<string, ReviewCensusEntry>,
+  after: ReadonlyMap<string, ReviewCensusEntry>,
+): void {
+  if (before.size !== after.size) {
+    throw new Error("Review census changed identity before snapshot assembly");
+  }
+  for (const [id, entry] of before) {
+    const current = after.get(id);
+    if (
+      !current ||
+      current.reviewCount !== entry.reviewCount ||
+      current.updatedAt !== entry.updatedAt
+    ) {
+      throw new Error(
+        `Review census changed for ${id} before snapshot assembly`,
+      );
+    }
+  }
 }
 
 async function collectOpenIssues(
@@ -2323,6 +2402,7 @@ async function collectOpenIssues(
   targetRepository: TargetRepository,
   repositoryId: string,
   onProgress: (progress: GenerationProgress) => void,
+  reservedCost = 0,
 ): Promise<IssueRecord[]> {
   for (let attempt = 1; attempt <= MAX_TRANSIENT_ATTEMPTS; attempt += 1) {
     try {
@@ -2336,7 +2416,7 @@ async function collectOpenIssues(
       if (before.repositoryId !== repositoryId) {
         throw new Error("GitHub returned an inconsistent repository node ID");
       }
-      assertEstimatedBudget(client, 0, before.references.length);
+      assertEstimatedBudget(client, 0, before.references.length, reservedCost);
       return await hydrateIssues(
         client,
         before.references,
@@ -2363,6 +2443,7 @@ async function collectOpenPullRequests(
   targetRepository: TargetRepository,
   repositoryId: string,
   onProgress: (progress: GenerationProgress) => void,
+  reservedCost = 0,
 ): Promise<PullRequestRecord[]> {
   for (let attempt = 1; attempt <= MAX_TRANSIENT_ATTEMPTS; attempt += 1) {
     try {
@@ -2376,7 +2457,7 @@ async function collectOpenPullRequests(
       if (before.repositoryId !== repositoryId) {
         throw new Error("GitHub returned an inconsistent repository node ID");
       }
-      assertEstimatedBudget(client, before.references.length, 0);
+      assertEstimatedBudget(client, before.references.length, 0, reservedCost);
       return await hydratePullRequests(
         client,
         before.references,
@@ -2471,6 +2552,7 @@ function assertEstimatedBudget(
   client: GraphqlExecutor,
   pullRequestCount: number,
   issueCount: number,
+  reservedCost = 0,
 ): void {
   const rateLimit = client.getRateLimit();
   const estimate = estimateFirstPageDetailCost(pullRequestCount, issueCount);
@@ -2478,9 +2560,9 @@ function assertEstimatedBudget(
     MAX_GENERATION_COST - rateLimit.consumedDuringRun,
     rateLimit.remaining - MINIMUM_RATE_LIMIT_RESERVE,
   );
-  if (estimate > available) {
+  if (estimate + reservedCost > available) {
     throw new Error(
-      `Estimated first-page detail cost ${estimate} exceeds the safe GraphQL budget ${available}; no partial snapshot will be written`,
+      `Estimated first-page detail cost ${estimate} plus reserved cost ${reservedCost} exceeds the safe GraphQL budget ${available}; no partial snapshot will be written`,
     );
   }
 }
@@ -2865,21 +2947,30 @@ export async function generateLeaderboardFromGitHub(
     });
   }
 
-  const detailedMergedPullRequestIds = await selectHydratedMergedPullRequestIds(
+  const hydrationCandidates = collections.flatMap((collection) =>
+    collection.mergedPullRequestOutcomes.map((outcome) => ({
+      outcome,
+      projectId: collection.repository.projectId,
+    })),
+  );
+  const hydrationPlan = await planMergedPullRequestHydration(
     client,
-    collections.flatMap((collection) =>
-      collection.mergedPullRequestOutcomes.map((outcome) => ({
-        outcome,
-        projectId: collection.repository.projectId,
-      })),
-    ),
+    hydrationCandidates,
     verificationWindowFrom,
+  );
+  const finalReviewCensusCost = Math.ceil(
+    hydrationCandidates.length / REVIEW_DETAIL_BATCH_SIZE,
   );
   for (const collection of collections) {
     const detailedReferences = collection.mergedPullRequestReferences.filter(
-      (reference) => detailedMergedPullRequestIds.has(reference.id),
+      (reference) => hydrationPlan.hydratedIds.has(reference.id),
     );
-    assertEstimatedBudget(client, detailedReferences.length, 0);
+    assertEstimatedBudget(
+      client,
+      detailedReferences.length,
+      0,
+      finalReviewCensusCost,
+    );
     const detailedPullRequests = await hydratePullRequests(
       client,
       detailedReferences,
@@ -2887,17 +2978,36 @@ export async function generateLeaderboardFromGitHub(
       onProgress,
       "merged-pull-requests",
     );
+    for (const pullRequest of detailedPullRequests) {
+      const censusCount = hydrationPlan.reviewCounts.get(pullRequest.id);
+      if (
+        censusCount === undefined ||
+        pullRequest.reviews.length !== censusCount.reviewCount ||
+        pullRequest.updatedAt !== censusCount.updatedAt
+      ) {
+        throw new Error(
+          `Review census changed for ${pullRequest.id} during detail hydration`,
+        );
+      }
+    }
     mergedPullRequests.push(...detailedPullRequests);
 
     const linkedIssueIds = new Set(
-      detailedPullRequests.flatMap(
-        (pullRequest) => pullRequest.closingIssueIds,
-      ),
+      detailedPullRequests
+        .filter((pullRequest) =>
+          hydrationPlan.detailEligibleIds.has(pullRequest.id),
+        )
+        .flatMap((pullRequest) => pullRequest.closingIssueIds),
     );
     const linkedClosedIssueReferences = collection.closedIssueReferences.filter(
       (reference) => linkedIssueIds.has(reference.id),
     );
-    assertEstimatedBudget(client, 0, linkedClosedIssueReferences.length);
+    assertEstimatedBudget(
+      client,
+      0,
+      linkedClosedIssueReferences.length,
+      finalReviewCensusCost,
+    );
     closedIssues.push(
       ...(await hydrateIssues(
         client,
@@ -2912,17 +3022,22 @@ export async function generateLeaderboardFromGitHub(
       collection.repository,
       collection.preflight.id,
       onProgress,
+      finalReviewCensusCost,
     );
     collection.openPullRequests = await collectOpenPullRequests(
       client,
       collection.repository,
       collection.preflight.id,
       onProgress,
+      finalReviewCensusCost,
     );
   }
 
   const dedupedOutcomes = dedupeByNodeId(mergedPullRequestOutcomes);
   const dedupedMergedPullRequests = dedupeByNodeId(mergedPullRequests);
+  const detailEligibleMergedPullRequests = dedupedMergedPullRequests.filter(
+    (pullRequest) => hydrationPlan.detailEligibleIds.has(pullRequest.id),
+  );
   const dedupedClosedIssues = dedupeByNodeId(closedIssues);
   const { evidenceVerification, openIssues, openPullRequests } =
     await retrySlopSnapshot(async (attempt) => {
@@ -2933,6 +3048,7 @@ export async function generateLeaderboardFromGitHub(
             collection.repository,
             collection.preflight.id,
             onProgress,
+            finalReviewCensusCost,
           );
         }
       }
@@ -2943,7 +3059,7 @@ export async function generateLeaderboardFromGitHub(
         collections.flatMap((collection) => collection.openPullRequests),
       );
       const currentEvidenceVerification = await verifyPullRequestEvidence(
-        [...dedupedMergedPullRequests, ...currentOpenPullRequests],
+        [...detailEligibleMergedPullRequests, ...currentOpenPullRequests],
         options,
       );
       for (const collection of collections) {
@@ -2967,6 +3083,12 @@ export async function generateLeaderboardFromGitHub(
         openPullRequests: currentOpenPullRequests,
       };
     });
+
+  const finalReviewCounts = await collectPullRequestReviewCounts(
+    client,
+    hydrationCandidates.map(({ outcome }) => ({ id: outcome.id })),
+  );
+  assertReviewCensusStable(hydrationPlan.reviewCounts, finalReviewCounts);
 
   const allRecords = [
     ...dedupedOutcomes,
@@ -2996,7 +3118,7 @@ export async function generateLeaderboardFromGitHub(
     rateLimit,
     counts: {
       mergedPullRequests: dedupedOutcomes.length,
-      detailedMergedPullRequests: dedupedMergedPullRequests.length,
+      detailedMergedPullRequests: detailEligibleMergedPullRequests.length,
       closedIssues: closedIssueCount,
       detailedClosedIssues: dedupedClosedIssues.length,
       resolvedIssues: 0,
@@ -3024,6 +3146,7 @@ export async function generateLeaderboardFromGitHub(
     source,
     mergedPullRequestOutcomes: dedupedOutcomes,
     mergedPullRequests: dedupedMergedPullRequests,
+    detailEligibleMergedPullRequestIds: [...hydrationPlan.detailEligibleIds],
     closedIssueCount,
     resolvedIssues: dedupedClosedIssues,
     openIssues,

--- a/scripts/generate-leaderboard.ts
+++ b/scripts/generate-leaderboard.ts
@@ -406,6 +406,19 @@ const PULL_REQUEST_DETAILS_QUERY = `
   ${PULL_REQUEST_FRAGMENT}
 `;
 
+const REVIEWED_PULL_REQUEST_REFERENCES_QUERY = `
+  query LeaderboardReviewedPullRequestReferences($ids: [ID!]!) {
+    nodes(ids: $ids) {
+      __typename
+      ... on PullRequest {
+        id
+        reviews { totalCount }
+      }
+    }
+    rateLimit { cost limit remaining resetAt }
+  }
+`;
+
 const ISSUE_DETAILS_QUERY = `
   query LeaderboardIssueDetails($ids: [ID!]!) {
     nodes(ids: $ids) {
@@ -589,6 +602,7 @@ export const LEADERBOARD_QUERY_DOCUMENTS = {
   openPullRequestReferences: OPEN_PULL_REQUEST_REFERENCES_QUERY,
   issueDetails: ISSUE_DETAILS_QUERY,
   pullRequestDetails: PULL_REQUEST_DETAILS_QUERY,
+  reviewedPullRequestReferences: REVIEWED_PULL_REQUEST_REFERENCES_QUERY,
   reviewInlineComments: REVIEW_INLINE_COMMENTS_QUERY,
   morePullRequestComments: MORE_PULL_REQUEST_COMMENTS_QUERY,
   moreIssueComments: MORE_ISSUE_COMMENTS_QUERY,
@@ -1482,6 +1496,56 @@ function chunks<T>(values: T[], size: number): T[][] {
   return result;
 }
 
+export async function collectReviewedPullRequestIds(
+  client: GraphqlExecutor,
+  references: ReadonlyArray<{ id: string }>,
+): Promise<Set<string>> {
+  const batches = chunks([...references], REVIEW_DETAIL_BATCH_SIZE);
+  const rateLimit = client.getRateLimit();
+  const available = Math.min(
+    MAX_GENERATION_COST - rateLimit.consumedDuringRun,
+    rateLimit.remaining - MINIMUM_RATE_LIMIT_RESERVE,
+  );
+  if (batches.length > available) {
+    throw new Error(
+      `Review census cost ${batches.length} exceeds the safe GraphQL budget ${available}; no partial snapshot will be written`,
+    );
+  }
+  const reviewed = new Set<string>();
+  for (const batch of batches) {
+    const data = await client.execute(REVIEWED_PULL_REQUEST_REFERENCES_QUERY, {
+      ids: batch.map((reference) => reference.id),
+    });
+    const nodes = asArray(data.nodes, "data.nodes");
+    if (nodes.length !== batch.length) {
+      throw new Error(
+        `GitHub returned ${nodes.length} review census nodes for ${batch.length} requested IDs`,
+      );
+    }
+    for (const [index, reference] of batch.entries()) {
+      const path = `data.nodes[${index}]`;
+      const node = asRecord(nodes[index], path);
+      if (
+        node.__typename !== "PullRequest" ||
+        asString(node.id, `${path}.id`) !== reference.id
+      ) {
+        throw new Error(`${path} did not match the requested pull request`);
+      }
+      const totalCount = asNumber(
+        child(node, "reviews", path).totalCount,
+        `${path}.reviews.totalCount`,
+      );
+      if (!Number.isSafeInteger(totalCount) || totalCount < 0) {
+        throw new Error(
+          `${path}.reviews.totalCount must be a non-negative integer`,
+        );
+      }
+      if (totalCount > 0) reviewed.add(reference.id);
+    }
+  }
+  return reviewed;
+}
+
 async function preflightRepository(
   client: GraphqlExecutor,
   targetRepository: TargetRepository,
@@ -2195,6 +2259,7 @@ export function selectDetailedMergedPullRequestIds(
     projectId: string;
   }>,
   verificationWindowFrom: Date,
+  reviewedPullRequestIds: ReadonlySet<string> = new Set(),
 ): Set<string> {
   const from = verificationWindowFrom.getTime();
   if (!Number.isFinite(from)) {
@@ -2202,6 +2267,14 @@ export function selectDetailedMergedPullRequestIds(
   }
   const usage = new Map<string, number>();
   const selected = new Set<string>();
+  for (const { outcome } of candidates) {
+    if (
+      reviewedPullRequestIds.has(outcome.id) &&
+      Date.parse(outcome.mergedAt) >= from
+    ) {
+      selected.add(outcome.id);
+    }
+  }
   for (const candidate of [...candidates].sort(
     (left, right) =>
       right.outcome.mergedAt.localeCompare(left.outcome.mergedAt) ||
@@ -2224,6 +2297,25 @@ export function selectDetailedMergedPullRequestIds(
     selected.add(outcome.id);
   }
   return selected;
+}
+
+export async function selectHydratedMergedPullRequestIds(
+  client: GraphqlExecutor,
+  candidates: ReadonlyArray<{
+    outcome: MergedPullRequestOutcome;
+    projectId: string;
+  }>,
+  verificationWindowFrom: Date,
+): Promise<Set<string>> {
+  const reviewedPullRequestIds = await collectReviewedPullRequestIds(
+    client,
+    candidates.map(({ outcome }) => ({ id: outcome.id })),
+  );
+  return selectDetailedMergedPullRequestIds(
+    candidates,
+    verificationWindowFrom,
+    reviewedPullRequestIds,
+  );
 }
 
 async function collectOpenIssues(
@@ -2773,7 +2865,8 @@ export async function generateLeaderboardFromGitHub(
     });
   }
 
-  const detailedMergedPullRequestIds = selectDetailedMergedPullRequestIds(
+  const detailedMergedPullRequestIds = await selectHydratedMergedPullRequestIds(
+    client,
     collections.flatMap((collection) =>
       collection.mergedPullRequestOutcomes.map((outcome) => ({
         outcome,

--- a/src/lib/leaderboard.test.ts
+++ b/src/lib/leaderboard.test.ts
@@ -418,6 +418,9 @@ function input(overrides: Partial<LeaderboardInput> = {}): LeaderboardInput {
       deletions: pullRequest.deletions,
     })),
     mergedPullRequests,
+    detailEligibleMergedPullRequestIds: mergedPullRequests.map(
+      (pullRequest) => pullRequest.id,
+    ),
     closedIssueCount: resolvedIssues.length,
     resolvedIssues,
     openIssues: [],
@@ -618,6 +621,7 @@ describe("score v2 work units", () => {
       {
         id: "PR_REVIEW_EXCLUSIONS:review-exclusion:REVIEW_SELF",
         pullRequestId: "PR_REVIEW_EXCLUSIONS",
+        pullRequestNumber: 61,
         reason: "self-review",
         repository: "elizaOS/eliza",
         reviewId: "REVIEW_SELF",
@@ -626,6 +630,7 @@ describe("score v2 work units", () => {
       {
         id: "PR_REVIEW_EXCLUSIONS:review-exclusion:REVIEW_THIN",
         pullRequestId: "PR_REVIEW_EXCLUSIONS",
+        pullRequestNumber: 61,
         reason: "insufficient-substance",
         repository: "elizaOS/eliza",
         reviewId: "REVIEW_THIN",
@@ -634,9 +639,22 @@ describe("score v2 work units", () => {
     ]);
 
     const invalid = structuredClone(snapshot);
+    if (invalid.reviewExclusions?.[0] === undefined) {
+      throw new Error("expected a review exclusion fixture");
+    }
     invalid.reviewExclusions[0].reason = "author-detail-cap" as never;
     expect(() => assertLeaderboardSnapshot(invalid)).toThrow(
       "snapshot.reviewExclusions[0].reason",
+    );
+
+    const invalidUrl = structuredClone(snapshot);
+    if (invalidUrl.reviewExclusions?.[0] === undefined) {
+      throw new Error("expected a review exclusion fixture");
+    }
+    invalidUrl.reviewExclusions[0].url =
+      "https://github.com/elizaOS/eliza/pull/61";
+    expect(() => assertLeaderboardSnapshot(invalidUrl)).toThrow(
+      "review URL must identify",
     );
 
     const legacy = structuredClone(snapshot) as Partial<LeaderboardSnapshot>;
@@ -2137,6 +2155,186 @@ describe("scoring and limits", () => {
         }),
       ),
     ).toThrow("duplicates a score-bearing source");
+  });
+
+  it("scores an out-of-cap formal review without enabling author bonuses", () => {
+    const reviewer = actor("outside-cap-reviewer");
+    const merged = pullRequest({
+      id: "PR_OUTSIDE_DETAIL_CAP",
+      number: 77,
+      files: [
+        {
+          path: "src/review-cap.test.ts",
+          additions: MATERIAL_TEST_ADDITIONS,
+          deletions: MATERIAL_TEST_CHURN - MATERIAL_TEST_ADDITIONS,
+        },
+      ],
+      reviews: [
+        {
+          id: "REVIEW_OUTSIDE_DETAIL_CAP",
+          body: "This review identifies the exact regression and its required fix.",
+          state: "APPROVED",
+          submittedAt: "2026-07-30T10:00:00.000Z",
+          url: "https://github.com/elizaOS/eliza/pull/77#pullrequestreview-770",
+          author: reviewer,
+          inlineCommentCount: 0,
+        },
+      ],
+    });
+
+    const snapshot = createLeaderboardSnapshot(
+      input({
+        mergedPullRequests: [merged],
+        detailEligibleMergedPullRequestIds: [],
+      }),
+    );
+
+    expect(snapshot.ledger).toContainEqual(
+      expect.objectContaining({
+        category: "substantive-review",
+        source: expect.objectContaining({ id: "REVIEW_OUTSIDE_DETAIL_CAP" }),
+      }),
+    );
+    expect(snapshot.ledger).not.toContainEqual(
+      expect.objectContaining({
+        category: "material-test-change",
+        actor: merged.author,
+      }),
+    );
+    expect(snapshot.source.counts.detailedMergedPullRequests).toBe(0);
+
+    const contradictory = structuredClone(snapshot);
+    contradictory.reviewExclusions = [
+      {
+        id: `${merged.id}:review-exclusion:REVIEW_OUTSIDE_DETAIL_CAP`,
+        pullRequestId: merged.id,
+        pullRequestNumber: merged.number,
+        reason: "insufficient-substance",
+        repository: "elizaOS/eliza",
+        reviewId: "REVIEW_OUTSIDE_DETAIL_CAP",
+        url: "https://github.com/elizaOS/eliza/pull/77#pullrequestreview-770",
+      },
+    ];
+    expect(() => assertLeaderboardSnapshot(contradictory)).toThrow(
+      "cannot contain a score-bearing review source",
+    );
+  });
+
+  it("rejects a detail-eligible pull request that was not hydrated", () => {
+    expect(() =>
+      createLeaderboardSnapshot(
+        input({
+          mergedPullRequests: [],
+          detailEligibleMergedPullRequestIds: ["PR_NOT_HYDRATED"],
+        }),
+      ),
+    ).toThrow("Detail-eligible pull request PR_NOT_HYDRATED was not hydrated");
+  });
+
+  it("keeps an evaluated review award authoritative over ordinary review credit", () => {
+    const reviewer = actor("evaluated-reviewer");
+    const submittedAt = "2026-07-28T10:00:00.000Z";
+    const priorReview = {
+      id: "REVIEW_EVALUATED_PRIOR",
+      body: "This earlier review also identified a concrete blocking defect.",
+      state: "CHANGES_REQUESTED",
+      submittedAt: "2026-07-27T10:00:00.000Z",
+      url: "https://github.com/elizaOS/eliza/pull/78#pullrequestreview-779",
+      author: reviewer,
+      inlineCommentCount: 0,
+    };
+    const review = {
+      id: "REVIEW_EVALUATED_AUTHORITY",
+      body: "This exact-head review found and explained a material defect.",
+      state: "CHANGES_REQUESTED",
+      submittedAt,
+      url: "https://github.com/elizaOS/eliza/pull/78#pullrequestreview-780",
+      author: reviewer,
+      inlineCommentCount: 0,
+    };
+    const merged = pullRequest({
+      id: "PR_EVALUATED_AUTHORITY",
+      number: 78,
+      reviews: [priorReview, review],
+    });
+    const evaluated = {
+      ...evaluatedContribution(0, reviewer),
+      occurredAt: submittedAt,
+      source: {
+        id: review.id,
+        kind: "review" as const,
+        number: merged.number,
+        title: merged.title,
+        url: review.url,
+      },
+    };
+
+    const snapshot = createLeaderboardSnapshot(
+      input({
+        mergedPullRequests: [merged],
+        detailEligibleMergedPullRequestIds: [],
+        evaluatedContributions: [evaluated],
+      }),
+    );
+
+    expect(
+      snapshot.ledger.filter((event) => event.source.id === review.id),
+    ).toEqual([expect.objectContaining({ id: evaluated.id, points: 4 })]);
+    expect(snapshot.reviewExclusions).toEqual([
+      expect.objectContaining({
+        reviewId: priorReview.id,
+        reason: "evaluated-contribution-award",
+      }),
+    ]);
+  });
+
+  it("rejects two evaluator awards for one reviewer and pull request", () => {
+    const reviewer = actor("duplicate-evaluated-reviewer");
+    const firstReview = {
+      id: "REVIEW_EVALUATED_DUPLICATE_1",
+      body: "This review identifies the first concrete blocking defect.",
+      state: "CHANGES_REQUESTED",
+      submittedAt: "2026-07-27T10:00:00.000Z",
+      url: "https://github.com/elizaOS/eliza/pull/79#pullrequestreview-791",
+      author: reviewer,
+      inlineCommentCount: 0,
+    };
+    const secondReview = {
+      ...firstReview,
+      id: "REVIEW_EVALUATED_DUPLICATE_2",
+      body: "This review identifies the second concrete blocking defect.",
+      submittedAt: "2026-07-28T10:00:00.000Z",
+      url: "https://github.com/elizaOS/eliza/pull/79#pullrequestreview-792",
+    };
+    const merged = pullRequest({
+      id: "PR_EVALUATED_DUPLICATE",
+      number: 79,
+      reviews: [firstReview, secondReview],
+    });
+    const award = (review: typeof firstReview, index: number): ScoreEvent => ({
+      ...evaluatedContribution(index, reviewer),
+      id: `award_review_duplicate_${index}`,
+      occurredAt: review.submittedAt,
+      source: {
+        id: review.id,
+        kind: "review",
+        number: merged.number,
+        title: merged.title,
+        url: review.url,
+      },
+    });
+
+    expect(() =>
+      createLeaderboardSnapshot(
+        input({
+          mergedPullRequests: [merged],
+          evaluatedContributions: [
+            award(firstReview, 0),
+            award(secondReview, 1),
+          ],
+        }),
+      ),
+    ).toThrow("duplicates a reviewer/pull-request award");
   });
 
   it("scores accepted outcomes while capping evidence and reviews", () => {

--- a/src/lib/leaderboard.test.ts
+++ b/src/lib/leaderboard.test.ts
@@ -862,6 +862,29 @@ describe("score v2 work units", () => {
       scoreThirds: 3,
       evidenceBonusBasisPoints: 1_500,
     });
+    const outsideAuthorDetailCap = createLeaderboardSnapshot({
+      ...postUsageBonusInput,
+      detailEligibleMergedPullRequestIds: [],
+      verifyRunReceipt: (value) => value as ProjectRunReceipt,
+    });
+    expect(
+      outsideAuthorDetailCap.ledger.find(
+        (event) => event.id === `${pr.id}:automated-review:${source.id}`,
+      ),
+    ).toMatchObject({
+      scoreThirds: 3,
+      evidenceBonusBasisPoints: 1_500,
+    });
+    expect(
+      outsideAuthorDetailCap.ledger.find(
+        (event) => event.id === `${pr.id}:merged`,
+      ),
+    ).toMatchObject({ scoreThirds: 1 });
+    expect(
+      outsideAuthorDetailCap.ledger.find(
+        (event) => event.id === `${pr.id}:ratifier:COMMENT_V2_RATIFICATION`,
+      ),
+    ).toMatchObject({ scoreThirds: 1 });
     const legacy = structuredClone(accepted);
     legacy.generatedAt = "2026-08-18T05:00:00.000Z";
     legacy.source.fetchedAt = legacy.generatedAt;

--- a/src/lib/leaderboard.test.ts
+++ b/src/lib/leaderboard.test.ts
@@ -27,6 +27,7 @@ import {
   isNearMaterialTestChange,
   LEADERBOARD_REPOSITORY,
   type LeaderboardInput,
+  type LeaderboardSnapshot,
   MATERIAL_TEST_ADDITIONS,
   MATERIAL_TEST_CHURN,
   mergedPullRequestPoints,
@@ -580,6 +581,67 @@ describe("score v2 work units", () => {
         (event) => event.category === "merged-pull-request",
       ),
     ).toHaveLength(1);
+  });
+
+  it("publishes deterministic reasons for formal reviews that do not score", () => {
+    const pr = pullRequest({
+      id: "PR_REVIEW_EXCLUSIONS",
+      number: 61,
+      createdAt: "2026-08-17T08:00:00.000Z",
+      updatedAt: "2026-08-18T03:00:00.000Z",
+      mergedAt: "2026-08-18T03:00:00.000Z",
+      reviews: [
+        {
+          id: "REVIEW_SELF",
+          body: "I verified every required path in my own pull request.",
+          state: "APPROVED",
+          submittedAt: "2026-08-18T02:00:00.000Z",
+          url: "https://github.com/elizaOS/eliza/pull/61#pullrequestreview-601",
+          author: actor("author"),
+          inlineCommentCount: 0,
+        },
+        {
+          id: "REVIEW_THIN",
+          body: "Looks good",
+          state: "APPROVED",
+          submittedAt: "2026-08-18T02:30:00.000Z",
+          url: "https://github.com/elizaOS/eliza/pull/61#pullrequestreview-602",
+          author: actor("reviewer"),
+          inlineCommentCount: 0,
+        },
+      ],
+    });
+
+    const snapshot = createLeaderboardSnapshot(v2Input([pr]));
+
+    expect(snapshot.reviewExclusions).toEqual([
+      {
+        id: "PR_REVIEW_EXCLUSIONS:review-exclusion:REVIEW_SELF",
+        pullRequestId: "PR_REVIEW_EXCLUSIONS",
+        reason: "self-review",
+        repository: "elizaOS/eliza",
+        reviewId: "REVIEW_SELF",
+        url: "https://github.com/elizaOS/eliza/pull/61#pullrequestreview-601",
+      },
+      {
+        id: "PR_REVIEW_EXCLUSIONS:review-exclusion:REVIEW_THIN",
+        pullRequestId: "PR_REVIEW_EXCLUSIONS",
+        reason: "insufficient-substance",
+        repository: "elizaOS/eliza",
+        reviewId: "REVIEW_THIN",
+        url: "https://github.com/elizaOS/eliza/pull/61#pullrequestreview-602",
+      },
+    ]);
+
+    const invalid = structuredClone(snapshot);
+    invalid.reviewExclusions[0].reason = "author-detail-cap" as never;
+    expect(() => assertLeaderboardSnapshot(invalid)).toThrow(
+      "snapshot.reviewExclusions[0].reason",
+    );
+
+    const legacy = structuredClone(snapshot) as Partial<LeaderboardSnapshot>;
+    delete legacy.reviewExclusions;
+    expect(() => assertLeaderboardSnapshot(legacy)).not.toThrow();
   });
 
   it("rejects a self slop-score without a second maintainer co-ratifier", () => {
@@ -2193,7 +2255,7 @@ describe("scoring and limits", () => {
           body: "A human review of automated churn must not become an incentive.",
           state: "APPROVED",
           submittedAt: "2026-07-10T11:00:00.000Z",
-          url: "https://github.com/elizaOS/eliza/pull/3#human-review",
+          url: "https://github.com/elizaOS/eliza/pull/3#pullrequestreview-303",
           author: actor("bot-reviewer"),
           inlineCommentCount: 1,
         },
@@ -2207,7 +2269,7 @@ describe("scoring and limits", () => {
           body: "This is long enough but is still a self review.",
           state: "APPROVED",
           submittedAt: "2026-07-10T11:00:00.000Z",
-          url: "https://github.com/elizaOS/eliza/pull/1#self",
+          url: "https://github.com/elizaOS/eliza/pull/1#pullrequestreview-101",
           author: pullRequestAuthor,
           inlineCommentCount: 1,
         },
@@ -2216,7 +2278,7 @@ describe("scoring and limits", () => {
           body: "Automated approval cannot score.",
           state: "APPROVED",
           submittedAt: "2026-07-10T11:00:00.000Z",
-          url: "https://github.com/elizaOS/eliza/pull/1#bot",
+          url: "https://github.com/elizaOS/eliza/pull/1#pullrequestreview-102",
           author: bot,
           inlineCommentCount: 1,
         },
@@ -2225,7 +2287,7 @@ describe("scoring and limits", () => {
           body: "This review arrived after the pull request was merged.",
           state: "APPROVED",
           submittedAt: "2026-07-30T11:30:00.000Z",
-          url: "https://github.com/elizaOS/eliza/pull/1#late",
+          url: "https://github.com/elizaOS/eliza/pull/1#pullrequestreview-103",
           author: lateReviewer,
           inlineCommentCount: 1,
         },

--- a/src/lib/leaderboard.test.ts
+++ b/src/lib/leaderboard.test.ts
@@ -2352,7 +2352,10 @@ describe("scoring and limits", () => {
     };
     const review = {
       id: "REVIEW_EVALUATED_AUTHORITY",
-      body: "This exact-head review found and explained a material defect.",
+      body: [
+        "This exact-head review found and explained a material defect.",
+        machineAttribution("OpenAI", "gpt-5.6-sol"),
+      ].join("\n\n"),
       state: "CHANGES_REQUESTED",
       submittedAt,
       url: "https://github.com/elizaOS/eliza/pull/78#pullrequestreview-780",
@@ -2387,6 +2390,13 @@ describe("scoring and limits", () => {
     expect(
       snapshot.ledger.filter((event) => event.source.id === review.id),
     ).toEqual([expect.objectContaining({ id: evaluated.id, points: 4 })]);
+    expect(snapshot.attributions).toContainEqual(
+      expect.objectContaining({
+        actor: reviewer,
+        sourceId: review.id,
+        identifier: "openai/gpt-5.6-sol",
+      }),
+    );
     expect(snapshot.reviewExclusions).toEqual([
       expect.objectContaining({
         reviewId: priorReview.id,

--- a/src/lib/leaderboard.test.ts
+++ b/src/lib/leaderboard.test.ts
@@ -2337,6 +2337,33 @@ describe("scoring and limits", () => {
     ).toThrow("duplicates a reviewer/pull-request award");
   });
 
+  it("retains a historic review award whose closed unmerged parent is outside the live window", () => {
+    const reviewer = actor("historic-evaluated-reviewer");
+    const award: ScoreEvent = {
+      ...evaluatedContribution(0, reviewer),
+      id: "award_historic_closed_review",
+      occurredAt: "2026-07-27T10:00:00.000Z",
+      source: {
+        id: "REVIEW_HISTORIC_CLOSED",
+        kind: "review",
+        number: 79,
+        title: "Closed unmerged contribution",
+        url: "https://github.com/elizaOS/eliza/pull/79#pullrequestreview-799",
+      },
+    };
+
+    const snapshot = createLeaderboardSnapshot(
+      input({ evaluatedContributions: [award] }),
+    );
+
+    expect(snapshot.ledger).toContainEqual(
+      expect.objectContaining({
+        id: award.id,
+        source: expect.objectContaining({ id: award.source.id }),
+      }),
+    );
+  });
+
   it("scores accepted outcomes while capping evidence and reviews", () => {
     const reviewer = actor("reviewer");
     const evidenceBody = [

--- a/src/lib/leaderboard.test.ts
+++ b/src/lib/leaderboard.test.ts
@@ -885,6 +885,53 @@ describe("score v2 work units", () => {
         (event) => event.id === `${pr.id}:ratifier:COMMENT_V2_RATIFICATION`,
       ),
     ).toMatchObject({ scoreThirds: 1 });
+    const evaluatedReview = {
+      id: "REVIEW_V2_EVALUATED",
+      body: "This formal review identified a concrete release blocker.",
+      state: "CHANGES_REQUESTED",
+      submittedAt: "2026-08-18T01:00:00.000Z",
+      url: "https://github.com/elizaOS/eliza/pull/1#pullrequestreview-1001",
+      author: reviewer,
+      inlineCommentCount: 0,
+    };
+    pr.reviews = [evaluatedReview];
+    const evaluatedAward: ScoreEvent = {
+      id: "award_v2_evaluated_reviewer",
+      actor: reviewer,
+      category: "evaluated-contribution",
+      points: 4,
+      occurredAt: evaluatedReview.submittedAt,
+      repository: "elizaOS/eliza",
+      source: {
+        id: evaluatedReview.id,
+        kind: "review",
+        number: pr.number,
+        title: pr.title,
+        url: evaluatedReview.url,
+      },
+      reason: "Maintainer-evaluated review award remains authoritative.",
+      evaluation: {
+        reviewer: "maintainer",
+        reviewedAt: "2026-08-18T04:00:00.000Z",
+        decisionUrl: "https://github.com/SlopDotCash/slopdotcash/pull/99",
+        manifestPath: "evaluations/eliza/award-v2-reviewer.json",
+        manifestSha256: "a".repeat(64),
+      },
+    };
+    const reserved = createLeaderboardSnapshot({
+      ...postUsageBonusInput,
+      mergedPullRequests: [pr],
+      evaluatedContributions: [evaluatedAward],
+      verifyRunReceipt: (value) => value as ProjectRunReceipt,
+    });
+    expect(
+      reserved.ledger.find(
+        (event) => event.id === `${pr.id}:automated-review:${source.id}`,
+      ),
+    ).toBeUndefined();
+    expect(reserved.ledger).toContainEqual(
+      expect.objectContaining({ id: evaluatedAward.id }),
+    );
     const legacy = structuredClone(accepted);
     legacy.generatedAt = "2026-08-18T05:00:00.000Z";
     legacy.source.fetchedAt = legacy.generatedAt;

--- a/src/lib/leaderboard.test.ts
+++ b/src/lib/leaderboard.test.ts
@@ -1048,6 +1048,43 @@ describe("model attribution", () => {
     expect(result.declarations[0].run?.traceUpload).not.toBeNull();
   });
 
+  it("excludes a replayed trace object without discarding the scored source", () => {
+    const sourceContext = {
+      artifactUrl: "https://github.com/elizaOS/eliza/pull/1",
+      artifactHeadSha: "a".repeat(40),
+    };
+    const first = {
+      ...textSource("REVIEW_TRACE_FIRST", reviewAttribution()),
+      ...sourceContext,
+    };
+    const second = {
+      ...textSource(
+        "REVIEW_TRACE_REPLAY",
+        reviewAttribution({
+          runId: "run_01K3JZ6Y7E8M9N0P1Q2R3S4T6V",
+          traceUpload: {
+            authority: "https://api.slop.cash",
+            serverRunId: "server_review_replay",
+            objectId: `sha256:${"b".repeat(64)}`,
+            sha256: "b".repeat(64),
+          },
+        }),
+      ),
+      ...sourceContext,
+    };
+
+    const result = assessModelAttribution([first, second]);
+
+    expect(result.declarations).toHaveLength(1);
+    expect(result.declarations[0].sourceId).toBe(first.id);
+    expect(result.invalidMarkers).toContainEqual(
+      expect.objectContaining({
+        sourceId: second.id,
+        reason: expect.stringContaining("trace object already claimed"),
+      }),
+    );
+  });
+
   it("rejects review ingestion without finalization or with a mismatched join", () => {
     const missingFinalization = {
       ...textSource(

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -5414,7 +5414,7 @@ export function assertLeaderboardSnapshot(
     }
     if (
       event.category === "evaluated-contribution" &&
-      event.source.kind === "comment"
+      (event.source.kind === "comment" || event.source.kind === "review")
     ) {
       causalAttributionKeys.add(
         `${event.actor.id}\0source\0${event.source.id}`,

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -2928,7 +2928,7 @@ export function createLeaderboardSnapshot(
     string,
     { record: ScoreRatificationRecord; source: GitHubTextSource }
   >();
-  for (const pullRequest of detailEligibleMergedPullRequests) {
+  for (const pullRequest of mergedPullRequests) {
     const repository = findTargetRepositoryById(
       repositoryIdFromUrl(pullRequest.url),
     );
@@ -3051,7 +3051,9 @@ export function createLeaderboardSnapshot(
 
   for (const pullRequest of mergedPullRequestOutcomes) {
     const repositoryId = repositoryIdFromUrl(pullRequest.url);
-    const ratification = scoreRatifications.get(pullRequest.id);
+    const ratification = detailEligibleMergedPullRequestIds.has(pullRequest.id)
+      ? scoreRatifications.get(pullRequest.id)
+      : undefined;
     if (
       pullRequest.author &&
       !isBotActor(pullRequest.author) &&
@@ -3308,7 +3310,7 @@ export function createLeaderboardSnapshot(
 
     const ratification = scoreRatifications.get(pullRequest.id);
     const awardedReviewers = new Set<string>();
-    for (const source of detailEligible ? sources : []) {
+    for (const source of sources) {
       let rawReview: unknown | null;
       try {
         rawReview = parseReviewRecordBlock(source.body);
@@ -3381,7 +3383,6 @@ export function createLeaderboardSnapshot(
     }
 
     if (
-      detailEligible &&
       ratification?.source.author &&
       !sameActor(ratification.source.author, pullRequest.author) &&
       !awardedReviewers.has(ratification.source.author.id)

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -1347,6 +1347,7 @@ export function assessModelAttribution(
   const invalidSourceIds = new Set<string>();
   const humanOnlySourceIds = new Set<string>();
   const receiptArtifactMismatchSourceIds = new Set<string>();
+  const receiptClaims = new Map<string, string>();
 
   for (const source of eligibleSources) {
     if (hasMarkdownLine(source.body, HUMAN_ONLY_PATTERN)) {
@@ -1468,6 +1469,30 @@ export function assessModelAttribution(
         });
         markerIndex += 1;
         continue;
+      }
+      if (verifiedRun?.traceUpload) {
+        const claims = [
+          ["client run", verifiedRun.runId],
+          ["server run", verifiedRun.traceUpload.serverRunId],
+          ["trace object", verifiedRun.traceUpload.objectId],
+        ] as const;
+        const duplicate = claims.find(([kind, value]) =>
+          receiptClaims.has(`${kind}:${value}`),
+        );
+        if (duplicate) {
+          const [kind, value] = duplicate;
+          invalidSourceIds.add(source.id);
+          invalidMarkers.push({
+            sourceId: source.id,
+            sourceUrl: source.url,
+            reason: `run receipt excluded: ${kind} already claimed by ${receiptClaims.get(`${kind}:${value}`)}`,
+          });
+          markerIndex += 1;
+          continue;
+        }
+        for (const [kind, value] of claims) {
+          receiptClaims.set(`${kind}:${value}`, source.id);
+        }
       }
       const identifier = exactIdentifier(marker.provider, marker.model);
       validSourceIds.add(source.id);

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -3119,6 +3119,17 @@ export function createLeaderboardSnapshot(
   const evaluatedSourceKeys = new Set<string>();
   const evaluatedReviewReservations = new Set<string>();
   const evaluatedTextSources = new Map<string, GitHubTextSource>();
+  const evaluatedArtifactKeys = new Set<string>();
+  for (const artifact of [
+    ...mergedPullRequests,
+    ...openPullRequests,
+    ...resolvedIssues,
+    ...openIssues,
+  ]) {
+    evaluatedArtifactKeys.add(
+      `${repositoryIdFromUrl(artifact.url)}\0${artifact.number}`,
+    );
+  }
   for (const source of [
     ...mergedPullRequests.flatMap(pullRequestTextSources),
     ...openPullRequests.flatMap(pullRequestTextSources),
@@ -3174,10 +3185,15 @@ export function createLeaderboardSnapshot(
     const source = evaluatedTextSources.get(event.source.id);
     if (event.source.kind === "comment" || event.source.kind === "review") {
       if (
-        source?.kind !== event.source.kind ||
-        source.url !== event.source.url ||
-        source.author?.id !== event.actor.id ||
-        parseIsoTime(source.createdAt) !== occurredAt
+        (source !== undefined &&
+          (source.kind !== event.source.kind ||
+            source.url !== event.source.url ||
+            source.author?.id !== event.actor.id ||
+            parseIsoTime(source.createdAt) !== occurredAt)) ||
+        (source === undefined &&
+          evaluatedArtifactKeys.has(
+            `${event.repository}\0${event.source.number}`,
+          ))
       ) {
         throw new TypeError(
           `Evaluated contribution ${event.id} does not match its exact GitHub ${event.source.kind}`,

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -3310,6 +3310,10 @@ export function createLeaderboardSnapshot(
 
     const ratification = scoreRatifications.get(pullRequest.id);
     const awardedReviewers = new Set<string>();
+    const hasEvaluatedReviewReservation = (actorId: string): boolean =>
+      evaluatedReviewReservations.has(
+        `${repositoryId}\0${pullRequest.number}\0${actorId}`,
+      );
     for (const source of sources) {
       let rawReview: unknown | null;
       try {
@@ -3323,6 +3327,7 @@ export function createLeaderboardSnapshot(
         sameActor(source.author, pullRequest.author)
       )
         continue;
+      if (hasEvaluatedReviewReservation(source.author.id)) continue;
       const assessment = assessModelAttribution([source], {
         requireEverySource: true,
         verifyRunReceipt: input.verifyRunReceipt,
@@ -3385,6 +3390,7 @@ export function createLeaderboardSnapshot(
     if (
       ratification?.source.author &&
       !sameActor(ratification.source.author, pullRequest.author) &&
+      !hasEvaluatedReviewReservation(ratification.source.author.id) &&
       !awardedReviewers.has(ratification.source.author.id)
     ) {
       addScore(entries, ledger, {
@@ -5122,10 +5128,23 @@ export function assertLeaderboardSnapshot(
   }
 
   const evaluatedSources = new Set<string>();
+  const evaluatedReviewSemanticKeys = new Set<string>();
   const nonEvaluatedSourceIds = new Set<string>();
   const nonEvaluatedSourceUrls = new Set<string>();
   const eventsByActor = new Map<string, ScoreEvent[]>();
   for (const event of validatedLedger) {
+    if (
+      event.category === "evaluated-contribution" &&
+      event.source.kind === "review"
+    ) {
+      const semanticKey = `${event.repository}\0${event.source.number}\0${event.actor.id}`;
+      if (evaluatedReviewSemanticKeys.has(semanticKey)) {
+        throw new Error(
+          "snapshot.ledger repeats evaluated reviewer/pull-request credit",
+        );
+      }
+      evaluatedReviewSemanticKeys.add(semanticKey);
+    }
     if (event.category !== "evaluated-contribution") {
       nonEvaluatedSourceIds.add(`${event.repository}\0${event.source.id}`);
       nonEvaluatedSourceUrls.add(`${event.repository}\0${event.source.url}`);
@@ -5160,6 +5179,16 @@ export function assertLeaderboardSnapshot(
       resolvedIssues: 0,
       substantiveReviews: 0,
     };
+    if (
+      event.category === "substantive-review" &&
+      evaluatedReviewSemanticKeys.has(
+        `${event.repository}\0${event.source.number}\0${event.actor.id}`,
+      )
+    ) {
+      throw new Error(
+        `snapshot.ledger review event ${event.id} duplicates evaluated reviewer/pull-request credit`,
+      );
+    }
     if (event.category === "merged-pull-request") {
       usage.mergedPullRequests += 1;
       const group = mergedEventsByProjectMonth.get(capKey) ?? [];

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -163,6 +163,7 @@ export const REVIEW_EXCLUSION_REASONS = [
   "non-decision",
   "insufficient-substance",
   "already-awarded-reviewer",
+  "evaluated-contribution-award",
   "external-prize-policy",
   "reviewer-cycle-cap",
 ] as const;
@@ -173,6 +174,7 @@ export interface ReviewExclusion {
   id: string;
   reviewId: string;
   pullRequestId: string;
+  pullRequestNumber: number;
   repository: RepositoryId;
   url: string;
   reason: ReviewExclusionReason;
@@ -585,7 +587,7 @@ export interface LeaderboardSnapshot {
   source: LeaderboardSourceMetadata;
   leaders: LeaderboardEntry[];
   ledger: ScoreEvent[];
-  reviewExclusions: ReviewExclusion[];
+  reviewExclusions?: ReviewExclusion[];
   opportunities: ScoreOpportunity[];
   attributions: ModelAttribution[];
   invalidAttributionMarkers: InvalidAttributionMarker[];
@@ -604,6 +606,7 @@ export interface LeaderboardInput {
   source: LeaderboardSourceMetadata;
   mergedPullRequestOutcomes: MergedPullRequestOutcome[];
   mergedPullRequests: PullRequestRecord[];
+  detailEligibleMergedPullRequestIds: string[];
   closedIssueCount: number;
   resolvedIssues: IssueRecord[];
   openIssues: IssueRecord[];
@@ -2816,6 +2819,20 @@ export function createLeaderboardSnapshot(
       right.number - left.number ||
       left.id.localeCompare(right.id),
   );
+  const detailEligibleMergedPullRequestIds = new Set(
+    input.detailEligibleMergedPullRequestIds,
+  );
+  const mergedPullRequestIds = new Set(
+    mergedPullRequests.map((pullRequest) => pullRequest.id),
+  );
+  for (const id of detailEligibleMergedPullRequestIds) {
+    if (!mergedPullRequestIds.has(id)) {
+      throw new Error(`Detail-eligible pull request ${id} was not hydrated`);
+    }
+  }
+  const detailEligibleMergedPullRequests = mergedPullRequests.filter(
+    (pullRequest) => detailEligibleMergedPullRequestIds.has(pullRequest.id),
+  );
   const resolvedIssues = dedupeByNodeId(input.resolvedIssues)
     .filter(qualifiesResolvedIssue)
     .sort(
@@ -2829,7 +2846,7 @@ export function createLeaderboardSnapshot(
   const openPullRequests = dedupeByNodeId(input.openPullRequests);
   const verifiedEvidence = selectUniqueVerifiedEvidence(
     input.verifiedEvidence,
-    [...mergedPullRequests, ...openPullRequests],
+    [...detailEligibleMergedPullRequests, ...openPullRequests],
   );
   const entries = new Map<string, MutableLeaderboardEntry>();
   const ledger: ScoreEvent[] = [];
@@ -2843,6 +2860,7 @@ export function createLeaderboardSnapshot(
       id: `${pullRequest.id}:review-exclusion:${review.id}`,
       reviewId: review.id,
       pullRequestId: pullRequest.id,
+      pullRequestNumber: pullRequest.number,
       repository: repositoryIdFromUrl(pullRequest.url),
       url: review.url,
       reason,
@@ -2856,6 +2874,15 @@ export function createLeaderboardSnapshot(
       }
     }
   };
+  const isScoreBearingSource = (
+    repository: RepositoryId,
+    source: { id: string; url: string },
+  ): boolean =>
+    ledger.some(
+      (event) =>
+        event.repository === repository &&
+        (event.source.id === source.id || event.source.url === source.url),
+    );
   const outcomeIds = new Set(
     mergedPullRequestOutcomes.map((pullRequest) => pullRequest.id),
   );
@@ -2901,7 +2928,7 @@ export function createLeaderboardSnapshot(
     string,
     { record: ScoreRatificationRecord; source: GitHubTextSource }
   >();
-  for (const pullRequest of mergedPullRequests) {
+  for (const pullRequest of detailEligibleMergedPullRequests) {
     const repository = findTargetRepositoryById(
       repositoryIdFromUrl(pullRequest.url),
     );
@@ -3089,6 +3116,88 @@ export function createLeaderboardSnapshot(
     }
   }
 
+  const evaluatedSourceKeys = new Set<string>();
+  const evaluatedReviewReservations = new Set<string>();
+  const evaluatedTextSources = new Map<string, GitHubTextSource>();
+  for (const source of [
+    ...mergedPullRequests.flatMap(pullRequestTextSources),
+    ...openPullRequests.flatMap(pullRequestTextSources),
+    ...resolvedIssues.flatMap(issueTextSources),
+    ...openIssues.flatMap(issueTextSources),
+  ]) {
+    const existing = evaluatedTextSources.get(source.id);
+    if (
+      existing &&
+      (existing.url !== source.url ||
+        existing.body !== source.body ||
+        existing.author?.id !== source.author?.id)
+    ) {
+      throw new TypeError(
+        `Evaluated source ${source.id} has conflicting GitHub records`,
+      );
+    }
+    evaluatedTextSources.set(source.id, source);
+  }
+  const evaluatedContributions = [...(input.evaluatedContributions ?? [])].sort(
+    (left, right) =>
+      parseIsoTime(right.occurredAt) - parseIsoTime(left.occurredAt) ||
+      left.id.localeCompare(right.id),
+  );
+  for (const [index, event] of evaluatedContributions.entries()) {
+    assertLedgerValue(event, `evaluatedContributions[${index}]`);
+    if (event.category !== "evaluated-contribution") {
+      throw new TypeError(
+        `evaluatedContributions[${index}] must use the evaluated-contribution category`,
+      );
+    }
+    const occurredAt = parseIsoTime(event.occurredAt);
+    if (occurredAt < parseIsoTime(input.windowFrom) || occurredAt >= windowTo) {
+      throw new RangeError(
+        `Evaluated contribution ${event.id} falls outside the rolling window`,
+      );
+    }
+    const sourceKey = `${event.repository}\0${event.source.id}`;
+    if (
+      evaluatedSourceKeys.has(sourceKey) ||
+      ledger.some(
+        (existing) =>
+          existing.repository === event.repository &&
+          (existing.source.id === event.source.id ||
+            existing.source.url === event.source.url),
+      )
+    ) {
+      throw new TypeError(
+        `Evaluated contribution ${event.id} duplicates a score-bearing source`,
+      );
+    }
+    evaluatedSourceKeys.add(sourceKey);
+    const source = evaluatedTextSources.get(event.source.id);
+    if (event.source.kind === "comment" || event.source.kind === "review") {
+      if (
+        source?.kind !== event.source.kind ||
+        source.url !== event.source.url ||
+        source.author?.id !== event.actor.id ||
+        parseIsoTime(source.createdAt) !== occurredAt
+      ) {
+        throw new TypeError(
+          `Evaluated contribution ${event.id} does not match its exact GitHub ${event.source.kind}`,
+        );
+      }
+    }
+    if (event.source.kind === "review") {
+      const reservationKey = `${event.repository}\0${event.source.number}\0${event.actor.id}`;
+      if (evaluatedReviewReservations.has(reservationKey)) {
+        throw new TypeError(
+          `Evaluated contribution ${event.id} duplicates a reviewer/pull-request award`,
+        );
+      }
+      evaluatedReviewReservations.add(reservationKey);
+    }
+    if (addScore(entries, ledger, event) && source) {
+      recordScoredSources([source]);
+    }
+  }
+
   for (const pullRequest of mergedPullRequests) {
     if (!pullRequest.mergedAt) {
       throw new Error(
@@ -3099,9 +3208,16 @@ export function createLeaderboardSnapshot(
     const repositoryId = repositoryIdFromUrl(pullRequest.url);
     const explicitPrizeAcceptance =
       requiresExplicitPrizeAcceptance(repositoryId);
-    recordTextActivity(entries, sources);
+    const detailEligible = detailEligibleMergedPullRequestIds.has(
+      pullRequest.id,
+    );
+    if (detailEligible) recordTextActivity(entries, sources);
 
-    if (pullRequest.author && !isBotActor(pullRequest.author)) {
+    if (
+      detailEligible &&
+      pullRequest.author &&
+      !isBotActor(pullRequest.author)
+    ) {
       const authorEntry = actorEntry(entries, pullRequest.author);
       authorEntry.rawActivity.commits += pullRequest.commitCount;
       if (
@@ -3176,7 +3292,7 @@ export function createLeaderboardSnapshot(
 
     const ratification = scoreRatifications.get(pullRequest.id);
     const awardedReviewers = new Set<string>();
-    for (const source of sources) {
+    for (const source of detailEligible ? sources : []) {
       let rawReview: unknown | null;
       try {
         rawReview = parseReviewRecordBlock(source.body);
@@ -3215,6 +3331,7 @@ export function createLeaderboardSnapshot(
       if (parseIsoTime(source.createdAt) > parseIsoTime(pullRequest.mergedAt)) {
         continue;
       }
+      if (isScoreBearingSource(repositoryId, source)) continue;
       const reviewThirds = {
         triage: 1,
         standard: 3,
@@ -3248,6 +3365,7 @@ export function createLeaderboardSnapshot(
     }
 
     if (
+      detailEligible &&
       ratification?.source.author &&
       !sameActor(ratification.source.author, pullRequest.author) &&
       !awardedReviewers.has(ratification.source.author.id)
@@ -3288,6 +3406,16 @@ export function createLeaderboardSnapshot(
     )) {
       if (review.author && !isBotActor(review.author)) {
         actorEntry(entries, review.author).rawActivity.reviews += 1;
+      }
+      if (isScoreBearingSource(repositoryId, review)) continue;
+      if (
+        review.author &&
+        evaluatedReviewReservations.has(
+          `${repositoryId}\0${pullRequest.number}\0${review.author.id}`,
+        )
+      ) {
+        excludeReview(pullRequest, review, "evaluated-contribution-award");
+        continue;
       }
       const exclusionReason = reviewExclusionReason(review, pullRequest);
       if (exclusionReason !== null) {
@@ -3383,77 +3511,6 @@ export function createLeaderboardSnapshot(
     }
   }
 
-  const evaluatedSourceKeys = new Set<string>();
-  const evaluatedTextSources = new Map<string, GitHubTextSource>();
-  for (const source of [
-    ...mergedPullRequests.flatMap(pullRequestTextSources),
-    ...openPullRequests.flatMap(pullRequestTextSources),
-    ...resolvedIssues.flatMap(issueTextSources),
-    ...openIssues.flatMap(issueTextSources),
-  ]) {
-    const existing = evaluatedTextSources.get(source.id);
-    if (
-      existing &&
-      (existing.url !== source.url ||
-        existing.body !== source.body ||
-        existing.author?.id !== source.author?.id)
-    ) {
-      throw new TypeError(
-        `Evaluated source ${source.id} has conflicting GitHub records`,
-      );
-    }
-    evaluatedTextSources.set(source.id, source);
-  }
-  const evaluatedContributions = [...(input.evaluatedContributions ?? [])].sort(
-    (left, right) =>
-      parseIsoTime(right.occurredAt) - parseIsoTime(left.occurredAt) ||
-      left.id.localeCompare(right.id),
-  );
-  for (const [index, event] of evaluatedContributions.entries()) {
-    assertLedgerValue(event, `evaluatedContributions[${index}]`);
-    if (event.category !== "evaluated-contribution") {
-      throw new TypeError(
-        `evaluatedContributions[${index}] must use the evaluated-contribution category`,
-      );
-    }
-    const occurredAt = parseIsoTime(event.occurredAt);
-    if (occurredAt < parseIsoTime(input.windowFrom) || occurredAt >= windowTo) {
-      throw new RangeError(
-        `Evaluated contribution ${event.id} falls outside the rolling window`,
-      );
-    }
-    const sourceKey = `${event.repository}\0${event.source.id}`;
-    if (
-      evaluatedSourceKeys.has(sourceKey) ||
-      ledger.some(
-        (existing) =>
-          existing.repository === event.repository &&
-          (existing.source.id === event.source.id ||
-            existing.source.url === event.source.url),
-      )
-    ) {
-      throw new TypeError(
-        `Evaluated contribution ${event.id} duplicates a score-bearing source`,
-      );
-    }
-    evaluatedSourceKeys.add(sourceKey);
-    addScore(entries, ledger, event);
-    if (event.source.kind === "comment") {
-      const source = evaluatedTextSources.get(event.source.id);
-      if (
-        source?.kind !== "comment" ||
-        source.url !== event.source.url ||
-        source.author?.id !== event.actor.id ||
-        parseIsoTime(source.createdAt) !== occurredAt
-      ) {
-        throw new TypeError(
-          `Evaluated contribution ${event.id} does not match its exact GitHub comment`,
-        );
-      }
-      recordScoredSources([source]);
-    }
-  }
-
   const issueQueue = openIssues.map((record) =>
     issueWorkItem(record, input.generatedAt),
   );
@@ -3531,7 +3588,7 @@ export function createLeaderboardSnapshot(
       ...input.source,
       counts: {
         mergedPullRequests: mergedPullRequestOutcomes.length,
-        detailedMergedPullRequests: mergedPullRequests.length,
+        detailedMergedPullRequests: detailEligibleMergedPullRequests.length,
         closedIssues: input.closedIssueCount,
         detailedClosedIssues: input.resolvedIssues.length,
         resolvedIssues: resolvedIssues.length,
@@ -3903,6 +3960,7 @@ function assertReviewExclusionValue(value: unknown, path: string): void {
   const expectedKeys = [
     "id",
     "pullRequestId",
+    "pullRequestNumber",
     "reason",
     "repository",
     "reviewId",
@@ -3916,6 +3974,10 @@ function assertReviewExclusionValue(value: unknown, path: string): void {
   }
   assertString(exclusion.id, `${path}.id`);
   assertString(exclusion.pullRequestId, `${path}.pullRequestId`);
+  assertPositiveInteger(
+    exclusion.pullRequestNumber,
+    `${path}.pullRequestNumber`,
+  );
   assertString(exclusion.reviewId, `${path}.reviewId`);
   if (
     exclusion.id !==
@@ -3929,10 +3991,13 @@ function assertReviewExclusionValue(value: unknown, path: string): void {
     TARGET_REPOSITORIES.map((repository) => repository.id),
     `${path}.repository`,
   );
-  assertString(exclusion.url, `${path}.url`);
-  if (repositoryIdFromUrl(exclusion.url) !== exclusion.repository) {
-    throw new Error(`${path}.url must match ${path}.repository`);
-  }
+  assertRepositoryUrl(
+    exclusion.url,
+    `${path}.url`,
+    "review",
+    exclusion.pullRequestNumber,
+    exclusion.repository as RepositoryId,
+  );
 }
 
 function assertSourceValue(value: unknown, path: string): void {
@@ -4982,6 +5047,20 @@ export function assertLeaderboardSnapshot(
     ) {
       throw new Error("snapshot.reviewExclusions must contain unique IDs");
     }
+    for (const exclusion of validatedReviewExclusions) {
+      if (
+        validatedLedger.some(
+          (event) =>
+            event.repository === exclusion.repository &&
+            (event.source.id === exclusion.reviewId ||
+              event.source.url === exclusion.url),
+        )
+      ) {
+        throw new Error(
+          "snapshot.reviewExclusions cannot contain a score-bearing review source",
+        );
+      }
+    }
     for (let index = 1; index < validatedReviewExclusions.length; index += 1) {
       const previous = validatedReviewExclusions[index - 1];
       const current = validatedReviewExclusions[index];
@@ -5502,14 +5581,16 @@ export function assertLeaderboardSnapshot(
   const detailedPullRequestIds = new Set(
     validatedLedger
       .filter((event) =>
-        ["material-test-change", "evidence", "substantive-review"].includes(
-          event.category,
-        ),
+        ["material-test-change", "evidence"].includes(event.category),
       )
-      .map((event) =>
-        event.category === "substantive-review"
-          ? event.id.split(/:(?:automated-review|ratifier|reviewer):/u)[0]
-          : event.source.id,
+      .map((event) => event.source.id),
+  );
+  const reviewedPullRequestIds = new Set(
+    validatedLedger
+      .filter((event) => event.category === "substantive-review")
+      .map(
+        (event) =>
+          event.id.split(/:(?:automated-review|ratifier|reviewer):/u)[0],
       ),
   );
   const resolvedIssueEvents = validatedLedger.filter(
@@ -5533,6 +5614,7 @@ export function assertLeaderboardSnapshot(
   if (
     mergedOutcomeEvents.length > mergedPullRequestCount ||
     detailedPullRequestIds.size > detailedMergedPullRequestCount ||
+    reviewedPullRequestIds.size > mergedPullRequestCount ||
     resolvedIssueEvents.length > resolvedIssueCount
   ) {
     throw new Error(

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -151,6 +151,33 @@ export interface PullRequestReview {
   inlineCommentCount: number;
 }
 
+export const REVIEW_EXCLUSION_REASONS = [
+  "missing-reviewer",
+  "bot-reviewer",
+  "missing-pull-request-author",
+  "bot-pull-request-author",
+  "self-review",
+  "missing-submission-time",
+  "unmerged-pull-request",
+  "post-merge",
+  "non-decision",
+  "insufficient-substance",
+  "already-awarded-reviewer",
+  "external-prize-policy",
+  "reviewer-cycle-cap",
+] as const;
+
+export type ReviewExclusionReason = (typeof REVIEW_EXCLUSION_REASONS)[number];
+
+export interface ReviewExclusion {
+  id: string;
+  reviewId: string;
+  pullRequestId: string;
+  repository: RepositoryId;
+  url: string;
+  reason: ReviewExclusionReason;
+}
+
 export interface PullRequestRecord {
   id: string;
   number: number;
@@ -558,6 +585,7 @@ export interface LeaderboardSnapshot {
   source: LeaderboardSourceMetadata;
   leaders: LeaderboardEntry[];
   ledger: ScoreEvent[];
+  reviewExclusions: ReviewExclusion[];
   opportunities: ScoreOpportunity[];
   attributions: ModelAttribution[];
   invalidAttributionMarkers: InvalidAttributionMarker[];
@@ -1616,30 +1644,32 @@ export function isSubstantiveReview(
   review: PullRequestReview,
   pullRequest: PullRequestRecord,
 ): boolean {
-  if (
-    !review.author ||
-    isBotActor(review.author) ||
-    !pullRequest.author ||
-    isBotActor(pullRequest.author)
-  ) {
-    return false;
-  }
+  return reviewExclusionReason(review, pullRequest) === null;
+}
+
+function reviewExclusionReason(
+  review: PullRequestReview,
+  pullRequest: PullRequestRecord,
+): ReviewExclusionReason | null {
+  if (!review.author) return "missing-reviewer";
+  if (isBotActor(review.author)) return "bot-reviewer";
+  if (!pullRequest.author) return "missing-pull-request-author";
+  if (isBotActor(pullRequest.author)) return "bot-pull-request-author";
   if (
     review.author.id === pullRequest.author.id ||
     review.author.login.toLowerCase() === pullRequest.author.login.toLowerCase()
   ) {
-    return false;
+    return "self-review";
   }
-  if (!review.submittedAt || !pullRequest.mergedAt) {
-    return false;
-  }
+  if (!review.submittedAt) return "missing-submission-time";
+  if (!pullRequest.mergedAt) return "unmerged-pull-request";
   if (parseIsoTime(review.submittedAt) > parseIsoTime(pullRequest.mergedAt)) {
-    return false;
+    return "post-merge";
   }
   if (!["APPROVED", "CHANGES_REQUESTED"].includes(review.state)) {
-    return false;
+    return "non-decision";
   }
-  return hasSubstantiveReviewBody(review);
+  return hasSubstantiveReviewBody(review) ? null : "insufficient-substance";
 }
 
 /**
@@ -1728,7 +1758,7 @@ export function leaderboardMethodology(): LeaderboardMethodology {
           "triage 1/3; standard 1; deep reproduction 3; specialist 8; ratification 1/3",
         cap: "uncapped; no self-review and no duplicate reviewer credit on one artifact",
         qualification:
-          "Within the published deep-inspection set of human-authored pull requests, a pre-merge APPROVED or CHANGES_REQUESTED review has substantive text or inline discussion.",
+          "Every merged pull request with a formal review is selected through a separate bounded review census, independent of the pull-request author's detail cap. A pre-merge APPROVED or CHANGES_REQUESTED review of human-authored work has substantive text or inline discussion; excluded formal reviews publish a machine-readable reason.",
       },
       {
         id: "evaluated-contribution",
@@ -1767,7 +1797,7 @@ export function leaderboardMethodology(): LeaderboardMethodology {
     ],
     provenancePolicy:
       "Leaderboard model identifiers come only from text sources causally attached to a scored contribution by the same actor. Exact provider/model declarations, human-only declarations, and contribution-attribution markers remain self-reported provenance; complete, partial, missing, and invalid states add no points.",
-    collectionPolicy: `The same complete collection pipeline runs for every repository in the published project registry; records merge by immutable GitHub node ID and every artifact keeps its repository attribution. Score v2 applies to work from 2026-08-01 UTC. Every accepted merge receives at least provisional micro credit. Higher scores require an unedited maintainer-authored slop-score record bound to the PR node ID and exact head SHA; corrections append a successor. Proposal review records disclose exact provider, model, client, run, trace, effort, complexity, impact, review load, split risk, and confidence. XL and exceptional decisions require a second maintainer. Project reward views exclude work before the published reward start.`,
+    collectionPolicy: `The same complete collection pipeline runs for every repository in the published project registry; records merge by immutable GitHub node ID and every artifact keeps its repository attribution. A scalar-only, budget-preflighted census selects every merged pull request with formal reviews for complete review hydration; missing or inconsistent census/detail data aborts the snapshot instead of publishing partial review credit. Score v2 applies to work from 2026-08-01 UTC. Every accepted merge receives at least provisional micro credit. Higher scores require an unedited maintainer-authored slop-score record bound to the PR node ID and exact head SHA; corrections append a successor. Proposal review records disclose exact provider, model, client, run, trace, effort, complexity, impact, review load, split risk, and confidence. XL and exceptional decisions require a second maintainer. Project reward views exclude work before the published reward start.`,
   };
 }
 
@@ -2803,6 +2833,21 @@ export function createLeaderboardSnapshot(
   );
   const entries = new Map<string, MutableLeaderboardEntry>();
   const ledger: ScoreEvent[] = [];
+  const reviewExclusions: ReviewExclusion[] = [];
+  const excludeReview = (
+    pullRequest: PullRequestRecord,
+    review: PullRequestReview,
+    reason: ReviewExclusionReason,
+  ): void => {
+    reviewExclusions.push({
+      id: `${pullRequest.id}:review-exclusion:${review.id}`,
+      reviewId: review.id,
+      pullRequestId: pullRequest.id,
+      repository: repositoryIdFromUrl(pullRequest.url),
+      url: review.url,
+      reason,
+    });
+  };
   const scoredAttributionSources = new Map<string, GitHubTextSource>();
   const recordScoredSources = (sources: GitHubTextSource[]): void => {
     for (const source of sources) {
@@ -3244,12 +3289,20 @@ export function createLeaderboardSnapshot(
       if (review.author && !isBotActor(review.author)) {
         actorEntry(entries, review.author).rawActivity.reviews += 1;
       }
-      if (
-        !review.author ||
-        awardedReviewers.has(review.author.id) ||
-        explicitPrizeAcceptance ||
-        !isSubstantiveReview(review, pullRequest)
-      ) {
+      const exclusionReason = reviewExclusionReason(review, pullRequest);
+      if (exclusionReason !== null) {
+        excludeReview(pullRequest, review, exclusionReason);
+        continue;
+      }
+      if (!review.author) {
+        throw new Error("Qualifying review lost its reviewer");
+      }
+      if (awardedReviewers.has(review.author.id)) {
+        excludeReview(pullRequest, review, "already-awarded-reviewer");
+        continue;
+      }
+      if (explicitPrizeAcceptance) {
+        excludeReview(pullRequest, review, "external-prize-policy");
         continue;
       }
       if (!review.submittedAt) {
@@ -3280,6 +3333,8 @@ export function createLeaderboardSnapshot(
         if (source) {
           recordScoredSources([source]);
         }
+      } else {
+        excludeReview(pullRequest, review, "reviewer-cycle-cap");
       }
     }
   }
@@ -3495,6 +3550,11 @@ export function createLeaderboardSnapshot(
         right.points - left.points ||
         left.source.number - right.source.number ||
         left.id.localeCompare(right.id),
+    ),
+    reviewExclusions: reviewExclusions.sort(
+      (left, right) =>
+        left.pullRequestId.localeCompare(right.pullRequestId) ||
+        left.reviewId.localeCompare(right.reviewId),
     ),
     opportunities,
     attributions,
@@ -3836,6 +3896,43 @@ function assertMethodologyValue(value: unknown, path: string): void {
   );
   assertString(methodology.provenancePolicy, `${path}.provenancePolicy`);
   assertString(methodology.collectionPolicy, `${path}.collectionPolicy`);
+}
+
+function assertReviewExclusionValue(value: unknown, path: string): void {
+  const exclusion = assertObject(value, path);
+  const expectedKeys = [
+    "id",
+    "pullRequestId",
+    "reason",
+    "repository",
+    "reviewId",
+    "url",
+  ];
+  if (
+    JSON.stringify(Object.keys(exclusion).sort()) !==
+    JSON.stringify(expectedKeys)
+  ) {
+    throw new Error(`${path} must contain exactly the review exclusion fields`);
+  }
+  assertString(exclusion.id, `${path}.id`);
+  assertString(exclusion.pullRequestId, `${path}.pullRequestId`);
+  assertString(exclusion.reviewId, `${path}.reviewId`);
+  if (
+    exclusion.id !==
+    `${exclusion.pullRequestId}:review-exclusion:${exclusion.reviewId}`
+  ) {
+    throw new Error(`${path}.id must bind the pull request and review IDs`);
+  }
+  assertEnum(exclusion.reason, REVIEW_EXCLUSION_REASONS, `${path}.reason`);
+  assertEnum(
+    exclusion.repository,
+    TARGET_REPOSITORIES.map((repository) => repository.id),
+    `${path}.repository`,
+  );
+  assertString(exclusion.url, `${path}.url`);
+  if (repositoryIdFromUrl(exclusion.url) !== exclusion.repository) {
+    throw new Error(`${path}.url must match ${path}.repository`);
+  }
 }
 
 function assertSourceValue(value: unknown, path: string): void {
@@ -4860,6 +4957,44 @@ export function assertLeaderboardSnapshot(
     validatedLedger.length
   ) {
     throw new Error("snapshot.ledger must contain unique score event IDs");
+  }
+
+  const reviewExclusions = snapshot.reviewExclusions;
+  if (reviewExclusions === undefined) {
+    // Schema 6 was deployed before this additive audit field existed. Newly
+    // generated snapshots always publish it, while readers remain compatible
+    // with the last deployed snapshot during rollout.
+  } else if (!Array.isArray(reviewExclusions)) {
+    throw new Error("snapshot.reviewExclusions must be an array");
+  } else {
+    const validatedReviewExclusions = reviewExclusions.map(
+      (exclusion, index) => {
+        assertReviewExclusionValue(
+          exclusion,
+          `snapshot.reviewExclusions[${index}]`,
+        );
+        return exclusion;
+      },
+    );
+    if (
+      new Set(validatedReviewExclusions.map((exclusion) => exclusion.id))
+        .size !== validatedReviewExclusions.length
+    ) {
+      throw new Error("snapshot.reviewExclusions must contain unique IDs");
+    }
+    for (let index = 1; index < validatedReviewExclusions.length; index += 1) {
+      const previous = validatedReviewExclusions[index - 1];
+      const current = validatedReviewExclusions[index];
+      if (
+        previous.pullRequestId.localeCompare(current.pullRequestId) > 0 ||
+        (previous.pullRequestId === current.pullRequestId &&
+          previous.reviewId.localeCompare(current.reviewId) > 0)
+      ) {
+        throw new Error(
+          "snapshot.reviewExclusions must be ordered by pull request and review ID",
+        );
+      }
+    }
   }
 
   if (!Array.isArray(snapshot.opportunities)) {

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -307,6 +307,7 @@ export function snapshotFixture(): LeaderboardSnapshot {
         reason: "Substantive review completed before merge.",
       },
     ],
+    reviewExclusions: [],
     opportunities: [
       {
         id: "PR_open_fixture:opportunity:missing-evidence",


### PR DESCRIPTION
## Summary

- decouple formal review discovery and scoring from the reviewed author's five-PR detail cap while preserving the capped author-only evidence and activity paths
- retain a complete review census with initial hydration and final exact recensus checks for IDs, review counts, and update timestamps
- make evaluator-awarded reviewer/PR reservations authoritative across formal, automated, and ratifier credit while retaining valid historic awards
- preserve signed review attribution, quarantine replayed run receipts deterministically, and publish machine-readable review exclusions

Fixes #254.

Base: `1a2017b9fbbcef4263da9dda8d0b4e1d0a7bff42`

Head: `05e09245d3a532d6102b291ff136759cbf86b325`

## Validation

- `bunx vitest run src/lib/leaderboard.test.ts scripts/generate-leaderboard.test.ts` — 157 passed
- `bun run verify` — 64 Vitest files / 621 tests passed; 89 skill tests passed; project, award, funding, cycle, protocol, dependency, type, format, lint, and production-build gates passed
- `bun run test:e2e` — 36 responsive browser tests passed; 1 byte-consistent artifact test passed
- `bun run leaderboard:generate` in a detached clean worktree at the exact head — wrote a valid live snapshot with 121 leaders, 9,752 score events, 616 GraphQL requests, and 4,447/5,000 rate-limit points remaining
- independent exact-head Sol xhigh review — no Critical, Important, or Minor findings; Ready: yes

The live generator exposed and drove fail-closed repairs for evaluator-award collisions, historic closed-unmerged awards, volatile open-set recensus, replayed private trace objects, and evaluated-review causal attribution. No generated leaderboard snapshot is included in this PR.

## Evidence

- Before screenshots: N/A - scoring and GitHub collection change; no UI changed
- After screenshots: N/A - scoring and GitHub collection change; no UI changed
- Walkthrough video: N/A - no interactive product surface changed
- Backend logs: canonical live generator completed at the exact head with 121 leaders, 9,752 score events, 616 GraphQL requests, and 4,447/5,000 rate-limit points remaining
- Frontend console/network logs: N/A - no frontend code changed
- Real-LLM trajectory: N/A - deterministic scoring and collection code; no model behavior changed
- Domain artifacts: isolated live `leaderboard.json` passed publishability validation; awarded review `PRR_kwDOMT5cIs8AAAABKglAuA` retained its evaluator event and signed attribution, while replayed trace-object claims were quarantined

## Contribution provenance

- AI assistance: Yes - implementation, tests, live proof, and independent review
- AI provider/model: OpenAI / GPT-5.6 (Luna and Terra analysis; Sol xhigh exact-head review)
- Client / agent tooling: Codex desktop
- Contribution skill revision: N/A - Slop scoring-repository fix; no downstream project contributor skill was invoked
- Attribution status: self-reported

## Slop protocol changes

- Project manifest (`projects/<id>/project.json`): N/A - no project proposal or manifest change
- Contributor skill (`skills/contribute-to-<id>/`): N/A - no contributor-skill change
- Isolated reviewer skill (`skills/review-<id>-contributions/`): N/A - no reviewer-skill change
- Evaluated-contribution award (`evaluations/<id>/award-*.json`): N/A - existing awards are validated and preserved unchanged
- Reward-cycle transition (`cycles/<id>/<YYYY-MM>/`): N/A - no reward-cycle transition

`protocol/scoring-v2.md` documents the complete review census, author-cap isolation, evaluated-review authority, and historic award boundary.

## Safety review

- [x] No private key, seed phrase, API token, raw private trajectory, or secret was added.
- [x] Untrusted project code is not executed with repository or deployment credentials.
- [x] New telemetry is bounded, disclosed, project-attributed, and covered by adversarial tests.
- [x] Money state is derived from validated manifests and finalized on-chain evidence, not a transaction signature alone.
