### PR TITLE
fix: isolate live open-queue retries

### DIFF
--- a/scripts/generate-leaderboard.test.ts
+++ b/scripts/generate-leaderboard.test.ts
@@ -33,6 +33,7 @@ import {
   planMergedPullRequestHydration,
   resolveGitHubToken,
   retryOpenBatch,
+  retryOpenReferenceListing,
   retrySlopSnapshot,
   runGenerator,
   SEARCH_SAFE_RESULT_LIMIT,
@@ -1506,6 +1507,20 @@ describe("rate-efficient query plan", () => {
         throw new OpenSetChangedError("merged outcome changed");
       }),
     ).rejects.toThrow("merged outcome changed");
+  });
+
+  it("retries a paginated open-work listing when its live count changes", async () => {
+    let attempts = 0;
+    await expect(
+      retryOpenReferenceListing(async () => {
+        attempts += 1;
+        if (attempts === 1) {
+          throw new OpenSetChangedError("open queue count moved");
+        }
+        return ["stable-reference"];
+      }),
+    ).resolves.toEqual(["stable-reference"]);
+    expect(attempts).toBe(2);
   });
 
   it("fails when the non-scoring queue never stabilizes", async () => {

--- a/scripts/generate-leaderboard.test.ts
+++ b/scripts/generate-leaderboard.test.ts
@@ -32,6 +32,7 @@ import {
   parseGenerationArguments,
   planMergedPullRequestHydration,
   resolveGitHubToken,
+  retryOpenBatch,
   retrySlopSnapshot,
   runGenerator,
   SEARCH_SAFE_RESULT_LIMIT,
@@ -1487,6 +1488,26 @@ describe("rate-efficient query plan", () => {
     ).rejects.toThrow("evidence verifier failed");
   });
 
+  it("retries only the changing open-work hydration batch", async () => {
+    let attempts = 0;
+    await expect(
+      retryOpenBatch("open", async () => {
+        attempts += 1;
+        if (attempts === 1) {
+          throw new OpenSetChangedError("open work moved");
+        }
+        return ["stable-pr"];
+      }),
+    ).resolves.toEqual(["stable-pr"]);
+    expect(attempts).toBe(2);
+
+    await expect(
+      retryOpenBatch("merged", async () => {
+        throw new OpenSetChangedError("merged outcome changed");
+      }),
+    ).rejects.toThrow("merged outcome changed");
+  });
+
   it("fails when the non-scoring queue never stabilizes", async () => {
     let attempts = 0;
     await expect(
@@ -1960,7 +1981,7 @@ describe("current-head review selection", () => {
     await expect(
       generateLeaderboardFromGitHub(client, { now }),
     ).rejects.toThrow(
-      "Open pull-request state changed during 3 consecutive collection attempts",
+      "Open work batch changed during 3 consecutive hydration attempts",
     );
   });
 });

--- a/scripts/generate-leaderboard.ts
+++ b/scripts/generate-leaderboard.ts
@@ -180,6 +180,14 @@ export async function retrySlopSnapshot<T>(
     { cause: lastChange },
   );
 }
+
+/** Retries a paginated open-work listing when its live total changes. */
+export async function retryOpenReferenceListing<T>(
+  collect: () => Promise<T>,
+): Promise<T> {
+  return await retrySlopSnapshot(() => collect());
+}
+
 class GraphqlResponseBoundaryError extends Error {}
 
 export interface RateLimitSnapshot {
@@ -2698,12 +2706,14 @@ async function collectOpenIssues(
   onProgress: (progress: GenerationProgress) => void,
   reservedCost = 0,
 ): Promise<IssueRecord[]> {
-  const before = await collectOpenReferences(
-    client,
-    targetRepository,
-    OPEN_ISSUE_REFERENCES_QUERY,
-    "issues",
-    "Issue",
+  const before = await retryOpenReferenceListing(() =>
+    collectOpenReferences(
+      client,
+      targetRepository,
+      OPEN_ISSUE_REFERENCES_QUERY,
+      "issues",
+      "Issue",
+    ),
   );
   if (before.repositoryId !== repositoryId) {
     throw new Error("GitHub returned an inconsistent repository node ID");
@@ -2730,12 +2740,14 @@ async function collectOpenPullRequests(
   onProgress: (progress: GenerationProgress) => void,
   reservedCost = 0,
 ): Promise<PullRequestRecord[]> {
-  const before = await collectOpenReferences(
-    client,
-    targetRepository,
-    OPEN_PULL_REQUEST_REFERENCES_QUERY,
-    "pullRequests",
-    "PullRequest",
+  const before = await retryOpenReferenceListing(() =>
+    collectOpenReferences(
+      client,
+      targetRepository,
+      OPEN_PULL_REQUEST_REFERENCES_QUERY,
+      "pullRequests",
+      "PullRequest",
+    ),
   );
   if (before.repositoryId !== repositoryId) {
     throw new Error("GitHub returned an inconsistent repository node ID");

--- a/scripts/generate-leaderboard.ts
+++ b/scripts/generate-leaderboard.ts
@@ -2431,18 +2431,24 @@ async function hydratePullRequests(
 ): Promise<PullRequestRecord[]> {
   const pending: PendingPullRequestRecord[] = [];
   for (const batch of chunks(references, DETAIL_BATCH_SIZE)) {
-    const ids = batch.map((reference) => reference.id);
-    const data = await client.execute(PULL_REQUEST_DETAILS_QUERY, { ids });
-    const parsed = parseDetailBatch(data, ids, "PullRequest", parsePullRequest);
-    for (const value of parsed) {
-      validateRecordState(value, expectedState);
-      pending.push(await completePullRequestConnections(client, value));
-      onProgress({
-        phase,
-        completed: pending.length,
-        total: references.length,
-      });
-    }
+    const hydratedBatch = await retryOpenBatch(expectedState, async () => {
+      const ids = batch.map((reference) => reference.id);
+      const data = await client.execute(PULL_REQUEST_DETAILS_QUERY, { ids });
+      const parsed = parseDetailBatch(
+        data,
+        ids,
+        "PullRequest",
+        parsePullRequest,
+      );
+      const completed: PendingPullRequestRecord[] = [];
+      for (const value of parsed) {
+        validateRecordState(value, expectedState);
+        completed.push(await completePullRequestConnections(client, value));
+      }
+      return completed;
+    });
+    pending.push(...hydratedBatch);
+    onProgress({ phase, completed: pending.length, total: references.length });
   }
   const pullRequests = await finalizePullRequests(client, pending);
   onProgress({
@@ -2500,20 +2506,47 @@ async function hydrateIssues(
 ): Promise<IssueRecord[]> {
   const issues: IssueRecord[] = [];
   for (const batch of chunks(references, DETAIL_BATCH_SIZE)) {
-    const ids = batch.map((reference) => reference.id);
-    const data = await client.execute(ISSUE_DETAILS_QUERY, { ids });
-    const parsed = parseDetailBatch(data, ids, "Issue", parseIssue);
-    for (const value of parsed) {
-      validateRecordState(value, expectedState);
-      issues.push(await completeIssueConnections(client, value));
-      onProgress({
-        phase,
-        completed: issues.length,
-        total: references.length,
-      });
-    }
+    const hydratedBatch = await retryOpenBatch(expectedState, async () => {
+      const ids = batch.map((reference) => reference.id);
+      const data = await client.execute(ISSUE_DETAILS_QUERY, { ids });
+      const parsed = parseDetailBatch(data, ids, "Issue", parseIssue);
+      const completed: IssueRecord[] = [];
+      for (const value of parsed) {
+        validateRecordState(value, expectedState);
+        completed.push(await completeIssueConnections(client, value));
+      }
+      return completed;
+    });
+    issues.push(...hydratedBatch);
+    onProgress({ phase, completed: issues.length, total: references.length });
   }
   return issues;
+}
+
+/**
+ * Rehydrates only a changing open-work batch. Open queues are intentionally
+ * live, so a global three-attempt freeze penalizes healthy contribution input.
+ */
+export async function retryOpenBatch<T>(
+  expectedState: ExpectedRecordState,
+  hydrate: () => Promise<T>,
+): Promise<T> {
+  let lastChange: OpenSetChangedError | null = null;
+  const attempts = expectedState === "open" ? MAX_TRANSIENT_ATTEMPTS : 1;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return await hydrate();
+    } catch (error) {
+      if (expectedState !== "open" || !(error instanceof OpenSetChangedError)) {
+        throw error;
+      }
+      lastChange = error;
+    }
+  }
+  throw new OpenSetChangedError(
+    `Open work batch changed during ${MAX_TRANSIENT_ATTEMPTS} consecutive hydration attempts`,
+    { cause: lastChange },
+  );
 }
 
 export function sameReferenceSet(
@@ -2665,42 +2698,28 @@ async function collectOpenIssues(
   onProgress: (progress: GenerationProgress) => void,
   reservedCost = 0,
 ): Promise<IssueRecord[]> {
-  for (let attempt = 1; attempt <= MAX_TRANSIENT_ATTEMPTS; attempt += 1) {
-    try {
-      const before = await collectOpenReferences(
-        client,
-        targetRepository,
-        OPEN_ISSUE_REFERENCES_QUERY,
-        "issues",
-        "Issue",
-      );
-      if (before.repositoryId !== repositoryId) {
-        throw new Error("GitHub returned an inconsistent repository node ID");
-      }
-      await ensureEstimatedBudget(
-        client,
-        0,
-        before.references.length,
-        reservedCost,
-      );
-      return await hydrateIssues(
-        client,
-        before.references,
-        "open",
-        onProgress,
-        "open-issues",
-      );
-    } catch (error) {
-      // error-policy:J1 A record that closes while its details are read is
-      // recollected; unrelated additions do not invalidate the point-in-time
-      // queue reference set.
-      if (!(error instanceof OpenSetChangedError)) {
-        throw error;
-      }
-    }
+  const before = await collectOpenReferences(
+    client,
+    targetRepository,
+    OPEN_ISSUE_REFERENCES_QUERY,
+    "issues",
+    "Issue",
+  );
+  if (before.repositoryId !== repositoryId) {
+    throw new Error("GitHub returned an inconsistent repository node ID");
   }
-  throw new Error(
-    `Open issue state changed during ${MAX_TRANSIENT_ATTEMPTS} consecutive collection attempts`,
+  await ensureEstimatedBudget(
+    client,
+    0,
+    before.references.length,
+    reservedCost,
+  );
+  return await hydrateIssues(
+    client,
+    before.references,
+    "open",
+    onProgress,
+    "open-issues",
   );
 }
 
@@ -2711,42 +2730,28 @@ async function collectOpenPullRequests(
   onProgress: (progress: GenerationProgress) => void,
   reservedCost = 0,
 ): Promise<PullRequestRecord[]> {
-  for (let attempt = 1; attempt <= MAX_TRANSIENT_ATTEMPTS; attempt += 1) {
-    try {
-      const before = await collectOpenReferences(
-        client,
-        targetRepository,
-        OPEN_PULL_REQUEST_REFERENCES_QUERY,
-        "pullRequests",
-        "PullRequest",
-      );
-      if (before.repositoryId !== repositoryId) {
-        throw new Error("GitHub returned an inconsistent repository node ID");
-      }
-      await ensureEstimatedBudget(
-        client,
-        before.references.length,
-        0,
-        reservedCost,
-      );
-      return await hydratePullRequests(
-        client,
-        before.references,
-        "open",
-        onProgress,
-        "open-pull-requests",
-      );
-    } catch (error) {
-      // error-policy:J1 A record that closes or changes head while its nested
-      // details are read is recollected; unrelated additions do not invalidate
-      // the point-in-time queue reference set.
-      if (!(error instanceof OpenSetChangedError)) {
-        throw error;
-      }
-    }
+  const before = await collectOpenReferences(
+    client,
+    targetRepository,
+    OPEN_PULL_REQUEST_REFERENCES_QUERY,
+    "pullRequests",
+    "PullRequest",
+  );
+  if (before.repositoryId !== repositoryId) {
+    throw new Error("GitHub returned an inconsistent repository node ID");
   }
-  throw new Error(
-    `Open pull-request state changed during ${MAX_TRANSIENT_ATTEMPTS} consecutive collection attempts`,
+  await ensureEstimatedBudget(
+    client,
+    before.references.length,
+    0,
+    reservedCost,
+  );
+  return await hydratePullRequests(
+    client,
+    before.references,
+    "open",
+    onProgress,
+    "open-pull-requests",
   );
 }
 


### PR DESCRIPTION
Follow-up to #267/#268 and the trusted develop failure in run 32917515041.

The production generator completed all 1,918 review-only PRs and 554 open issues, then discarded the entire open-PR collection three times because one record changed while its nested details were read.

This patch retries only the affected 25-record open hydration batch. Stable batches are retained. Merged and closed records still fail immediately on the same typed state-change signal. The existing three-attempt transient boundary remains, but it no longer restarts hundreds of stable records.

Proof:
- reproduced production failure: `Open pull-request state changed during 3 consecutive collection attempts`
- focused generator/scoring suite: 159/159
- TypeScript and diff checks pass

Independent review is required before merge.
