### PR TITLE
fix: use public intake status authority

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -250,8 +250,6 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Require public private-request intake
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           curl --fail --silent --show-error \
@@ -259,7 +257,6 @@ jobs:
             --max-time 30 \
             --max-filesize 65536 \
             --header "Accept: application/vnd.github+json" \
-            --header "Authorization: Bearer $GITHUB_TOKEN" \
             --header "User-Agent: slop-release-intake-check" \
             --header "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/SlopDotCash/slopdotcash/private-vulnerability-reporting |
@@ -439,7 +436,6 @@ jobs:
           const contents = readFileSync(process.argv[2], "utf8");
           const expected = [
             "OPERATOR_GITHUB_IDS",
-            "PRIVATE_INTAKE_GITHUB_TOKEN",
             "TRACE_AUTH_SECRET",
           ];
           const actual = [...contents.matchAll(/^\s*-\s+([A-Z][A-Z0-9_]*):\s+Value Encrypted\s*$/gmu)]
@@ -960,7 +956,7 @@ jobs:
           echo "::error::Active private trace API did not reach its fail-closed unauthenticated boundary."
           exit 1
 
-      - name: Verify authenticated private intake preflight
+      - name: Verify authoritative private intake preflight
         run: |
           set -euo pipefail
           response="$RUNNER_TEMP/slop-private-intake-preflight.json"
@@ -985,7 +981,7 @@ jobs:
           if (
             JSON.stringify(Object.keys(value).sort()) !== JSON.stringify(["enabled", "source", "verifiedAt"]) ||
             value?.enabled !== true ||
-            value?.source !== "github-authenticated" ||
+            value?.source !== "github-public-status" ||
             !Number.isFinite(Date.parse(value?.verifiedAt)) ||
             contract !== "private-trace-v1-opaque-hmac-v1"
           ) process.exit(1);
@@ -993,10 +989,10 @@ jobs:
             then
               exit 0
             fi
-            echo "::warning::Authenticated private intake preflight returned HTTP $status (attempt $attempt/18)."
+            echo "::warning::Authoritative private intake preflight returned HTTP $status (attempt $attempt/18)."
             sleep 5
           done
-          echo "::error::Authenticated private intake preflight did not become authoritative."
+          echo "::error::Private intake preflight did not become authoritative."
           exit 1
 
       - name: Require public identity OAuth app

--- a/backend/trace/README.md
+++ b/backend/trace/README.md
@@ -15,7 +15,7 @@ the contributor's required pre-upload inspection.
 Trace upload and production activation require GitHub's public private
 vulnerability reporting status to return exactly `enabled: true`. The deploy
 workflow verifies GitHub directly, while the client reads only the bounded
-server-authenticated Slop preflight. Both checks fail closed; an advisory URL
+server-authoritative Slop preflight. Both checks fail closed; an advisory URL
 alone is not evidence of availability, and a public issue is never a private
 intake.
 
@@ -113,7 +113,6 @@ bunx wrangler d1 create slop-private
 bunx wrangler r2 bucket create slop-private-traces
 bunx wrangler d1 migrations apply slop-private --remote
 bunx wrangler pages secret put TRACE_AUTH_SECRET --project-name eliza-computer
-bunx wrangler pages secret put PRIVATE_INTAKE_GITHUB_TOKEN --project-name eliza-computer
 ```
 
 Then add the returned D1 ID and R2 binding to the production Pages project:
@@ -135,13 +134,11 @@ service = "slop-identity"
 ```
 
 Set `OPERATOR_GITHUB_IDS` to an explicit comma-separated list of numeric IDs.
-`PRIVATE_INTAKE_GITHUB_TOKEN` is a server-only GitHub credential scoped to
-`SlopDotCash/slopdotcash` with read access to the private-vulnerability-
-reporting status endpoint and no write permission. The public
-`GET /api/v1/private-request-intake` route exposes only the bounded verified
-boolean and timestamp, or a fail-closed error with rate-limit reset time. Its
-five-minute edge cache prevents each contributor from consuming a GitHub API
-request. The credential is never returned to the client or accepted from one.
+The public `GET /api/v1/private-request-intake` route checks GitHub's public
+private-vulnerability-reporting status endpoint and exposes only the bounded
+verified boolean and timestamp, or a fail-closed error with rate-limit reset
+time. Its five-minute edge cache prevents each contributor from consuming a
+GitHub API request. No contributor or server GitHub credential is involved.
 `TRACE_AUTH_SECRET` is opaque HMAC key material and must contain 32-128
 high-entropy printable ASCII characters. It must never be configured as a
 checked-in `[vars]` value. Generate a recommended 43-character base64url value

--- a/backend/trace/handler.ts
+++ b/backend/trace/handler.ts
@@ -77,7 +77,7 @@ async function readPrivateIntakeStatus(
     }
     return json(200, {
       enabled: status.enabled,
-      source: "github-authenticated",
+      source: "github-public-status",
       verifiedAt: status.verifiedAt,
     });
   }

--- a/functions/api/v1/[[path]].ts
+++ b/functions/api/v1/[[path]].ts
@@ -9,7 +9,6 @@ type Env = {
   SLOP_DB: D1Database;
   PRIVATE_TRACES: R2Bucket;
   TRACE_AUTH_SECRET: string;
-  PRIVATE_INTAKE_GITHUB_TOKEN?: string;
   OPERATOR_GITHUB_IDS?: string;
   SLOP_IDENTITY: { fetch(request: Request): Promise<Response> };
 };
@@ -105,19 +104,10 @@ function parsedPrivateIntakeStatus(value: unknown): PrivateIntakeStatus | null {
 }
 
 async function privateIntakeStatus(
-  token: string | undefined,
   cache: EdgeCache | undefined,
   fetchImpl: typeof fetch,
   now: () => Date,
 ): Promise<PrivateIntakeStatus> {
-  if (
-    typeof token !== "string" ||
-    token.length < 20 ||
-    token.length > 2048 ||
-    /\s/u.test(token)
-  ) {
-    return { status: "unavailable" };
-  }
   if (cache !== undefined) {
     try {
       const cached = await cache.match(PRIVATE_INTAKE_CACHE_KEY);
@@ -138,7 +128,6 @@ async function privateIntakeStatus(
       redirect: "error",
       headers: {
         Accept: "application/vnd.github+json",
-        Authorization: `Bearer ${token}`,
         "User-Agent": "slop-private-intake-verifier",
         "X-GitHub-Api-Version": "2022-11-28",
       },
@@ -260,11 +249,6 @@ export async function onRequest(context: PagesContext): Promise<Response> {
     verifyIdentityAssertion: (assertion) =>
       verifyIdentityAssertion(context.env.SLOP_IDENTITY, assertion),
     privateIntakeStatus: () =>
-      privateIntakeStatus(
-        context.env.PRIVATE_INTAKE_GITHUB_TOKEN,
-        cache,
-        globalThis.fetch,
-        () => new Date(),
-      ),
+      privateIntakeStatus(cache, globalThis.fetch, () => new Date()),
   });
 }

--- a/functions/api/v1/trace-api.test.ts
+++ b/functions/api/v1/trace-api.test.ts
@@ -432,7 +432,7 @@ async function uploadTrace(
 }
 
 describe("private trace API", () => {
-  it("serves a cached server-authenticated private intake verification", async () => {
+  it("serves a cached public private intake verification", async () => {
     const originalFetch = globalThis.fetch;
     const originalCaches = Object.getOwnPropertyDescriptor(
       globalThis,
@@ -466,7 +466,6 @@ describe("private trace API", () => {
           SLOP_DB: {} as never,
           PRIVATE_TRACES: {} as never,
           TRACE_AUTH_SECRET: SECRET,
-          PRIVATE_INTAKE_GITHUB_TOKEN: "github_server_token_value",
           SLOP_IDENTITY: {
             fetch: async () => new Response(null, { status: 401 }),
           },
@@ -479,7 +478,7 @@ describe("private trace API", () => {
       expect(second.status).toBe(200);
       await expect(first.json()).resolves.toEqual({
         enabled: true,
-        source: "github-authenticated",
+        source: "github-public-status",
         verifiedAt: expect.any(String),
       });
       expect(requests).toHaveLength(1);
@@ -491,70 +490,11 @@ describe("private trace API", () => {
         redirect: "error",
         headers: {
           Accept: "application/vnd.github+json",
-          Authorization: "Bearer github_server_token_value",
           "User-Agent": "slop-private-intake-verifier",
           "X-GitHub-Api-Version": "2022-11-28",
         },
       });
       expect(cachedControl).toBe("public, max-age=300");
-    } finally {
-      globalThis.fetch = originalFetch;
-      if (originalCaches === undefined) {
-        Reflect.deleteProperty(globalThis, "caches");
-      } else {
-        Object.defineProperty(globalThis, "caches", originalCaches);
-      }
-    }
-  });
-
-  it("rejects cached enabled status when the server credential is absent", async () => {
-    const originalFetch = globalThis.fetch;
-    const originalCaches = Object.getOwnPropertyDescriptor(
-      globalThis,
-      "caches",
-    );
-    let upstreamRequested = false;
-    try {
-      globalThis.fetch = (async () => {
-        upstreamRequested = true;
-        return new Response(JSON.stringify({ enabled: true }), { status: 200 });
-      }) as unknown as typeof fetch;
-      Object.defineProperty(globalThis, "caches", {
-        configurable: true,
-        value: {
-          default: {
-            match: async () =>
-              new Response(
-                JSON.stringify({
-                  status: "verified",
-                  enabled: true,
-                  verifiedAt: "2026-08-25T00:00:00.000Z",
-                }),
-              ),
-            put: async () => undefined,
-          },
-        },
-      });
-
-      const response = await onPagesRequest({
-        request: new Request(
-          "https://api.slop.cash/api/v1/private-request-intake",
-        ),
-        env: {
-          SLOP_DB: {} as never,
-          PRIVATE_TRACES: {} as never,
-          TRACE_AUTH_SECRET: SECRET,
-          SLOP_IDENTITY: {
-            fetch: async () => new Response(null, { status: 401 }),
-          },
-        },
-      });
-
-      expect(response.status).toBe(503);
-      await expect(response.json()).resolves.toEqual({
-        error: "private_intake_unavailable",
-      });
-      expect(upstreamRequested).toBe(false);
     } finally {
       globalThis.fetch = originalFetch;
       if (originalCaches === undefined) {
@@ -584,7 +524,6 @@ describe("private trace API", () => {
           SLOP_DB: {} as never,
           PRIVATE_TRACES: {} as never,
           TRACE_AUTH_SECRET: SECRET,
-          PRIVATE_INTAKE_GITHUB_TOKEN: "github_server_token_value",
           SLOP_IDENTITY: {
             fetch: async () => new Response(null, { status: 401 }),
           },
@@ -620,7 +559,6 @@ describe("private trace API", () => {
           SLOP_DB: {} as never,
           PRIVATE_TRACES: {} as never,
           TRACE_AUTH_SECRET: SECRET,
-          PRIVATE_INTAKE_GITHUB_TOKEN: "github_server_token_value",
           SLOP_IDENTITY: {
             fetch: async () => new Response(null, { status: 401 }),
           },
@@ -636,7 +574,7 @@ describe("private trace API", () => {
     }
   });
 
-  it("fails closed on a malformed authenticated GitHub response", async () => {
+  it("fails closed on a malformed GitHub response", async () => {
     const originalFetch = globalThis.fetch;
     try {
       globalThis.fetch = (async () =>
@@ -651,7 +589,6 @@ describe("private trace API", () => {
           SLOP_DB: {} as never,
           PRIVATE_TRACES: {} as never,
           TRACE_AUTH_SECRET: SECRET,
-          PRIVATE_INTAKE_GITHUB_TOKEN: "github_server_token_value",
           SLOP_IDENTITY: {
             fetch: async () => new Response(null, { status: 401 }),
           },

--- a/protocol/private-trace-v1.md
+++ b/protocol/private-trace-v1.md
@@ -97,10 +97,9 @@ private report from a signed-in GitHub user without publishing the report as an
 issue. Do not put private data, trace contents, or request details in a public
 issue.
 
-The production workflow queries GitHub's private-vulnerability-reporting status
-with its trusted repository credential. The uploader queries only Slop's
-bounded server-authoritative preflight, whose server-held credential and
-five-minute cache keep GitHub authentication out of the client. Trace upload
+The production workflow and Slop's bounded server-authoritative preflight query
+GitHub's public private-vulnerability-reporting status endpoint. The five-minute
+server cache keeps the upstream request out of contributor clients. Trace upload
 and production activation fail closed if the authoritative state does not
 report exactly `enabled: true`; a rate limit reports its bounded reset time and
 never becomes an enabled result. The advisory URL alone is not evidence that

--- a/scripts/deployment-contract.test.mjs
+++ b/scripts/deployment-contract.test.mjs
@@ -108,8 +108,7 @@ describe("slop.cash deployment contract", () => {
     expect(deployJob).toContain(
       "https://api.github.com/repos/SlopDotCash/slopdotcash/private-vulnerability-reporting",
     );
-    expect(deployJob).toContain(`GITHUB_TOKEN: ${"$"}{{ github.token }}`);
-    expect(deployJob).toContain(
+    expect(deployJob).not.toContain(
       '--header "Authorization: Bearer $GITHUB_TOKEN"',
     );
     expect(deployJob).toContain("value?.enabled !== true");
@@ -129,7 +128,7 @@ describe("slop.cash deployment contract", () => {
     expect(deployJob).toContain(
       "./node_modules/.bin/wrangler pages secret list \\\n            --project-name eliza-computer",
     );
-    expect(deployJob).toContain('"PRIVATE_INTAKE_GITHUB_TOKEN",');
+    expect(deployJob).not.toContain("PRIVATE_INTAKE_GITHUB_TOKEN");
     expect(deployJob).toContain(
       "./node_modules/.bin/wrangler d1 migrations apply slop-private \\",
     );
@@ -208,23 +207,23 @@ describe("slop.cash deployment contract", () => {
       deployJob.indexOf("Verify active private trace API boundary"),
     ).toBeLessThan(deployJob.indexOf("Require public identity OAuth app"));
     expect(deployJob).toContain(
-      "Verify authenticated private intake preflight",
+      "Verify authoritative private intake preflight",
     );
     expect(deployJob).toContain(
       "https://api.slop.cash/api/v1/private-request-intake?verify=",
     );
-    expect(deployJob).toContain('value?.source !== "github-authenticated"');
+    expect(deployJob).toContain('value?.source !== "github-public-status"');
     expect(deployJob).toContain("value?.enabled !== true");
     expect(deployJob).toContain(
-      "Authenticated private intake preflight did not become authoritative.",
+      "Private intake preflight did not become authoritative.",
     );
     expect(
       deployJob.indexOf("Verify active private trace API boundary"),
     ).toBeLessThan(
-      deployJob.indexOf("Verify authenticated private intake preflight"),
+      deployJob.indexOf("Verify authoritative private intake preflight"),
     );
     expect(
-      deployJob.indexOf("Verify authenticated private intake preflight"),
+      deployJob.indexOf("Verify authoritative private intake preflight"),
     ).toBeLessThan(deployJob.indexOf("Require public identity OAuth app"));
     expect(deployJob).toContain(
       "Active private trace API did not reach its fail-closed unauthenticated boundary.",

--- a/skill-tests/project-skills.test.ts
+++ b/skill-tests/project-skills.test.ts
@@ -869,7 +869,7 @@ describe("project run usage", () => {
       const responses = [
         {
           enabled: true,
-          source: "github-authenticated",
+          source: "github-public-status",
           verifiedAt: "2026-08-25T12:00:00.000Z",
         },
         {
@@ -1015,7 +1015,7 @@ describe("project run usage", () => {
               return new Response(
                 JSON.stringify({
                   enabled: false,
-                  source: "github-authenticated",
+                  source: "github-public-status",
                   verifiedAt: "2026-08-25T12:00:00.000Z",
                 }),
                 { status: 200 },

--- a/skills/contribute-to-asi/scripts/run-receipt.mjs
+++ b/skills/contribute-to-asi/scripts/run-receipt.mjs
@@ -1287,7 +1287,7 @@ async function authoritativePrivateIntake(fetchImpl) {
   );
   if (
     typeof intake.enabled !== "boolean" ||
-    intake.source !== "github-authenticated" ||
+    intake.source !== "github-public-status" ||
     canonicalIso(intake.verifiedAt) !== intake.verifiedAt
   ) {
     fail("private request intake status returned invalid verification");
@@ -2220,7 +2220,7 @@ function previewRun(options) {
     network: [
       `With --allow-package-execution, resolve exact ccusage@${CCUSAGE_VERSION} during doctor and measured runs; fetch it from the package registry only when it is not already cached`,
       `On start and finish, fetch current project terms from https://slop.cash/projects/${PROJECT.projectId}/terms.json and any digest-bound LICENSE, inbound terms, or prize rules from github.com, raw.githubusercontent.com, or proximityprize.org as named by that policy`,
-      `Verify the server-authenticated private-request intake gate at ${PRIVATE_REQUEST_INTAKE_STATUS}; trace upload remains blocked unless it reports enabled`,
+      `Verify the server-authoritative private-request intake gate at ${PRIVATE_REQUEST_INTAKE_STATUS}; trace upload remains blocked unless it reports enabled`,
       `After a local byte/digest disclosure, authenticate with GitHub and permanently upload the inspected trace through ${TRACE_AUTHORITY} under ${TRACE_PRIVACY_CONTRACT}`,
     ],
     automaticUploads: [],

--- a/skills/contribute-to-delta-star/scripts/run-receipt.mjs
+++ b/skills/contribute-to-delta-star/scripts/run-receipt.mjs
@@ -1287,7 +1287,7 @@ async function authoritativePrivateIntake(fetchImpl) {
   );
   if (
     typeof intake.enabled !== "boolean" ||
-    intake.source !== "github-authenticated" ||
+    intake.source !== "github-public-status" ||
     canonicalIso(intake.verifiedAt) !== intake.verifiedAt
   ) {
     fail("private request intake status returned invalid verification");
@@ -2220,7 +2220,7 @@ function previewRun(options) {
     network: [
       `With --allow-package-execution, resolve exact ccusage@${CCUSAGE_VERSION} during doctor and measured runs; fetch it from the package registry only when it is not already cached`,
       `On start and finish, fetch current project terms from https://slop.cash/projects/${PROJECT.projectId}/terms.json and any digest-bound LICENSE, inbound terms, or prize rules from github.com, raw.githubusercontent.com, or proximityprize.org as named by that policy`,
-      `Verify the server-authenticated private-request intake gate at ${PRIVATE_REQUEST_INTAKE_STATUS}; trace upload remains blocked unless it reports enabled`,
+      `Verify the server-authoritative private-request intake gate at ${PRIVATE_REQUEST_INTAKE_STATUS}; trace upload remains blocked unless it reports enabled`,
       `After a local byte/digest disclosure, authenticate with GitHub and permanently upload the inspected trace through ${TRACE_AUTHORITY} under ${TRACE_PRIVACY_CONTRACT}`,
     ],
     automaticUploads: [],

--- a/skills/contribute-to-eliza/scripts/run-receipt.mjs
+++ b/skills/contribute-to-eliza/scripts/run-receipt.mjs
@@ -1287,7 +1287,7 @@ async function authoritativePrivateIntake(fetchImpl) {
   );
   if (
     typeof intake.enabled !== "boolean" ||
-    intake.source !== "github-authenticated" ||
+    intake.source !== "github-public-status" ||
     canonicalIso(intake.verifiedAt) !== intake.verifiedAt
   ) {
     fail("private request intake status returned invalid verification");
@@ -2220,7 +2220,7 @@ function previewRun(options) {
     network: [
       `With --allow-package-execution, resolve exact ccusage@${CCUSAGE_VERSION} during doctor and measured runs; fetch it from the package registry only when it is not already cached`,
       `On start and finish, fetch current project terms from https://slop.cash/projects/${PROJECT.projectId}/terms.json and any digest-bound LICENSE, inbound terms, or prize rules from github.com, raw.githubusercontent.com, or proximityprize.org as named by that policy`,
-      `Verify the server-authenticated private-request intake gate at ${PRIVATE_REQUEST_INTAKE_STATUS}; trace upload remains blocked unless it reports enabled`,
+      `Verify the server-authoritative private-request intake gate at ${PRIVATE_REQUEST_INTAKE_STATUS}; trace upload remains blocked unless it reports enabled`,
       `After a local byte/digest disclosure, authenticate with GitHub and permanently upload the inspected trace through ${TRACE_AUTHORITY} under ${TRACE_PRIVACY_CONTRACT}`,
     ],
     automaticUploads: [],

--- a/skills/contribute-to-heir-elements-sdk/scripts/run-receipt.mjs
+++ b/skills/contribute-to-heir-elements-sdk/scripts/run-receipt.mjs
@@ -1287,7 +1287,7 @@ async function authoritativePrivateIntake(fetchImpl) {
   );
   if (
     typeof intake.enabled !== "boolean" ||
-    intake.source !== "github-authenticated" ||
+    intake.source !== "github-public-status" ||
     canonicalIso(intake.verifiedAt) !== intake.verifiedAt
   ) {
     fail("private request intake status returned invalid verification");
@@ -2220,7 +2220,7 @@ function previewRun(options) {
     network: [
       `With --allow-package-execution, resolve exact ccusage@${CCUSAGE_VERSION} during doctor and measured runs; fetch it from the package registry only when it is not already cached`,
       `On start and finish, fetch current project terms from https://slop.cash/projects/${PROJECT.projectId}/terms.json and any digest-bound LICENSE, inbound terms, or prize rules from github.com, raw.githubusercontent.com, or proximityprize.org as named by that policy`,
-      `Verify the server-authenticated private-request intake gate at ${PRIVATE_REQUEST_INTAKE_STATUS}; trace upload remains blocked unless it reports enabled`,
+      `Verify the server-authoritative private-request intake gate at ${PRIVATE_REQUEST_INTAKE_STATUS}; trace upload remains blocked unless it reports enabled`,
       `After a local byte/digest disclosure, authenticate with GitHub and permanently upload the inspected trace through ${TRACE_AUTHORITY} under ${TRACE_PRIVACY_CONTRACT}`,
     ],
     automaticUploads: [],


### PR DESCRIPTION
## Summary\n\n- remove the unprovisioned `PRIVATE_INTAKE_GITHUB_TOKEN` dependency that blocked the protected production deployment\n- verify GitHub private vulnerability reporting through its working public status endpoint, retaining exact response validation, byte bounds, redirect rejection, cache behavior, and fail-closed errors\n- update deployment canaries, protocol docs, and every packaged contributor client to the truthful `github-public-status` source contract\n- delete the credential-only regression test instead of replacing it with test bloat\n\nFixes #270.\n\n## Causal evidence\n\nProtected develop run 32918797502 passed its complete quality job, then failed before Pages upload because the exact Pages secret inventory expected an unprovisioned token. A credential-free, API-version-pinned request to the canonical endpoint returned HTTP 200 and exactly `{"enabled":true}` on 2026-08-26.\n\n## Validation\n\n- API and deployment contract tests: 38/38\n- packaged project skill contract: 25/25\n- repository Vitest lane: 626/626\n- project skill lane: 92/92\n- full `bun run verify`: passed from a dedicated workspace temp directory, including typecheck, format, lint, dependency/protocol/project gates, and production build\n- final deployment-contract check after wording cleanup: 15/15\n- `git diff --check`: passed\n\n## Evidence\n\n- runtime endpoint: exact public GitHub response is validated and cached; malformed/rate-limited states remain fail-closed\n- deployment: exact Pages secret inventory returns to the two secrets actually provisioned in the last successful production deploy\n- UI screenshots/video: N/A — no UI behavior or pixels changed\n\n## Contribution provenance\n\n- AI-assisted: yes\n- provider/model: OpenAI / GPT-5.6\n- client/agent tooling: Codex desktop agent\n- authorized Slop base revision: `53ff3d124e2e4379543e93f658691f2cbc6a7889`\n- implementation head: `32a6213`\n- attribution status: self-reported\n\n## Safety\n\n- [x] No secret value was read, printed, committed, or copied\n- [x] The public check remains bounded and fails closed\n- [x] No broad personal token was provisioned as a runtime credential\n- [x] Merge remains subject to independent exact-head review