### PR TITLE
Keep contribution intake open across edge-cache failures

### DIFF
--- a/functions/api/v1/[[path]].ts
+++ b/functions/api/v1/[[path]].ts
@@ -118,7 +118,9 @@ async function privateIntakeStatus(
         if (status !== null) return status;
       }
     } catch {
-      return { status: "unavailable" };
+      // The edge cache is an availability optimization, not an authority.
+      // Fall through to the bounded live GitHub status check when it cannot
+      // be read so a cache outage cannot close an otherwise verified intake.
     }
   }
   let response: Response;
@@ -188,7 +190,8 @@ async function privateIntakeStatus(
         }),
       );
     } catch {
-      return { status: "unavailable" };
+      // A verified live response remains authoritative when the optional
+      // cache cannot be updated. The next request will verify GitHub again.
     }
   }
   return status;

--- a/functions/api/v1/trace-api.test.ts
+++ b/functions/api/v1/trace-api.test.ts
@@ -505,6 +505,112 @@ describe("private trace API", () => {
     }
   });
 
+  it("uses the live public authority when the edge cache cannot be read", async () => {
+    const originalFetch = globalThis.fetch;
+    const originalCaches = Object.getOwnPropertyDescriptor(
+      globalThis,
+      "caches",
+    );
+    let requests = 0;
+    try {
+      globalThis.fetch = (async () => {
+        requests += 1;
+        return new Response(JSON.stringify({ enabled: true }), { status: 200 });
+      }) as unknown as typeof fetch;
+      Object.defineProperty(globalThis, "caches", {
+        configurable: true,
+        value: {
+          default: {
+            match: async () => {
+              throw new Error("cache unavailable");
+            },
+            put: async () => undefined,
+          },
+        },
+      });
+
+      const response = await onPagesRequest({
+        request: new Request(
+          "https://api.slop.cash/api/v1/private-request-intake",
+        ),
+        env: {
+          SLOP_DB: {} as never,
+          PRIVATE_TRACES: {} as never,
+          TRACE_AUTH_SECRET: SECRET,
+          SLOP_IDENTITY: {
+            fetch: async () => new Response(null, { status: 401 }),
+          },
+        },
+      });
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({
+        enabled: true,
+        source: "github-public-status",
+      });
+      expect(requests).toBe(1);
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (originalCaches === undefined) {
+        Reflect.deleteProperty(globalThis, "caches");
+      } else {
+        Object.defineProperty(globalThis, "caches", originalCaches);
+      }
+    }
+  });
+
+  it("keeps a verified live public status when the edge cache cannot be written", async () => {
+    const originalFetch = globalThis.fetch;
+    const originalCaches = Object.getOwnPropertyDescriptor(
+      globalThis,
+      "caches",
+    );
+    try {
+      globalThis.fetch = (async () =>
+        new Response(JSON.stringify({ enabled: true }), {
+          status: 200,
+        })) as unknown as typeof fetch;
+      Object.defineProperty(globalThis, "caches", {
+        configurable: true,
+        value: {
+          default: {
+            match: async () => undefined,
+            put: async () => {
+              throw new Error("cache unavailable");
+            },
+          },
+        },
+      });
+
+      const response = await onPagesRequest({
+        request: new Request(
+          "https://api.slop.cash/api/v1/private-request-intake",
+        ),
+        env: {
+          SLOP_DB: {} as never,
+          PRIVATE_TRACES: {} as never,
+          TRACE_AUTH_SECRET: SECRET,
+          SLOP_IDENTITY: {
+            fetch: async () => new Response(null, { status: 401 }),
+          },
+        },
+      });
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({
+        enabled: true,
+        source: "github-public-status",
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (originalCaches === undefined) {
+        Reflect.deleteProperty(globalThis, "caches");
+      } else {
+        Object.defineProperty(globalThis, "caches", originalCaches);
+      }
+    }
+  });
+
   it("reports bounded reset diagnostics for an upstream GitHub rate limit", async () => {
     const originalFetch = globalThis.fetch;
     try {


### PR DESCRIPTION
## Summary

- preserve GitHub public private-intake authority when the optional Cloudflare edge cache cannot be read
- preserve an already verified live status when the optional cache cannot be written
- keep malformed, rate-limited, disabled, and unavailable upstream authority fail-closed

Closes #274

## Production incident evidence

- stale skill manifest was republished from exact `develop` SHA `eb5702c87fef7e2b9c95b258b2bdfd9f449d9d0b`
- live root and Eliza manifests now bind `SKILL.md` SHA-256 `cad790f06be2d61bcfe8f661c6cecb57027ba6362805314ea785e1347aa6d46b`
- live archive/checksum agree on SHA-256 `58fd3dba45f59b4e76eee9cac3127acfb0f50d913b7b7f7e5d20649efb61215c`
- the deployed archive provenance names the exact `develop` SHA and its `SKILL.md` bytes match the canonical source
- the post-deploy intake preflight reproduced HTTP 503 because cache failure overrode an authoritative GitHub `enabled: true` response

## Verification for exact head `9710f42f49e2ceeb0e0127ef160763dd9cfe3d82`

- `bun test functions/api/v1/trace-api.test.ts` — 25 passed
- `bun run verify` — 64 test files / 630 tests and 92 skill tests passed; build succeeded
- `bun run test:e2e` using the same deployed-ledger preparation as PR CI — 36 browser tests across wide desktop, desktop, tablet, and narrow mobile passed; Pages artifact contract passed
- `bun run typecheck`
- `bun run format:check`
- `bun run lint:check`

## Boundaries

The production environment review, private trace write-only model, authority validation, and all upstream failure/disabled states remain fail-closed. Only the optional cache is removed as a false authority.