### PR TITLE
Fix Cloudflare private intake preflight

### DIFF
--- a/functions/api/v1/[[path]].ts
+++ b/functions/api/v1/[[path]].ts
@@ -158,7 +158,10 @@ async function privateIntakeStatus(
   try {
     response = await fetchImpl(PRIVATE_INTAKE_STATUS_URL, {
       method: "GET",
-      redirect: "error",
+      // Cloudflare Workers supports manual redirect handling, not the browser
+      // `error` mode. Every redirect is still rejected below because a 3xx
+      // response is not successful and its body is never followed or parsed.
+      redirect: "manual",
       headers: {
         Accept: "application/vnd.github+json",
         "User-Agent": "slop-private-intake-verifier",

--- a/functions/api/v1/trace-api.test.ts
+++ b/functions/api/v1/trace-api.test.ts
@@ -529,7 +529,7 @@ describe("private trace API", () => {
       );
       expect(requests[0]?.init).toMatchObject({
         method: "GET",
-        redirect: "error",
+        redirect: "manual",
         headers: {
           Accept: "application/vnd.github+json",
           "User-Agent": "slop-private-intake-verifier",
@@ -680,6 +680,43 @@ describe("private trace API", () => {
         new Response(JSON.stringify({ enabled: "yes" }), {
           status: 200,
         })) as unknown as typeof fetch;
+      const response = await onPagesRequest({
+        request: new Request(
+          "https://api.slop.cash/api/v1/private-request-intake",
+        ),
+        env: {
+          SLOP_DB: {} as never,
+          PRIVATE_TRACES: {} as never,
+          TRACE_AUTH_SECRET: SECRET,
+          SLOP_IDENTITY: {
+            fetch: async () => new Response(null, { status: 401 }),
+          },
+        },
+      });
+
+      expect(response.status).toBe(503);
+      await expect(response.json()).resolves.toEqual({
+        error: "private_intake_unavailable",
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("rejects GitHub redirects without following them", async () => {
+    const originalFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = (async (
+        _input: RequestInfo | URL,
+        init?: RequestInit,
+      ) => {
+        expect(init?.redirect).toBe("manual");
+        return new Response(null, {
+          status: 302,
+          headers: { location: "https://example.com/not-github" },
+        });
+      }) as unknown as typeof fetch;
+
       const response = await onPagesRequest({
         request: new Request(
           "https://api.slop.cash/api/v1/private-request-intake",


### PR DESCRIPTION
Closes #274

## Root cause

Cloudflare Workers rejects Fetch API `redirect: "error"`, so the production private-intake preflight threw before it could query GitHub and returned `503 private_intake_unavailable`. Node-based tests accepted that redirect mode and did not reproduce the edge-runtime failure.

## Fix

- use Cloudflare-supported `redirect: "manual"`
- preserve fail-closed behavior: no redirect is followed and every 3xx remains rejected as non-success
- add a regression test proving a GitHub redirect cannot be followed

## Evidence

- real local Wrangler/Cloudflare runtime: preflight changed from the exact invalid-redirect exception to HTTP 200 with `source: github-public-status`
- `bun run verify`: 64 files / 630 tests, 92 skill tests, production build
- `bun run test:e2e`: 36 browser tests across wide desktop, desktop, tablet, and narrow mobile; 1 Pages artifact consistency test
- focused private trace API suite: 25 passed