### PR TITLE
fix: preserve complete ledger across production boundaries

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -127,7 +127,7 @@ jobs:
             --tlsv1.2 \
             --connect-timeout 10 \
             --max-time 60 \
-            --max-filesize 16777216 \
+            --max-filesize 26214400 \
             --output "$ledger_file" \
             https://slop.cash/data/leaderboard.json
           test -s "$ledger_file"

--- a/scripts/deployment-contract.test.mjs
+++ b/scripts/deployment-contract.test.mjs
@@ -370,7 +370,7 @@ describe("slop.cash deployment contract", () => {
       "- name: Load deployed public ledger for pull-request checks",
     );
     expect(qualityJob).toContain("if: github.event_name == 'pull_request'");
-    expect(qualityJob).toContain("--max-filesize 16777216");
+    expect(qualityJob).toContain("--max-filesize 26214400");
     expect(qualityJob).toContain("https://slop.cash/data/leaderboard.json");
     expect(qualityJob).toContain(
       "- name: Validate finalized Solana evidence on trusted revisions\n        if: github.event_name != 'pull_request'",

--- a/scripts/dist-manifest.mjs
+++ b/scripts/dist-manifest.mjs
@@ -16,7 +16,10 @@ export const MANIFEST_FILENAME = "deployment-manifest.json";
 const SCHEMA_VERSION = 1;
 const MAXIMUM_DIRECTORIES = 128;
 const MAXIMUM_FILES = 256;
-const MAXIMUM_FILE_BYTES = 16 * 1024 * 1024;
+// Cloudflare Pages accepts individual static assets up to 25 MiB. Keep the
+// local release gate aligned with that external boundary instead of imposing
+// a smaller product-specific cap on the complete public ledger.
+const MAXIMUM_FILE_BYTES = 25 * 1024 * 1024;
 const MAXIMUM_TOTAL_BYTES = 128 * 1024 * 1024;
 const MAXIMUM_PATH_BYTES = 1_024;
 const MAXIMUM_MANIFEST_BYTES = 256 * 1024;

--- a/scripts/generate-leaderboard.test.ts
+++ b/scripts/generate-leaderboard.test.ts
@@ -1074,7 +1074,7 @@ describe("GitHub GraphQL boundary", () => {
       client.execute("query { viewer { login } }"),
     ).resolves.toBeDefined();
     await expect(client.execute("query { viewer { login } }")).rejects.toThrow(
-      "safety budget exceeded (800/750 points consumed",
+      "safety budget exceeded (800/750 points consumed in the current window",
     );
   });
 
@@ -1106,7 +1106,7 @@ describe("GitHub GraphQL boundary", () => {
       client.execute("query { viewer { login } }"),
     ).resolves.toBeDefined();
     expect(attempts).toBe(3);
-    expect(client.getRateLimit().consumedDuringRun).toBe(450);
+    expect(client.getRateLimit().consumedDuringRun).toBe(1_350);
   });
 
   it("does not call the writer after live generation fails", async () => {

--- a/scripts/generate-leaderboard.ts
+++ b/scripts/generate-leaderboard.ts
@@ -1273,6 +1273,7 @@ export class GitHubGraphqlClient implements GraphqlExecutor {
   #requestCount = 0;
   #rateLimit: RateLimitSnapshot | null = null;
   #consumedCost = 0;
+  #windowConsumedCost = 0;
   #startingRemaining: number | null = null;
 
   #effectiveMaxGenerationCost(): number {
@@ -1329,7 +1330,7 @@ export class GitHubGraphqlClient implements GraphqlExecutor {
       );
     }
     const available = Math.min(
-      effectiveMaxGenerationCost - this.#consumedCost,
+      effectiveMaxGenerationCost - this.#windowConsumedCost,
       this.#rateLimit.remaining - this.#minimumRateLimitReserve,
     );
     if (requiredCost <= available) return;
@@ -1339,12 +1340,12 @@ export class GitHubGraphqlClient implements GraphqlExecutor {
       throw new Error("GitHub GraphQL returned an invalid rate-limit resetAt");
     }
     await retryDelay(Math.max(0, resetAt - Date.now() + 1_000));
-    this.#consumedCost = 0;
+    this.#windowConsumedCost = 0;
     this.#startingRemaining = null;
     this.#rateLimit = {
       ...this.#rateLimit,
       cost: 0,
-      consumedDuringRun: 0,
+      consumedDuringRun: this.#consumedCost,
       remaining: this.#rateLimit.limit,
     };
   }
@@ -1459,8 +1460,9 @@ export class GitHubGraphqlClient implements GraphqlExecutor {
     const rateLimit = parseRateLimit(data.rateLimit);
     this.#startingRemaining =
       this.#startingRemaining ?? rateLimit.remaining + rateLimit.cost;
-    this.#consumedCost = Math.max(
-      this.#consumedCost + rateLimit.cost,
+    this.#consumedCost += rateLimit.cost;
+    this.#windowConsumedCost = Math.max(
+      this.#windowConsumedCost + rateLimit.cost,
       this.#startingRemaining - rateLimit.remaining,
     );
     this.#rateLimit = {
@@ -1469,11 +1471,11 @@ export class GitHubGraphqlClient implements GraphqlExecutor {
     };
     const effectiveMaxGenerationCost = this.#effectiveMaxGenerationCost();
     if (
-      this.#consumedCost > effectiveMaxGenerationCost ||
+      this.#windowConsumedCost > effectiveMaxGenerationCost ||
       rateLimit.remaining < this.#minimumRateLimitReserve
     ) {
       throw new Error(
-        `GitHub GraphQL safety budget exceeded (${this.#consumedCost}/${effectiveMaxGenerationCost} points consumed, ${rateLimit.remaining} remaining; reserve ${this.#minimumRateLimitReserve})`,
+        `GitHub GraphQL safety budget exceeded (${this.#windowConsumedCost}/${effectiveMaxGenerationCost} points consumed in the current window, ${rateLimit.remaining} remaining; reserve ${this.#minimumRateLimitReserve})`,
       );
     }
     return data;


### PR DESCRIPTION
Follow-up to #267 and #266.

## Fixes
- separate cumulative GraphQL run cost (public audit metadata) from renewable per-window cost (100-point safety reserve)
- align the bundle and PR-ledger download boundary with Cloudflare Pages' documented 25 MiB per-file limit instead of the repository's arbitrary 16 MiB cap

The complete live ledger is 19,007,854 bytes. It remains complete: no truncation, compaction, item cap, or reduced history.

## Proof
- authenticated atomic generation succeeded for all 4 repositories: 6,807 merged outcomes, 416 full-detail PRs, 615 open issues, 564 open PRs, 121 leaders, 9,776 score events
- 537 GraphQL requests; 574 cumulative points; 4,084/5,000 remaining
- focused generator/scoring tests: 158/158
- deployment contract tests: 15/15
- production build and 174-file deployment manifest succeed with the complete 19 MB ledger

Independent review is required before merge.
