### PR TITLE
fix: complete uncapped review refreshes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-24.04
     # The public elizaOS ledger can contain several thousand accepted outcomes.
     # Leave room for complete fail-closed hydration plus four browser projects.
-    timeout-minutes: 90
+    timeout-minutes: 180
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.github/workflows/monthly-rewards.yml
+++ b/.github/workflows/monthly-rewards.yml
@@ -30,7 +30,7 @@ jobs:
   propose:
     if: github.ref == 'refs/heads/develop'
     runs-on: ubuntu-24.04
-    timeout-minutes: 90
+    timeout-minutes: 180
     steps:
       - name: Checkout trusted develop
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/scripts/generate-leaderboard.test.ts
+++ b/scripts/generate-leaderboard.test.ts
@@ -23,6 +23,7 @@ import {
   deriveCurrentHeadReviewDecision,
   deriveSourceUpdatedAt,
   estimateFirstPageDetailCost,
+  estimateReviewFirstPageDetailCost,
   GitHubGraphqlClient,
   type GraphqlExecutor,
   generateLeaderboardFromGitHub,
@@ -847,6 +848,37 @@ describe("GitHub GraphQL boundary", () => {
     expect(client.getRateLimit().consumedDuringRun).toBe(1);
   });
 
+  it("honors GitHub secondary-limit retry guidance before returning data", async () => {
+    let attempts = 0;
+    const fetcher = async () => {
+      attempts += 1;
+      if (attempts === 1) {
+        return new Response(
+          JSON.stringify({
+            message: "You have exceeded a secondary rate limit.",
+          }),
+          {
+            status: 403,
+            headers: {
+              "Content-Type": "application/json",
+              "Retry-After": "0",
+            },
+          },
+        );
+      }
+      return successResponse();
+    };
+    const client = new GitHubGraphqlClient("secret-token", fetcher, {
+      retryBaseDelayMs: 0,
+    });
+
+    await expect(
+      client.execute("query { viewer { login } }"),
+    ).resolves.toMatchObject({ viewer: { login: "eliza" } });
+    expect(attempts).toBe(2);
+    expect(client.getRequestCount()).toBe(2);
+  });
+
   it("retries transient network failures before returning validated data", async () => {
     let attempts = 0;
     const fetcher = async () => {
@@ -1046,7 +1078,7 @@ describe("GitHub GraphQL boundary", () => {
     );
   });
 
-  it("adapts its run cap to a 1,000-point Actions token", async () => {
+  it("resumes a 1,000-point Actions token after its rate window resets", async () => {
     let attempts = 0;
     const fetcher = async () => {
       attempts += 1;
@@ -1055,7 +1087,7 @@ describe("GitHub GraphQL boundary", () => {
         {
           cost: 450,
           limit: 1_000,
-          remaining: 1_000 - attempts * 450,
+          remaining: attempts <= 2 ? 1_000 - attempts * 450 : 550,
           resetAt: "2026-07-30T13:00:00.000Z",
         },
       );
@@ -1070,10 +1102,11 @@ describe("GitHub GraphQL boundary", () => {
     await expect(
       client.execute("query { viewer { login } }"),
     ).resolves.toBeDefined();
-    await expect(client.execute("query { viewer { login } }")).rejects.toThrow(
-      "900/900 points consumed",
-    );
-    expect(attempts).toBe(2);
+    await expect(
+      client.execute("query { viewer { login } }"),
+    ).resolves.toBeDefined();
+    expect(attempts).toBe(3);
+    expect(client.getRateLimit().consumedDuringRun).toBe(450);
   });
 
   it("does not call the writer after live generation fails", async () => {
@@ -1128,7 +1161,9 @@ describe("rate-efficient query plan", () => {
       ]),
     ).resolves.toEqual(new Set(["PR_REVIEWED"]));
     expect(seenDocuments).toHaveLength(1);
-    expect(seenDocuments[0]).toContain("reviews { totalCount }");
+    expect(seenDocuments[0]).toContain(
+      "reviews(states: [APPROVED, CHANGES_REQUESTED]) { totalCount }",
+    );
     expect(seenDocuments[0]).not.toContain("reviews(first:");
   });
 
@@ -1249,6 +1284,21 @@ describe("rate-efficient query plan", () => {
     expect(LEADERBOARD_QUERY_DOCUMENTS.pullRequestDetails).not.toMatch(
       /author\s*\{[^}]+}\s*comments\s*\{/,
     );
+    expect(LEADERBOARD_QUERY_DOCUMENTS.mergedPullRequestReviews).toContain(
+      "reviews(states: [APPROVED, CHANGES_REQUESTED], first: 100)",
+    );
+    expect(LEADERBOARD_QUERY_DOCUMENTS.mergedPullRequestReviews).toContain(
+      "comments(first: 100)",
+    );
+    expect(LEADERBOARD_QUERY_DOCUMENTS.mergedPullRequestReviews).not.toContain(
+      "files(first:",
+    );
+    expect(LEADERBOARD_QUERY_DOCUMENTS.mergedPullRequestReviews).not.toContain(
+      "closingIssuesReferences",
+    );
+    expect(LEADERBOARD_QUERY_DOCUMENTS.moreFormalReviews).toContain(
+      "states: [APPROVED, CHANGES_REQUESTED]",
+    );
     expect(LEADERBOARD_QUERY_DOCUMENTS.reviewInlineComments).toContain(
       "comments(first: 100)",
     );
@@ -1258,8 +1308,13 @@ describe("rate-efficient query plan", () => {
     expect(estimateFirstPageDetailCost(0, 0)).toBe(0);
     expect(estimateFirstPageDetailCost(25, 25)).toBe(3);
     expect(estimateFirstPageDetailCost(26, 0)).toBe(3);
+    expect(estimateReviewFirstPageDetailCost(25)).toBe(1);
+    expect(estimateReviewFirstPageDetailCost(26)).toBe(2);
     expect(() => estimateFirstPageDetailCost(-1, 0)).toThrow(
       "non-negative integers",
+    );
+    expect(() => estimateReviewFirstPageDetailCost(-1)).toThrow(
+      "non-negative integer",
     );
   });
 

--- a/scripts/generate-leaderboard.ts
+++ b/scripts/generate-leaderboard.ts
@@ -26,6 +26,7 @@ import {
   type LeaderboardSnapshot,
   type LeaderboardSourceMetadata,
   type MergedPullRequestOutcome,
+  type MergedPullRequestReviewRecord,
   type PullRequestFile,
   type PullRequestRecord,
   type PullRequestReview,
@@ -112,6 +113,12 @@ type PendingPullRequestRecord = Omit<PullRequestRecord, "reviews"> & {
   headRefOid: string;
   reviews: PendingPullRequestReview[];
 };
+type PendingMergedPullRequestReviewRecord = Omit<
+  MergedPullRequestReviewRecord,
+  "reviews"
+> & {
+  reviews: PendingPullRequestReview[];
+};
 
 interface ParsedPullRequest {
   record: PendingPullRequestRecord;
@@ -121,6 +128,15 @@ interface ParsedPullRequest {
     reviews: NestedPageState;
     files: NestedPageState;
     closingIssues: NestedPageState;
+  };
+}
+
+interface ParsedMergedPullRequestReview {
+  record: PendingMergedPullRequestReviewRecord;
+  state: string;
+  pages: {
+    comments: NestedPageState;
+    reviews: NestedPageState;
   };
 }
 
@@ -176,6 +192,7 @@ export interface RateLimitSnapshot {
 
 export interface GraphqlExecutor {
   execute(document: string, variables?: GraphqlVariables): Promise<JsonRecord>;
+  ensureBudget?(requiredCost: number): Promise<void>;
   getRequestCount(): number;
   getRateLimit(): RateLimitSnapshot;
 }
@@ -316,6 +333,26 @@ const PULL_REQUEST_FRAGMENT = `
   }
 `;
 
+const MERGED_PULL_REQUEST_REVIEW_FRAGMENT = `
+  fragment LeaderboardMergedPullRequestReview on PullRequest {
+    id
+    state
+    number
+    title
+    url
+    body
+    createdAt
+    updatedAt
+    lastEditedAt
+    editor { ...LeaderboardActor }
+    mergedAt
+    headRefOid
+    author { ...LeaderboardActor }
+    comments(first: 100) { ${COMMENT_FIELDS} }
+    reviews(states: [APPROVED, CHANGES_REQUESTED], first: 100) { ${REVIEW_FIELDS} }
+  }
+`;
+
 const ISSUE_FRAGMENT = `
   fragment LeaderboardIssue on Issue {
     id
@@ -406,6 +443,18 @@ const PULL_REQUEST_DETAILS_QUERY = `
   ${PULL_REQUEST_FRAGMENT}
 `;
 
+const MERGED_PULL_REQUEST_REVIEWS_QUERY = `
+  query LeaderboardMergedPullRequestReviews($ids: [ID!]!) {
+    nodes(ids: $ids) {
+      __typename
+      ... on PullRequest { ...LeaderboardMergedPullRequestReview }
+    }
+    rateLimit { cost limit remaining resetAt }
+  }
+  ${ACTOR_FRAGMENT}
+  ${MERGED_PULL_REQUEST_REVIEW_FRAGMENT}
+`;
+
 const REVIEWED_PULL_REQUEST_REFERENCES_QUERY = `
   query LeaderboardReviewedPullRequestReferences($ids: [ID!]!) {
     nodes(ids: $ids) {
@@ -413,7 +462,7 @@ const REVIEWED_PULL_REQUEST_REFERENCES_QUERY = `
       ... on PullRequest {
         id
         updatedAt
-        reviews { totalCount }
+        reviews(states: [APPROVED, CHANGES_REQUESTED]) { totalCount }
       }
     }
     rateLimit { cost limit remaining resetAt }
@@ -518,6 +567,24 @@ const MORE_REVIEWS_QUERY = `
   ${ACTOR_FRAGMENT}
 `;
 
+const MORE_FORMAL_REVIEWS_QUERY = `
+  query LeaderboardMoreFormalReviews($id: ID!, $after: String!) {
+    node(id: $id) {
+      ... on PullRequest {
+        id
+        headRefOid
+        reviews(
+          states: [APPROVED, CHANGES_REQUESTED]
+          first: 100
+          after: $after
+        ) { ${REVIEW_FIELDS} }
+      }
+    }
+    rateLimit { cost limit remaining resetAt }
+  }
+  ${ACTOR_FRAGMENT}
+`;
+
 const REVIEW_INLINE_COMMENTS_QUERY = `
   query LeaderboardReviewInlineComments($ids: [ID!]!) {
     nodes(ids: $ids) {
@@ -603,11 +670,13 @@ export const LEADERBOARD_QUERY_DOCUMENTS = {
   openPullRequestReferences: OPEN_PULL_REQUEST_REFERENCES_QUERY,
   issueDetails: ISSUE_DETAILS_QUERY,
   pullRequestDetails: PULL_REQUEST_DETAILS_QUERY,
+  mergedPullRequestReviews: MERGED_PULL_REQUEST_REVIEWS_QUERY,
   reviewedPullRequestReferences: REVIEWED_PULL_REQUEST_REFERENCES_QUERY,
   reviewInlineComments: REVIEW_INLINE_COMMENTS_QUERY,
   morePullRequestComments: MORE_PULL_REQUEST_COMMENTS_QUERY,
   moreIssueComments: MORE_ISSUE_COMMENTS_QUERY,
   moreReviews: MORE_REVIEWS_QUERY,
+  moreFormalReviews: MORE_FORMAL_REVIEWS_QUERY,
   moreReviewInlineComments: MORE_REVIEW_INLINE_COMMENTS_QUERY,
   moreFiles: MORE_FILES_QUERY,
   moreClosingIssues: MORE_CLOSING_ISSUES_QUERY,
@@ -940,6 +1009,39 @@ function parsePullRequest(value: unknown, path: string): ParsedPullRequest {
   };
 }
 
+function parseMergedPullRequestReview(
+  value: unknown,
+  path: string,
+): ParsedMergedPullRequestReview {
+  const node = asRecord(value, path);
+  const id = asString(node.id, `${path}.id`);
+  const comments = parseComments(node.comments, `${path}.comments`, id);
+  const reviews = parseReviews(node.reviews, `${path}.reviews`);
+  return {
+    state: asString(node.state, `${path}.state`),
+    record: {
+      id,
+      number: asNumber(node.number, `${path}.number`),
+      title: asString(node.title, `${path}.title`),
+      url: asString(node.url, `${path}.url`),
+      body: asString(node.body, `${path}.body`),
+      createdAt: asString(node.createdAt, `${path}.createdAt`),
+      updatedAt: asString(node.updatedAt, `${path}.updatedAt`),
+      lastEditedAt: asNullableString(node.lastEditedAt, `${path}.lastEditedAt`),
+      editor: parseActor(node.editor, `${path}.editor`),
+      mergedAt: asNullableString(node.mergedAt, `${path}.mergedAt`),
+      headRefOid: asFullCommitSha(node.headRefOid, `${path}.headRefOid`),
+      author: parseActor(node.author, `${path}.author`),
+      comments: comments.nodes,
+      reviews: reviews.nodes,
+    },
+    pages: {
+      comments: pageState(comments),
+      reviews: pageState(reviews),
+    },
+  };
+}
+
 function parseIssue(value: unknown, path: string): ParsedIssue {
   const node = asRecord(value, path);
   const id = asString(node.id, `${path}.id`);
@@ -1079,6 +1181,29 @@ function isJsonContentType(value: string | null): boolean {
   );
 }
 
+function secondaryRateLimitDelayMs(
+  response: Response,
+  responseBody: string,
+): number | null {
+  if (response.status !== 403 && response.status !== 429) return null;
+  let message = "";
+  try {
+    const payload = JSON.parse(responseBody) as { message?: unknown };
+    if (typeof payload.message === "string") message = payload.message;
+  } catch {
+    return null;
+  }
+  if (!/secondary rate limit|abuse detection/iu.test(message)) return null;
+  const retryAfter = response.headers.get("retry-after");
+  if (retryAfter !== null && /^\d+$/u.test(retryAfter)) {
+    const seconds = Number(retryAfter);
+    if (Number.isSafeInteger(seconds)) return seconds * 1_000;
+  }
+  // GitHub directs clients without Retry-After guidance to wait at least one
+  // minute before retrying a secondary-limit response.
+  return 60_000;
+}
+
 async function retryDelay(milliseconds: number): Promise<void> {
   await new Promise<void>((resolveDelay) => {
     setTimeout(resolveDelay, milliseconds);
@@ -1192,6 +1317,38 @@ export class GitHubGraphqlClient implements GraphqlExecutor {
     this.#retryBaseDelayMs = retryBaseDelayMs;
   }
 
+  async ensureBudget(requiredCost: number): Promise<void> {
+    if (!Number.isInteger(requiredCost) || requiredCost < 0) {
+      throw new Error("requiredCost must be a non-negative integer");
+    }
+    if (!this.#rateLimit) return;
+    const effectiveMaxGenerationCost = this.#effectiveMaxGenerationCost();
+    if (requiredCost > effectiveMaxGenerationCost) {
+      throw new Error(
+        `Required GitHub GraphQL cost ${requiredCost} exceeds the safe per-window budget ${effectiveMaxGenerationCost}`,
+      );
+    }
+    const available = Math.min(
+      effectiveMaxGenerationCost - this.#consumedCost,
+      this.#rateLimit.remaining - this.#minimumRateLimitReserve,
+    );
+    if (requiredCost <= available) return;
+
+    const resetAt = Date.parse(this.#rateLimit.resetAt);
+    if (!Number.isFinite(resetAt)) {
+      throw new Error("GitHub GraphQL returned an invalid rate-limit resetAt");
+    }
+    await retryDelay(Math.max(0, resetAt - Date.now() + 1_000));
+    this.#consumedCost = 0;
+    this.#startingRemaining = null;
+    this.#rateLimit = {
+      ...this.#rateLimit,
+      cost: 0,
+      consumedDuringRun: 0,
+      remaining: this.#rateLimit.limit,
+    };
+  }
+
   async execute(
     document: string,
     variables: GraphqlVariables = {},
@@ -1204,16 +1361,7 @@ export class GitHubGraphqlClient implements GraphqlExecutor {
       attempt <= MAX_GRAPHQL_REQUEST_ATTEMPTS;
       attempt += 1
     ) {
-      const effectiveMaxGenerationCost = this.#effectiveMaxGenerationCost();
-      if (
-        this.#consumedCost >= effectiveMaxGenerationCost ||
-        (this.#rateLimit &&
-          this.#rateLimit.remaining <= this.#minimumRateLimitReserve)
-      ) {
-        throw new Error(
-          `GitHub GraphQL safety budget reached before request ${this.#requestCount + 1} (${this.#consumedCost}/${effectiveMaxGenerationCost} points consumed, ${this.#rateLimit?.remaining ?? "unknown"} remaining)`,
-        );
-      }
+      await this.ensureBudget(1);
       this.#requestCount += 1;
       const controller = new AbortController();
       const timeout = setTimeout(() => {
@@ -1256,6 +1404,17 @@ export class GitHubGraphqlClient implements GraphqlExecutor {
       const retryableStatus = [502, 503, 504].includes(response.status);
       if (retryableStatus && attempt < MAX_GRAPHQL_REQUEST_ATTEMPTS) {
         await retryDelay(this.#retryBaseDelayMs * 2 ** (attempt - 1));
+        continue;
+      }
+      const secondaryLimitDelay = secondaryRateLimitDelayMs(
+        response,
+        responseBody,
+      );
+      if (
+        secondaryLimitDelay !== null &&
+        attempt < MAX_GRAPHQL_REQUEST_ATTEMPTS
+      ) {
+        await retryDelay(secondaryLimitDelay);
         continue;
       }
 
@@ -1502,6 +1661,14 @@ export interface ReviewCensusEntry {
   updatedAt: string;
 }
 
+function formalDecisionReviewCount(
+  reviews: ReadonlyArray<{ state: string }>,
+): number {
+  return reviews.filter((review) =>
+    ["APPROVED", "CHANGES_REQUESTED"].includes(review.state),
+  ).length;
+}
+
 export async function collectPullRequestReviewCounts(
   client: GraphqlExecutor,
   references: ReadonlyArray<{ id: string }>,
@@ -1515,9 +1682,13 @@ export async function collectPullRequestReviewCounts(
   );
   const estimatedCost = batches.length * reservedPasses;
   if (estimatedCost > available) {
-    throw new Error(
-      `Review census cost ${estimatedCost} exceeds the safe GraphQL budget ${available}; no partial snapshot will be written`,
-    );
+    if (client.ensureBudget) {
+      await client.ensureBudget(estimatedCost);
+    } else {
+      throw new Error(
+        `Review census cost ${estimatedCost} exceeds the safe GraphQL budget ${available}; no partial snapshot will be written`,
+      );
+    }
   }
   const reviewCounts = new Map<string, ReviewCensusEntry>();
   for (const batch of batches) {
@@ -1765,7 +1936,7 @@ async function collectOpenReferences(
 }
 
 function validateRecordState(
-  parsed: ParsedIssue | ParsedPullRequest,
+  parsed: ParsedIssue | ParsedPullRequest | ParsedMergedPullRequestReview,
   expectedState: ExpectedRecordState,
 ): void {
   if (
@@ -1813,7 +1984,9 @@ function parsePullRequestOutcome(
   };
 }
 
-function parseDetailBatch<T extends ParsedIssue | ParsedPullRequest>(
+function parseDetailBatch<
+  T extends ParsedIssue | ParsedPullRequest | ParsedMergedPullRequestReview,
+>(
   data: JsonRecord,
   ids: string[],
   expectedKind: NodeReference["kind"],
@@ -1841,13 +2014,19 @@ function parseDetailBatch<T extends ParsedIssue | ParsedPullRequest>(
   });
 }
 
-async function completePullRequestConnections(
-  client: GraphqlExecutor,
-  parsed: ParsedPullRequest,
-): Promise<PendingPullRequestRecord> {
-  const pullRequest = parsed.record;
+type PendingPullRequestTextRecord =
+  | PendingPullRequestRecord
+  | PendingMergedPullRequestReviewRecord;
 
-  let commentsState = parsed.pages.comments;
+async function completePullRequestTextConnections<
+  T extends PendingPullRequestTextRecord,
+>(
+  client: GraphqlExecutor,
+  pullRequest: T,
+  pages: Pick<ParsedPullRequest["pages"], "comments" | "reviews">,
+  moreReviewsQuery: string,
+): Promise<T> {
+  let commentsState = pages.comments;
   while (commentsState.pageInfo.hasNextPage) {
     if (!commentsState.pageInfo.endCursor) {
       throw new Error(`PR #${pullRequest.number} comments cursor is missing`);
@@ -1865,12 +2044,12 @@ async function completePullRequestConnections(
     commentsState = pageState(page);
   }
 
-  let reviewsState = parsed.pages.reviews;
+  let reviewsState = pages.reviews;
   while (reviewsState.pageInfo.hasNextPage) {
     if (!reviewsState.pageInfo.endCursor) {
       throw new Error(`PR #${pullRequest.number} reviews cursor is missing`);
     }
-    const data = await client.execute(MORE_REVIEWS_QUERY, {
+    const data = await client.execute(moreReviewsQuery, {
       id: pullRequest.id,
       after: reviewsState.pageInfo.endCursor,
     });
@@ -1892,6 +2071,30 @@ async function completePullRequestConnections(
     pullRequest.reviews.push(...page.nodes);
     reviewsState = pageState(page);
   }
+
+  pullRequest.comments = dedupeByNodeId(pullRequest.comments);
+  pullRequest.reviews = dedupeByNodeId(pullRequest.reviews);
+  if (
+    pullRequest.comments.length !== pages.comments.totalCount ||
+    pullRequest.reviews.length !== pages.reviews.totalCount
+  ) {
+    throw new Error(
+      `PR #${pullRequest.number} changed during collection; review connection totals no longer match`,
+    );
+  }
+  return pullRequest;
+}
+
+async function completePullRequestConnections(
+  client: GraphqlExecutor,
+  parsed: ParsedPullRequest,
+): Promise<PendingPullRequestRecord> {
+  const pullRequest = await completePullRequestTextConnections(
+    client,
+    parsed.record,
+    parsed.pages,
+    MORE_REVIEWS_QUERY,
+  );
 
   let filesState = parsed.pages.files;
   while (filesState.pageInfo.hasNextPage) {
@@ -1929,12 +2132,8 @@ async function completePullRequestConnections(
     closingState = pageState(page);
   }
 
-  pullRequest.comments = dedupeByNodeId(pullRequest.comments);
-  pullRequest.reviews = dedupeByNodeId(pullRequest.reviews);
   pullRequest.closingIssueIds = [...new Set(pullRequest.closingIssueIds)];
   if (
-    pullRequest.comments.length !== parsed.pages.comments.totalCount ||
-    pullRequest.reviews.length !== parsed.pages.reviews.totalCount ||
     pullRequest.files.length !== parsed.pages.files.totalCount ||
     pullRequest.closingIssueIds.length !== parsed.pages.closingIssues.totalCount
   ) {
@@ -1943,6 +2142,18 @@ async function completePullRequestConnections(
     );
   }
   return pullRequest;
+}
+
+async function completeMergedPullRequestReviewConnections(
+  client: GraphqlExecutor,
+  parsed: ParsedMergedPullRequestReview,
+): Promise<PendingMergedPullRequestReviewRecord> {
+  return await completePullRequestTextConnections(
+    client,
+    parsed.record,
+    parsed.pages,
+    MORE_FORMAL_REVIEWS_QUERY,
+  );
 }
 
 async function completeIssueConnections(
@@ -2111,7 +2322,17 @@ export function deriveCurrentHeadReviewDecision(
 async function finalizePullRequests(
   client: GraphqlExecutor,
   pending: PendingPullRequestRecord[],
-): Promise<PullRequestRecord[]> {
+): Promise<PullRequestRecord[]>;
+async function finalizePullRequests(
+  client: GraphqlExecutor,
+  pending: PendingMergedPullRequestReviewRecord[],
+): Promise<MergedPullRequestReviewRecord[]>;
+async function finalizePullRequests(
+  client: GraphqlExecutor,
+  pending: Array<
+    PendingPullRequestRecord | PendingMergedPullRequestReviewRecord
+  >,
+): Promise<Array<PullRequestRecord | MergedPullRequestReviewRecord>> {
   const bindings = pending.flatMap((pullRequest) =>
     pullRequest.reviews.map((review) => ({
       artifactId: pullRequest.id,
@@ -2224,6 +2445,44 @@ async function hydratePullRequests(
   const pullRequests = await finalizePullRequests(client, pending);
   onProgress({
     phase,
+    completed: pullRequests.length,
+    total: references.length,
+  });
+  return pullRequests;
+}
+
+async function hydrateReviewedMergedPullRequests(
+  client: GraphqlExecutor,
+  references: NodeReference[],
+  onProgress: (progress: GenerationProgress) => void,
+): Promise<MergedPullRequestReviewRecord[]> {
+  const pending: PendingMergedPullRequestReviewRecord[] = [];
+  for (const batch of chunks(references, DETAIL_BATCH_SIZE)) {
+    const ids = batch.map((reference) => reference.id);
+    const data = await client.execute(MERGED_PULL_REQUEST_REVIEWS_QUERY, {
+      ids,
+    });
+    const parsed = parseDetailBatch(
+      data,
+      ids,
+      "PullRequest",
+      parseMergedPullRequestReview,
+    );
+    for (const value of parsed) {
+      validateRecordState(value, "merged");
+      pending.push(
+        await completeMergedPullRequestReviewConnections(client, value),
+      );
+      onProgress({
+        phase: "merged-pull-requests",
+        completed: pending.length,
+        total: references.length,
+      });
+    }
+  }
+  const pullRequests = await finalizePullRequests(client, pending);
+  onProgress({
+    phase: "merged-pull-requests",
     completed: pullRequests.length,
     total: references.length,
   });
@@ -2416,7 +2675,12 @@ async function collectOpenIssues(
       if (before.repositoryId !== repositoryId) {
         throw new Error("GitHub returned an inconsistent repository node ID");
       }
-      assertEstimatedBudget(client, 0, before.references.length, reservedCost);
+      await ensureEstimatedBudget(
+        client,
+        0,
+        before.references.length,
+        reservedCost,
+      );
       return await hydrateIssues(
         client,
         before.references,
@@ -2457,7 +2721,12 @@ async function collectOpenPullRequests(
       if (before.repositoryId !== repositoryId) {
         throw new Error("GitHub returned an inconsistent repository node ID");
       }
-      assertEstimatedBudget(client, before.references.length, 0, reservedCost);
+      await ensureEstimatedBudget(
+        client,
+        before.references.length,
+        0,
+        reservedCost,
+      );
       return await hydratePullRequests(
         client,
         before.references,
@@ -2548,19 +2817,35 @@ export function estimateFirstPageDetailCost(
   );
 }
 
-function assertEstimatedBudget(
+export function estimateReviewFirstPageDetailCost(
+  pullRequestCount: number,
+): number {
+  if (!Number.isInteger(pullRequestCount) || pullRequestCount < 0) {
+    throw new Error("Review-detail count must be a non-negative integer");
+  }
+  return estimateBatchedConnectionCost(pullRequestCount, 2);
+}
+
+async function ensureEstimatedBudget(
   client: GraphqlExecutor,
   pullRequestCount: number,
   issueCount: number,
   reservedCost = 0,
-): void {
+  reviewPullRequestCount = 0,
+): Promise<void> {
   const rateLimit = client.getRateLimit();
-  const estimate = estimateFirstPageDetailCost(pullRequestCount, issueCount);
+  const estimate =
+    estimateFirstPageDetailCost(pullRequestCount, issueCount) +
+    estimateReviewFirstPageDetailCost(reviewPullRequestCount);
   const available = Math.min(
     MAX_GENERATION_COST - rateLimit.consumedDuringRun,
     rateLimit.remaining - MINIMUM_RATE_LIMIT_RESERVE,
   );
   if (estimate + reservedCost > available) {
+    if (client.ensureBudget) {
+      await client.ensureBudget(estimate + reservedCost);
+      return;
+    }
     throw new Error(
       `Estimated first-page detail cost ${estimate} plus reserved cost ${reservedCost} exceeds the safe GraphQL budget ${available}; no partial snapshot will be written`,
     );
@@ -2883,6 +3168,7 @@ export async function generateLeaderboardFromGitHub(
   const collections: RepositoryCollection[] = [];
   const mergedPullRequestOutcomes: MergedPullRequestOutcome[] = [];
   const mergedPullRequests: PullRequestRecord[] = [];
+  const reviewedMergedPullRequests: MergedPullRequestReviewRecord[] = [];
   const closedIssues: IssueRecord[] = [];
   let closedIssueCount = 0;
 
@@ -2963,13 +3249,19 @@ export async function generateLeaderboardFromGitHub(
   );
   for (const collection of collections) {
     const detailedReferences = collection.mergedPullRequestReferences.filter(
-      (reference) => hydrationPlan.hydratedIds.has(reference.id),
+      (reference) => hydrationPlan.detailEligibleIds.has(reference.id),
     );
-    assertEstimatedBudget(
+    const reviewedReferences = collection.mergedPullRequestReferences.filter(
+      (reference) =>
+        hydrationPlan.hydratedIds.has(reference.id) &&
+        !hydrationPlan.detailEligibleIds.has(reference.id),
+    );
+    await ensureEstimatedBudget(
       client,
       detailedReferences.length,
       0,
       finalReviewCensusCost,
+      reviewedReferences.length,
     );
     const detailedPullRequests = await hydratePullRequests(
       client,
@@ -2978,11 +3270,20 @@ export async function generateLeaderboardFromGitHub(
       onProgress,
       "merged-pull-requests",
     );
-    for (const pullRequest of detailedPullRequests) {
+    const reviewedPullRequests = await hydrateReviewedMergedPullRequests(
+      client,
+      reviewedReferences,
+      onProgress,
+    );
+    for (const pullRequest of [
+      ...detailedPullRequests,
+      ...reviewedPullRequests,
+    ]) {
       const censusCount = hydrationPlan.reviewCounts.get(pullRequest.id);
       if (
         censusCount === undefined ||
-        pullRequest.reviews.length !== censusCount.reviewCount ||
+        formalDecisionReviewCount(pullRequest.reviews) !==
+          censusCount.reviewCount ||
         pullRequest.updatedAt !== censusCount.updatedAt
       ) {
         throw new Error(
@@ -2991,18 +3292,17 @@ export async function generateLeaderboardFromGitHub(
       }
     }
     mergedPullRequests.push(...detailedPullRequests);
+    reviewedMergedPullRequests.push(...reviewedPullRequests);
 
     const linkedIssueIds = new Set(
-      detailedPullRequests
-        .filter((pullRequest) =>
-          hydrationPlan.detailEligibleIds.has(pullRequest.id),
-        )
-        .flatMap((pullRequest) => pullRequest.closingIssueIds),
+      detailedPullRequests.flatMap(
+        (pullRequest) => pullRequest.closingIssueIds,
+      ),
     );
     const linkedClosedIssueReferences = collection.closedIssueReferences.filter(
       (reference) => linkedIssueIds.has(reference.id),
     );
-    assertEstimatedBudget(
+    await ensureEstimatedBudget(
       client,
       0,
       linkedClosedIssueReferences.length,
@@ -3035,6 +3335,9 @@ export async function generateLeaderboardFromGitHub(
 
   const dedupedOutcomes = dedupeByNodeId(mergedPullRequestOutcomes);
   const dedupedMergedPullRequests = dedupeByNodeId(mergedPullRequests);
+  const dedupedReviewedMergedPullRequests = dedupeByNodeId(
+    reviewedMergedPullRequests,
+  );
   const detailEligibleMergedPullRequests = dedupedMergedPullRequests.filter(
     (pullRequest) => hydrationPlan.detailEligibleIds.has(pullRequest.id),
   );
@@ -3093,6 +3396,7 @@ export async function generateLeaderboardFromGitHub(
   const allRecords = [
     ...dedupedOutcomes,
     ...dedupedMergedPullRequests,
+    ...dedupedReviewedMergedPullRequests,
     ...dedupedClosedIssues,
     ...openIssues,
     ...openPullRequests,
@@ -3146,6 +3450,7 @@ export async function generateLeaderboardFromGitHub(
     source,
     mergedPullRequestOutcomes: dedupedOutcomes,
     mergedPullRequests: dedupedMergedPullRequests,
+    reviewedMergedPullRequests: dedupedReviewedMergedPullRequests,
     detailEligibleMergedPullRequestIds: [...hydrationPlan.detailEligibleIds],
     closedIssueCount,
     resolvedIssues: dedupedClosedIssues,

--- a/src/lib/leaderboard.test.ts
+++ b/src/lib/leaderboard.test.ts
@@ -30,6 +30,7 @@ import {
   type LeaderboardSnapshot,
   MATERIAL_TEST_ADDITIONS,
   MATERIAL_TEST_CHURN,
+  type MergedPullRequestReviewRecord,
   mergedPullRequestPoints,
   type PullRequestRecord,
   parseEvidenceHeadOid,
@@ -2288,10 +2289,43 @@ describe("scoring and limits", () => {
         },
       ],
     });
+    if (!merged.mergedAt) throw new Error("test pull request must be merged");
+    const reviewHydration: MergedPullRequestReviewRecord = {
+      id: merged.id,
+      number: merged.number,
+      title: merged.title,
+      url: merged.url,
+      body: merged.body,
+      createdAt: merged.createdAt,
+      updatedAt: merged.updatedAt,
+      lastEditedAt: merged.lastEditedAt,
+      editor: merged.editor,
+      mergedAt: merged.mergedAt,
+      headRefOid: merged.headRefOid,
+      author: merged.author,
+      comments: merged.comments,
+      reviews: merged.reviews,
+    };
 
     const snapshot = createLeaderboardSnapshot(
       input({
-        mergedPullRequests: [merged],
+        mergedPullRequestOutcomes: [
+          {
+            id: merged.id,
+            number: merged.number,
+            title: merged.title,
+            url: merged.url,
+            body: merged.body,
+            createdAt: merged.createdAt,
+            updatedAt: merged.updatedAt,
+            mergedAt: merged.mergedAt,
+            author: merged.author,
+            additions: merged.additions,
+            deletions: merged.deletions,
+          },
+        ],
+        mergedPullRequests: [],
+        reviewedMergedPullRequests: [reviewHydration],
         detailEligibleMergedPullRequestIds: [],
       }),
     );

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -213,6 +213,29 @@ export interface PullRequestRecord {
   commitCount: number;
 }
 
+/**
+ * Complete text and review evidence for a merged pull request whose expensive
+ * author-detail connections were not requested. Detail-only fields are
+ * deliberately absent rather than represented by plausible empty values.
+ */
+export type MergedPullRequestReviewRecord = Pick<
+  PullRequestRecord,
+  | "id"
+  | "number"
+  | "title"
+  | "url"
+  | "body"
+  | "createdAt"
+  | "updatedAt"
+  | "lastEditedAt"
+  | "editor"
+  | "mergedAt"
+  | "headRefOid"
+  | "author"
+  | "comments"
+  | "reviews"
+>;
+
 export interface MergedPullRequestOutcome {
   id: string;
   number: number;
@@ -606,6 +629,7 @@ export interface LeaderboardInput {
   source: LeaderboardSourceMetadata;
   mergedPullRequestOutcomes: MergedPullRequestOutcome[];
   mergedPullRequests: PullRequestRecord[];
+  reviewedMergedPullRequests?: MergedPullRequestReviewRecord[];
   detailEligibleMergedPullRequestIds: string[];
   closedIssueCount: number;
   resolvedIssues: IssueRecord[];
@@ -1613,7 +1637,7 @@ export function assessModelAttribution(
 }
 
 export function pullRequestTextSources(
-  pullRequest: PullRequestRecord,
+  pullRequest: MergedPullRequestReviewRecord,
 ): GitHubTextSource[] {
   const body = pullRequestBodySource(pullRequest);
   const reviewSources: GitHubTextSource[] = pullRequest.reviews.map(
@@ -1677,7 +1701,7 @@ export function isSubstantiveReview(
 
 function reviewExclusionReason(
   review: PullRequestReview,
-  pullRequest: PullRequestRecord,
+  pullRequest: Pick<PullRequestRecord, "author" | "mergedAt">,
 ): ReviewExclusionReason | null {
   if (!review.author) return "missing-reviewer";
   if (isBotActor(review.author)) return "bot-reviewer";
@@ -2167,7 +2191,7 @@ function evidenceSourcesAtMerge(
 }
 
 function pullRequestBodySource(
-  pullRequest: PullRequestRecord | MergedPullRequestOutcome,
+  pullRequest: MergedPullRequestReviewRecord | MergedPullRequestOutcome,
 ): GitHubTextSource {
   return {
     id: `${pullRequest.id}:body`,
@@ -2817,6 +2841,9 @@ function latestSourceUpdate(input: LeaderboardInput): string {
     input.sourceUpdatedAt,
     ...input.mergedPullRequestOutcomes.map((record) => record.updatedAt),
     ...input.mergedPullRequests.map((record) => record.updatedAt),
+    ...(input.reviewedMergedPullRequests ?? []).map(
+      (record) => record.updatedAt,
+    ),
     ...input.resolvedIssues.map((record) => record.updatedAt),
     ...input.openIssues.map((record) => record.updatedAt),
     ...input.openPullRequests.map((record) => record.updatedAt),
@@ -2837,7 +2864,33 @@ export function createLeaderboardSnapshot(
       right.number - left.number ||
       left.id.localeCompare(right.id),
   );
-  const mergedPullRequests = dedupeByNodeId(input.mergedPullRequests).sort(
+  const detailHydratedMergedPullRequests = dedupeByNodeId(
+    input.mergedPullRequests,
+  ).sort(
+    (left, right) =>
+      parseIsoTime(right.mergedAt ?? right.updatedAt) -
+        parseIsoTime(left.mergedAt ?? left.updatedAt) ||
+      right.number - left.number ||
+      left.id.localeCompare(right.id),
+  );
+  const reviewedMergedPullRequests = dedupeByNodeId(
+    input.reviewedMergedPullRequests ?? [],
+  );
+  const detailHydratedIds = new Set(
+    detailHydratedMergedPullRequests.map((record) => record.id),
+  );
+  const overlappingHydrationId = reviewedMergedPullRequests.find((record) =>
+    detailHydratedIds.has(record.id),
+  )?.id;
+  if (overlappingHydrationId) {
+    throw new Error(
+      `Merged pull request ${overlappingHydrationId} was supplied as both full-detail and review-only hydration`,
+    );
+  }
+  const mergedPullRequests: MergedPullRequestReviewRecord[] = [
+    ...detailHydratedMergedPullRequests,
+    ...reviewedMergedPullRequests,
+  ].sort(
     (left, right) =>
       parseIsoTime(right.mergedAt ?? right.updatedAt) -
         parseIsoTime(left.mergedAt ?? left.updatedAt) ||
@@ -2847,16 +2900,20 @@ export function createLeaderboardSnapshot(
   const detailEligibleMergedPullRequestIds = new Set(
     input.detailEligibleMergedPullRequestIds,
   );
-  const mergedPullRequestIds = new Set(
-    mergedPullRequests.map((pullRequest) => pullRequest.id),
-  );
   for (const id of detailEligibleMergedPullRequestIds) {
-    if (!mergedPullRequestIds.has(id)) {
+    if (!detailHydratedIds.has(id)) {
       throw new Error(`Detail-eligible pull request ${id} was not hydrated`);
     }
   }
-  const detailEligibleMergedPullRequests = mergedPullRequests.filter(
-    (pullRequest) => detailEligibleMergedPullRequestIds.has(pullRequest.id),
+  const detailEligibleMergedPullRequests =
+    detailHydratedMergedPullRequests.filter((pullRequest) =>
+      detailEligibleMergedPullRequestIds.has(pullRequest.id),
+    );
+  const detailEligibleMergedPullRequestById = new Map(
+    detailEligibleMergedPullRequests.map((pullRequest) => [
+      pullRequest.id,
+      pullRequest,
+    ]),
   );
   const resolvedIssues = dedupeByNodeId(input.resolvedIssues)
     .filter(qualifiesResolvedIssue)
@@ -2877,7 +2934,7 @@ export function createLeaderboardSnapshot(
   const ledger: ScoreEvent[] = [];
   const reviewExclusions: ReviewExclusion[] = [];
   const excludeReview = (
-    pullRequest: PullRequestRecord,
+    pullRequest: MergedPullRequestReviewRecord,
     review: PullRequestReview,
     reason: ReviewExclusionReason,
   ): void => {
@@ -3254,44 +3311,48 @@ export function createLeaderboardSnapshot(
     const detailEligible = detailEligibleMergedPullRequestIds.has(
       pullRequest.id,
     );
+    const detailedPullRequest = detailEligibleMergedPullRequestById.get(
+      pullRequest.id,
+    );
     if (detailEligible) recordTextActivity(entries, sources);
 
     if (
-      detailEligible &&
-      pullRequest.author &&
-      !isBotActor(pullRequest.author)
+      detailedPullRequest?.author &&
+      !isBotActor(detailedPullRequest.author)
     ) {
-      const authorEntry = actorEntry(entries, pullRequest.author);
-      authorEntry.rawActivity.commits += pullRequest.commitCount;
+      const authorEntry = actorEntry(entries, detailedPullRequest.author);
+      authorEntry.rawActivity.commits += detailedPullRequest.commitCount;
       if (
         !explicitPrizeAcceptance &&
-        hasMaterialTestChange(pullRequest.files)
+        hasMaterialTestChange(detailedPullRequest.files)
       ) {
         const scored = addScore(entries, ledger, {
-          id: `${pullRequest.id}:tests`,
-          actor: pullRequest.author,
+          id: `${detailedPullRequest.id}:tests`,
+          actor: detailedPullRequest.author,
           category: "material-test-change",
           points: 4,
           occurredAt: pullRequest.mergedAt,
-          repository: repositoryIdFromUrl(pullRequest.url),
+          repository: repositoryIdFromUrl(detailedPullRequest.url),
           source: {
-            id: pullRequest.id,
+            id: detailedPullRequest.id,
             kind: "pull-request",
-            number: pullRequest.number,
-            title: pullRequest.title,
-            url: pullRequest.url,
+            number: detailedPullRequest.number,
+            title: detailedPullRequest.title,
+            url: detailedPullRequest.url,
           },
           reason: `Recognized test files met the ${MATERIAL_TEST_ADDITIONS}-addition and ${MATERIAL_TEST_CHURN}-churn threshold.`,
         });
         if (scored) {
-          recordScoredSources([pullRequestBodySource(pullRequest)]);
+          recordScoredSources([pullRequestBodySource(detailedPullRequest)]);
         }
       }
 
       const attributableEvidenceSources = evidenceSourcesAtMerge(
-        pullRequest,
+        detailedPullRequest,
         sources,
-      ).filter((source) => sameActor(source.author, pullRequest.author));
+      ).filter((source) =>
+        sameActor(source.author, detailedPullRequest.author),
+      );
       const evidence = assessEvidence(
         attributableEvidenceSources,
         verifiedEvidence.filter(
@@ -3308,7 +3369,7 @@ export function createLeaderboardSnapshot(
       for (const finding of evidence.findings) {
         const scored = addScore(entries, ledger, {
           id: `${pullRequest.id}:evidence:${finding.category}`,
-          actor: pullRequest.author,
+          actor: detailedPullRequest.author,
           category: "evidence",
           points: finding.points,
           occurredAt: pullRequest.mergedAt,


### PR DESCRIPTION
Closes #266.

## Outcome
- preserves formal review credit for every merged PR without hydrating unrelated author-detail connections
- keeps the existing author detail allowance limited to files, closing issues, evidence, and author bonuses only
- retries GitHub secondary limits using `Retry-After` when supplied and a documented 60-second fallback
- preserves the 100-point GraphQL reserve per rate window, waits for GitHub's real hourly reset, and resumes every registered repository instead of truncating or failing after the first project
- gives trusted deploy and monthly reward workflows enough time for a worst-case reset

## Design
Review-only records are a separate typed shape. Unknown files, labels, assignees, commit counts, and closing issues are absent rather than fabricated as empty values. Review-only hydration fetches complete PR text/comments and every formal `APPROVED` or `CHANGES_REQUESTED` review, including paginated inline comments. Full detail continues to collect all review states and author evidence.

## Verification
- `bun run verify` (64 files, 622 tests; 90 skill tests; build passed)
- focused generator/scoring suite: 158/158
- authenticated live run passed complete collection for all four registered repositories and reached the final all-PR review census; the remaining pre-fix lifetime-budget guard exposed there is replaced by the tested renewable-window contract in this revision
- atomic output remained fail-closed throughout unsuccessful exploratory runs; no partial public ledger was written

Independent review is required before merge. The next trusted `develop` run is the authoritative 1,000-point Actions-token/deployment proof.
