### PR TITLE
fix: keep public intake authority available

### DIFF
--- a/functions/api/v1/[[path]].ts
+++ b/functions/api/v1/[[path]].ts
@@ -118,7 +118,8 @@ async function privateIntakeStatus(
         if (status !== null) return status;
       }
     } catch {
-      return { status: "unavailable" };
+      // The cache is an availability optimization, not the authority. Continue
+      // to the bounded GitHub check when the runtime cache is unavailable.
     }
   }
   let response: Response;
@@ -188,7 +189,8 @@ async function privateIntakeStatus(
         }),
       );
     } catch {
-      return { status: "unavailable" };
+      // A verified GitHub response remains authoritative even when the edge
+      // runtime cannot persist the optional cache entry.
     }
   }
   return status;

--- a/functions/api/v1/trace-api.test.ts
+++ b/functions/api/v1/trace-api.test.ts
@@ -505,6 +505,63 @@ describe("private trace API", () => {
     }
   });
 
+  it("uses the public authority when the optional edge cache fails", async () => {
+    const originalFetch = globalThis.fetch;
+    const originalCaches = Object.getOwnPropertyDescriptor(
+      globalThis,
+      "caches",
+    );
+    let fetches = 0;
+    try {
+      globalThis.fetch = (async () => {
+        fetches += 1;
+        return new Response(JSON.stringify({ enabled: true }), { status: 200 });
+      }) as unknown as typeof fetch;
+      Object.defineProperty(globalThis, "caches", {
+        configurable: true,
+        value: {
+          default: {
+            match: async () => {
+              throw new Error("cache unavailable");
+            },
+            put: async () => {
+              throw new Error("cache unavailable");
+            },
+          },
+        },
+      });
+
+      const response = await onPagesRequest({
+        request: new Request(
+          "https://api.slop.cash/api/v1/private-request-intake",
+        ),
+        env: {
+          SLOP_DB: {} as never,
+          PRIVATE_TRACES: {} as never,
+          TRACE_AUTH_SECRET: SECRET,
+          SLOP_IDENTITY: {
+            fetch: async () => new Response(null, { status: 401 }),
+          },
+        },
+      });
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({
+        enabled: true,
+        source: "github-public-status",
+        verifiedAt: expect.any(String),
+      });
+      expect(fetches).toBe(1);
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (originalCaches === undefined) {
+        Reflect.deleteProperty(globalThis, "caches");
+      } else {
+        Object.defineProperty(globalThis, "caches", originalCaches);
+      }
+    }
+  });
+
   it("reports bounded reset diagnostics for an upstream GitHub rate limit", async () => {
     const originalFetch = globalThis.fetch;
     try {


### PR DESCRIPTION
Closes #270

The protected production deployment proved that GitHub public private-vulnerability reporting is enabled, while the Pages Function returned `503 private_intake_unavailable`. The edge cache is an availability optimization; cache runtime failures must not replace a valid authoritative GitHub response.

This change:
- falls through to the bounded GitHub authority check when `cache.match` fails;
- preserves the verified authority result when optional `cache.put` fails;
- retains fail-closed behavior for malformed, unavailable, or rate-limited GitHub responses;
- adds a regression test covering both cache failure points.

Exact-head local evidence (`68fbac80`):
- `bun run verify` — 64 test files / 629 tests, 92 skill tests, typecheck, format, lint, dependency audit, build all passed.
- `functions/api/v1/trace-api.test.ts` — 24/24 passed.