### PR TITLE
Stop advertising legacy evidence points under Score v2

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2056,9 +2056,7 @@ function opportunityPointsLabel(opportunity: ScoreOpportunity): string {
     opportunity.kind === "missing-evidence" ||
     opportunity.kind === "partial-evidence"
   ) {
-    // Evidence is the least certain category: each attachment must still pass
-    // remote structure and head-binding verification after merge.
-    return `+${opportunity.potentialPoints} if it verifies`;
+    return "Evidence guidance";
   }
   return `+${opportunity.potentialPoints} if it qualifies`;
 }

--- a/src/lib/leaderboard.test.ts
+++ b/src/lib/leaderboard.test.ts
@@ -3924,6 +3924,20 @@ describe("work queue claims and prioritization", () => {
       "near-material-test",
     ]);
     expect(
+      snapshot.opportunities.filter(
+        (opportunity) => opportunity.category === "evidence",
+      ),
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          potentialPoints: null,
+          reason: expect.stringContaining(
+            "Evidence does not add standalone Score v2 points.",
+          ),
+        }),
+      ]),
+    );
+    expect(
       snapshot.opportunities.some(
         (opportunity) => opportunity.source.id === mergedNearTest.id,
       ),

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -404,7 +404,8 @@ export interface ScoreOpportunity {
   actor: GitHubActor;
   kind: ScoreOpportunityKind;
   category: ScoreCategory;
-  potentialPoints: number;
+  /** Null when the row is useful guidance but cannot add standalone score. */
+  potentialPoints: number | null;
   occurredAt: string;
   repository: RepositoryId;
   source: ScoreEvent["source"];
@@ -2744,7 +2745,6 @@ function collectOpenPullRequestOpportunities(
           (status.status === "missing" &&
             hasOpenPullRequestOpportunitySignal(pullRequest));
         if (publishEvidenceGap) {
-          const remaining = status.maxPoints - status.points;
           opportunities.push({
             id: `${pullRequest.id}:opportunity:${status.status}-evidence`,
             actor: pullRequest.author,
@@ -2753,11 +2753,11 @@ function collectOpenPullRequestOpportunities(
                 ? "missing-evidence"
                 : "partial-evidence",
             category: "evidence",
-            potentialPoints: remaining,
+            potentialPoints: null,
             occurredAt: pullRequest.updatedAt,
             repository,
             source: pullRequestSource,
-            reason: `Open pull request evidence is ${status.status} with ${status.points} of ${status.maxPoints} points verified.`,
+            reason: `Open pull request evidence is ${status.status}; its legacy evidence assessment is ${status.points} of ${status.maxPoints}. Evidence does not add standalone Score v2 points.`,
             hint:
               status.status === "missing"
                 ? "Add verified screenshot, video, or log evidence before merge."
@@ -4894,10 +4894,16 @@ function assertOpportunityValue(
     ],
     `${path}.category`,
   );
-  assertPositiveInteger(opportunity.potentialPoints, `${path}.potentialPoints`);
-  const potentialPoints = Number(opportunity.potentialPoints);
   const kind = opportunity.kind as ScoreOpportunityKind;
   const category = opportunity.category as ScoreCategory;
+  let potentialPoints: number | null = null;
+  if (opportunity.potentialPoints !== null) {
+    assertPositiveInteger(
+      opportunity.potentialPoints,
+      `${path}.potentialPoints`,
+    );
+    potentialPoints = Number(opportunity.potentialPoints);
+  }
   const validPair =
     (kind === "near-material-test" &&
       category === "material-test-change" &&
@@ -4907,8 +4913,8 @@ function assertOpportunityValue(
       potentialPoints === 3) ||
     ((kind === "missing-evidence" || kind === "partial-evidence") &&
       category === "evidence" &&
-      potentialPoints >= 1 &&
-      potentialPoints <= 6);
+      (potentialPoints === null ||
+        (potentialPoints >= 1 && potentialPoints <= 6)));
   if (!validPair) {
     throw new Error(
       `${path} kind/category/potentialPoints combination is invalid`,

--- a/src/lib/project-view.test.ts
+++ b/src/lib/project-view.test.ts
@@ -129,7 +129,7 @@ describe("project views", () => {
         actor: snapshot.leaders[0].actor,
         kind: "missing-evidence",
         category: "evidence",
-        potentialPoints: 6,
+        potentialPoints: null,
         occurredAt: "2026-06-20T12:00:00.000Z",
         repository: "elizaOS/eliza",
         source: {
@@ -140,7 +140,7 @@ describe("project views", () => {
           url: "https://github.com/elizaOS/eliza/pull/17000",
         },
         reason:
-          "Open pull request evidence is missing with 0 of 6 points verified.",
+          "Open pull request evidence is missing; its legacy evidence assessment is 0 of 6. Evidence does not add standalone Score v2 points.",
         hint: "Add verified screenshot, video, or log evidence before merge.",
       },
       {
@@ -148,7 +148,7 @@ describe("project views", () => {
         actor: snapshot.leaders[0].actor,
         kind: "partial-evidence",
         category: "evidence",
-        potentialPoints: 4,
+        potentialPoints: null,
         occurredAt: "2026-07-29T12:00:00.000Z",
         repository: "elizaOS/proximityprize",
         source: {
@@ -159,7 +159,7 @@ describe("project views", () => {
           url: "https://github.com/SlopDotCash/proximityprize/pull/99",
         },
         reason:
-          "Open pull request evidence is partial with 2 of 6 points verified.",
+          "Open pull request evidence is partial; its legacy evidence assessment is 2 of 6. Evidence does not add standalone Score v2 points.",
         hint: "Finish verified evidence categories before merge.",
       },
     ];
@@ -189,7 +189,7 @@ describe("project views", () => {
     ]);
   });
 
-  it("does not advertise points after the contributor has filled that cap", () => {
+  it("keeps non-scoring evidence guidance after legacy evidence cap usage", () => {
     const snapshot = snapshotFixture();
     const evidenceTemplate = snapshot.ledger.find(
       (event) => event.category === "evidence",
@@ -212,7 +212,7 @@ describe("project views", () => {
 
     expect(
       createProjectView(snapshot, "eliza", "2026-07").opportunities,
-    ).toEqual([]);
+    ).toMatchObject([{ potentialPoints: null, category: "evidence" }]);
   });
 
   it("keeps pre-v2 receipt evidence diagnostic", () => {

--- a/src/lib/project-view.ts
+++ b/src/lib/project-view.ts
@@ -166,12 +166,12 @@ function capUsageForEvents(
 function opportunityPointsWithinCap(
   opportunity: ScoreOpportunity,
   usage: CapUsageStatus,
-): number {
+): number | null {
   if (opportunity.category === "evidence") {
-    return Math.min(
-      opportunity.potentialPoints,
-      Math.max(0, SCORE_CAPS.evidencePoints - usage.evidencePoints.used),
-    );
+    return null;
+  }
+  if (opportunity.potentialPoints === null) {
+    return 0;
   }
   if (
     opportunity.category === "material-test-change" &&
@@ -620,6 +620,9 @@ export function createProjectView(
         ledger.filter((event) => event.actor.id === opportunity.actor.id),
       );
       const potentialPoints = opportunityPointsWithinCap(opportunity, usage);
+      if (potentialPoints === null) {
+        return { ...opportunity, potentialPoints: null };
+      }
       return potentialPoints > 0 ? { ...opportunity, potentialPoints } : null;
     })
     .filter(

--- a/tests/app.test.tsx
+++ b/tests/app.test.tsx
@@ -843,7 +843,7 @@ describe("public records", () => {
       ),
     ).toBeInTheDocument();
     expect(screen.queryAllByText(/2026-07 scoring ·/)).toHaveLength(0);
-    expect(screen.getByText(/\+6 if it verifies/)).toBeInTheDocument();
+    expect(screen.getByText("Evidence guidance")).toBeInTheDocument();
     expect(screen.getByText("all-time score")).toBeInTheDocument();
     expect(screen.getByText("monthly estimate")).toBeInTheDocument();
     expect(
@@ -868,7 +868,7 @@ describe("public records", () => {
         actor: openOnly,
         kind: "partial-evidence",
         category: "evidence",
-        potentialPoints: 4,
+        potentialPoints: null,
         occurredAt: "2026-07-29T18:00:00.000Z",
         repository: "elizaOS/eliza",
         source: {
@@ -879,7 +879,7 @@ describe("public records", () => {
           url: "https://github.com/elizaOS/eliza/pull/17399",
         },
         reason:
-          "Open pull request evidence is partial with 2 of 6 points verified.",
+          "Open pull request evidence is partial; its legacy evidence assessment is 2 of 6. Evidence does not add standalone Score v2 points.",
         hint: "Finish verified evidence categories before merge.",
       },
     ];
@@ -948,7 +948,7 @@ describe("public records", () => {
         actor,
         kind: "missing-evidence" as const,
         category: "evidence" as const,
-        potentialPoints: 6,
+        potentialPoints: null,
         occurredAt: `2026-07-${String(29 - index).padStart(2, "0")}T12:00:00.000Z`,
         repository: "elizaOS/eliza" as const,
         source: {
@@ -959,7 +959,7 @@ describe("public records", () => {
           url: `https://github.com/elizaOS/eliza/pull/${number}`,
         },
         reason:
-          "Open pull request evidence is missing with 0 of 6 points verified.",
+          "Open pull request evidence is missing; its legacy evidence assessment is 0 of 6. Evidence does not add standalone Score v2 points.",
         hint: "Add verified screenshot, video, or log evidence before merge.",
       };
     });
@@ -985,7 +985,7 @@ describe("public records", () => {
         name: "Open work",
       }),
     ).toBeInTheDocument();
-    expect(screen.getAllByText(/\+6 if it verifies/)).toHaveLength(5);
+    expect(screen.getAllByText("Evidence guidance")).toHaveLength(5);
     expect(screen.getByText(/Open checklist 18000/)).toBeInTheDocument();
     expect(screen.queryByText(/Open checklist 18005/)).not.toBeInTheDocument();
   });

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -314,7 +314,7 @@ export function snapshotFixture(): LeaderboardSnapshot {
         actor: leaderActor,
         kind: "missing-evidence",
         category: "evidence",
-        potentialPoints: 6,
+        potentialPoints: null,
         occurredAt: "2026-07-29T18:00:00.000Z",
         repository: "elizaOS/eliza",
         source: {
@@ -325,7 +325,7 @@ export function snapshotFixture(): LeaderboardSnapshot {
           url: "https://github.com/elizaOS/eliza/pull/17340",
         },
         reason:
-          "Open pull request evidence is missing with 0 of 6 points verified.",
+          "Open pull request evidence is missing; its legacy evidence assessment is 0 of 6. Evidence does not add standalone Score v2 points.",
         hint: "Add verified screenshot, video, or log evidence before merge.",
       },
     ],


### PR DESCRIPTION
## Summary

- publish evidence gaps as non-scoring verification guidance under Score v2
- keep legacy numeric opportunity rows readable without displaying them as attainable points
- preserve evidence guidance after legacy evidence-cap usage
- add generator, project-view, and UI regressions

Closes #285.

## Verification

- `bun x vitest run src/lib/leaderboard.test.ts src/lib/project-view.test.ts tests/app.test.tsx` (153 passed)
- `bun run verify` (65 files / 634 tests; 96 skill tests; audit, typecheck, format, lint, build green)