### PR TITLE
Bound contributor PR review epochs

### DIFF
--- a/skill-tests/contribute-to-eliza.test.ts
+++ b/skill-tests/contribute-to-eliza.test.ts
@@ -1502,6 +1502,49 @@ describe("live report parsing", () => {
       json: false,
       help: false,
     });
+    assert.deepStrictEqual(parseCliArguments(["--epoch-only"]), {
+      repo: "elizaOS/eliza",
+      json: false,
+      help: false,
+      epochOnly: true,
+    });
+    assert.throws(
+      () => parseCliArguments(["--epoch-only", "--json"]),
+      /cannot be combined/,
+    );
+    assert.deepStrictEqual(
+      parseCliArguments([
+        "--complete-epoch",
+        "report.json",
+        "--dispositions",
+        "dispositions.json",
+      ]),
+      {
+        repo: "elizaOS/eliza",
+        json: false,
+        help: false,
+        completeEpochPath: "report.json",
+        dispositionsPath: "dispositions.json",
+      },
+    );
+    assert.throws(
+      () => parseCliArguments(["--complete-epoch", "report.json"]),
+      /must be provided together/,
+    );
+    assert.throws(
+      () =>
+        parseCliArguments([
+          "--recheck-pr",
+          "1",
+          "--expected-head",
+          "a".repeat(40),
+          "--complete-epoch",
+          "report.json",
+          "--dispositions",
+          "dispositions.json",
+        ]),
+      /cannot be combined/,
+    );
     assert.throws(
       () => parseCliArguments(["--repo", "invalid"]),
       /owner\/name/,
@@ -1557,7 +1600,9 @@ describe("live report behavior", () => {
       {
         number: 1,
         expectedHeadSha: epoch.candidates[0].headSha,
-        status: "reviewed",
+        status: "merge",
+        recommendationUrl:
+          "https://github.com/elizaOS/eliza/pull/1#pullrequestreview-1",
       },
     ]);
     assert.strictEqual(incomplete.allowsNextTier, false);
@@ -1567,13 +1612,132 @@ describe("live report behavior", () => {
       epoch.candidates.map((candidate) => ({
         number: candidate.number,
         expectedHeadSha: candidate.headSha,
-        status: "reviewed",
+        status: "fix",
+        recommendationUrl: `https://github.com/elizaOS/eliza/pull/${candidate.number}#pullrequestreview-${candidate.number}`,
       })),
     );
     assert.strictEqual(completed.complete, true);
     assert.strictEqual(completed.allowsNextTier, true);
     assert.strictEqual(completed.nextTier, "next-eligible-lower-tier");
     assert.strictEqual(completed.maxNextTierOutcomes, 1);
+    assert.throws(
+      () =>
+        completeReviewEpoch(epoch, [
+          {
+            number: 1,
+            expectedHeadSha: epoch.candidates[0].headSha,
+            status: "reviewed",
+          },
+        ]),
+      /not a terminal disposition/,
+    );
+    assert.throws(
+      () =>
+        completeReviewEpoch(epoch, [
+          {
+            number: 1,
+            expectedHeadSha: epoch.candidates[0].headSha,
+            status: "merge",
+          },
+        ]),
+      /recommendationUrl/,
+    );
+    assert.throws(
+      () =>
+        completeReviewEpoch(epoch, [
+          {
+            number: 1,
+            expectedHeadSha: epoch.candidates[0].headSha,
+            status: "merge",
+            recommendationUrl:
+              "https://github.com/elizaOS/eliza/pull/2#pullrequestreview-2",
+          },
+        ]),
+      /bounded public GitHub HTTPS URL/,
+    );
+  });
+
+  it("emits an executable epoch completion record from saved JSON", () => {
+    const fixtureRoot = mkdtempSync(join(tmpdir(), "slop-review-epoch-"));
+    try {
+      const epoch = createReviewEpoch(
+        [
+          {
+            number: 7,
+            headSha: "a".repeat(40),
+            updatedAt: "2026-01-18T12:00:00.000Z",
+          },
+        ],
+        "2026-01-20T12:00:00.000Z",
+      );
+      const reportPath = join(fixtureRoot, "report.json");
+      const dispositionsPath = join(fixtureRoot, "dispositions.json");
+      writeFileSync(reportPath, `${JSON.stringify(epoch)}\n`);
+      writeFileSync(
+        dispositionsPath,
+        `${JSON.stringify([
+          {
+            number: 7,
+            expectedHeadSha: "a".repeat(40),
+            status: "close",
+            recommendationUrl:
+              "https://github.com/elizaOS/eliza/pull/7#pullrequestreview-7",
+          },
+        ])}\n`,
+      );
+      const result = spawnSync(
+        process.execPath,
+        [
+          liveReportPath,
+          "--complete-epoch",
+          reportPath,
+          "--dispositions",
+          dispositionsPath,
+        ],
+        { encoding: "utf8" },
+      );
+      assert.strictEqual(result.status, 0, result.stderr);
+      assert.deepStrictEqual(JSON.parse(result.stdout), {
+        schemaVersion: 1,
+        cutoff: "2026-01-20T12:00:00.000Z",
+        complete: true,
+        dispositionCount: 1,
+        requiredCandidateCount: 1,
+        remainingCandidates: [],
+        dispositions: [
+          {
+            number: 7,
+            expectedHeadSha: "a".repeat(40),
+            status: "close",
+            recommendationUrl:
+              "https://github.com/elizaOS/eliza/pull/7#pullrequestreview-7",
+          },
+        ],
+        allowsNextTier: true,
+        nextTier: "next-eligible-lower-tier",
+        maxNextTierOutcomes: 1,
+      });
+
+      writeFileSync(dispositionsPath, "[]\n");
+      const incomplete = spawnSync(
+        process.execPath,
+        [
+          liveReportPath,
+          "--complete-epoch",
+          reportPath,
+          "--dispositions",
+          dispositionsPath,
+        ],
+        { encoding: "utf8" },
+      );
+      assert.strictEqual(incomplete.status, 2, incomplete.stderr);
+      assert.deepStrictEqual(
+        JSON.parse(incomplete.stdout).remainingCandidates,
+        [7],
+      );
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true });
+    }
   });
 
   it("requires an exact current head before publishing and defers churn", () => {

--- a/skill-tests/contribute-to-eliza.test.ts
+++ b/skill-tests/contribute-to-eliza.test.ts
@@ -30,9 +30,12 @@ import {
   CLAIM_RECENCY_DAYS,
   closingIssueNumbers,
   collectLiveReport,
+  completeReviewEpoch,
   createGhCommandBudget,
+  createReviewEpoch,
   isBotAccount,
   MAX_ACTIVITY_CONNECTION_ITEMS,
+  MAX_REVIEW_EPOCH_CANDIDATES,
   MISSION_READY_LABEL,
   parseCliArguments,
   parseModelDisclosure,
@@ -40,7 +43,9 @@ import {
   REQUIRED_EVIDENCE_ROWS,
   readGhOpenActivity,
   readGhPages,
+  readLivePullHead,
   readProjectSelectionPolicy,
+  recheckReviewEpochCandidate,
   renderMarkdown,
 } from "../skills/contribute-to-eliza/scripts/live-report.mjs";
 import {
@@ -1506,6 +1511,135 @@ describe("live report parsing", () => {
 });
 
 describe("live report behavior", () => {
+  it("freezes a finite oldest-first epoch and defers arrivals and overflow", () => {
+    const candidates = Array.from(
+      { length: MAX_REVIEW_EPOCH_CANDIDATES + 3 },
+      (_, index) => ({
+        number: index + 1,
+        headSha: `${String(index + 1).padStart(2, "0")}${"a".repeat(38)}`,
+        updatedAt: "2026-01-18T12:00:00.000Z",
+      }),
+    );
+    candidates.push({
+      number: 99,
+      headSha: "f".repeat(40),
+      updatedAt: "2026-01-20T12:00:01.000Z",
+    });
+
+    const epoch = createReviewEpoch(
+      candidates,
+      "2026-01-20T12:00:00.000Z",
+      MAX_REVIEW_EPOCH_CANDIDATES,
+    );
+
+    assert.deepStrictEqual(
+      epoch.candidates.map((candidate) => candidate.number),
+      Array.from(
+        { length: MAX_REVIEW_EPOCH_CANDIDATES },
+        (_, index) => index + 1,
+      ),
+    );
+    assert.deepStrictEqual(
+      epoch.deferred.map((candidate) => [
+        candidate.number,
+        candidate.deferredReason,
+      ]),
+      [
+        [21, "epoch-limit"],
+        [22, "epoch-limit"],
+        [23, "epoch-limit"],
+        [99, "after-cutoff"],
+      ],
+    );
+    assert.strictEqual(epoch.completion.allowsNextTier, false);
+    assert.strictEqual(epoch.completion.maxNextTierOutcomes, 0);
+    const incomplete = completeReviewEpoch(epoch, [
+      {
+        number: 1,
+        expectedHeadSha: epoch.candidates[0].headSha,
+        status: "reviewed",
+      },
+    ]);
+    assert.strictEqual(incomplete.allowsNextTier, false);
+    assert.strictEqual(incomplete.remainingCandidates.length, 19);
+    const completed = completeReviewEpoch(
+      epoch,
+      epoch.candidates.map((candidate) => ({
+        number: candidate.number,
+        expectedHeadSha: candidate.headSha,
+        status: "reviewed",
+      })),
+    );
+    assert.strictEqual(completed.complete, true);
+    assert.strictEqual(completed.allowsNextTier, true);
+    assert.strictEqual(completed.nextTier, "next-eligible-lower-tier");
+    assert.strictEqual(completed.maxNextTierOutcomes, 1);
+  });
+
+  it("requires an exact current head before publishing and defers churn", () => {
+    const candidate = {
+      number: 7,
+      headSha: "a".repeat(40),
+      updatedAt: "2026-01-18T12:00:00.000Z",
+    };
+    assert.deepStrictEqual(
+      recheckReviewEpochCandidate(candidate, "A".repeat(40)),
+      {
+        number: 7,
+        status: "current",
+        publishable: true,
+      },
+    );
+    assert.deepStrictEqual(
+      recheckReviewEpochCandidate(candidate, "b".repeat(40)),
+      {
+        number: 7,
+        status: "stale",
+        publishable: false,
+        currentHeadSha: "b".repeat(40),
+        deferredReason: "head-changed",
+      },
+    );
+    assert.deepStrictEqual(
+      recheckReviewEpochCandidate(candidate, "c".repeat(40)),
+      {
+        number: 7,
+        status: "stale",
+        publishable: false,
+        currentHeadSha: "c".repeat(40),
+        deferredReason: "head-changed",
+      },
+    );
+  });
+
+  it("uses a read-only live GET as the publication head guard", () => {
+    const calls: string[][] = [];
+    const live = readLivePullHead("elizaOS/eliza", 7, (_command, args) => {
+      calls.push(args);
+      return {
+        status: 0,
+        stderr: "",
+        stdout: JSON.stringify({
+          number: 7,
+          headSha: "b".repeat(40),
+          updatedAt: "2026-01-20T12:00:01.000Z",
+        }),
+      };
+    });
+    assert.deepStrictEqual(live, {
+      number: 7,
+      headSha: "b".repeat(40),
+      updatedAt: "2026-01-20T12:00:01.000Z",
+    });
+    assert.deepStrictEqual(calls[0].slice(0, 4), [
+      "api",
+      "--method",
+      "GET",
+      "--jq",
+    ]);
+    assert.ok(calls[0].at(-1)?.endsWith("/pulls/7"));
+  });
+
   it("invokes gh only through paginated GET requests", () => {
     let invocation:
       | {

--- a/skill-tests/project-skills.test.ts
+++ b/skill-tests/project-skills.test.ts
@@ -187,6 +187,9 @@ describe("project skill contracts", () => {
         /\*\*merge\*\*, \*\*fix\*\*, or \*\*close\*\*/iu,
       );
       assert.match(contributor, /exact current head|exact-head/iu);
+      assert.match(contributor, /--epoch-only/u);
+      assert.match(contributor, /--complete-epoch/u);
+      assert.match(contributor, /recommendationUrl/u);
       const newIssueGate = contributor.search(
         /(?:a new (?:issue|one)\s+requires|open a new\s+issue only)/iu,
       );

--- a/skills/contribute-to-asi/SKILL.md
+++ b/skills/contribute-to-asi/SKILL.md
@@ -106,9 +106,31 @@ acting — someone may already be running your experiment.
 
 ## Finish the existing queue and workflows before inventing work
 
-Use the live report as a filter, then inspect GitHub directly. Follow this
-priority order without skipping a nonempty higher tier for easier, newer, or
-more interesting work:
+The report freezes at most 20 oldest eligible PR numbers and exact head SHAs in
+`selection.reviewEpoch`; later arrivals and overflow remain visible in
+`reviewEpoch.deferred`. Recheck each frozen head immediately before publishing:
+
+```bash
+node <skill-directory>/scripts/live-report.mjs --repo SlopDotCash/asi \
+  --recheck-pr <number> --expected-head <frozen-head-sha>
+```
+
+Save the frozen epoch with `--epoch-only`, record one `merge`, `fix`, or `close` disposition
+and public GitHub `recommendationUrl` per frozen head (or `stale-head` plus the
+different `currentHeadSha`), then run:
+
+```bash
+node <skill-directory>/scripts/live-report.mjs --repo SlopDotCash/asi \
+  --epoch-only > review-epoch.json
+node <skill-directory>/scripts/live-report.mjs \
+  --complete-epoch review-epoch.json --dispositions dispositions.json \
+  > epoch-completion.json
+```
+
+An incomplete command exits 2. A complete record permits exactly one bounded
+outcome in the next eligible lower tier even when deferred PRs remain; begin a
+fresh epoch before another. Use the live report as a filter, inspect GitHub
+directly, and follow this priority order within each finite epoch:
 
 1. **Review and test every current PR.** Start with the oldest non-draft,
    unblocked, non-sensitive PR lacking a substantive independent review of its
@@ -119,20 +141,24 @@ more interesting work:
    failure-sensitive tests, and rerunning exact-head checks; never approve your
    own work. Do not leave any reviewable PR without a current-head test and
    disposition merely because its premise is weak or its author is inactive.
-2. **Finish every existing issue without a PR.** Only after tier one is empty,
+2. **Finish every existing issue without a PR.** After the epoch completion
+   record permits one lower-tier outcome,
    choose the oldest bounded, unblocked, unclaimed open issue that fits the
    measured ASI mission. Confirm no open PR has a closing reference or
    substantively implements it, then resolve it completely through a focused PR
    with the required paired evidence. Give duplicate, obsolete, invalid, or
    out-of-scope issues an explicit closure recommendation instead of turning
    them into cleanup work.
-3. **Restore integration-branch workflow health.** Only after tiers one and two
-   are empty, inspect every required GitHub Actions workflow on `main`. Repair
+3. **Restore integration-branch workflow health.** After the epoch completion
+   record permits the next eligible lower-tier outcome and no bounded issue
+   outcome is available, inspect every required GitHub Actions workflow on
+   `main`. Repair
    every reproducible repository-caused failure and rerun it at the exact head.
    A queued run, missing runner, credential/environment gate, or external outage
    is not green and not a code bug; record the precise blocker instead of
    weakening checks or inventing unrelated work.
-4. **Advance the research only after all three gates are clear.** New work
+4. **Advance the research only after the completion record permits the next
+   eligible lower-tier outcome and all three gates are clear.** New work
    must be a benchmark hill climb, a measured port or decisive experimental
    advancement/refutation, or a fix for an actual reproduced runtime,
    harness, metric, validator, or test-system bug. Do not make random

--- a/skills/contribute-to-asi/scripts/live-report.mjs
+++ b/skills/contribute-to-asi/scripts/live-report.mjs
@@ -23,6 +23,11 @@ export const REQUIRED_EVIDENCE_ROWS = [
 export const CLAIM_RECENCY_DAYS = 7;
 export const MISSION_READY_LABEL = "mission-ready";
 export const MAX_OPEN_ITEMS = 10_000;
+// The repository-size bound protects discovery. This smaller work-epoch bound
+// is the liveness contract: one run has a finite frozen PR frontier and may
+// advance after that frontier is dispositioned even while new PRs arrive.
+export const MAX_REVIEW_EPOCH_CANDIDATES = 20;
+export const REVIEW_EPOCH_SCHEMA_VERSION = 1;
 export const MAX_API_READS = 16;
 export const MAX_ACTIVITY_CONNECTION_ITEMS = 1_000;
 export const MIN_GRAPHQL_ACTIVITY_POINTS = 1_000;
@@ -370,6 +375,208 @@ function compareByNumber(left, right) {
   return left.number - right.number;
 }
 
+function reviewEpochCandidate(
+  value,
+  index,
+  context = "review epoch candidate",
+) {
+  const record = asRecord(value, `${context}[${index}]`);
+  const number = asNumberField(record, "number", `${context}[${index}]`);
+  if (number < 1) {
+    throw new TypeError(`${context}[${index}].number must be positive`);
+  }
+  const headSha = asStringField(
+    record,
+    "headSha",
+    `${context}[${index}]`,
+  ).toLowerCase();
+  if (!FULL_COMMIT_RE.test(headSha)) {
+    throw new TypeError(
+      `${context}[${index}].headSha must be a full commit SHA`,
+    );
+  }
+  const updatedAt = isoTime(record.updatedAt, `${context}[${index}].updatedAt`);
+  return { number, headSha, updatedAt };
+}
+
+function reviewEpochIdentity(value, context = "review epoch candidate") {
+  const record = asRecord(value, context);
+  const number = asNumberField(record, "number", context);
+  if (number < 1) {
+    throw new TypeError(`${context}.number must be positive`);
+  }
+  const headSha = asStringField(record, "headSha", context).toLowerCase();
+  if (!FULL_COMMIT_RE.test(headSha)) {
+    throw new TypeError(`${context}.headSha must be a full commit SHA`);
+  }
+  return { number, headSha };
+}
+
+/**
+ * Freezes a deterministic, bounded PR review frontier. Candidates updated
+ * after the cutoff are explicitly deferred, as are candidates beyond the
+ * finite epoch count; both are eligible for a later epoch and never vanish
+ * from diagnostics.
+ */
+export function createReviewEpoch(
+  candidates,
+  cutoff,
+  maxCandidates = MAX_REVIEW_EPOCH_CANDIDATES,
+) {
+  if (!Array.isArray(candidates)) {
+    throw new TypeError("review epoch candidates must be an array");
+  }
+  const cutoffTime = Date.parse(isoTime(cutoff, "review epoch cutoff"));
+  if (
+    !Number.isInteger(maxCandidates) ||
+    maxCandidates < 1 ||
+    maxCandidates > MAX_REVIEW_EPOCH_CANDIDATES
+  ) {
+    throw new TypeError(
+      `review epoch maxCandidates must be an integer from 1 to ${MAX_REVIEW_EPOCH_CANDIDATES}`,
+    );
+  }
+  const normalized = candidates
+    .map((value, index) => reviewEpochCandidate(value, index))
+    .sort(compareByNumber);
+  const seen = new Set();
+  for (const candidate of normalized) {
+    if (seen.has(candidate.number)) {
+      throw new TypeError(
+        `duplicate review epoch candidate #${candidate.number}`,
+      );
+    }
+    seen.add(candidate.number);
+  }
+  const frozen = normalized.filter(
+    (candidate) => Date.parse(candidate.updatedAt) <= cutoffTime,
+  );
+  const arrivals = normalized
+    .filter((candidate) => Date.parse(candidate.updatedAt) > cutoffTime)
+    .map((candidate) => ({ ...candidate, deferredReason: "after-cutoff" }));
+  const selected = frozen.slice(0, maxCandidates);
+  const overLimit = frozen
+    .slice(maxCandidates)
+    .map((candidate) => ({ ...candidate, deferredReason: "epoch-limit" }));
+  return {
+    schemaVersion: REVIEW_EPOCH_SCHEMA_VERSION,
+    cutoff,
+    maxCandidates,
+    candidateCount: normalized.length,
+    candidates: selected,
+    deferred: [...overLimit, ...arrivals].sort(compareByNumber),
+    completion: {
+      requiredCandidateCount: selected.length,
+      allowsNextTier: false,
+      maxNextTierOutcomes: 0,
+    },
+  };
+}
+
+const REVIEW_EPOCH_DISPOSITIONS = new Set([
+  "reviewed",
+  "fix",
+  "close",
+  "stale-head",
+]);
+
+/** Returns the lower-tier permit only after every frozen candidate is closed. */
+export function completeReviewEpoch(epoch, dispositions) {
+  const record = asRecord(epoch, "review epoch");
+  const candidates = asArrayField(record, "candidates", "review epoch").map(
+    (candidate, index) =>
+      reviewEpochIdentity(candidate, `review epoch.candidates[${index}]`),
+  );
+  if (!Array.isArray(dispositions)) {
+    throw new TypeError("review epoch dispositions must be an array");
+  }
+  const expected = new Map(
+    candidates.map((candidate) => [candidate.number, candidate]),
+  );
+  const completed = new Set();
+  for (const [index, value] of dispositions.entries()) {
+    const context = `review epoch dispositions[${index}]`;
+    const disposition = asRecord(value, context);
+    const number = asNumberField(disposition, "number", context);
+    const candidate = expected.get(number);
+    if (!candidate) {
+      throw new TypeError(`${context} names non-epoch candidate #${number}`);
+    }
+    if (completed.has(number)) {
+      throw new TypeError(`duplicate review epoch disposition for #${number}`);
+    }
+    const expectedHeadSha = asStringField(
+      disposition,
+      "expectedHeadSha",
+      context,
+    ).toLowerCase();
+    if (expectedHeadSha !== candidate.headSha) {
+      throw new TypeError(
+        `${context} does not bind the frozen head for #${number}`,
+      );
+    }
+    const status = asStringField(disposition, "status", context);
+    if (!REVIEW_EPOCH_DISPOSITIONS.has(status)) {
+      throw new TypeError(`${context}.status is not a terminal disposition`);
+    }
+    if (status === "stale-head") {
+      const currentHeadSha = asStringField(
+        disposition,
+        "currentHeadSha",
+        context,
+      ).toLowerCase();
+      if (
+        !FULL_COMMIT_RE.test(currentHeadSha) ||
+        currentHeadSha === candidate.headSha
+      ) {
+        throw new TypeError(
+          `${context}.currentHeadSha must be a different full commit SHA`,
+        );
+      }
+    }
+    completed.add(number);
+  }
+  const remainingCandidates = candidates
+    .filter((candidate) => !completed.has(candidate.number))
+    .map((candidate) => candidate.number);
+  const complete = remainingCandidates.length === 0;
+  return {
+    complete,
+    dispositionCount: completed.size,
+    requiredCandidateCount: candidates.length,
+    remainingCandidates,
+    allowsNextTier: complete,
+    ...(complete
+      ? { nextTier: "next-eligible-lower-tier", maxNextTierOutcomes: 1 }
+      : { maxNextTierOutcomes: 0 }),
+  };
+}
+
+/**
+ * Publication boundary for an epoch candidate. A changed head is stale and
+ * must be deferred; only an exact byte-for-byte head match is publishable.
+ */
+export function recheckReviewEpochCandidate(candidate, currentHeadSha) {
+  const normalized = reviewEpochIdentity(candidate);
+  if (
+    typeof currentHeadSha !== "string" ||
+    !FULL_COMMIT_RE.test(currentHeadSha)
+  ) {
+    throw new TypeError("currentHeadSha must be a full commit SHA");
+  }
+  const current = currentHeadSha.toLowerCase();
+  if (current === normalized.headSha) {
+    return { number: normalized.number, status: "current", publishable: true };
+  }
+  return {
+    number: normalized.number,
+    status: "stale",
+    publishable: false,
+    currentHeadSha: current,
+    deferredReason: "head-changed",
+  };
+}
+
 function compareComment(left, right) {
   return left.id - right.id || left.url.localeCompare(right.url);
 }
@@ -459,6 +666,86 @@ export function readGhPages(endpoint, spawn = spawnSync) {
     throw new TypeError("gh api did not return text output");
   }
   return parsePaginatedJson(result.stdout, endpoint);
+}
+
+/** Performs the single live GET used as the pre-publication head guard. */
+export function readLivePullHead(repo, number, spawn = spawnSync) {
+  if (!REPOSITORY_RE.test(repo)) {
+    throw new TypeError("Repository must use the owner/name form");
+  }
+  if (!Number.isInteger(number) || number < 1) {
+    throw new TypeError("pull request number must be a positive integer");
+  }
+  const endpoint = `repos/${repo}/pulls/${number}`;
+  const result = spawn(
+    "gh",
+    [
+      "api",
+      "--method",
+      "GET",
+      "--jq",
+      "{number: .number, headSha: .head.sha, updatedAt: .updated_at}",
+      endpoint,
+    ],
+    {
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024,
+      windowsHide: true,
+    },
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const detail =
+      typeof result.stderr === "string" && result.stderr.trim().length > 0
+        ? `: ${result.stderr.trim()}`
+        : "";
+    throw new Error(`gh api failed for ${endpoint}${detail}`);
+  }
+  let value;
+  try {
+    value = JSON.parse(result.stdout);
+  } catch (cause) {
+    throw new SyntaxError(`gh api returned malformed JSON for ${endpoint}`, {
+      cause,
+    });
+  }
+  const record = asRecord(value, `live pull request #${number}`);
+  const liveNumber = asNumberField(
+    record,
+    "number",
+    `live pull request #${number}`,
+  );
+  if (liveNumber !== number) {
+    throw new TypeError(`live pull request number changed from #${number}`);
+  }
+  const headSha = asStringField(
+    record,
+    "headSha",
+    `live pull request #${number}`,
+  ).toLowerCase();
+  if (!FULL_COMMIT_RE.test(headSha)) {
+    throw new TypeError(
+      `live pull request #${number}.headSha must be a full commit SHA`,
+    );
+  }
+  return {
+    number,
+    headSha,
+    updatedAt: isoTime(
+      record.updatedAt,
+      `live pull request #${number}.updatedAt`,
+    ),
+  };
+}
+
+export function recheckLivePullHead(repo, candidate, spawn = spawnSync) {
+  const normalized = reviewEpochIdentity(candidate);
+  const live = readLivePullHead(repo, normalized.number, spawn);
+  return {
+    ...recheckReviewEpochCandidate(normalized, live.headSha),
+    expectedHeadSha: normalized.headSha,
+    updatedAt: live.updatedAt,
+  };
 }
 
 const ACTIVITY_PAGE_SIZE = 100;
@@ -1739,6 +2026,7 @@ export function collectLiveReport(
     throw new TypeError("Repository must use the owner/name form");
   }
   const referenceTime = nowTime(now);
+  const snapshotCutoff = now.toISOString();
   const candidateLabelSet = new Set(
     eligibleIssueLabels(projectEligibleIssueLabels, "eligible issue labels"),
   );
@@ -1970,7 +2258,18 @@ export function collectLiveReport(
       currentHeadApprovals: currentReviews.approved,
       currentHeadChangesRequested: currentReviews.changesRequested,
     };
-    const detailedSummary = { ...summary, reviewState };
+    const head = asRecord(item.head, `${context}.head`);
+    const headSha = asStringField(head, "sha", `${context}.head`).toLowerCase();
+    if (!FULL_COMMIT_RE.test(headSha)) {
+      throw new TypeError(`${context}.head.sha must be a full commit SHA`);
+    }
+    const updatedAt = isoTime(item.updated_at, `${context}.updated_at`);
+    const detailedSummary = {
+      ...summary,
+      updatedAt,
+      headSha,
+      reviewState,
+    };
     pullRequestAudits.push({
       ...detailedSummary,
       bodyProviderModel: parseModelDisclosure(body),
@@ -2010,10 +2309,13 @@ export function collectLiveReport(
     reviewablePullRequests.push(detailedSummary);
   }
 
+  const reviewEpoch = createReviewEpoch(reviewablePullRequests, snapshotCutoff);
   return {
     repository: repo,
+    snapshot: { cutoff: snapshotCutoff },
     selection: {
       eligibleIssueLabels: [...candidateLabelSet].sort(),
+      reviewEpoch,
     },
     totals: {
       openIssues: issueItems.length,
@@ -2080,6 +2382,9 @@ export function renderMarkdown(report) {
     "",
     `Open issues: ${report.totals.openIssues}; unclaimed candidates: ${report.totals.candidateIssues}.`,
     `Open PRs: ${report.totals.openPullRequests}; reviewable candidates: ${report.totals.reviewablePullRequests}.`,
+    report.selection?.reviewEpoch
+      ? `Review epoch cutoff: ${report.selection.reviewEpoch.cutoff}; frozen candidates: ${report.selection.reviewEpoch.candidates.length}/${report.selection.reviewEpoch.candidateCount}; deferred to a later epoch: ${report.selection.reviewEpoch.deferred.length}.`
+      : "Review epoch: unavailable.",
     "",
     "## Priority 1: unclaimed issue candidates with no open closing PR",
     "",
@@ -2143,7 +2448,11 @@ export function parseCliArguments(
   if (!REPOSITORY_RE.test(defaultRepository)) {
     throw new TypeError("default repository must use the owner/name form");
   }
-  const options = { repo: defaultRepository, json: false, help: false };
+  const options = {
+    repo: defaultRepository,
+    json: false,
+    help: false,
+  };
   for (let index = 0; index < args.length; index += 1) {
     const argument = args[index];
     if (argument === "--json") {
@@ -2158,12 +2467,43 @@ export function parseCliArguments(
       options.repo = args[index];
     } else if (argument.startsWith("--repo=")) {
       options.repo = argument.slice("--repo=".length);
+    } else if (argument === "--recheck-pr") {
+      index += 1;
+      if (index >= args.length) {
+        throw new TypeError("--recheck-pr requires a pull request number");
+      }
+      options.recheckPr = Number(args[index]);
+    } else if (argument.startsWith("--recheck-pr=")) {
+      options.recheckPr = Number(argument.slice("--recheck-pr=".length));
+    } else if (argument === "--expected-head") {
+      index += 1;
+      if (index >= args.length) {
+        throw new TypeError("--expected-head requires a full commit SHA");
+      }
+      options.expectedHead = args[index];
+    } else if (argument.startsWith("--expected-head=")) {
+      options.expectedHead = argument.slice("--expected-head=".length);
     } else {
       throw new TypeError(`Unknown argument: ${argument}`);
     }
   }
   if (!REPOSITORY_RE.test(options.repo)) {
     throw new TypeError("--repo must use the owner/name form");
+  }
+  if (options.recheckPr !== undefined) {
+    if (!Number.isInteger(options.recheckPr) || options.recheckPr < 1) {
+      throw new TypeError("--recheck-pr must be a positive integer");
+    }
+    if (
+      typeof options.expectedHead !== "string" ||
+      !FULL_COMMIT_RE.test(options.expectedHead)
+    ) {
+      throw new TypeError(
+        "--expected-head must be a full commit SHA when rechecking a PR",
+      );
+    }
+  } else if (options.expectedHead !== undefined) {
+    throw new TypeError("--expected-head requires --recheck-pr");
   }
   return options;
 }
@@ -2176,6 +2516,8 @@ Read and paginate open GitHub issues and pull requests without changing them.
 Options:
   --repo <owner/name>  Repository to inspect (default: this skill's project)
   --json               Print stable machine-readable JSON
+  --recheck-pr <n>     GET one live PR head before publishing a review
+  --expected-head <sha>  Frozen epoch head required by --recheck-pr
   --help, -h           Show this help
 `;
 }
@@ -2188,6 +2530,19 @@ export function main(args = process.argv.slice(2)) {
     return;
   }
   const commandBudget = createGhCommandBudget();
+  if (options.recheckPr !== undefined) {
+    const result = recheckLivePullHead(
+      options.repo,
+      {
+        number: options.recheckPr,
+        headSha: options.expectedHead,
+      },
+      commandBudget.run,
+    );
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    if (!result.publishable) process.exitCode = 2;
+    return;
+  }
   const boundedRead = (endpoint) => {
     return readGhPages(endpoint, commandBudget.run);
   };

--- a/skills/contribute-to-asi/scripts/live-report.mjs
+++ b/skills/contribute-to-asi/scripts/live-report.mjs
@@ -6,7 +6,7 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -28,6 +28,7 @@ export const MAX_OPEN_ITEMS = 10_000;
 // advance after that frontier is dispositioned even while new PRs arrive.
 export const MAX_REVIEW_EPOCH_CANDIDATES = 20;
 export const REVIEW_EPOCH_SCHEMA_VERSION = 1;
+export const MAX_REVIEW_EPOCH_FILE_BYTES = 262_144;
 export const MAX_API_READS = 16;
 export const MAX_ACTIVITY_CONNECTION_ITEMS = 1_000;
 export const MIN_GRAPHQL_ACTIVITY_POINTS = 1_000;
@@ -474,7 +475,7 @@ export function createReviewEpoch(
 }
 
 const REVIEW_EPOCH_DISPOSITIONS = new Set([
-  "reviewed",
+  "merge",
   "fix",
   "close",
   "stale-head",
@@ -483,6 +484,13 @@ const REVIEW_EPOCH_DISPOSITIONS = new Set([
 /** Returns the lower-tier permit only after every frozen candidate is closed. */
 export function completeReviewEpoch(epoch, dispositions) {
   const record = asRecord(epoch, "review epoch");
+  const schemaVersion = asNumberField(record, "schemaVersion", "review epoch");
+  if (schemaVersion !== REVIEW_EPOCH_SCHEMA_VERSION) {
+    throw new TypeError(
+      `review epoch.schemaVersion must be ${REVIEW_EPOCH_SCHEMA_VERSION}`,
+    );
+  }
+  const cutoff = isoTime(record.cutoff, "review epoch.cutoff");
   const candidates = asArrayField(record, "candidates", "review epoch").map(
     (candidate, index) =>
       reviewEpochIdentity(candidate, `review epoch.candidates[${index}]`),
@@ -493,7 +501,11 @@ export function completeReviewEpoch(epoch, dispositions) {
   const expected = new Map(
     candidates.map((candidate) => [candidate.number, candidate]),
   );
+  if (expected.size !== candidates.length) {
+    throw new TypeError("review epoch contains duplicate candidates");
+  }
   const completed = new Set();
+  const normalizedDispositions = new Map();
   for (const [index, value] of dispositions.entries()) {
     const context = `review epoch dispositions[${index}]`;
     const disposition = asRecord(value, context);
@@ -519,6 +531,11 @@ export function completeReviewEpoch(epoch, dispositions) {
     if (!REVIEW_EPOCH_DISPOSITIONS.has(status)) {
       throw new TypeError(`${context}.status is not a terminal disposition`);
     }
+    const normalizedDisposition = {
+      number,
+      expectedHeadSha,
+      status,
+    };
     if (status === "stale-head") {
       const currentHeadSha = asStringField(
         disposition,
@@ -533,23 +550,103 @@ export function completeReviewEpoch(epoch, dispositions) {
           `${context}.currentHeadSha must be a different full commit SHA`,
         );
       }
+      normalizedDisposition.currentHeadSha = currentHeadSha;
+    } else {
+      const recommendationUrl = asStringField(
+        disposition,
+        "recommendationUrl",
+        context,
+      );
+      let parsedRecommendationUrl;
+      try {
+        parsedRecommendationUrl = new URL(recommendationUrl);
+      } catch (cause) {
+        throw new TypeError(`${context}.recommendationUrl must be a URL`, {
+          cause,
+        });
+      }
+      const pathParts = parsedRecommendationUrl.pathname
+        .split("/")
+        .filter(Boolean);
+      if (
+        parsedRecommendationUrl.protocol !== "https:" ||
+        parsedRecommendationUrl.hostname !== "github.com" ||
+        parsedRecommendationUrl.username !== "" ||
+        parsedRecommendationUrl.password !== "" ||
+        pathParts.length < 4 ||
+        pathParts[2] !== "pull" ||
+        Number(pathParts[3]) !== number ||
+        recommendationUrl.length > 2_048
+      ) {
+        throw new TypeError(
+          `${context}.recommendationUrl must be a bounded public GitHub HTTPS URL`,
+        );
+      }
+      normalizedDisposition.recommendationUrl =
+        parsedRecommendationUrl.toString();
     }
     completed.add(number);
+    normalizedDispositions.set(number, normalizedDisposition);
   }
   const remainingCandidates = candidates
     .filter((candidate) => !completed.has(candidate.number))
     .map((candidate) => candidate.number);
   const complete = remainingCandidates.length === 0;
   return {
+    schemaVersion: REVIEW_EPOCH_SCHEMA_VERSION,
+    cutoff,
     complete,
     dispositionCount: completed.size,
     requiredCandidateCount: candidates.length,
     remainingCandidates,
+    dispositions: candidates.flatMap((candidate) => {
+      const disposition = normalizedDispositions.get(candidate.number);
+      return disposition ? [disposition] : [];
+    }),
     allowsNextTier: complete,
     ...(complete
       ? { nextTier: "next-eligible-lower-tier", maxNextTierOutcomes: 1 }
       : { maxNextTierOutcomes: 0 }),
   };
+}
+
+function readBoundedJsonFile(path, context) {
+  if (typeof path !== "string" || path.trim() === "") {
+    throw new TypeError(`${context} path must be a non-empty string`);
+  }
+  const statistics = statSync(path);
+  if (!statistics.isFile()) {
+    throw new TypeError(`${context} must be a regular file`);
+  }
+  if (statistics.size > MAX_REVIEW_EPOCH_FILE_BYTES) {
+    throw new RangeError(
+      `${context} exceeds ${MAX_REVIEW_EPOCH_FILE_BYTES} bytes`,
+    );
+  }
+  const contents = readFileSync(path);
+  if (contents.byteLength > MAX_REVIEW_EPOCH_FILE_BYTES) {
+    throw new RangeError(
+      `${context} exceeds ${MAX_REVIEW_EPOCH_FILE_BYTES} bytes`,
+    );
+  }
+  try {
+    return JSON.parse(contents.toString("utf8"));
+  } catch (cause) {
+    throw new SyntaxError(`${context} must contain valid JSON`, { cause });
+  }
+}
+
+function reviewEpochFromFile(path) {
+  const value = asRecord(
+    readBoundedJsonFile(path, "review epoch input"),
+    "review epoch input",
+  );
+  if (value.selection === undefined) return value;
+  const selection = asRecord(value.selection, "review epoch input.selection");
+  return asRecord(
+    selection.reviewEpoch,
+    "review epoch input.selection.reviewEpoch",
+  );
 }
 
 /**
@@ -2457,6 +2554,8 @@ export function parseCliArguments(
     const argument = args[index];
     if (argument === "--json") {
       options.json = true;
+    } else if (argument === "--epoch-only") {
+      options.epochOnly = true;
     } else if (argument === "--help" || argument === "-h") {
       options.help = true;
     } else if (argument === "--repo") {
@@ -2483,6 +2582,22 @@ export function parseCliArguments(
       options.expectedHead = args[index];
     } else if (argument.startsWith("--expected-head=")) {
       options.expectedHead = argument.slice("--expected-head=".length);
+    } else if (argument === "--complete-epoch") {
+      index += 1;
+      if (index >= args.length) {
+        throw new TypeError("--complete-epoch requires a JSON file path");
+      }
+      options.completeEpochPath = args[index];
+    } else if (argument.startsWith("--complete-epoch=")) {
+      options.completeEpochPath = argument.slice("--complete-epoch=".length);
+    } else if (argument === "--dispositions") {
+      index += 1;
+      if (index >= args.length) {
+        throw new TypeError("--dispositions requires a JSON file path");
+      }
+      options.dispositionsPath = args[index];
+    } else if (argument.startsWith("--dispositions=")) {
+      options.dispositionsPath = argument.slice("--dispositions=".length);
     } else {
       throw new TypeError(`Unknown argument: ${argument}`);
     }
@@ -2505,6 +2620,34 @@ export function parseCliArguments(
   } else if (options.expectedHead !== undefined) {
     throw new TypeError("--expected-head requires --recheck-pr");
   }
+  const completionRequested =
+    options.completeEpochPath !== undefined ||
+    options.dispositionsPath !== undefined;
+  if (completionRequested) {
+    if (
+      typeof options.completeEpochPath !== "string" ||
+      options.completeEpochPath.trim() === "" ||
+      typeof options.dispositionsPath !== "string" ||
+      options.dispositionsPath.trim() === ""
+    ) {
+      throw new TypeError(
+        "--complete-epoch and --dispositions must be provided together",
+      );
+    }
+    if (options.recheckPr !== undefined) {
+      throw new TypeError(
+        "--complete-epoch cannot be combined with --recheck-pr",
+      );
+    }
+  }
+  if (
+    options.epochOnly === true &&
+    (options.json || completionRequested || options.recheckPr !== undefined)
+  ) {
+    throw new TypeError(
+      "--epoch-only cannot be combined with another output operation",
+    );
+  }
   return options;
 }
 
@@ -2516,8 +2659,11 @@ Read and paginate open GitHub issues and pull requests without changing them.
 Options:
   --repo <owner/name>  Repository to inspect (default: this skill's project)
   --json               Print stable machine-readable JSON
+  --epoch-only         Print only the finite review epoch JSON
   --recheck-pr <n>     GET one live PR head before publishing a review
   --expected-head <sha>  Frozen epoch head required by --recheck-pr
+  --complete-epoch <path>  Validate a saved report or epoch JSON file
+  --dispositions <path>  Terminal disposition JSON required for completion
   --help, -h           Show this help
 `;
 }
@@ -2527,6 +2673,17 @@ export function main(args = process.argv.slice(2)) {
   const options = parseCliArguments(args, selectionPolicy.repositoryId);
   if (options.help) {
     process.stdout.write(usage());
+    return;
+  }
+  if (options.completeEpochPath !== undefined) {
+    const epoch = reviewEpochFromFile(options.completeEpochPath);
+    const dispositions = readBoundedJsonFile(
+      options.dispositionsPath,
+      "review epoch dispositions",
+    );
+    const result = completeReviewEpoch(epoch, dispositions);
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    if (!result.complete) process.exitCode = 2;
     return;
   }
   const commandBudget = createGhCommandBudget();
@@ -2568,9 +2725,11 @@ export function main(args = process.argv.slice(2)) {
     selectionPolicy.eligibleIssueLabels,
   );
   process.stdout.write(
-    options.json
-      ? `${JSON.stringify(report, null, 2)}\n`
-      : renderMarkdown(report),
+    options.epochOnly
+      ? `${JSON.stringify(report.selection.reviewEpoch, null, 2)}\n`
+      : options.json
+        ? `${JSON.stringify(report, null, 2)}\n`
+        : renderMarkdown(report),
   );
 }
 

--- a/skills/contribute-to-delta-star/SKILL.md
+++ b/skills/contribute-to-delta-star/SKILL.md
@@ -117,7 +117,30 @@ issue or pull request immediately before acting.
 
 ## Finish the existing queue and workflows before inventing work
 
-Follow this order without skipping a nonempty higher tier:
+The report freezes at most 20 oldest eligible PR numbers and exact head SHAs in
+`selection.reviewEpoch`; later arrivals and overflow remain visible in
+`reviewEpoch.deferred`. Recheck each frozen head immediately before publishing:
+
+```bash
+node <skill-directory>/scripts/live-report.mjs --repo SlopDotCash/proximityprize \
+  --recheck-pr <number> --expected-head <frozen-head-sha>
+```
+
+Save the frozen epoch with `--epoch-only`, record one `merge`, `fix`, or `close` disposition
+and public GitHub `recommendationUrl` per frozen head (or `stale-head` plus the
+different `currentHeadSha`), then run:
+
+```bash
+node <skill-directory>/scripts/live-report.mjs --repo SlopDotCash/proximityprize \
+  --epoch-only > review-epoch.json
+node <skill-directory>/scripts/live-report.mjs \
+  --complete-epoch review-epoch.json --dispositions dispositions.json \
+  > epoch-completion.json
+```
+
+An incomplete command exits 2. A complete record permits exactly one bounded
+outcome in the next eligible lower tier even when deferred PRs remain; begin a
+fresh epoch before another. Follow this order within each finite epoch:
 
 1. Review and test every current PR, starting with the oldest non-draft,
    unblocked, non-sensitive PR lacking a substantive independent review of its
@@ -125,17 +148,20 @@ Follow this order without skipping a nonempty higher tier:
    **merge**, **fix**, or **close** recommendation. When authorized, repair real
    defects and rerun exact-head checks so an existing PR is completely solid;
    never approve your own work or leave a reviewable PR undisposed.
-2. Only when tier one is empty, finish the oldest bounded, unblocked, unclaimed
+2. After the epoch completion record permits one lower-tier outcome, finish the oldest
+   bounded, unblocked, unclaimed
    open issue that advances the live Delta Star frontier and has no open PR that
    closes or substantively implements it. Complete it through a focused PR, or
    give duplicate, obsolete, invalid, and out-of-scope issues an explicit
    closure recommendation.
-3. Only when tiers one and two are empty, inspect every required GitHub Actions
+3. After the completion record permits the next eligible lower-tier outcome and
+   no bounded issue outcome is available, inspect every required GitHub Actions
    workflow on `main`. Repair every reproducible repository-caused failure and
    rerun it at the exact head. Treat queued runs, missing runners,
    credential/environment gates, and external outages as precise blockers, not
    green results or reasons to weaken validation.
-4. Only after every PR, issue, and fixable workflow failure is reconciled may
+4. Only after the completion record permits the next eligible lower-tier
+   outcome and every PR, issue, and fixable workflow failure is reconciled may
    you select new
    frontier work. It must discharge or narrow a named mathematical residual,
    produce a machine-checked refutation, validate a consequential claim, or

--- a/skills/contribute-to-delta-star/scripts/live-report.mjs
+++ b/skills/contribute-to-delta-star/scripts/live-report.mjs
@@ -23,6 +23,11 @@ export const REQUIRED_EVIDENCE_ROWS = [
 export const CLAIM_RECENCY_DAYS = 7;
 export const MISSION_READY_LABEL = "mission-ready";
 export const MAX_OPEN_ITEMS = 10_000;
+// The repository-size bound protects discovery. This smaller work-epoch bound
+// is the liveness contract: one run has a finite frozen PR frontier and may
+// advance after that frontier is dispositioned even while new PRs arrive.
+export const MAX_REVIEW_EPOCH_CANDIDATES = 20;
+export const REVIEW_EPOCH_SCHEMA_VERSION = 1;
 export const MAX_API_READS = 16;
 export const MAX_ACTIVITY_CONNECTION_ITEMS = 1_000;
 export const MIN_GRAPHQL_ACTIVITY_POINTS = 1_000;
@@ -370,6 +375,208 @@ function compareByNumber(left, right) {
   return left.number - right.number;
 }
 
+function reviewEpochCandidate(
+  value,
+  index,
+  context = "review epoch candidate",
+) {
+  const record = asRecord(value, `${context}[${index}]`);
+  const number = asNumberField(record, "number", `${context}[${index}]`);
+  if (number < 1) {
+    throw new TypeError(`${context}[${index}].number must be positive`);
+  }
+  const headSha = asStringField(
+    record,
+    "headSha",
+    `${context}[${index}]`,
+  ).toLowerCase();
+  if (!FULL_COMMIT_RE.test(headSha)) {
+    throw new TypeError(
+      `${context}[${index}].headSha must be a full commit SHA`,
+    );
+  }
+  const updatedAt = isoTime(record.updatedAt, `${context}[${index}].updatedAt`);
+  return { number, headSha, updatedAt };
+}
+
+function reviewEpochIdentity(value, context = "review epoch candidate") {
+  const record = asRecord(value, context);
+  const number = asNumberField(record, "number", context);
+  if (number < 1) {
+    throw new TypeError(`${context}.number must be positive`);
+  }
+  const headSha = asStringField(record, "headSha", context).toLowerCase();
+  if (!FULL_COMMIT_RE.test(headSha)) {
+    throw new TypeError(`${context}.headSha must be a full commit SHA`);
+  }
+  return { number, headSha };
+}
+
+/**
+ * Freezes a deterministic, bounded PR review frontier. Candidates updated
+ * after the cutoff are explicitly deferred, as are candidates beyond the
+ * finite epoch count; both are eligible for a later epoch and never vanish
+ * from diagnostics.
+ */
+export function createReviewEpoch(
+  candidates,
+  cutoff,
+  maxCandidates = MAX_REVIEW_EPOCH_CANDIDATES,
+) {
+  if (!Array.isArray(candidates)) {
+    throw new TypeError("review epoch candidates must be an array");
+  }
+  const cutoffTime = Date.parse(isoTime(cutoff, "review epoch cutoff"));
+  if (
+    !Number.isInteger(maxCandidates) ||
+    maxCandidates < 1 ||
+    maxCandidates > MAX_REVIEW_EPOCH_CANDIDATES
+  ) {
+    throw new TypeError(
+      `review epoch maxCandidates must be an integer from 1 to ${MAX_REVIEW_EPOCH_CANDIDATES}`,
+    );
+  }
+  const normalized = candidates
+    .map((value, index) => reviewEpochCandidate(value, index))
+    .sort(compareByNumber);
+  const seen = new Set();
+  for (const candidate of normalized) {
+    if (seen.has(candidate.number)) {
+      throw new TypeError(
+        `duplicate review epoch candidate #${candidate.number}`,
+      );
+    }
+    seen.add(candidate.number);
+  }
+  const frozen = normalized.filter(
+    (candidate) => Date.parse(candidate.updatedAt) <= cutoffTime,
+  );
+  const arrivals = normalized
+    .filter((candidate) => Date.parse(candidate.updatedAt) > cutoffTime)
+    .map((candidate) => ({ ...candidate, deferredReason: "after-cutoff" }));
+  const selected = frozen.slice(0, maxCandidates);
+  const overLimit = frozen
+    .slice(maxCandidates)
+    .map((candidate) => ({ ...candidate, deferredReason: "epoch-limit" }));
+  return {
+    schemaVersion: REVIEW_EPOCH_SCHEMA_VERSION,
+    cutoff,
+    maxCandidates,
+    candidateCount: normalized.length,
+    candidates: selected,
+    deferred: [...overLimit, ...arrivals].sort(compareByNumber),
+    completion: {
+      requiredCandidateCount: selected.length,
+      allowsNextTier: false,
+      maxNextTierOutcomes: 0,
+    },
+  };
+}
+
+const REVIEW_EPOCH_DISPOSITIONS = new Set([
+  "reviewed",
+  "fix",
+  "close",
+  "stale-head",
+]);
+
+/** Returns the lower-tier permit only after every frozen candidate is closed. */
+export function completeReviewEpoch(epoch, dispositions) {
+  const record = asRecord(epoch, "review epoch");
+  const candidates = asArrayField(record, "candidates", "review epoch").map(
+    (candidate, index) =>
+      reviewEpochIdentity(candidate, `review epoch.candidates[${index}]`),
+  );
+  if (!Array.isArray(dispositions)) {
+    throw new TypeError("review epoch dispositions must be an array");
+  }
+  const expected = new Map(
+    candidates.map((candidate) => [candidate.number, candidate]),
+  );
+  const completed = new Set();
+  for (const [index, value] of dispositions.entries()) {
+    const context = `review epoch dispositions[${index}]`;
+    const disposition = asRecord(value, context);
+    const number = asNumberField(disposition, "number", context);
+    const candidate = expected.get(number);
+    if (!candidate) {
+      throw new TypeError(`${context} names non-epoch candidate #${number}`);
+    }
+    if (completed.has(number)) {
+      throw new TypeError(`duplicate review epoch disposition for #${number}`);
+    }
+    const expectedHeadSha = asStringField(
+      disposition,
+      "expectedHeadSha",
+      context,
+    ).toLowerCase();
+    if (expectedHeadSha !== candidate.headSha) {
+      throw new TypeError(
+        `${context} does not bind the frozen head for #${number}`,
+      );
+    }
+    const status = asStringField(disposition, "status", context);
+    if (!REVIEW_EPOCH_DISPOSITIONS.has(status)) {
+      throw new TypeError(`${context}.status is not a terminal disposition`);
+    }
+    if (status === "stale-head") {
+      const currentHeadSha = asStringField(
+        disposition,
+        "currentHeadSha",
+        context,
+      ).toLowerCase();
+      if (
+        !FULL_COMMIT_RE.test(currentHeadSha) ||
+        currentHeadSha === candidate.headSha
+      ) {
+        throw new TypeError(
+          `${context}.currentHeadSha must be a different full commit SHA`,
+        );
+      }
+    }
+    completed.add(number);
+  }
+  const remainingCandidates = candidates
+    .filter((candidate) => !completed.has(candidate.number))
+    .map((candidate) => candidate.number);
+  const complete = remainingCandidates.length === 0;
+  return {
+    complete,
+    dispositionCount: completed.size,
+    requiredCandidateCount: candidates.length,
+    remainingCandidates,
+    allowsNextTier: complete,
+    ...(complete
+      ? { nextTier: "next-eligible-lower-tier", maxNextTierOutcomes: 1 }
+      : { maxNextTierOutcomes: 0 }),
+  };
+}
+
+/**
+ * Publication boundary for an epoch candidate. A changed head is stale and
+ * must be deferred; only an exact byte-for-byte head match is publishable.
+ */
+export function recheckReviewEpochCandidate(candidate, currentHeadSha) {
+  const normalized = reviewEpochIdentity(candidate);
+  if (
+    typeof currentHeadSha !== "string" ||
+    !FULL_COMMIT_RE.test(currentHeadSha)
+  ) {
+    throw new TypeError("currentHeadSha must be a full commit SHA");
+  }
+  const current = currentHeadSha.toLowerCase();
+  if (current === normalized.headSha) {
+    return { number: normalized.number, status: "current", publishable: true };
+  }
+  return {
+    number: normalized.number,
+    status: "stale",
+    publishable: false,
+    currentHeadSha: current,
+    deferredReason: "head-changed",
+  };
+}
+
 function compareComment(left, right) {
   return left.id - right.id || left.url.localeCompare(right.url);
 }
@@ -459,6 +666,86 @@ export function readGhPages(endpoint, spawn = spawnSync) {
     throw new TypeError("gh api did not return text output");
   }
   return parsePaginatedJson(result.stdout, endpoint);
+}
+
+/** Performs the single live GET used as the pre-publication head guard. */
+export function readLivePullHead(repo, number, spawn = spawnSync) {
+  if (!REPOSITORY_RE.test(repo)) {
+    throw new TypeError("Repository must use the owner/name form");
+  }
+  if (!Number.isInteger(number) || number < 1) {
+    throw new TypeError("pull request number must be a positive integer");
+  }
+  const endpoint = `repos/${repo}/pulls/${number}`;
+  const result = spawn(
+    "gh",
+    [
+      "api",
+      "--method",
+      "GET",
+      "--jq",
+      "{number: .number, headSha: .head.sha, updatedAt: .updated_at}",
+      endpoint,
+    ],
+    {
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024,
+      windowsHide: true,
+    },
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const detail =
+      typeof result.stderr === "string" && result.stderr.trim().length > 0
+        ? `: ${result.stderr.trim()}`
+        : "";
+    throw new Error(`gh api failed for ${endpoint}${detail}`);
+  }
+  let value;
+  try {
+    value = JSON.parse(result.stdout);
+  } catch (cause) {
+    throw new SyntaxError(`gh api returned malformed JSON for ${endpoint}`, {
+      cause,
+    });
+  }
+  const record = asRecord(value, `live pull request #${number}`);
+  const liveNumber = asNumberField(
+    record,
+    "number",
+    `live pull request #${number}`,
+  );
+  if (liveNumber !== number) {
+    throw new TypeError(`live pull request number changed from #${number}`);
+  }
+  const headSha = asStringField(
+    record,
+    "headSha",
+    `live pull request #${number}`,
+  ).toLowerCase();
+  if (!FULL_COMMIT_RE.test(headSha)) {
+    throw new TypeError(
+      `live pull request #${number}.headSha must be a full commit SHA`,
+    );
+  }
+  return {
+    number,
+    headSha,
+    updatedAt: isoTime(
+      record.updatedAt,
+      `live pull request #${number}.updatedAt`,
+    ),
+  };
+}
+
+export function recheckLivePullHead(repo, candidate, spawn = spawnSync) {
+  const normalized = reviewEpochIdentity(candidate);
+  const live = readLivePullHead(repo, normalized.number, spawn);
+  return {
+    ...recheckReviewEpochCandidate(normalized, live.headSha),
+    expectedHeadSha: normalized.headSha,
+    updatedAt: live.updatedAt,
+  };
 }
 
 const ACTIVITY_PAGE_SIZE = 100;
@@ -1739,6 +2026,7 @@ export function collectLiveReport(
     throw new TypeError("Repository must use the owner/name form");
   }
   const referenceTime = nowTime(now);
+  const snapshotCutoff = now.toISOString();
   const candidateLabelSet = new Set(
     eligibleIssueLabels(projectEligibleIssueLabels, "eligible issue labels"),
   );
@@ -1970,7 +2258,18 @@ export function collectLiveReport(
       currentHeadApprovals: currentReviews.approved,
       currentHeadChangesRequested: currentReviews.changesRequested,
     };
-    const detailedSummary = { ...summary, reviewState };
+    const head = asRecord(item.head, `${context}.head`);
+    const headSha = asStringField(head, "sha", `${context}.head`).toLowerCase();
+    if (!FULL_COMMIT_RE.test(headSha)) {
+      throw new TypeError(`${context}.head.sha must be a full commit SHA`);
+    }
+    const updatedAt = isoTime(item.updated_at, `${context}.updated_at`);
+    const detailedSummary = {
+      ...summary,
+      updatedAt,
+      headSha,
+      reviewState,
+    };
     pullRequestAudits.push({
       ...detailedSummary,
       bodyProviderModel: parseModelDisclosure(body),
@@ -2010,10 +2309,13 @@ export function collectLiveReport(
     reviewablePullRequests.push(detailedSummary);
   }
 
+  const reviewEpoch = createReviewEpoch(reviewablePullRequests, snapshotCutoff);
   return {
     repository: repo,
+    snapshot: { cutoff: snapshotCutoff },
     selection: {
       eligibleIssueLabels: [...candidateLabelSet].sort(),
+      reviewEpoch,
     },
     totals: {
       openIssues: issueItems.length,
@@ -2080,6 +2382,9 @@ export function renderMarkdown(report) {
     "",
     `Open issues: ${report.totals.openIssues}; unclaimed candidates: ${report.totals.candidateIssues}.`,
     `Open PRs: ${report.totals.openPullRequests}; reviewable candidates: ${report.totals.reviewablePullRequests}.`,
+    report.selection?.reviewEpoch
+      ? `Review epoch cutoff: ${report.selection.reviewEpoch.cutoff}; frozen candidates: ${report.selection.reviewEpoch.candidates.length}/${report.selection.reviewEpoch.candidateCount}; deferred to a later epoch: ${report.selection.reviewEpoch.deferred.length}.`
+      : "Review epoch: unavailable.",
     "",
     "## Priority 1: unclaimed issue candidates with no open closing PR",
     "",
@@ -2143,7 +2448,11 @@ export function parseCliArguments(
   if (!REPOSITORY_RE.test(defaultRepository)) {
     throw new TypeError("default repository must use the owner/name form");
   }
-  const options = { repo: defaultRepository, json: false, help: false };
+  const options = {
+    repo: defaultRepository,
+    json: false,
+    help: false,
+  };
   for (let index = 0; index < args.length; index += 1) {
     const argument = args[index];
     if (argument === "--json") {
@@ -2158,12 +2467,43 @@ export function parseCliArguments(
       options.repo = args[index];
     } else if (argument.startsWith("--repo=")) {
       options.repo = argument.slice("--repo=".length);
+    } else if (argument === "--recheck-pr") {
+      index += 1;
+      if (index >= args.length) {
+        throw new TypeError("--recheck-pr requires a pull request number");
+      }
+      options.recheckPr = Number(args[index]);
+    } else if (argument.startsWith("--recheck-pr=")) {
+      options.recheckPr = Number(argument.slice("--recheck-pr=".length));
+    } else if (argument === "--expected-head") {
+      index += 1;
+      if (index >= args.length) {
+        throw new TypeError("--expected-head requires a full commit SHA");
+      }
+      options.expectedHead = args[index];
+    } else if (argument.startsWith("--expected-head=")) {
+      options.expectedHead = argument.slice("--expected-head=".length);
     } else {
       throw new TypeError(`Unknown argument: ${argument}`);
     }
   }
   if (!REPOSITORY_RE.test(options.repo)) {
     throw new TypeError("--repo must use the owner/name form");
+  }
+  if (options.recheckPr !== undefined) {
+    if (!Number.isInteger(options.recheckPr) || options.recheckPr < 1) {
+      throw new TypeError("--recheck-pr must be a positive integer");
+    }
+    if (
+      typeof options.expectedHead !== "string" ||
+      !FULL_COMMIT_RE.test(options.expectedHead)
+    ) {
+      throw new TypeError(
+        "--expected-head must be a full commit SHA when rechecking a PR",
+      );
+    }
+  } else if (options.expectedHead !== undefined) {
+    throw new TypeError("--expected-head requires --recheck-pr");
   }
   return options;
 }
@@ -2176,6 +2516,8 @@ Read and paginate open GitHub issues and pull requests without changing them.
 Options:
   --repo <owner/name>  Repository to inspect (default: this skill's project)
   --json               Print stable machine-readable JSON
+  --recheck-pr <n>     GET one live PR head before publishing a review
+  --expected-head <sha>  Frozen epoch head required by --recheck-pr
   --help, -h           Show this help
 `;
 }
@@ -2188,6 +2530,19 @@ export function main(args = process.argv.slice(2)) {
     return;
   }
   const commandBudget = createGhCommandBudget();
+  if (options.recheckPr !== undefined) {
+    const result = recheckLivePullHead(
+      options.repo,
+      {
+        number: options.recheckPr,
+        headSha: options.expectedHead,
+      },
+      commandBudget.run,
+    );
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    if (!result.publishable) process.exitCode = 2;
+    return;
+  }
   const boundedRead = (endpoint) => {
     return readGhPages(endpoint, commandBudget.run);
   };

--- a/skills/contribute-to-delta-star/scripts/live-report.mjs
+++ b/skills/contribute-to-delta-star/scripts/live-report.mjs
@@ -6,7 +6,7 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -28,6 +28,7 @@ export const MAX_OPEN_ITEMS = 10_000;
 // advance after that frontier is dispositioned even while new PRs arrive.
 export const MAX_REVIEW_EPOCH_CANDIDATES = 20;
 export const REVIEW_EPOCH_SCHEMA_VERSION = 1;
+export const MAX_REVIEW_EPOCH_FILE_BYTES = 262_144;
 export const MAX_API_READS = 16;
 export const MAX_ACTIVITY_CONNECTION_ITEMS = 1_000;
 export const MIN_GRAPHQL_ACTIVITY_POINTS = 1_000;
@@ -474,7 +475,7 @@ export function createReviewEpoch(
 }
 
 const REVIEW_EPOCH_DISPOSITIONS = new Set([
-  "reviewed",
+  "merge",
   "fix",
   "close",
   "stale-head",
@@ -483,6 +484,13 @@ const REVIEW_EPOCH_DISPOSITIONS = new Set([
 /** Returns the lower-tier permit only after every frozen candidate is closed. */
 export function completeReviewEpoch(epoch, dispositions) {
   const record = asRecord(epoch, "review epoch");
+  const schemaVersion = asNumberField(record, "schemaVersion", "review epoch");
+  if (schemaVersion !== REVIEW_EPOCH_SCHEMA_VERSION) {
+    throw new TypeError(
+      `review epoch.schemaVersion must be ${REVIEW_EPOCH_SCHEMA_VERSION}`,
+    );
+  }
+  const cutoff = isoTime(record.cutoff, "review epoch.cutoff");
   const candidates = asArrayField(record, "candidates", "review epoch").map(
     (candidate, index) =>
       reviewEpochIdentity(candidate, `review epoch.candidates[${index}]`),
@@ -493,7 +501,11 @@ export function completeReviewEpoch(epoch, dispositions) {
   const expected = new Map(
     candidates.map((candidate) => [candidate.number, candidate]),
   );
+  if (expected.size !== candidates.length) {
+    throw new TypeError("review epoch contains duplicate candidates");
+  }
   const completed = new Set();
+  const normalizedDispositions = new Map();
   for (const [index, value] of dispositions.entries()) {
     const context = `review epoch dispositions[${index}]`;
     const disposition = asRecord(value, context);
@@ -519,6 +531,11 @@ export function completeReviewEpoch(epoch, dispositions) {
     if (!REVIEW_EPOCH_DISPOSITIONS.has(status)) {
       throw new TypeError(`${context}.status is not a terminal disposition`);
     }
+    const normalizedDisposition = {
+      number,
+      expectedHeadSha,
+      status,
+    };
     if (status === "stale-head") {
       const currentHeadSha = asStringField(
         disposition,
@@ -533,23 +550,103 @@ export function completeReviewEpoch(epoch, dispositions) {
           `${context}.currentHeadSha must be a different full commit SHA`,
         );
       }
+      normalizedDisposition.currentHeadSha = currentHeadSha;
+    } else {
+      const recommendationUrl = asStringField(
+        disposition,
+        "recommendationUrl",
+        context,
+      );
+      let parsedRecommendationUrl;
+      try {
+        parsedRecommendationUrl = new URL(recommendationUrl);
+      } catch (cause) {
+        throw new TypeError(`${context}.recommendationUrl must be a URL`, {
+          cause,
+        });
+      }
+      const pathParts = parsedRecommendationUrl.pathname
+        .split("/")
+        .filter(Boolean);
+      if (
+        parsedRecommendationUrl.protocol !== "https:" ||
+        parsedRecommendationUrl.hostname !== "github.com" ||
+        parsedRecommendationUrl.username !== "" ||
+        parsedRecommendationUrl.password !== "" ||
+        pathParts.length < 4 ||
+        pathParts[2] !== "pull" ||
+        Number(pathParts[3]) !== number ||
+        recommendationUrl.length > 2_048
+      ) {
+        throw new TypeError(
+          `${context}.recommendationUrl must be a bounded public GitHub HTTPS URL`,
+        );
+      }
+      normalizedDisposition.recommendationUrl =
+        parsedRecommendationUrl.toString();
     }
     completed.add(number);
+    normalizedDispositions.set(number, normalizedDisposition);
   }
   const remainingCandidates = candidates
     .filter((candidate) => !completed.has(candidate.number))
     .map((candidate) => candidate.number);
   const complete = remainingCandidates.length === 0;
   return {
+    schemaVersion: REVIEW_EPOCH_SCHEMA_VERSION,
+    cutoff,
     complete,
     dispositionCount: completed.size,
     requiredCandidateCount: candidates.length,
     remainingCandidates,
+    dispositions: candidates.flatMap((candidate) => {
+      const disposition = normalizedDispositions.get(candidate.number);
+      return disposition ? [disposition] : [];
+    }),
     allowsNextTier: complete,
     ...(complete
       ? { nextTier: "next-eligible-lower-tier", maxNextTierOutcomes: 1 }
       : { maxNextTierOutcomes: 0 }),
   };
+}
+
+function readBoundedJsonFile(path, context) {
+  if (typeof path !== "string" || path.trim() === "") {
+    throw new TypeError(`${context} path must be a non-empty string`);
+  }
+  const statistics = statSync(path);
+  if (!statistics.isFile()) {
+    throw new TypeError(`${context} must be a regular file`);
+  }
+  if (statistics.size > MAX_REVIEW_EPOCH_FILE_BYTES) {
+    throw new RangeError(
+      `${context} exceeds ${MAX_REVIEW_EPOCH_FILE_BYTES} bytes`,
+    );
+  }
+  const contents = readFileSync(path);
+  if (contents.byteLength > MAX_REVIEW_EPOCH_FILE_BYTES) {
+    throw new RangeError(
+      `${context} exceeds ${MAX_REVIEW_EPOCH_FILE_BYTES} bytes`,
+    );
+  }
+  try {
+    return JSON.parse(contents.toString("utf8"));
+  } catch (cause) {
+    throw new SyntaxError(`${context} must contain valid JSON`, { cause });
+  }
+}
+
+function reviewEpochFromFile(path) {
+  const value = asRecord(
+    readBoundedJsonFile(path, "review epoch input"),
+    "review epoch input",
+  );
+  if (value.selection === undefined) return value;
+  const selection = asRecord(value.selection, "review epoch input.selection");
+  return asRecord(
+    selection.reviewEpoch,
+    "review epoch input.selection.reviewEpoch",
+  );
 }
 
 /**
@@ -2457,6 +2554,8 @@ export function parseCliArguments(
     const argument = args[index];
     if (argument === "--json") {
       options.json = true;
+    } else if (argument === "--epoch-only") {
+      options.epochOnly = true;
     } else if (argument === "--help" || argument === "-h") {
       options.help = true;
     } else if (argument === "--repo") {
@@ -2483,6 +2582,22 @@ export function parseCliArguments(
       options.expectedHead = args[index];
     } else if (argument.startsWith("--expected-head=")) {
       options.expectedHead = argument.slice("--expected-head=".length);
+    } else if (argument === "--complete-epoch") {
+      index += 1;
+      if (index >= args.length) {
+        throw new TypeError("--complete-epoch requires a JSON file path");
+      }
+      options.completeEpochPath = args[index];
+    } else if (argument.startsWith("--complete-epoch=")) {
+      options.completeEpochPath = argument.slice("--complete-epoch=".length);
+    } else if (argument === "--dispositions") {
+      index += 1;
+      if (index >= args.length) {
+        throw new TypeError("--dispositions requires a JSON file path");
+      }
+      options.dispositionsPath = args[index];
+    } else if (argument.startsWith("--dispositions=")) {
+      options.dispositionsPath = argument.slice("--dispositions=".length);
     } else {
       throw new TypeError(`Unknown argument: ${argument}`);
     }
@@ -2505,6 +2620,34 @@ export function parseCliArguments(
   } else if (options.expectedHead !== undefined) {
     throw new TypeError("--expected-head requires --recheck-pr");
   }
+  const completionRequested =
+    options.completeEpochPath !== undefined ||
+    options.dispositionsPath !== undefined;
+  if (completionRequested) {
+    if (
+      typeof options.completeEpochPath !== "string" ||
+      options.completeEpochPath.trim() === "" ||
+      typeof options.dispositionsPath !== "string" ||
+      options.dispositionsPath.trim() === ""
+    ) {
+      throw new TypeError(
+        "--complete-epoch and --dispositions must be provided together",
+      );
+    }
+    if (options.recheckPr !== undefined) {
+      throw new TypeError(
+        "--complete-epoch cannot be combined with --recheck-pr",
+      );
+    }
+  }
+  if (
+    options.epochOnly === true &&
+    (options.json || completionRequested || options.recheckPr !== undefined)
+  ) {
+    throw new TypeError(
+      "--epoch-only cannot be combined with another output operation",
+    );
+  }
   return options;
 }
 
@@ -2516,8 +2659,11 @@ Read and paginate open GitHub issues and pull requests without changing them.
 Options:
   --repo <owner/name>  Repository to inspect (default: this skill's project)
   --json               Print stable machine-readable JSON
+  --epoch-only         Print only the finite review epoch JSON
   --recheck-pr <n>     GET one live PR head before publishing a review
   --expected-head <sha>  Frozen epoch head required by --recheck-pr
+  --complete-epoch <path>  Validate a saved report or epoch JSON file
+  --dispositions <path>  Terminal disposition JSON required for completion
   --help, -h           Show this help
 `;
 }
@@ -2527,6 +2673,17 @@ export function main(args = process.argv.slice(2)) {
   const options = parseCliArguments(args, selectionPolicy.repositoryId);
   if (options.help) {
     process.stdout.write(usage());
+    return;
+  }
+  if (options.completeEpochPath !== undefined) {
+    const epoch = reviewEpochFromFile(options.completeEpochPath);
+    const dispositions = readBoundedJsonFile(
+      options.dispositionsPath,
+      "review epoch dispositions",
+    );
+    const result = completeReviewEpoch(epoch, dispositions);
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    if (!result.complete) process.exitCode = 2;
     return;
   }
   const commandBudget = createGhCommandBudget();
@@ -2568,9 +2725,11 @@ export function main(args = process.argv.slice(2)) {
     selectionPolicy.eligibleIssueLabels,
   );
   process.stdout.write(
-    options.json
-      ? `${JSON.stringify(report, null, 2)}\n`
-      : renderMarkdown(report),
+    options.epochOnly
+      ? `${JSON.stringify(report.selection.reviewEpoch, null, 2)}\n`
+      : options.json
+        ? `${JSON.stringify(report, null, 2)}\n`
+        : renderMarkdown(report),
   );
 }
 

--- a/skills/contribute-to-eliza/SKILL.md
+++ b/skills/contribute-to-eliza/SKILL.md
@@ -169,6 +169,34 @@ the gh 2.45 packaged with Ubuntu 24.04. A blank result is a valid empty
 collection; command failures and malformed or truncated records fail closed
 with endpoint context.
 
+### Finite review epochs
+
+The report's `snapshot.cutoff` and `selection.reviewEpoch` define one finite
+review frontier. The repository discovery bound (`MAX_OPEN_ITEMS`) protects the
+read-only inventory; it is not a contributor work budget. A review epoch freezes
+the oldest eligible PR numbers and their exact `headSha` values, up to the
+reported `maxCandidates` (currently 20). Review the frozen candidates in number
+order. When the frozen set is fully dispositioned, the run may advance one
+bounded outcome to the next eligible tier even if newer PRs are already open.
+
+PRs updated after the cutoff and candidates beyond the epoch limit are listed in
+`reviewEpoch.deferred` with a deterministic reason and must be considered by a
+later epoch. They are never discarded or treated as reviewed. Immediately before
+publishing each review, run the live GET guard:
+
+```bash
+node <skill-directory>/scripts/live-report.mjs --repo elizaOS/eliza \
+  --recheck-pr <number> --expected-head <frozen-head-sha>
+```
+
+The guard is read-only, not a publication command: use the separate authorized
+GitHub review path only when it returns `publishable: true`. On a changed head it
+returns non-zero with `status: "stale"` and the observed `currentHeadSha`; record
+that candidate as stale and defer its new head to the next epoch. This recheck is
+mandatory even when the report was just generated. Sustained arrivals and head
+churn therefore cannot keep lower-tier issue or workflow work behind a moving
+frontier, while the complete live report remains available for diagnostics.
+
 Do not infer that review publication is blocked from `CONTRIBUTING.md` or a
 standalone validator alone. Re-run `review-preflight.mjs` against the current
 integration-branch workflows and forward proof. Report documentation drift as
@@ -180,13 +208,18 @@ with the authorized demand, affected user path, observed failure or missing
 capability, mission surface, acceptance proof, and duplication check. Do not
 post this note merely to reserve work. Stop when any field is unknown.
 
-Follow this priority ladder. Do not skip a nonempty higher tier for newer,
-easier, or more interesting work:
+Follow this priority ladder within each finite epoch. Do not skip a frozen
+candidate for newer, easier, or more interesting work. After every frozen
+higher-tier candidate has a terminal disposition, the epoch completion receipt
+permits exactly one bounded outcome in the next eligible lower tier, even when
+new or deferred higher-tier PRs remain open. Begin a fresh epoch before taking
+another lower-tier outcome:
 
 1. **Review and test every current PR**: start with the oldest non-draft,
    unblocked, non-sensitive PR lacking a substantive independent review of its
-   exact current head. Inspect every open PR, including previously reviewed PRs
-   whose head changed. Reproduce the affected product path and give an explicit
+   exact current head in the frozen review epoch. Inspect the complete live
+   report for diagnostics, then disposition every frozen candidate. Reproduce
+   the affected product path and give an explicit
    **merge**, **fix**, or **close** recommendation. When authorized, make an
    existing PR completely solid by repairing real defects, strengthening
    failure-sensitive tests, and rerunning exact-head checks; never approve your
@@ -194,18 +227,19 @@ easier, or more interesting work:
    neglect while new work is invented. Apply the anti-slop gate before asking
    for repairs: close a valueless premise instead of requesting more tests,
    guards, documentation, or polish that only makes it larger.
-2. **Finish every existing issue without a PR**: only when tier one is empty,
-   choose the oldest bounded, unblocked, unclaimed open issue carrying the exact
-   repository label `mission-ready`, or an issue explicitly selected by the
-   operator. Confirm that no open PR has a GitHub closing reference or
-   substantively implements it, then resolve it completely through a focused PR
-   with acceptance criteria, tests, and proof. Give duplicate, obsolete,
-   invalid, low-value, or out-of-scope issues an explicit closure recommendation.
-   Other labels, Project membership, and text that merely says "mission-ready"
-   do not qualify for implementation.
-3. **Restore `develop` workflow health**: only when tiers one and two are empty,
-   inspect every required GitHub Actions workflow on the current `develop`
-   head. Repair every reproducible repository-caused failure and rerun it at the
+2. **Finish every existing issue without a PR**: after the epoch completion
+   receipt permits one lower-tier outcome, choose the oldest bounded, unblocked,
+   unclaimed open issue carrying the exact repository label `mission-ready`, or
+   an issue explicitly selected by the operator. Confirm that no open PR has a
+   GitHub closing reference or substantively implements it, then resolve it
+   completely through a focused PR with acceptance criteria, tests, and proof.
+   Give duplicate, obsolete, invalid, low-value, or out-of-scope issues an
+   explicit closure recommendation. Other labels, Project membership, and text
+   that merely says "mission-ready" do not qualify for implementation.
+3. **Restore `develop` workflow health**: after the epoch completion receipt
+   permits the next eligible lower-tier outcome and no bounded issue outcome is
+   available, inspect every required GitHub Actions workflow on the current
+   `develop` head. Repair every reproducible repository-caused failure and rerun it at the
    exact head. A queued run, missing runner, credential/environment gate, or
    external outage is not green and not a code bug; record the precise blocker
    instead of weakening checks or inventing unrelated work.

--- a/skills/contribute-to-eliza/SKILL.md
+++ b/skills/contribute-to-eliza/SKILL.md
@@ -197,6 +197,24 @@ mandatory even when the report was just generated. Sustained arrivals and head
 churn therefore cannot keep lower-tier issue or workflow work behind a moving
 frontier, while the complete live report remains available for diagnostics.
 
+Persist the report and produce the completion record through the bundled CLI;
+do not hand-edit the frozen epoch:
+
+```bash
+node <skill-directory>/scripts/live-report.mjs --repo elizaOS/eliza \
+  --epoch-only > review-epoch.json
+node <skill-directory>/scripts/live-report.mjs \
+  --complete-epoch review-epoch.json --dispositions dispositions.json \
+  > epoch-completion.json
+```
+
+`dispositions.json` is an array with one entry per frozen candidate. Every entry
+binds `number` and `expectedHeadSha`; use only `merge`, `fix`, or `close` with the
+public GitHub `recommendationUrl`, or `stale-head` with the different observed
+`currentHeadSha`. The command exits 2 and denies lower-tier progression while
+any frozen candidate is missing. A complete record permits exactly one bounded
+outcome in the next eligible lower tier; begin a fresh epoch before another.
+
 Do not infer that review publication is blocked from `CONTRIBUTING.md` or a
 standalone validator alone. Re-run `review-preflight.mjs` against the current
 integration-branch workflows and forward proof. Report documentation drift as

--- a/skills/contribute-to-eliza/scripts/live-report.mjs
+++ b/skills/contribute-to-eliza/scripts/live-report.mjs
@@ -23,6 +23,11 @@ export const REQUIRED_EVIDENCE_ROWS = [
 export const CLAIM_RECENCY_DAYS = 7;
 export const MISSION_READY_LABEL = "mission-ready";
 export const MAX_OPEN_ITEMS = 10_000;
+// The repository-size bound protects discovery. This smaller work-epoch bound
+// is the liveness contract: one run has a finite frozen PR frontier and may
+// advance after that frontier is dispositioned even while new PRs arrive.
+export const MAX_REVIEW_EPOCH_CANDIDATES = 20;
+export const REVIEW_EPOCH_SCHEMA_VERSION = 1;
 export const MAX_API_READS = 16;
 export const MAX_ACTIVITY_CONNECTION_ITEMS = 1_000;
 export const MIN_GRAPHQL_ACTIVITY_POINTS = 1_000;
@@ -370,6 +375,208 @@ function compareByNumber(left, right) {
   return left.number - right.number;
 }
 
+function reviewEpochCandidate(
+  value,
+  index,
+  context = "review epoch candidate",
+) {
+  const record = asRecord(value, `${context}[${index}]`);
+  const number = asNumberField(record, "number", `${context}[${index}]`);
+  if (number < 1) {
+    throw new TypeError(`${context}[${index}].number must be positive`);
+  }
+  const headSha = asStringField(
+    record,
+    "headSha",
+    `${context}[${index}]`,
+  ).toLowerCase();
+  if (!FULL_COMMIT_RE.test(headSha)) {
+    throw new TypeError(
+      `${context}[${index}].headSha must be a full commit SHA`,
+    );
+  }
+  const updatedAt = isoTime(record.updatedAt, `${context}[${index}].updatedAt`);
+  return { number, headSha, updatedAt };
+}
+
+function reviewEpochIdentity(value, context = "review epoch candidate") {
+  const record = asRecord(value, context);
+  const number = asNumberField(record, "number", context);
+  if (number < 1) {
+    throw new TypeError(`${context}.number must be positive`);
+  }
+  const headSha = asStringField(record, "headSha", context).toLowerCase();
+  if (!FULL_COMMIT_RE.test(headSha)) {
+    throw new TypeError(`${context}.headSha must be a full commit SHA`);
+  }
+  return { number, headSha };
+}
+
+/**
+ * Freezes a deterministic, bounded PR review frontier. Candidates updated
+ * after the cutoff are explicitly deferred, as are candidates beyond the
+ * finite epoch count; both are eligible for a later epoch and never vanish
+ * from diagnostics.
+ */
+export function createReviewEpoch(
+  candidates,
+  cutoff,
+  maxCandidates = MAX_REVIEW_EPOCH_CANDIDATES,
+) {
+  if (!Array.isArray(candidates)) {
+    throw new TypeError("review epoch candidates must be an array");
+  }
+  const cutoffTime = Date.parse(isoTime(cutoff, "review epoch cutoff"));
+  if (
+    !Number.isInteger(maxCandidates) ||
+    maxCandidates < 1 ||
+    maxCandidates > MAX_REVIEW_EPOCH_CANDIDATES
+  ) {
+    throw new TypeError(
+      `review epoch maxCandidates must be an integer from 1 to ${MAX_REVIEW_EPOCH_CANDIDATES}`,
+    );
+  }
+  const normalized = candidates
+    .map((value, index) => reviewEpochCandidate(value, index))
+    .sort(compareByNumber);
+  const seen = new Set();
+  for (const candidate of normalized) {
+    if (seen.has(candidate.number)) {
+      throw new TypeError(
+        `duplicate review epoch candidate #${candidate.number}`,
+      );
+    }
+    seen.add(candidate.number);
+  }
+  const frozen = normalized.filter(
+    (candidate) => Date.parse(candidate.updatedAt) <= cutoffTime,
+  );
+  const arrivals = normalized
+    .filter((candidate) => Date.parse(candidate.updatedAt) > cutoffTime)
+    .map((candidate) => ({ ...candidate, deferredReason: "after-cutoff" }));
+  const selected = frozen.slice(0, maxCandidates);
+  const overLimit = frozen
+    .slice(maxCandidates)
+    .map((candidate) => ({ ...candidate, deferredReason: "epoch-limit" }));
+  return {
+    schemaVersion: REVIEW_EPOCH_SCHEMA_VERSION,
+    cutoff,
+    maxCandidates,
+    candidateCount: normalized.length,
+    candidates: selected,
+    deferred: [...overLimit, ...arrivals].sort(compareByNumber),
+    completion: {
+      requiredCandidateCount: selected.length,
+      allowsNextTier: false,
+      maxNextTierOutcomes: 0,
+    },
+  };
+}
+
+const REVIEW_EPOCH_DISPOSITIONS = new Set([
+  "reviewed",
+  "fix",
+  "close",
+  "stale-head",
+]);
+
+/** Returns the lower-tier permit only after every frozen candidate is closed. */
+export function completeReviewEpoch(epoch, dispositions) {
+  const record = asRecord(epoch, "review epoch");
+  const candidates = asArrayField(record, "candidates", "review epoch").map(
+    (candidate, index) =>
+      reviewEpochIdentity(candidate, `review epoch.candidates[${index}]`),
+  );
+  if (!Array.isArray(dispositions)) {
+    throw new TypeError("review epoch dispositions must be an array");
+  }
+  const expected = new Map(
+    candidates.map((candidate) => [candidate.number, candidate]),
+  );
+  const completed = new Set();
+  for (const [index, value] of dispositions.entries()) {
+    const context = `review epoch dispositions[${index}]`;
+    const disposition = asRecord(value, context);
+    const number = asNumberField(disposition, "number", context);
+    const candidate = expected.get(number);
+    if (!candidate) {
+      throw new TypeError(`${context} names non-epoch candidate #${number}`);
+    }
+    if (completed.has(number)) {
+      throw new TypeError(`duplicate review epoch disposition for #${number}`);
+    }
+    const expectedHeadSha = asStringField(
+      disposition,
+      "expectedHeadSha",
+      context,
+    ).toLowerCase();
+    if (expectedHeadSha !== candidate.headSha) {
+      throw new TypeError(
+        `${context} does not bind the frozen head for #${number}`,
+      );
+    }
+    const status = asStringField(disposition, "status", context);
+    if (!REVIEW_EPOCH_DISPOSITIONS.has(status)) {
+      throw new TypeError(`${context}.status is not a terminal disposition`);
+    }
+    if (status === "stale-head") {
+      const currentHeadSha = asStringField(
+        disposition,
+        "currentHeadSha",
+        context,
+      ).toLowerCase();
+      if (
+        !FULL_COMMIT_RE.test(currentHeadSha) ||
+        currentHeadSha === candidate.headSha
+      ) {
+        throw new TypeError(
+          `${context}.currentHeadSha must be a different full commit SHA`,
+        );
+      }
+    }
+    completed.add(number);
+  }
+  const remainingCandidates = candidates
+    .filter((candidate) => !completed.has(candidate.number))
+    .map((candidate) => candidate.number);
+  const complete = remainingCandidates.length === 0;
+  return {
+    complete,
+    dispositionCount: completed.size,
+    requiredCandidateCount: candidates.length,
+    remainingCandidates,
+    allowsNextTier: complete,
+    ...(complete
+      ? { nextTier: "next-eligible-lower-tier", maxNextTierOutcomes: 1 }
+      : { maxNextTierOutcomes: 0 }),
+  };
+}
+
+/**
+ * Publication boundary for an epoch candidate. A changed head is stale and
+ * must be deferred; only an exact byte-for-byte head match is publishable.
+ */
+export function recheckReviewEpochCandidate(candidate, currentHeadSha) {
+  const normalized = reviewEpochIdentity(candidate);
+  if (
+    typeof currentHeadSha !== "string" ||
+    !FULL_COMMIT_RE.test(currentHeadSha)
+  ) {
+    throw new TypeError("currentHeadSha must be a full commit SHA");
+  }
+  const current = currentHeadSha.toLowerCase();
+  if (current === normalized.headSha) {
+    return { number: normalized.number, status: "current", publishable: true };
+  }
+  return {
+    number: normalized.number,
+    status: "stale",
+    publishable: false,
+    currentHeadSha: current,
+    deferredReason: "head-changed",
+  };
+}
+
 function compareComment(left, right) {
   return left.id - right.id || left.url.localeCompare(right.url);
 }
@@ -459,6 +666,86 @@ export function readGhPages(endpoint, spawn = spawnSync) {
     throw new TypeError("gh api did not return text output");
   }
   return parsePaginatedJson(result.stdout, endpoint);
+}
+
+/** Performs the single live GET used as the pre-publication head guard. */
+export function readLivePullHead(repo, number, spawn = spawnSync) {
+  if (!REPOSITORY_RE.test(repo)) {
+    throw new TypeError("Repository must use the owner/name form");
+  }
+  if (!Number.isInteger(number) || number < 1) {
+    throw new TypeError("pull request number must be a positive integer");
+  }
+  const endpoint = `repos/${repo}/pulls/${number}`;
+  const result = spawn(
+    "gh",
+    [
+      "api",
+      "--method",
+      "GET",
+      "--jq",
+      "{number: .number, headSha: .head.sha, updatedAt: .updated_at}",
+      endpoint,
+    ],
+    {
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024,
+      windowsHide: true,
+    },
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const detail =
+      typeof result.stderr === "string" && result.stderr.trim().length > 0
+        ? `: ${result.stderr.trim()}`
+        : "";
+    throw new Error(`gh api failed for ${endpoint}${detail}`);
+  }
+  let value;
+  try {
+    value = JSON.parse(result.stdout);
+  } catch (cause) {
+    throw new SyntaxError(`gh api returned malformed JSON for ${endpoint}`, {
+      cause,
+    });
+  }
+  const record = asRecord(value, `live pull request #${number}`);
+  const liveNumber = asNumberField(
+    record,
+    "number",
+    `live pull request #${number}`,
+  );
+  if (liveNumber !== number) {
+    throw new TypeError(`live pull request number changed from #${number}`);
+  }
+  const headSha = asStringField(
+    record,
+    "headSha",
+    `live pull request #${number}`,
+  ).toLowerCase();
+  if (!FULL_COMMIT_RE.test(headSha)) {
+    throw new TypeError(
+      `live pull request #${number}.headSha must be a full commit SHA`,
+    );
+  }
+  return {
+    number,
+    headSha,
+    updatedAt: isoTime(
+      record.updatedAt,
+      `live pull request #${number}.updatedAt`,
+    ),
+  };
+}
+
+export function recheckLivePullHead(repo, candidate, spawn = spawnSync) {
+  const normalized = reviewEpochIdentity(candidate);
+  const live = readLivePullHead(repo, normalized.number, spawn);
+  return {
+    ...recheckReviewEpochCandidate(normalized, live.headSha),
+    expectedHeadSha: normalized.headSha,
+    updatedAt: live.updatedAt,
+  };
 }
 
 const ACTIVITY_PAGE_SIZE = 100;
@@ -1739,6 +2026,7 @@ export function collectLiveReport(
     throw new TypeError("Repository must use the owner/name form");
   }
   const referenceTime = nowTime(now);
+  const snapshotCutoff = now.toISOString();
   const candidateLabelSet = new Set(
     eligibleIssueLabels(projectEligibleIssueLabels, "eligible issue labels"),
   );
@@ -1970,7 +2258,18 @@ export function collectLiveReport(
       currentHeadApprovals: currentReviews.approved,
       currentHeadChangesRequested: currentReviews.changesRequested,
     };
-    const detailedSummary = { ...summary, reviewState };
+    const head = asRecord(item.head, `${context}.head`);
+    const headSha = asStringField(head, "sha", `${context}.head`).toLowerCase();
+    if (!FULL_COMMIT_RE.test(headSha)) {
+      throw new TypeError(`${context}.head.sha must be a full commit SHA`);
+    }
+    const updatedAt = isoTime(item.updated_at, `${context}.updated_at`);
+    const detailedSummary = {
+      ...summary,
+      updatedAt,
+      headSha,
+      reviewState,
+    };
     pullRequestAudits.push({
       ...detailedSummary,
       bodyProviderModel: parseModelDisclosure(body),
@@ -2010,10 +2309,13 @@ export function collectLiveReport(
     reviewablePullRequests.push(detailedSummary);
   }
 
+  const reviewEpoch = createReviewEpoch(reviewablePullRequests, snapshotCutoff);
   return {
     repository: repo,
+    snapshot: { cutoff: snapshotCutoff },
     selection: {
       eligibleIssueLabels: [...candidateLabelSet].sort(),
+      reviewEpoch,
     },
     totals: {
       openIssues: issueItems.length,
@@ -2080,6 +2382,9 @@ export function renderMarkdown(report) {
     "",
     `Open issues: ${report.totals.openIssues}; unclaimed candidates: ${report.totals.candidateIssues}.`,
     `Open PRs: ${report.totals.openPullRequests}; reviewable candidates: ${report.totals.reviewablePullRequests}.`,
+    report.selection?.reviewEpoch
+      ? `Review epoch cutoff: ${report.selection.reviewEpoch.cutoff}; frozen candidates: ${report.selection.reviewEpoch.candidates.length}/${report.selection.reviewEpoch.candidateCount}; deferred to a later epoch: ${report.selection.reviewEpoch.deferred.length}.`
+      : "Review epoch: unavailable.",
     "",
     "## Priority 1: unclaimed issue candidates with no open closing PR",
     "",
@@ -2143,7 +2448,11 @@ export function parseCliArguments(
   if (!REPOSITORY_RE.test(defaultRepository)) {
     throw new TypeError("default repository must use the owner/name form");
   }
-  const options = { repo: defaultRepository, json: false, help: false };
+  const options = {
+    repo: defaultRepository,
+    json: false,
+    help: false,
+  };
   for (let index = 0; index < args.length; index += 1) {
     const argument = args[index];
     if (argument === "--json") {
@@ -2158,12 +2467,43 @@ export function parseCliArguments(
       options.repo = args[index];
     } else if (argument.startsWith("--repo=")) {
       options.repo = argument.slice("--repo=".length);
+    } else if (argument === "--recheck-pr") {
+      index += 1;
+      if (index >= args.length) {
+        throw new TypeError("--recheck-pr requires a pull request number");
+      }
+      options.recheckPr = Number(args[index]);
+    } else if (argument.startsWith("--recheck-pr=")) {
+      options.recheckPr = Number(argument.slice("--recheck-pr=".length));
+    } else if (argument === "--expected-head") {
+      index += 1;
+      if (index >= args.length) {
+        throw new TypeError("--expected-head requires a full commit SHA");
+      }
+      options.expectedHead = args[index];
+    } else if (argument.startsWith("--expected-head=")) {
+      options.expectedHead = argument.slice("--expected-head=".length);
     } else {
       throw new TypeError(`Unknown argument: ${argument}`);
     }
   }
   if (!REPOSITORY_RE.test(options.repo)) {
     throw new TypeError("--repo must use the owner/name form");
+  }
+  if (options.recheckPr !== undefined) {
+    if (!Number.isInteger(options.recheckPr) || options.recheckPr < 1) {
+      throw new TypeError("--recheck-pr must be a positive integer");
+    }
+    if (
+      typeof options.expectedHead !== "string" ||
+      !FULL_COMMIT_RE.test(options.expectedHead)
+    ) {
+      throw new TypeError(
+        "--expected-head must be a full commit SHA when rechecking a PR",
+      );
+    }
+  } else if (options.expectedHead !== undefined) {
+    throw new TypeError("--expected-head requires --recheck-pr");
   }
   return options;
 }
@@ -2176,6 +2516,8 @@ Read and paginate open GitHub issues and pull requests without changing them.
 Options:
   --repo <owner/name>  Repository to inspect (default: this skill's project)
   --json               Print stable machine-readable JSON
+  --recheck-pr <n>     GET one live PR head before publishing a review
+  --expected-head <sha>  Frozen epoch head required by --recheck-pr
   --help, -h           Show this help
 `;
 }
@@ -2188,6 +2530,19 @@ export function main(args = process.argv.slice(2)) {
     return;
   }
   const commandBudget = createGhCommandBudget();
+  if (options.recheckPr !== undefined) {
+    const result = recheckLivePullHead(
+      options.repo,
+      {
+        number: options.recheckPr,
+        headSha: options.expectedHead,
+      },
+      commandBudget.run,
+    );
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    if (!result.publishable) process.exitCode = 2;
+    return;
+  }
   const boundedRead = (endpoint) => {
     return readGhPages(endpoint, commandBudget.run);
   };

--- a/skills/contribute-to-eliza/scripts/live-report.mjs
+++ b/skills/contribute-to-eliza/scripts/live-report.mjs
@@ -6,7 +6,7 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -28,6 +28,7 @@ export const MAX_OPEN_ITEMS = 10_000;
 // advance after that frontier is dispositioned even while new PRs arrive.
 export const MAX_REVIEW_EPOCH_CANDIDATES = 20;
 export const REVIEW_EPOCH_SCHEMA_VERSION = 1;
+export const MAX_REVIEW_EPOCH_FILE_BYTES = 262_144;
 export const MAX_API_READS = 16;
 export const MAX_ACTIVITY_CONNECTION_ITEMS = 1_000;
 export const MIN_GRAPHQL_ACTIVITY_POINTS = 1_000;
@@ -474,7 +475,7 @@ export function createReviewEpoch(
 }
 
 const REVIEW_EPOCH_DISPOSITIONS = new Set([
-  "reviewed",
+  "merge",
   "fix",
   "close",
   "stale-head",
@@ -483,6 +484,13 @@ const REVIEW_EPOCH_DISPOSITIONS = new Set([
 /** Returns the lower-tier permit only after every frozen candidate is closed. */
 export function completeReviewEpoch(epoch, dispositions) {
   const record = asRecord(epoch, "review epoch");
+  const schemaVersion = asNumberField(record, "schemaVersion", "review epoch");
+  if (schemaVersion !== REVIEW_EPOCH_SCHEMA_VERSION) {
+    throw new TypeError(
+      `review epoch.schemaVersion must be ${REVIEW_EPOCH_SCHEMA_VERSION}`,
+    );
+  }
+  const cutoff = isoTime(record.cutoff, "review epoch.cutoff");
   const candidates = asArrayField(record, "candidates", "review epoch").map(
     (candidate, index) =>
       reviewEpochIdentity(candidate, `review epoch.candidates[${index}]`),
@@ -493,7 +501,11 @@ export function completeReviewEpoch(epoch, dispositions) {
   const expected = new Map(
     candidates.map((candidate) => [candidate.number, candidate]),
   );
+  if (expected.size !== candidates.length) {
+    throw new TypeError("review epoch contains duplicate candidates");
+  }
   const completed = new Set();
+  const normalizedDispositions = new Map();
   for (const [index, value] of dispositions.entries()) {
     const context = `review epoch dispositions[${index}]`;
     const disposition = asRecord(value, context);
@@ -519,6 +531,11 @@ export function completeReviewEpoch(epoch, dispositions) {
     if (!REVIEW_EPOCH_DISPOSITIONS.has(status)) {
       throw new TypeError(`${context}.status is not a terminal disposition`);
     }
+    const normalizedDisposition = {
+      number,
+      expectedHeadSha,
+      status,
+    };
     if (status === "stale-head") {
       const currentHeadSha = asStringField(
         disposition,
@@ -533,23 +550,103 @@ export function completeReviewEpoch(epoch, dispositions) {
           `${context}.currentHeadSha must be a different full commit SHA`,
         );
       }
+      normalizedDisposition.currentHeadSha = currentHeadSha;
+    } else {
+      const recommendationUrl = asStringField(
+        disposition,
+        "recommendationUrl",
+        context,
+      );
+      let parsedRecommendationUrl;
+      try {
+        parsedRecommendationUrl = new URL(recommendationUrl);
+      } catch (cause) {
+        throw new TypeError(`${context}.recommendationUrl must be a URL`, {
+          cause,
+        });
+      }
+      const pathParts = parsedRecommendationUrl.pathname
+        .split("/")
+        .filter(Boolean);
+      if (
+        parsedRecommendationUrl.protocol !== "https:" ||
+        parsedRecommendationUrl.hostname !== "github.com" ||
+        parsedRecommendationUrl.username !== "" ||
+        parsedRecommendationUrl.password !== "" ||
+        pathParts.length < 4 ||
+        pathParts[2] !== "pull" ||
+        Number(pathParts[3]) !== number ||
+        recommendationUrl.length > 2_048
+      ) {
+        throw new TypeError(
+          `${context}.recommendationUrl must be a bounded public GitHub HTTPS URL`,
+        );
+      }
+      normalizedDisposition.recommendationUrl =
+        parsedRecommendationUrl.toString();
     }
     completed.add(number);
+    normalizedDispositions.set(number, normalizedDisposition);
   }
   const remainingCandidates = candidates
     .filter((candidate) => !completed.has(candidate.number))
     .map((candidate) => candidate.number);
   const complete = remainingCandidates.length === 0;
   return {
+    schemaVersion: REVIEW_EPOCH_SCHEMA_VERSION,
+    cutoff,
     complete,
     dispositionCount: completed.size,
     requiredCandidateCount: candidates.length,
     remainingCandidates,
+    dispositions: candidates.flatMap((candidate) => {
+      const disposition = normalizedDispositions.get(candidate.number);
+      return disposition ? [disposition] : [];
+    }),
     allowsNextTier: complete,
     ...(complete
       ? { nextTier: "next-eligible-lower-tier", maxNextTierOutcomes: 1 }
       : { maxNextTierOutcomes: 0 }),
   };
+}
+
+function readBoundedJsonFile(path, context) {
+  if (typeof path !== "string" || path.trim() === "") {
+    throw new TypeError(`${context} path must be a non-empty string`);
+  }
+  const statistics = statSync(path);
+  if (!statistics.isFile()) {
+    throw new TypeError(`${context} must be a regular file`);
+  }
+  if (statistics.size > MAX_REVIEW_EPOCH_FILE_BYTES) {
+    throw new RangeError(
+      `${context} exceeds ${MAX_REVIEW_EPOCH_FILE_BYTES} bytes`,
+    );
+  }
+  const contents = readFileSync(path);
+  if (contents.byteLength > MAX_REVIEW_EPOCH_FILE_BYTES) {
+    throw new RangeError(
+      `${context} exceeds ${MAX_REVIEW_EPOCH_FILE_BYTES} bytes`,
+    );
+  }
+  try {
+    return JSON.parse(contents.toString("utf8"));
+  } catch (cause) {
+    throw new SyntaxError(`${context} must contain valid JSON`, { cause });
+  }
+}
+
+function reviewEpochFromFile(path) {
+  const value = asRecord(
+    readBoundedJsonFile(path, "review epoch input"),
+    "review epoch input",
+  );
+  if (value.selection === undefined) return value;
+  const selection = asRecord(value.selection, "review epoch input.selection");
+  return asRecord(
+    selection.reviewEpoch,
+    "review epoch input.selection.reviewEpoch",
+  );
 }
 
 /**
@@ -2457,6 +2554,8 @@ export function parseCliArguments(
     const argument = args[index];
     if (argument === "--json") {
       options.json = true;
+    } else if (argument === "--epoch-only") {
+      options.epochOnly = true;
     } else if (argument === "--help" || argument === "-h") {
       options.help = true;
     } else if (argument === "--repo") {
@@ -2483,6 +2582,22 @@ export function parseCliArguments(
       options.expectedHead = args[index];
     } else if (argument.startsWith("--expected-head=")) {
       options.expectedHead = argument.slice("--expected-head=".length);
+    } else if (argument === "--complete-epoch") {
+      index += 1;
+      if (index >= args.length) {
+        throw new TypeError("--complete-epoch requires a JSON file path");
+      }
+      options.completeEpochPath = args[index];
+    } else if (argument.startsWith("--complete-epoch=")) {
+      options.completeEpochPath = argument.slice("--complete-epoch=".length);
+    } else if (argument === "--dispositions") {
+      index += 1;
+      if (index >= args.length) {
+        throw new TypeError("--dispositions requires a JSON file path");
+      }
+      options.dispositionsPath = args[index];
+    } else if (argument.startsWith("--dispositions=")) {
+      options.dispositionsPath = argument.slice("--dispositions=".length);
     } else {
       throw new TypeError(`Unknown argument: ${argument}`);
     }
@@ -2505,6 +2620,34 @@ export function parseCliArguments(
   } else if (options.expectedHead !== undefined) {
     throw new TypeError("--expected-head requires --recheck-pr");
   }
+  const completionRequested =
+    options.completeEpochPath !== undefined ||
+    options.dispositionsPath !== undefined;
+  if (completionRequested) {
+    if (
+      typeof options.completeEpochPath !== "string" ||
+      options.completeEpochPath.trim() === "" ||
+      typeof options.dispositionsPath !== "string" ||
+      options.dispositionsPath.trim() === ""
+    ) {
+      throw new TypeError(
+        "--complete-epoch and --dispositions must be provided together",
+      );
+    }
+    if (options.recheckPr !== undefined) {
+      throw new TypeError(
+        "--complete-epoch cannot be combined with --recheck-pr",
+      );
+    }
+  }
+  if (
+    options.epochOnly === true &&
+    (options.json || completionRequested || options.recheckPr !== undefined)
+  ) {
+    throw new TypeError(
+      "--epoch-only cannot be combined with another output operation",
+    );
+  }
   return options;
 }
 
@@ -2516,8 +2659,11 @@ Read and paginate open GitHub issues and pull requests without changing them.
 Options:
   --repo <owner/name>  Repository to inspect (default: this skill's project)
   --json               Print stable machine-readable JSON
+  --epoch-only         Print only the finite review epoch JSON
   --recheck-pr <n>     GET one live PR head before publishing a review
   --expected-head <sha>  Frozen epoch head required by --recheck-pr
+  --complete-epoch <path>  Validate a saved report or epoch JSON file
+  --dispositions <path>  Terminal disposition JSON required for completion
   --help, -h           Show this help
 `;
 }
@@ -2527,6 +2673,17 @@ export function main(args = process.argv.slice(2)) {
   const options = parseCliArguments(args, selectionPolicy.repositoryId);
   if (options.help) {
     process.stdout.write(usage());
+    return;
+  }
+  if (options.completeEpochPath !== undefined) {
+    const epoch = reviewEpochFromFile(options.completeEpochPath);
+    const dispositions = readBoundedJsonFile(
+      options.dispositionsPath,
+      "review epoch dispositions",
+    );
+    const result = completeReviewEpoch(epoch, dispositions);
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    if (!result.complete) process.exitCode = 2;
     return;
   }
   const commandBudget = createGhCommandBudget();
@@ -2568,9 +2725,11 @@ export function main(args = process.argv.slice(2)) {
     selectionPolicy.eligibleIssueLabels,
   );
   process.stdout.write(
-    options.json
-      ? `${JSON.stringify(report, null, 2)}\n`
-      : renderMarkdown(report),
+    options.epochOnly
+      ? `${JSON.stringify(report.selection.reviewEpoch, null, 2)}\n`
+      : options.json
+        ? `${JSON.stringify(report, null, 2)}\n`
+        : renderMarkdown(report),
   );
 }
 

--- a/skills/contribute-to-heir-elements-sdk/SKILL.md
+++ b/skills/contribute-to-heir-elements-sdk/SKILL.md
@@ -106,7 +106,30 @@ Re-read the chosen issue or pull request immediately before acting.
 
 ## Finish the existing queue and workflows before inventing work
 
-Follow this order without skipping a nonempty higher tier:
+The report freezes at most 20 oldest eligible PR numbers and exact head SHAs in
+`selection.reviewEpoch`; later arrivals and overflow remain visible in
+`reviewEpoch.deferred`. Recheck each frozen head immediately before publishing:
+
+```bash
+node <skill-directory>/scripts/live-report.mjs --repo heirlabs/element-sdk \
+  --recheck-pr <number> --expected-head <frozen-head-sha>
+```
+
+Save the frozen epoch with `--epoch-only`, record one `merge`, `fix`, or `close` disposition
+and public GitHub `recommendationUrl` per frozen head (or `stale-head` plus the
+different `currentHeadSha`), then run:
+
+```bash
+node <skill-directory>/scripts/live-report.mjs --repo heirlabs/element-sdk \
+  --epoch-only > review-epoch.json
+node <skill-directory>/scripts/live-report.mjs \
+  --complete-epoch review-epoch.json --dispositions dispositions.json \
+  > epoch-completion.json
+```
+
+An incomplete command exits 2. A complete record permits exactly one bounded
+outcome in the next eligible lower tier even when deferred PRs remain; begin a
+fresh epoch before another. Follow this order within each finite epoch:
 
 1. Review and test every current PR, starting with the oldest non-draft,
    unblocked, non-sensitive PR lacking a substantive independent review of its
@@ -114,17 +137,20 @@ Follow this order without skipping a nonempty higher tier:
    **merge**, **fix**, or **close** recommendation. When authorized, repair real
    defects and rerun exact-head checks so an existing PR is completely solid;
    never approve your own work or leave a reviewable PR undisposed.
-2. Only when tier one is empty, finish the oldest bounded, unblocked, unclaimed
+2. After the epoch completion record permits one lower-tier outcome, finish the oldest
+   bounded, unblocked, unclaimed
    open issue that fits the inheritance SDK mission and has no open PR that
    closes or substantively implements it. Complete it through a focused PR, or
    give duplicate, obsolete, invalid, and out-of-scope issues an explicit
    closure recommendation.
-3. Only when tiers one and two are empty, inspect every required GitHub Actions
+3. After the completion record permits the next eligible lower-tier outcome and
+   no bounded issue outcome is available, inspect every required GitHub Actions
    workflow on `main`. Repair every reproducible repository-caused failure and
    rerun it at the exact head. Treat queued runs, missing runners,
    credential/environment gates, and external outages as precise blockers, not
    green results or reasons to weaken validation.
-4. Only after every PR, issue, and fixable workflow failure is reconciled may
+4. Only after the completion record permits the next eligible lower-tier
+   outcome and every PR, issue, and fixable workflow failure is reconciled may
    you find new work. It
    must close a concrete sandbox or permission hole, fix an actual reproduced
    SDK defect, or add a failure-sensitive validator or test for demonstrated

--- a/skills/contribute-to-heir-elements-sdk/scripts/live-report.mjs
+++ b/skills/contribute-to-heir-elements-sdk/scripts/live-report.mjs
@@ -23,6 +23,11 @@ export const REQUIRED_EVIDENCE_ROWS = [
 export const CLAIM_RECENCY_DAYS = 7;
 export const MISSION_READY_LABEL = "mission-ready";
 export const MAX_OPEN_ITEMS = 10_000;
+// The repository-size bound protects discovery. This smaller work-epoch bound
+// is the liveness contract: one run has a finite frozen PR frontier and may
+// advance after that frontier is dispositioned even while new PRs arrive.
+export const MAX_REVIEW_EPOCH_CANDIDATES = 20;
+export const REVIEW_EPOCH_SCHEMA_VERSION = 1;
 export const MAX_API_READS = 16;
 export const MAX_ACTIVITY_CONNECTION_ITEMS = 1_000;
 export const MIN_GRAPHQL_ACTIVITY_POINTS = 1_000;
@@ -370,6 +375,208 @@ function compareByNumber(left, right) {
   return left.number - right.number;
 }
 
+function reviewEpochCandidate(
+  value,
+  index,
+  context = "review epoch candidate",
+) {
+  const record = asRecord(value, `${context}[${index}]`);
+  const number = asNumberField(record, "number", `${context}[${index}]`);
+  if (number < 1) {
+    throw new TypeError(`${context}[${index}].number must be positive`);
+  }
+  const headSha = asStringField(
+    record,
+    "headSha",
+    `${context}[${index}]`,
+  ).toLowerCase();
+  if (!FULL_COMMIT_RE.test(headSha)) {
+    throw new TypeError(
+      `${context}[${index}].headSha must be a full commit SHA`,
+    );
+  }
+  const updatedAt = isoTime(record.updatedAt, `${context}[${index}].updatedAt`);
+  return { number, headSha, updatedAt };
+}
+
+function reviewEpochIdentity(value, context = "review epoch candidate") {
+  const record = asRecord(value, context);
+  const number = asNumberField(record, "number", context);
+  if (number < 1) {
+    throw new TypeError(`${context}.number must be positive`);
+  }
+  const headSha = asStringField(record, "headSha", context).toLowerCase();
+  if (!FULL_COMMIT_RE.test(headSha)) {
+    throw new TypeError(`${context}.headSha must be a full commit SHA`);
+  }
+  return { number, headSha };
+}
+
+/**
+ * Freezes a deterministic, bounded PR review frontier. Candidates updated
+ * after the cutoff are explicitly deferred, as are candidates beyond the
+ * finite epoch count; both are eligible for a later epoch and never vanish
+ * from diagnostics.
+ */
+export function createReviewEpoch(
+  candidates,
+  cutoff,
+  maxCandidates = MAX_REVIEW_EPOCH_CANDIDATES,
+) {
+  if (!Array.isArray(candidates)) {
+    throw new TypeError("review epoch candidates must be an array");
+  }
+  const cutoffTime = Date.parse(isoTime(cutoff, "review epoch cutoff"));
+  if (
+    !Number.isInteger(maxCandidates) ||
+    maxCandidates < 1 ||
+    maxCandidates > MAX_REVIEW_EPOCH_CANDIDATES
+  ) {
+    throw new TypeError(
+      `review epoch maxCandidates must be an integer from 1 to ${MAX_REVIEW_EPOCH_CANDIDATES}`,
+    );
+  }
+  const normalized = candidates
+    .map((value, index) => reviewEpochCandidate(value, index))
+    .sort(compareByNumber);
+  const seen = new Set();
+  for (const candidate of normalized) {
+    if (seen.has(candidate.number)) {
+      throw new TypeError(
+        `duplicate review epoch candidate #${candidate.number}`,
+      );
+    }
+    seen.add(candidate.number);
+  }
+  const frozen = normalized.filter(
+    (candidate) => Date.parse(candidate.updatedAt) <= cutoffTime,
+  );
+  const arrivals = normalized
+    .filter((candidate) => Date.parse(candidate.updatedAt) > cutoffTime)
+    .map((candidate) => ({ ...candidate, deferredReason: "after-cutoff" }));
+  const selected = frozen.slice(0, maxCandidates);
+  const overLimit = frozen
+    .slice(maxCandidates)
+    .map((candidate) => ({ ...candidate, deferredReason: "epoch-limit" }));
+  return {
+    schemaVersion: REVIEW_EPOCH_SCHEMA_VERSION,
+    cutoff,
+    maxCandidates,
+    candidateCount: normalized.length,
+    candidates: selected,
+    deferred: [...overLimit, ...arrivals].sort(compareByNumber),
+    completion: {
+      requiredCandidateCount: selected.length,
+      allowsNextTier: false,
+      maxNextTierOutcomes: 0,
+    },
+  };
+}
+
+const REVIEW_EPOCH_DISPOSITIONS = new Set([
+  "reviewed",
+  "fix",
+  "close",
+  "stale-head",
+]);
+
+/** Returns the lower-tier permit only after every frozen candidate is closed. */
+export function completeReviewEpoch(epoch, dispositions) {
+  const record = asRecord(epoch, "review epoch");
+  const candidates = asArrayField(record, "candidates", "review epoch").map(
+    (candidate, index) =>
+      reviewEpochIdentity(candidate, `review epoch.candidates[${index}]`),
+  );
+  if (!Array.isArray(dispositions)) {
+    throw new TypeError("review epoch dispositions must be an array");
+  }
+  const expected = new Map(
+    candidates.map((candidate) => [candidate.number, candidate]),
+  );
+  const completed = new Set();
+  for (const [index, value] of dispositions.entries()) {
+    const context = `review epoch dispositions[${index}]`;
+    const disposition = asRecord(value, context);
+    const number = asNumberField(disposition, "number", context);
+    const candidate = expected.get(number);
+    if (!candidate) {
+      throw new TypeError(`${context} names non-epoch candidate #${number}`);
+    }
+    if (completed.has(number)) {
+      throw new TypeError(`duplicate review epoch disposition for #${number}`);
+    }
+    const expectedHeadSha = asStringField(
+      disposition,
+      "expectedHeadSha",
+      context,
+    ).toLowerCase();
+    if (expectedHeadSha !== candidate.headSha) {
+      throw new TypeError(
+        `${context} does not bind the frozen head for #${number}`,
+      );
+    }
+    const status = asStringField(disposition, "status", context);
+    if (!REVIEW_EPOCH_DISPOSITIONS.has(status)) {
+      throw new TypeError(`${context}.status is not a terminal disposition`);
+    }
+    if (status === "stale-head") {
+      const currentHeadSha = asStringField(
+        disposition,
+        "currentHeadSha",
+        context,
+      ).toLowerCase();
+      if (
+        !FULL_COMMIT_RE.test(currentHeadSha) ||
+        currentHeadSha === candidate.headSha
+      ) {
+        throw new TypeError(
+          `${context}.currentHeadSha must be a different full commit SHA`,
+        );
+      }
+    }
+    completed.add(number);
+  }
+  const remainingCandidates = candidates
+    .filter((candidate) => !completed.has(candidate.number))
+    .map((candidate) => candidate.number);
+  const complete = remainingCandidates.length === 0;
+  return {
+    complete,
+    dispositionCount: completed.size,
+    requiredCandidateCount: candidates.length,
+    remainingCandidates,
+    allowsNextTier: complete,
+    ...(complete
+      ? { nextTier: "next-eligible-lower-tier", maxNextTierOutcomes: 1 }
+      : { maxNextTierOutcomes: 0 }),
+  };
+}
+
+/**
+ * Publication boundary for an epoch candidate. A changed head is stale and
+ * must be deferred; only an exact byte-for-byte head match is publishable.
+ */
+export function recheckReviewEpochCandidate(candidate, currentHeadSha) {
+  const normalized = reviewEpochIdentity(candidate);
+  if (
+    typeof currentHeadSha !== "string" ||
+    !FULL_COMMIT_RE.test(currentHeadSha)
+  ) {
+    throw new TypeError("currentHeadSha must be a full commit SHA");
+  }
+  const current = currentHeadSha.toLowerCase();
+  if (current === normalized.headSha) {
+    return { number: normalized.number, status: "current", publishable: true };
+  }
+  return {
+    number: normalized.number,
+    status: "stale",
+    publishable: false,
+    currentHeadSha: current,
+    deferredReason: "head-changed",
+  };
+}
+
 function compareComment(left, right) {
   return left.id - right.id || left.url.localeCompare(right.url);
 }
@@ -459,6 +666,86 @@ export function readGhPages(endpoint, spawn = spawnSync) {
     throw new TypeError("gh api did not return text output");
   }
   return parsePaginatedJson(result.stdout, endpoint);
+}
+
+/** Performs the single live GET used as the pre-publication head guard. */
+export function readLivePullHead(repo, number, spawn = spawnSync) {
+  if (!REPOSITORY_RE.test(repo)) {
+    throw new TypeError("Repository must use the owner/name form");
+  }
+  if (!Number.isInteger(number) || number < 1) {
+    throw new TypeError("pull request number must be a positive integer");
+  }
+  const endpoint = `repos/${repo}/pulls/${number}`;
+  const result = spawn(
+    "gh",
+    [
+      "api",
+      "--method",
+      "GET",
+      "--jq",
+      "{number: .number, headSha: .head.sha, updatedAt: .updated_at}",
+      endpoint,
+    ],
+    {
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024,
+      windowsHide: true,
+    },
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const detail =
+      typeof result.stderr === "string" && result.stderr.trim().length > 0
+        ? `: ${result.stderr.trim()}`
+        : "";
+    throw new Error(`gh api failed for ${endpoint}${detail}`);
+  }
+  let value;
+  try {
+    value = JSON.parse(result.stdout);
+  } catch (cause) {
+    throw new SyntaxError(`gh api returned malformed JSON for ${endpoint}`, {
+      cause,
+    });
+  }
+  const record = asRecord(value, `live pull request #${number}`);
+  const liveNumber = asNumberField(
+    record,
+    "number",
+    `live pull request #${number}`,
+  );
+  if (liveNumber !== number) {
+    throw new TypeError(`live pull request number changed from #${number}`);
+  }
+  const headSha = asStringField(
+    record,
+    "headSha",
+    `live pull request #${number}`,
+  ).toLowerCase();
+  if (!FULL_COMMIT_RE.test(headSha)) {
+    throw new TypeError(
+      `live pull request #${number}.headSha must be a full commit SHA`,
+    );
+  }
+  return {
+    number,
+    headSha,
+    updatedAt: isoTime(
+      record.updatedAt,
+      `live pull request #${number}.updatedAt`,
+    ),
+  };
+}
+
+export function recheckLivePullHead(repo, candidate, spawn = spawnSync) {
+  const normalized = reviewEpochIdentity(candidate);
+  const live = readLivePullHead(repo, normalized.number, spawn);
+  return {
+    ...recheckReviewEpochCandidate(normalized, live.headSha),
+    expectedHeadSha: normalized.headSha,
+    updatedAt: live.updatedAt,
+  };
 }
 
 const ACTIVITY_PAGE_SIZE = 100;
@@ -1739,6 +2026,7 @@ export function collectLiveReport(
     throw new TypeError("Repository must use the owner/name form");
   }
   const referenceTime = nowTime(now);
+  const snapshotCutoff = now.toISOString();
   const candidateLabelSet = new Set(
     eligibleIssueLabels(projectEligibleIssueLabels, "eligible issue labels"),
   );
@@ -1970,7 +2258,18 @@ export function collectLiveReport(
       currentHeadApprovals: currentReviews.approved,
       currentHeadChangesRequested: currentReviews.changesRequested,
     };
-    const detailedSummary = { ...summary, reviewState };
+    const head = asRecord(item.head, `${context}.head`);
+    const headSha = asStringField(head, "sha", `${context}.head`).toLowerCase();
+    if (!FULL_COMMIT_RE.test(headSha)) {
+      throw new TypeError(`${context}.head.sha must be a full commit SHA`);
+    }
+    const updatedAt = isoTime(item.updated_at, `${context}.updated_at`);
+    const detailedSummary = {
+      ...summary,
+      updatedAt,
+      headSha,
+      reviewState,
+    };
     pullRequestAudits.push({
       ...detailedSummary,
       bodyProviderModel: parseModelDisclosure(body),
@@ -2010,10 +2309,13 @@ export function collectLiveReport(
     reviewablePullRequests.push(detailedSummary);
   }
 
+  const reviewEpoch = createReviewEpoch(reviewablePullRequests, snapshotCutoff);
   return {
     repository: repo,
+    snapshot: { cutoff: snapshotCutoff },
     selection: {
       eligibleIssueLabels: [...candidateLabelSet].sort(),
+      reviewEpoch,
     },
     totals: {
       openIssues: issueItems.length,
@@ -2080,6 +2382,9 @@ export function renderMarkdown(report) {
     "",
     `Open issues: ${report.totals.openIssues}; unclaimed candidates: ${report.totals.candidateIssues}.`,
     `Open PRs: ${report.totals.openPullRequests}; reviewable candidates: ${report.totals.reviewablePullRequests}.`,
+    report.selection?.reviewEpoch
+      ? `Review epoch cutoff: ${report.selection.reviewEpoch.cutoff}; frozen candidates: ${report.selection.reviewEpoch.candidates.length}/${report.selection.reviewEpoch.candidateCount}; deferred to a later epoch: ${report.selection.reviewEpoch.deferred.length}.`
+      : "Review epoch: unavailable.",
     "",
     "## Priority 1: unclaimed issue candidates with no open closing PR",
     "",
@@ -2143,7 +2448,11 @@ export function parseCliArguments(
   if (!REPOSITORY_RE.test(defaultRepository)) {
     throw new TypeError("default repository must use the owner/name form");
   }
-  const options = { repo: defaultRepository, json: false, help: false };
+  const options = {
+    repo: defaultRepository,
+    json: false,
+    help: false,
+  };
   for (let index = 0; index < args.length; index += 1) {
     const argument = args[index];
     if (argument === "--json") {
@@ -2158,12 +2467,43 @@ export function parseCliArguments(
       options.repo = args[index];
     } else if (argument.startsWith("--repo=")) {
       options.repo = argument.slice("--repo=".length);
+    } else if (argument === "--recheck-pr") {
+      index += 1;
+      if (index >= args.length) {
+        throw new TypeError("--recheck-pr requires a pull request number");
+      }
+      options.recheckPr = Number(args[index]);
+    } else if (argument.startsWith("--recheck-pr=")) {
+      options.recheckPr = Number(argument.slice("--recheck-pr=".length));
+    } else if (argument === "--expected-head") {
+      index += 1;
+      if (index >= args.length) {
+        throw new TypeError("--expected-head requires a full commit SHA");
+      }
+      options.expectedHead = args[index];
+    } else if (argument.startsWith("--expected-head=")) {
+      options.expectedHead = argument.slice("--expected-head=".length);
     } else {
       throw new TypeError(`Unknown argument: ${argument}`);
     }
   }
   if (!REPOSITORY_RE.test(options.repo)) {
     throw new TypeError("--repo must use the owner/name form");
+  }
+  if (options.recheckPr !== undefined) {
+    if (!Number.isInteger(options.recheckPr) || options.recheckPr < 1) {
+      throw new TypeError("--recheck-pr must be a positive integer");
+    }
+    if (
+      typeof options.expectedHead !== "string" ||
+      !FULL_COMMIT_RE.test(options.expectedHead)
+    ) {
+      throw new TypeError(
+        "--expected-head must be a full commit SHA when rechecking a PR",
+      );
+    }
+  } else if (options.expectedHead !== undefined) {
+    throw new TypeError("--expected-head requires --recheck-pr");
   }
   return options;
 }
@@ -2176,6 +2516,8 @@ Read and paginate open GitHub issues and pull requests without changing them.
 Options:
   --repo <owner/name>  Repository to inspect (default: this skill's project)
   --json               Print stable machine-readable JSON
+  --recheck-pr <n>     GET one live PR head before publishing a review
+  --expected-head <sha>  Frozen epoch head required by --recheck-pr
   --help, -h           Show this help
 `;
 }
@@ -2188,6 +2530,19 @@ export function main(args = process.argv.slice(2)) {
     return;
   }
   const commandBudget = createGhCommandBudget();
+  if (options.recheckPr !== undefined) {
+    const result = recheckLivePullHead(
+      options.repo,
+      {
+        number: options.recheckPr,
+        headSha: options.expectedHead,
+      },
+      commandBudget.run,
+    );
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    if (!result.publishable) process.exitCode = 2;
+    return;
+  }
   const boundedRead = (endpoint) => {
     return readGhPages(endpoint, commandBudget.run);
   };

--- a/skills/contribute-to-heir-elements-sdk/scripts/live-report.mjs
+++ b/skills/contribute-to-heir-elements-sdk/scripts/live-report.mjs
@@ -6,7 +6,7 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -28,6 +28,7 @@ export const MAX_OPEN_ITEMS = 10_000;
 // advance after that frontier is dispositioned even while new PRs arrive.
 export const MAX_REVIEW_EPOCH_CANDIDATES = 20;
 export const REVIEW_EPOCH_SCHEMA_VERSION = 1;
+export const MAX_REVIEW_EPOCH_FILE_BYTES = 262_144;
 export const MAX_API_READS = 16;
 export const MAX_ACTIVITY_CONNECTION_ITEMS = 1_000;
 export const MIN_GRAPHQL_ACTIVITY_POINTS = 1_000;
@@ -474,7 +475,7 @@ export function createReviewEpoch(
 }
 
 const REVIEW_EPOCH_DISPOSITIONS = new Set([
-  "reviewed",
+  "merge",
   "fix",
   "close",
   "stale-head",
@@ -483,6 +484,13 @@ const REVIEW_EPOCH_DISPOSITIONS = new Set([
 /** Returns the lower-tier permit only after every frozen candidate is closed. */
 export function completeReviewEpoch(epoch, dispositions) {
   const record = asRecord(epoch, "review epoch");
+  const schemaVersion = asNumberField(record, "schemaVersion", "review epoch");
+  if (schemaVersion !== REVIEW_EPOCH_SCHEMA_VERSION) {
+    throw new TypeError(
+      `review epoch.schemaVersion must be ${REVIEW_EPOCH_SCHEMA_VERSION}`,
+    );
+  }
+  const cutoff = isoTime(record.cutoff, "review epoch.cutoff");
   const candidates = asArrayField(record, "candidates", "review epoch").map(
     (candidate, index) =>
       reviewEpochIdentity(candidate, `review epoch.candidates[${index}]`),
@@ -493,7 +501,11 @@ export function completeReviewEpoch(epoch, dispositions) {
   const expected = new Map(
     candidates.map((candidate) => [candidate.number, candidate]),
   );
+  if (expected.size !== candidates.length) {
+    throw new TypeError("review epoch contains duplicate candidates");
+  }
   const completed = new Set();
+  const normalizedDispositions = new Map();
   for (const [index, value] of dispositions.entries()) {
     const context = `review epoch dispositions[${index}]`;
     const disposition = asRecord(value, context);
@@ -519,6 +531,11 @@ export function completeReviewEpoch(epoch, dispositions) {
     if (!REVIEW_EPOCH_DISPOSITIONS.has(status)) {
       throw new TypeError(`${context}.status is not a terminal disposition`);
     }
+    const normalizedDisposition = {
+      number,
+      expectedHeadSha,
+      status,
+    };
     if (status === "stale-head") {
       const currentHeadSha = asStringField(
         disposition,
@@ -533,23 +550,103 @@ export function completeReviewEpoch(epoch, dispositions) {
           `${context}.currentHeadSha must be a different full commit SHA`,
         );
       }
+      normalizedDisposition.currentHeadSha = currentHeadSha;
+    } else {
+      const recommendationUrl = asStringField(
+        disposition,
+        "recommendationUrl",
+        context,
+      );
+      let parsedRecommendationUrl;
+      try {
+        parsedRecommendationUrl = new URL(recommendationUrl);
+      } catch (cause) {
+        throw new TypeError(`${context}.recommendationUrl must be a URL`, {
+          cause,
+        });
+      }
+      const pathParts = parsedRecommendationUrl.pathname
+        .split("/")
+        .filter(Boolean);
+      if (
+        parsedRecommendationUrl.protocol !== "https:" ||
+        parsedRecommendationUrl.hostname !== "github.com" ||
+        parsedRecommendationUrl.username !== "" ||
+        parsedRecommendationUrl.password !== "" ||
+        pathParts.length < 4 ||
+        pathParts[2] !== "pull" ||
+        Number(pathParts[3]) !== number ||
+        recommendationUrl.length > 2_048
+      ) {
+        throw new TypeError(
+          `${context}.recommendationUrl must be a bounded public GitHub HTTPS URL`,
+        );
+      }
+      normalizedDisposition.recommendationUrl =
+        parsedRecommendationUrl.toString();
     }
     completed.add(number);
+    normalizedDispositions.set(number, normalizedDisposition);
   }
   const remainingCandidates = candidates
     .filter((candidate) => !completed.has(candidate.number))
     .map((candidate) => candidate.number);
   const complete = remainingCandidates.length === 0;
   return {
+    schemaVersion: REVIEW_EPOCH_SCHEMA_VERSION,
+    cutoff,
     complete,
     dispositionCount: completed.size,
     requiredCandidateCount: candidates.length,
     remainingCandidates,
+    dispositions: candidates.flatMap((candidate) => {
+      const disposition = normalizedDispositions.get(candidate.number);
+      return disposition ? [disposition] : [];
+    }),
     allowsNextTier: complete,
     ...(complete
       ? { nextTier: "next-eligible-lower-tier", maxNextTierOutcomes: 1 }
       : { maxNextTierOutcomes: 0 }),
   };
+}
+
+function readBoundedJsonFile(path, context) {
+  if (typeof path !== "string" || path.trim() === "") {
+    throw new TypeError(`${context} path must be a non-empty string`);
+  }
+  const statistics = statSync(path);
+  if (!statistics.isFile()) {
+    throw new TypeError(`${context} must be a regular file`);
+  }
+  if (statistics.size > MAX_REVIEW_EPOCH_FILE_BYTES) {
+    throw new RangeError(
+      `${context} exceeds ${MAX_REVIEW_EPOCH_FILE_BYTES} bytes`,
+    );
+  }
+  const contents = readFileSync(path);
+  if (contents.byteLength > MAX_REVIEW_EPOCH_FILE_BYTES) {
+    throw new RangeError(
+      `${context} exceeds ${MAX_REVIEW_EPOCH_FILE_BYTES} bytes`,
+    );
+  }
+  try {
+    return JSON.parse(contents.toString("utf8"));
+  } catch (cause) {
+    throw new SyntaxError(`${context} must contain valid JSON`, { cause });
+  }
+}
+
+function reviewEpochFromFile(path) {
+  const value = asRecord(
+    readBoundedJsonFile(path, "review epoch input"),
+    "review epoch input",
+  );
+  if (value.selection === undefined) return value;
+  const selection = asRecord(value.selection, "review epoch input.selection");
+  return asRecord(
+    selection.reviewEpoch,
+    "review epoch input.selection.reviewEpoch",
+  );
 }
 
 /**
@@ -2457,6 +2554,8 @@ export function parseCliArguments(
     const argument = args[index];
     if (argument === "--json") {
       options.json = true;
+    } else if (argument === "--epoch-only") {
+      options.epochOnly = true;
     } else if (argument === "--help" || argument === "-h") {
       options.help = true;
     } else if (argument === "--repo") {
@@ -2483,6 +2582,22 @@ export function parseCliArguments(
       options.expectedHead = args[index];
     } else if (argument.startsWith("--expected-head=")) {
       options.expectedHead = argument.slice("--expected-head=".length);
+    } else if (argument === "--complete-epoch") {
+      index += 1;
+      if (index >= args.length) {
+        throw new TypeError("--complete-epoch requires a JSON file path");
+      }
+      options.completeEpochPath = args[index];
+    } else if (argument.startsWith("--complete-epoch=")) {
+      options.completeEpochPath = argument.slice("--complete-epoch=".length);
+    } else if (argument === "--dispositions") {
+      index += 1;
+      if (index >= args.length) {
+        throw new TypeError("--dispositions requires a JSON file path");
+      }
+      options.dispositionsPath = args[index];
+    } else if (argument.startsWith("--dispositions=")) {
+      options.dispositionsPath = argument.slice("--dispositions=".length);
     } else {
       throw new TypeError(`Unknown argument: ${argument}`);
     }
@@ -2505,6 +2620,34 @@ export function parseCliArguments(
   } else if (options.expectedHead !== undefined) {
     throw new TypeError("--expected-head requires --recheck-pr");
   }
+  const completionRequested =
+    options.completeEpochPath !== undefined ||
+    options.dispositionsPath !== undefined;
+  if (completionRequested) {
+    if (
+      typeof options.completeEpochPath !== "string" ||
+      options.completeEpochPath.trim() === "" ||
+      typeof options.dispositionsPath !== "string" ||
+      options.dispositionsPath.trim() === ""
+    ) {
+      throw new TypeError(
+        "--complete-epoch and --dispositions must be provided together",
+      );
+    }
+    if (options.recheckPr !== undefined) {
+      throw new TypeError(
+        "--complete-epoch cannot be combined with --recheck-pr",
+      );
+    }
+  }
+  if (
+    options.epochOnly === true &&
+    (options.json || completionRequested || options.recheckPr !== undefined)
+  ) {
+    throw new TypeError(
+      "--epoch-only cannot be combined with another output operation",
+    );
+  }
   return options;
 }
 
@@ -2516,8 +2659,11 @@ Read and paginate open GitHub issues and pull requests without changing them.
 Options:
   --repo <owner/name>  Repository to inspect (default: this skill's project)
   --json               Print stable machine-readable JSON
+  --epoch-only         Print only the finite review epoch JSON
   --recheck-pr <n>     GET one live PR head before publishing a review
   --expected-head <sha>  Frozen epoch head required by --recheck-pr
+  --complete-epoch <path>  Validate a saved report or epoch JSON file
+  --dispositions <path>  Terminal disposition JSON required for completion
   --help, -h           Show this help
 `;
 }
@@ -2527,6 +2673,17 @@ export function main(args = process.argv.slice(2)) {
   const options = parseCliArguments(args, selectionPolicy.repositoryId);
   if (options.help) {
     process.stdout.write(usage());
+    return;
+  }
+  if (options.completeEpochPath !== undefined) {
+    const epoch = reviewEpochFromFile(options.completeEpochPath);
+    const dispositions = readBoundedJsonFile(
+      options.dispositionsPath,
+      "review epoch dispositions",
+    );
+    const result = completeReviewEpoch(epoch, dispositions);
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    if (!result.complete) process.exitCode = 2;
     return;
   }
   const commandBudget = createGhCommandBudget();
@@ -2568,9 +2725,11 @@ export function main(args = process.argv.slice(2)) {
     selectionPolicy.eligibleIssueLabels,
   );
   process.stdout.write(
-    options.json
-      ? `${JSON.stringify(report, null, 2)}\n`
-      : renderMarkdown(report),
+    options.epochOnly
+      ? `${JSON.stringify(report.selection.reviewEpoch, null, 2)}\n`
+      : options.json
+        ? `${JSON.stringify(report, null, 2)}\n`
+        : renderMarkdown(report),
   );
 }
 


### PR DESCRIPTION
## Summary

Closes #253.

- freeze a finite oldest-first PR review epoch with a snapshot cutoff and exact head SHAs
- defer post-cutoff arrivals, overflow, and changed heads deterministically
- expose an executable read-only exact-head recheck before review publication
- expose `--epoch-only` and `--complete-epoch` so contributors can persist dispositions and produce a machine-validated completion record
- require `merge`, `fix`, or `close` plus a matching public GitHub recommendation URL; reject the ambiguous `reviewed` status
- permit exactly one lower-tier outcome only after every frozen candidate is dispositioned
- apply the same progression contract and byte-identical CLI to all four contributor skills

## Verification

- `bun run verify` on the rebased exact head
- 65 Vitest files / 633 tests
- 96 skill tests
- focused executable completion, sustained-arrival, overflow, head-churn, invalid-disposition, and cross-project contract coverage

Exact head: `e55777d4546ca3e6a957545de197e6891b297986`