### PR TITLE
fix: report unknown API paths as not found before authentication

### DIFF
--- a/backend/trace/handler.ts
+++ b/backend/trace/handler.ts
@@ -849,6 +849,85 @@ async function readTrace(
   });
 }
 
+function matchAuthenticatedRoute(
+  request: Request,
+  parts: string[],
+  deps: TraceApiDependencies,
+): ((actor: AuthenticatedActor) => Promise<Response>) | null {
+  if (
+    request.method === "GET" &&
+    parts.length === 2 &&
+    parts[0] === "wallet-claims" &&
+    parts[1] === "current"
+  ) {
+    return async (actor) => {
+      const current = await deps.persistence.getCurrentWalletClaim(
+        actor.githubId,
+      );
+      if (current === null) fail(404, "not_found", "Wallet claim not found");
+      return json(200, publicWalletClaim(current));
+    };
+  }
+  if (
+    request.method === "POST" &&
+    parts.length === 1 &&
+    parts[0] === "wallet-claims"
+  ) {
+    return (actor) => createContributorWalletClaim(request, actor, deps);
+  }
+  if (request.method === "POST" && parts.length === 1 && parts[0] === "runs") {
+    return (actor) => createRun(request, actor, deps);
+  }
+  if (
+    request.method === "POST" &&
+    parts.length === 3 &&
+    parts[0] === "runs" &&
+    (parts[2] === "trace-intents" ||
+      parts[2] === "finalize" ||
+      parts[2] === "events")
+  ) {
+    const runId = parts[1];
+    const action = parts[2];
+    return (actor) => {
+      if (!validIdentifier(runId))
+        fail(400, "invalid_request", "Invalid run id");
+      if (action === "trace-intents") {
+        return createTraceIntent(request, actor, deps, runId);
+      }
+      if (action === "finalize") {
+        return finalizeRun(request, actor, deps, runId);
+      }
+      return appendEvent(request, actor, deps, runId);
+    };
+  }
+  if (
+    request.method === "POST" &&
+    parts.length === 4 &&
+    parts[0] === "operator" &&
+    parts[1] === "traces" &&
+    parts[3] === "grant"
+  ) {
+    return (actor) => createReadGrant(request, actor, deps, parts[2]);
+  }
+  if (
+    request.method === "GET" &&
+    parts.length === 3 &&
+    parts[0] === "operator" &&
+    parts[1] === "traces"
+  ) {
+    return (actor) => readTrace(request, actor, deps, parts[2]);
+  }
+  if (
+    request.method === "POST" &&
+    parts.length === 2 &&
+    parts[0] === "operator" &&
+    parts[1] === "wallet-claims"
+  ) {
+    return (actor) => createFallbackWalletClaim(request, actor, deps);
+  }
+  return null;
+}
+
 export async function handleTraceApi(
   request: Request,
   deps: TraceApiDependencies,
@@ -903,6 +982,9 @@ export async function handleTraceApi(
     ) {
       return await exchangeIdentityAssertion(request, deps);
     }
+    const route = matchAuthenticatedRoute(request, parts, deps);
+    // No contributor or project-owner read endpoint exists by design.
+    if (route === null) return json(404, { error: "not_found" });
     const actor = await verifyApiToken({
       authorization: request.headers.get("authorization"),
       secret: deps.authSecret,
@@ -910,75 +992,7 @@ export async function handleTraceApi(
       nowSeconds: Math.floor(deps.now().getTime() / 1000),
     });
     if (actor === null) fail(401, "unauthorized", "Authentication failed");
-
-    if (
-      request.method === "GET" &&
-      parts.length === 2 &&
-      parts[0] === "wallet-claims" &&
-      parts[1] === "current"
-    ) {
-      const current = await deps.persistence.getCurrentWalletClaim(
-        actor.githubId,
-      );
-      if (current === null) fail(404, "not_found", "Wallet claim not found");
-      return json(200, publicWalletClaim(current));
-    }
-    if (
-      request.method === "POST" &&
-      parts.length === 1 &&
-      parts[0] === "wallet-claims"
-    ) {
-      return await createContributorWalletClaim(request, actor, deps);
-    }
-
-    if (
-      request.method === "POST" &&
-      parts.length === 1 &&
-      parts[0] === "runs"
-    ) {
-      return await createRun(request, actor, deps);
-    }
-    if (parts[0] === "runs" && parts.length === 3) {
-      const runId = parts[1];
-      if (!validIdentifier(runId))
-        fail(400, "invalid_request", "Invalid run id");
-      if (request.method === "POST" && parts[2] === "trace-intents") {
-        return await createTraceIntent(request, actor, deps, runId);
-      }
-      if (request.method === "POST" && parts[2] === "finalize") {
-        return await finalizeRun(request, actor, deps, runId);
-      }
-      if (request.method === "POST" && parts[2] === "events") {
-        return await appendEvent(request, actor, deps, runId);
-      }
-    }
-    if (
-      parts[0] === "operator" &&
-      parts[1] === "traces" &&
-      parts.length === 4 &&
-      parts[3] === "grant" &&
-      request.method === "POST"
-    ) {
-      return await createReadGrant(request, actor, deps, parts[2]);
-    }
-    if (
-      parts[0] === "operator" &&
-      parts[1] === "traces" &&
-      parts.length === 3 &&
-      request.method === "GET"
-    ) {
-      return await readTrace(request, actor, deps, parts[2]);
-    }
-    if (
-      request.method === "POST" &&
-      parts.length === 2 &&
-      parts[0] === "operator" &&
-      parts[1] === "wallet-claims"
-    ) {
-      return await createFallbackWalletClaim(request, actor, deps);
-    }
-    // No contributor or project-owner read endpoint exists by design.
-    return json(404, { error: "not_found" });
+    return await route(actor);
   } catch (caught) {
     const error =
       typeof caught === "object" && caught !== null

--- a/functions/api/v1/trace-api.test.ts
+++ b/functions/api/v1/trace-api.test.ts
@@ -1536,4 +1536,46 @@ describe("private trace API", () => {
     );
     expect(response.status).toBe(401);
   });
+
+  it("reports unknown paths as not found instead of demanding authentication", async () => {
+    const unknown: Array<[string, string]> = [
+      ["private-request-intak", "GET"],
+      ["private-request-intake/extra", "GET"],
+      ["runs", "GET"],
+      ["runs/run_0000000000000001/unknown-action", "POST"],
+      ["operator/traces", "GET"],
+    ];
+    for (const [path, method] of unknown) {
+      const response = await handleTraceApi(
+        new Request(`https://api.slop.cash/api/v1/${path}`, { method }),
+        dependencies(),
+      );
+      expect(response.status).toBe(404);
+      expect(await response.json()).toMatchObject({ error: "not_found" });
+    }
+  });
+
+  it("still requires authentication before validating a matched run id", async () => {
+    const deps = dependencies();
+    const unauthenticated = await handleTraceApi(
+      new Request(
+        "https://api.slop.cash/api/v1/runs/not%20a%20valid%20id/finalize",
+        { method: "POST" },
+      ),
+      deps,
+    );
+    expect(unauthenticated.status).toBe(401);
+    expect(await unauthenticated.json()).toMatchObject({
+      error: "unauthorized",
+    });
+    const bearer = await token("42", "contributor-login", ["contributor"]);
+    const invalidRunId = await handleTraceApi(
+      request("runs/not%20a%20valid%20id/finalize", "POST", bearer),
+      deps,
+    );
+    expect(invalidRunId.status).toBe(400);
+    expect(await invalidRunId.json()).toMatchObject({
+      error: "invalid_request",
+    });
+  });
 });


### PR DESCRIPTION
## What

Unmatched paths under `/api/v1` previously fell through to the bearer-token check and returned `401 {"error":"unauthorized","message":"Authentication failed"}`. This reads as a credential problem when the real situation is that the deployed API does not have the route. The handler now matches the authenticated route first and returns `404 not_found` when nothing matches.

## Why

A contributor running the eliza contribute skill hit exactly this against `private-request-intake` while #271 was rolling out, read the 401 as an auth failure on their side, and stalled the run. They reported it by DM instead of finishing a contribution. The misleading status cost a real first-time contributor session.

## Behavior

- Unknown path or method, with or without a token: `404 not_found` (previously `401`).
- Known route without a valid token: `401 unauthorized`, unchanged.
- Known route with a valid token: unchanged, including `400 invalid_request` for a malformed run id, which still only surfaces after authentication.
- Route conditions live in one matcher, so the 404 fallthrough and the dispatch cannot drift apart.

## Tests

- New: unknown paths (typo, extra segment, wrong method, unknown run action) return `404 not_found` unauthenticated; a matched route still returns `401` before validating the run id and `400` after auth.
- `vitest run functions/api/v1/trace-api.test.ts`: 28 passed.
- Full `bun run verify` chain green locally (projects/evaluations/funding/cycles/protocol checks, audit, typecheck, lint, format, vitest 636 passed, build).
- Known local-environment exception: `skill-tests` case "starts and finishes a measured run without passing --project to ccusage" fails identically on a pristine `origin/develop` worktree on this machine, so it is unrelated to this change.

A green local test is not proof of merge or deployment. The live endpoint at `api.slop.cash` was probed read-only before and after diagnosis; `GET /api/v1/private-request-intake` currently returns `200 {"enabled":true,"source":"github-public-status"}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
