### PR TITLE
Define safe honor-system contribution access

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,9 +77,12 @@ skills/contribute-to-<project-id>/
 skills/review-<project-id>-contributions/
 ```
 
-New projects begin paused. Verify immutable repository and actor IDs, repository
+New projects begin paused. Public contribution access may open independently
+when missing authority and terms remain explicit, receipts stay pending, and
+payments stay disabled. Verify immutable repository and actor IDs, repository
 license facts, GitHub stewardship, integration branch, reward policy, and
-failure paths before activation. Stewardship is a GitHub identity only.
+failure paths before activating receipts or money states. Stewardship is a
+GitHub identity only.
 
 The contributor skill must inspect live GitHub, select bounded unblocked work,
 follow the target repository’s rules, test the result, prepare evidence, and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,9 +77,12 @@ skills/contribute-to-<project-id>/
 skills/review-<project-id>-contributions/
 ```
 
-New projects begin paused. Verify immutable repository and actor IDs, repository
+New projects begin paused. Public contribution access may open independently
+when missing authority and terms remain explicit, receipts stay pending, and
+payments stay disabled. Verify immutable repository and actor IDs, repository
 license facts, GitHub stewardship, integration branch, reward policy, and
-failure paths before activation. Stewardship is a GitHub identity only.
+failure paths before activating receipts or money states. Stewardship is a
+GitHub identity only.
 
 The contributor skill must inspect live GitHub, select bounded unblocked work,
 follow the target repository’s rules, test the result, prepare evidence, and

--- a/README.md
+++ b/README.md
@@ -79,9 +79,11 @@ The pull request must establish:
 - a clearly labeled monthly pool or external opportunity;
 - focused tests for validation, installation, and failure paths.
 
-New projects begin paused. Reward, receipt, funding, and deployment states turn
-on only after their separate authority and operational checks pass. For the
-full review checklist, see [CONTRIBUTING.md](CONTRIBUTING.md).
+New projects begin paused. Public contribution access may open independently
+when missing authority and terms remain explicit, receipts stay pending, and
+payments stay disabled. Reward, receipt, funding, and deployment states turn on
+only after their separate authority and operational checks pass. For the full
+review checklist, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Score v2
 

--- a/scripts/prepare-monthly-rewards.test.ts
+++ b/scripts/prepare-monthly-rewards.test.ts
@@ -41,6 +41,29 @@ describe("monthly reward close", () => {
     expect(validateCycles).toHaveBeenCalledOnce();
   });
 
+  it("keeps active honor-system projects out of reward cycles", async () => {
+    const heir = PROJECTS.find((project) => project.id === "heir-elements-sdk");
+    if (!heir) throw new Error("Heir Elements SDK fixture is missing");
+    const openHeir = { ...heir, status: "active" as const };
+    const prepare = vi.fn();
+    const result = await prepareMonthlyRewards(
+      {
+        cycleId: "2026-09",
+        generatedAt: "2026-10-01T00:11:00.000Z",
+      },
+      {
+        inspectPath: vi.fn().mockResolvedValue("missing"),
+        prepare,
+        projects: [openHeir],
+        validateCycles: vi.fn(),
+      },
+    );
+
+    expect(result.prepared).toEqual([]);
+    expect(result.skippedPrelaunch).toEqual(["heir-elements-sdk"]);
+    expect(prepare).not.toHaveBeenCalled();
+  });
+
   it("leaves complete existing cycles untouched and rejects partial state", async () => {
     const result = await prepareMonthlyRewards(
       {

--- a/scripts/prepare-monthly-rewards.ts
+++ b/scripts/prepare-monthly-rewards.ts
@@ -108,6 +108,8 @@ export async function prepareMonthlyRewards(
   for (const project of dependencies.projects) {
     if (
       project.status !== "active" ||
+      project.authority.state !== "verified" ||
+      project.terms.receiptPolicy.state !== "active" ||
       Date.parse(project.reward.rewardStartAt) >= end
     ) {
       result.skippedPrelaunch.push(project.id);

--- a/scripts/prepare-site.mjs
+++ b/scripts/prepare-site.mjs
@@ -909,7 +909,7 @@ for (const project of PROJECTS) {
       {
         schemaVersion: "1",
         projectId: project.id,
-        status: "active",
+        status: project.status,
         steward: project.steward,
         authority: project.authority,
         terms: project.terms,

--- a/scripts/prepare-site.test.ts
+++ b/scripts/prepare-site.test.ts
@@ -791,7 +791,7 @@ describe("contribution skill package", () => {
       ).toEqual({
         schemaVersion: "1",
         projectId: project.id,
-        status: "active",
+        status: project.status,
         steward: project.steward,
         authority: project.authority,
         terms: project.terms,

--- a/src/lib/project-schema.mjs
+++ b/src/lib/project-schema.mjs
@@ -988,12 +988,17 @@ function validateProjectDefinition(
     project.steward,
     { allowLegacyUnsupportedOwnershipClaim },
   );
-  if (project.status === "active" && project.authority.state !== "verified") {
+  if (
+    project.status === "active" &&
+    project.authority.state !== "verified" &&
+    (project.terms.receiptPolicy.state !== "pending-authority-activation" ||
+      project.reward.paymentMode !== "disabled")
+  ) {
     throw new TypeError(
-      "active projects require verified repository authority",
+      "active projects without verified repository authority require pending receipts and disabled payments",
     );
   }
-  if (project.status === "active") {
+  if (project.status === "active" && project.authority.state === "verified") {
     if (
       project.terms.receiptPolicy.state !== "active" ||
       project.terms.receiptPolicy.activatedAt !==
@@ -1006,6 +1011,7 @@ function validateProjectDefinition(
   }
   if (
     project.status === "active" &&
+    project.authority.state === "verified" &&
     (project.terms.inbound.mode === "unknown" ||
       project.terms.repositoryLicense.state === "unknown" ||
       (project.reward.kind === "external-prize-share" &&

--- a/src/lib/project-schema.test.ts
+++ b/src/lib/project-schema.test.ts
@@ -373,7 +373,7 @@ describe("project proposal schema", () => {
     unprovenAuthority.reason = "missing-repository-proof";
     unprovenAuthority.proof = null;
     expect(() => assertProjectDefinition(activeWithoutProof)).toThrow(
-      /verified repository authority/u,
+      /pending receipts and disabled payments/u,
     );
 
     const loginAsIdentity = structuredClone(eliza);
@@ -672,19 +672,16 @@ describe("project proposal schema", () => {
     );
   });
 
-  it("keeps a missing repository license explicit without blocking runs", () => {
-    expect(assertProjectDefinition(heirElements).status).toBe("paused");
-    expect(heirElements.terms.repositoryLicense).toEqual({
+  it("keeps missing authority explicit without blocking contribution access", () => {
+    const contributionOpen = structuredClone(heirElements);
+    contributionOpen.status = "active";
+    expect(assertProjectDefinition(contributionOpen).status).toBe("active");
+    expect(contributionOpen.terms.repositoryLicense).toEqual({
       state: "unknown",
       spdx: null,
       url: null,
       commitSha: null,
       fileSha256: null,
     });
-    const active = structuredClone(heirElements);
-    active.status = "active";
-    expect(() => assertProjectDefinition(active)).toThrow(
-      /verified repository authority/u,
-    );
   });
 });

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -809,7 +809,7 @@ test("serves byte-consistent install and read-only artifacts for every project",
     expect(await termsResponse.json()).toEqual({
       schemaVersion: "1",
       projectId: project.id,
-      status: "active",
+      status: project.status,
       steward: project.steward,
       authority: project.authority,
       terms: project.terms,


### PR DESCRIPTION
## Summary
- allow public contribution access to be active independently of verified receipt authority
- require active unverified projects to keep receipts pending and payments disabled
- exclude unverified or pending-receipt projects from monthly reward-cycle preparation
- publish each project actual status instead of hardcoding `active` in generated terms
- align unit and real-browser artifact tests with the manifest inventory
- document the separate contribution, receipt, and money-state boundaries

This policy PR intentionally makes no project-manifest transition. A separate exact-head PR will activate Heir after this policy is trusted by `develop`. Related to #264.

## Exact-head verification
- `bun run verify` (65 files / 634 tests; 96 skill tests; audit, typecheck, lint, format, build)
- complete live snapshot (116 leaders, 9,950 score events)
- `SLOP_E2E_PORT=41973 bun run test:e2e` (36 responsive browser tests + all-project artifact test)
- `AGENTS.md` and `CLAUDE.md` byte-identical

Exact head: `f996e3df630fb9b2321ca27e26195cad0ef8508a`