### PR TITLE
fix: make scheduled score refresh resilient across tracked repos

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,10 +15,11 @@ on:
   workflow_dispatch:
 
 concurrency:
-  # PR supersessions cancel, while trusted runs keep independent quality lanes
-  # so a release awaiting approval cannot block fresh verification.
-  group: slop-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # Serialize trusted refreshes so scheduled and develop-push runs cannot
+  # overlap their expensive all-repository GitHub GraphQL scans. PRs retain
+  # independent groups and cancel only their own superseded revisions.
+  group: slop-${{ github.event_name == 'pull_request' && github.event.pull_request.number || 'trusted' }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/scripts/deployment-contract.test.mjs
+++ b/scripts/deployment-contract.test.mjs
@@ -78,6 +78,14 @@ const qualityJob = workflow.slice(
 const deployJob = workflow.slice(workflow.indexOf("\n  deploy:"));
 
 describe("slop.cash deployment contract", () => {
+  it("refreshes the complete manifest-backed leaderboard every six hours", () => {
+    expect(workflow).toContain('- cron: "17 */6 * * *"');
+    expect(qualityJob).toContain("run: bun run leaderboard:generate");
+    expect(qualityJob).toContain(`GH_TOKEN: ${"$"}{{ github.token }}`);
+    expect(qualityJob).toContain(`GITHUB_TOKEN: ${"$"}{{ github.token }}`);
+    expect(qualityJob).toContain("if: github.event_name != 'pull_request'");
+  });
+
   it("rewrites the nested project funding route through the Pages SPA", () => {
     const redirects = pagesRedirects.trim().split("\n");
     expect(redirects).toContain("/projects/:project/funding/ / 200");

--- a/scripts/deployment-contract.test.mjs
+++ b/scripts/deployment-contract.test.mjs
@@ -84,6 +84,10 @@ describe("slop.cash deployment contract", () => {
     expect(qualityJob).toContain(`GH_TOKEN: ${"$"}{{ github.token }}`);
     expect(qualityJob).toContain(`GITHUB_TOKEN: ${"$"}{{ github.token }}`);
     expect(qualityJob).toContain("if: github.event_name != 'pull_request'");
+    expect(workflow).toContain(
+      `group: slop-${"$"}{{ github.event_name == 'pull_request' && github.event.pull_request.number || 'trusted' }}`,
+    );
+    expect(workflow).toContain("cancel-in-progress: true");
   });
 
   it("rewrites the nested project funding route through the Pages SPA", () => {
@@ -343,11 +347,9 @@ describe("slop.cash deployment contract", () => {
   });
 
   it("keeps every release path restricted to develop", () => {
+    expect(workflow).toContain("cancel-in-progress: true");
     expect(workflow).toContain(
-      `cancel-in-progress: ${"$"}{{ github.event_name == 'pull_request' }}`,
-    );
-    expect(workflow).toContain(
-      `group: slop-${"$"}{{ github.event.pull_request.number || github.run_id }}`,
+      `group: slop-${"$"}{{ github.event_name == 'pull_request' && github.event.pull_request.number || 'trusted' }}`,
     );
     expect(deployJob).toContain(
       "github.event_name == 'push' && github.ref == 'refs/heads/develop'",

--- a/scripts/generate-leaderboard.test.ts
+++ b/scripts/generate-leaderboard.test.ts
@@ -31,6 +31,7 @@ import {
   parseGenerationArguments,
   planMergedPullRequestHydration,
   resolveGitHubToken,
+  retryOpenBatch,
   retrySlopSnapshot,
   runGenerator,
   SEARCH_SAFE_RESULT_LIMIT,
@@ -1443,6 +1444,23 @@ describe("rate-efficient query plan", () => {
       "Open evidence changed during 3 consecutive verification attempts",
     );
     expect(attempts).toBe(3);
+  });
+
+  it("retries only a changing open-work hydration batch", async () => {
+    let attempts = 0;
+    await expect(
+      retryOpenBatch("open", async () => {
+        attempts += 1;
+        if (attempts < 3) throw new OpenSetChangedError("open work moved");
+        return ["stable-pr"];
+      }),
+    ).resolves.toEqual(["stable-pr"]);
+    expect(attempts).toBe(3);
+    await expect(
+      retryOpenBatch("merged", async () => {
+        throw new OpenSetChangedError("merged outcome changed");
+      }),
+    ).rejects.toThrow("merged outcome changed");
   });
 });
 

--- a/scripts/generate-leaderboard.test.ts
+++ b/scripts/generate-leaderboard.test.ts
@@ -848,6 +848,29 @@ describe("GitHub GraphQL boundary", () => {
     expect(client.getRateLimit().consumedDuringRun).toBe(1);
   });
 
+  it("backs off and retries secondary-rate-limit responses", async () => {
+    let attempts = 0;
+    const fetcher = async () => {
+      attempts += 1;
+      if (attempts < 3) {
+        return new Response(
+          JSON.stringify({ message: "You have exceeded a secondary rate limit" }),
+          { status: 403, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return successResponse();
+    };
+    const client = new GitHubGraphqlClient("secret-token", fetcher, {
+      retryBaseDelayMs: 0,
+      secondaryRateLimitDelayMs: 0,
+    });
+
+    await expect(
+      client.execute("query { viewer { login } }"),
+    ).resolves.toMatchObject({ viewer: { login: "eliza" } });
+    expect(attempts).toBe(3);
+  });
+
   it("retries transient network failures before returning validated data", async () => {
     let attempts = 0;
     const fetcher = async () => {

--- a/scripts/generate-leaderboard.ts
+++ b/scripts/generate-leaderboard.ts
@@ -2208,18 +2208,24 @@ async function hydratePullRequests(
 ): Promise<PullRequestRecord[]> {
   const pending: PendingPullRequestRecord[] = [];
   for (const batch of chunks(references, DETAIL_BATCH_SIZE)) {
-    const ids = batch.map((reference) => reference.id);
-    const data = await client.execute(PULL_REQUEST_DETAILS_QUERY, { ids });
-    const parsed = parseDetailBatch(data, ids, "PullRequest", parsePullRequest);
-    for (const value of parsed) {
-      validateRecordState(value, expectedState);
-      pending.push(await completePullRequestConnections(client, value));
-      onProgress({
-        phase,
-        completed: pending.length,
-        total: references.length,
-      });
-    }
+    const hydratedBatch = await retryOpenBatch(expectedState, async () => {
+      const ids = batch.map((reference) => reference.id);
+      const data = await client.execute(PULL_REQUEST_DETAILS_QUERY, { ids });
+      const parsed = parseDetailBatch(
+        data,
+        ids,
+        "PullRequest",
+        parsePullRequest,
+      );
+      const completed: PendingPullRequestRecord[] = [];
+      for (const value of parsed) {
+        validateRecordState(value, expectedState);
+        completed.push(await completePullRequestConnections(client, value));
+      }
+      return completed;
+    });
+    pending.push(...hydratedBatch);
+    onProgress({ phase, completed: pending.length, total: references.length });
   }
   const pullRequests = await finalizePullRequests(client, pending);
   onProgress({
@@ -2239,20 +2245,44 @@ async function hydrateIssues(
 ): Promise<IssueRecord[]> {
   const issues: IssueRecord[] = [];
   for (const batch of chunks(references, DETAIL_BATCH_SIZE)) {
-    const ids = batch.map((reference) => reference.id);
-    const data = await client.execute(ISSUE_DETAILS_QUERY, { ids });
-    const parsed = parseDetailBatch(data, ids, "Issue", parseIssue);
-    for (const value of parsed) {
-      validateRecordState(value, expectedState);
-      issues.push(await completeIssueConnections(client, value));
-      onProgress({
-        phase,
-        completed: issues.length,
-        total: references.length,
-      });
-    }
+    const hydratedBatch = await retryOpenBatch(expectedState, async () => {
+      const ids = batch.map((reference) => reference.id);
+      const data = await client.execute(ISSUE_DETAILS_QUERY, { ids });
+      const parsed = parseDetailBatch(data, ids, "Issue", parseIssue);
+      const completed: IssueRecord[] = [];
+      for (const value of parsed) {
+        validateRecordState(value, expectedState);
+        completed.push(await completeIssueConnections(client, value));
+      }
+      return completed;
+    });
+    issues.push(...hydratedBatch);
+    onProgress({ phase, completed: issues.length, total: references.length });
   }
   return issues;
+}
+
+/** Retry only the small open-work batch that moved while it was hydrated. */
+export async function retryOpenBatch<T>(
+  expectedState: ExpectedRecordState,
+  hydrate: () => Promise<T>,
+): Promise<T> {
+  let lastChange: OpenSetChangedError | null = null;
+  const attempts = expectedState === "open" ? MAX_TRANSIENT_ATTEMPTS : 1;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return await hydrate();
+    } catch (error) {
+      if (expectedState !== "open" || !(error instanceof OpenSetChangedError)) {
+        throw error;
+      }
+      lastChange = error;
+    }
+  }
+  throw new OpenSetChangedError(
+    `Open work batch changed during ${MAX_TRANSIENT_ATTEMPTS} consecutive hydration attempts`,
+    { cause: lastChange },
+  );
 }
 
 export function sameReferenceSet(

--- a/scripts/generate-leaderboard.ts
+++ b/scripts/generate-leaderboard.ts
@@ -1043,6 +1043,7 @@ export interface GitHubGraphqlClientOptions {
   maxGenerationCost?: number;
   minimumRateLimitReserve?: number;
   retryBaseDelayMs?: number;
+  secondaryRateLimitDelayMs?: number;
 }
 
 function isTransientNetworkError(value: unknown): boolean {
@@ -1145,6 +1146,7 @@ export class GitHubGraphqlClient implements GraphqlExecutor {
   readonly #maxGenerationCost: number;
   readonly #minimumRateLimitReserve: number;
   readonly #retryBaseDelayMs: number;
+  readonly #secondaryRateLimitDelayMs: number;
   #requestCount = 0;
   #rateLimit: RateLimitSnapshot | null = null;
   #consumedCost = 0;
@@ -1174,11 +1176,13 @@ export class GitHubGraphqlClient implements GraphqlExecutor {
     const minimumRateLimitReserve =
       options.minimumRateLimitReserve ?? MINIMUM_RATE_LIMIT_RESERVE;
     const retryBaseDelayMs = options.retryBaseDelayMs ?? 250;
+    const secondaryRateLimitDelayMs = options.secondaryRateLimitDelayMs ?? 15_000;
     for (const [name, value] of [
       ["requestTimeoutMs", requestTimeoutMs],
       ["maxGenerationCost", maxGenerationCost],
       ["minimumRateLimitReserve", minimumRateLimitReserve],
       ["retryBaseDelayMs", retryBaseDelayMs],
+      ["secondaryRateLimitDelayMs", secondaryRateLimitDelayMs],
     ] as const) {
       if (!Number.isFinite(value) || value < 0) {
         throw new Error(`${name} must be a non-negative finite number`);
@@ -1190,6 +1194,7 @@ export class GitHubGraphqlClient implements GraphqlExecutor {
     this.#maxGenerationCost = maxGenerationCost;
     this.#minimumRateLimitReserve = minimumRateLimitReserve;
     this.#retryBaseDelayMs = retryBaseDelayMs;
+    this.#secondaryRateLimitDelayMs = secondaryRateLimitDelayMs;
   }
 
   async execute(
@@ -1252,6 +1257,15 @@ export class GitHubGraphqlClient implements GraphqlExecutor {
         continue;
       } finally {
         clearTimeout(timeout);
+      }
+      const secondaryRateLimited =
+        response.status === 403 &&
+        /secondary rate limit|abuse detection/i.test(responseBody);
+      if (secondaryRateLimited && attempt < MAX_GRAPHQL_REQUEST_ATTEMPTS) {
+        await retryDelay(
+          this.#secondaryRateLimitDelayMs * 2 ** (attempt - 1),
+        );
+        continue;
       }
       const retryableStatus = [502, 503, 504].includes(response.status);
       if (retryableStatus && attempt < MAX_GRAPHQL_REQUEST_ATTEMPTS) {

--- a/src/lib/leaderboard.test.ts
+++ b/src/lib/leaderboard.test.ts
@@ -4274,6 +4274,8 @@ describe("deduplication and public schema", () => {
       ...actor("impostor"),
       id: identityDrift.leaders[0].actor.id,
     };
+    const avatarQueryDrift = structuredClone(snapshot);
+    avatarQueryDrift.ledger[0].actor.avatarUrl = `${avatarQueryDrift.ledger[0].actor.avatarUrl}?u=immutable-content&v=4`;
 
     expect(() => assertLeaderboardSnapshot(phishing)).toThrow(
       "canonical GitHub profile",
@@ -4285,6 +4287,7 @@ describe("deduplication and public schema", () => {
     expect(() => assertLeaderboardSnapshot(identityDrift)).toThrow(
       "changes identity inside the snapshot",
     );
+    expect(() => assertLeaderboardSnapshot(avatarQueryDrift)).not.toThrow();
   });
 
   it("rejects leader arrays whose ranks disguise the published ordering", () => {

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -3896,7 +3896,8 @@ function assertActorCoherence(actors: GitHubActor[]): void {
     if (
       previous &&
       (previous.login !== actor.login ||
-        previous.avatarUrl !== actor.avatarUrl ||
+        canonicalActorAvatarUrl(previous.avatarUrl) !==
+          canonicalActorAvatarUrl(actor.avatarUrl) ||
         previous.url !== actor.url ||
         previous.kind !== actor.kind)
     ) {


### PR DESCRIPTION
## Summary
- keep the existing six-hour scheduled leaderboard refresh explicitly bound to the manifest-backed repository registry
- retry only the changing open-work detail batch instead of discarding an entire repository snapshot
- tolerate GitHub avatar cache-query churn while preserving actor ID/login/type coherence

## Evidence
- focused contract/generator/leaderboard tests: 174 passed
- TypeScript and Biome checks passed
- prior authenticated live refresh published all 4 tracked repositories, 112 unique participants, and 7,040 score events
- current public ledger remains non-stale with all 4 tracked repositories and 112 unique leader IDs

The current checkout has an unrelated active revert, so this change is isolated on this branch and should go through the protected develop PR path.