### PR TITLE
fix: keep production evidence aligned with live site

### DIFF
--- a/scripts/evidence-contract.mjs
+++ b/scripts/evidence-contract.mjs
@@ -149,8 +149,8 @@ export function assertLiveLedgerReady(
       : contents,
     "leaderboard",
   );
-  if (snapshot.schemaVersion !== "5") {
-    throw new TypeError("leaderboard.schemaVersion must be 5");
+  if (snapshot.schemaVersion !== "6") {
+    throw new TypeError("leaderboard.schemaVersion must be 6");
   }
   if (snapshot.repository !== PRIMARY_REPOSITORY.id) {
     throw new TypeError(

--- a/scripts/evidence-contract.test.mjs
+++ b/scripts/evidence-contract.test.mjs
@@ -22,7 +22,7 @@ const now = Date.parse("2026-07-30T20:00:00.000Z");
 
 function liveLedger(overrides = {}) {
   return {
-    schemaVersion: "5",
+    schemaVersion: "6",
     repository: "elizaOS/eliza",
     repositories: [
       { id: "elizaOS/eliza" },
@@ -107,7 +107,7 @@ describe("live ledger readiness", () => {
     ).toThrow("leaderboard.ledger must be a non-empty array");
     expect(() =>
       assertLiveLedgerReady(liveLedger({ schemaVersion: "1" }), { now }),
-    ).toThrow("leaderboard.schemaVersion must be 5");
+    ).toThrow("leaderboard.schemaVersion must be 6");
     expect(() =>
       assertLiveLedgerReady(
         liveLedger({ repositories: [{ id: "elizaOS/eliza" }] }),

--- a/scripts/record-evidence.mjs
+++ b/scripts/record-evidence.mjs
@@ -537,7 +537,7 @@ try {
     });
     await page
       .locator(".hero-action")
-      .filter({ hasText: /^SHIPPING SLOP\.$/u })
+      .filter({ hasText: /^SHIPPING OPEN SOURCE\.$/u })
       .waitFor({ state: "visible", timeout: 10_000 });
     await page.locator("#projects").waitFor({ state: "visible" });
     await page.locator("#leaderboard table").waitFor({ state: "visible" });


### PR DESCRIPTION
## Summary
- accept the deployed leaderboard schema v6 in the production evidence contract
- align the recorder hero assertion with the current public product copy
- preserve fail-closed checks for stale or malformed live data

## Verification
- `bun run verify`
- `bunx vitest run scripts/evidence-contract.test.mjs`
- `bun run test:e2e:record:production` against the exact deployed artifact and https://slop.cash