### PR TITLE
feat: surface reviewers as their own leaderboard ranking

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,6 +64,7 @@ import {
   PROJECTS,
   type ProjectDefinition,
 } from "./lib/projects.mjs";
+import { formatThirds, selectReviewerLeaders } from "./lib/reviewer-leaders";
 import { feeForPrincipal, PLATFORM_FEE_BASIS_POINTS } from "./lib/rewards";
 
 const SOURCE_REPOSITORY = "https://github.com/SlopDotCash/slopdotcash";
@@ -617,6 +618,75 @@ function Avatar({
   );
 }
 
+function ReviewerLeaderboard({
+  caption,
+  cycleMonth,
+  ledger,
+}: {
+  caption: string;
+  cycleMonth: string;
+  ledger: readonly ScoreEvent[];
+}) {
+  const reviewers = selectReviewerLeaders(ledger);
+  return (
+    <div className="reviewer-leaderboard">
+      <div className="leaderboard-cycle-summary">
+        <div>
+          <strong>{cycleMonth} · Reviewers</strong>
+          <span>
+            Scored reviews of accepted work. Review points currently share the
+            monthly pool with authored work.
+          </span>
+        </div>
+      </div>
+      {reviewers.length === 0 ? (
+        <EmptyState text="No scored reviews in this project cycle yet." />
+      ) : (
+        <div className="leader-table global-leader-table">
+          <table className="leader-grid global-leader-grid">
+            <caption className="visually-hidden">{caption}</caption>
+            <thead>
+              <tr className="leader-row leader-head global-leader-head reviewer-leader-row">
+                <th scope="col">Rank</th>
+                <th scope="col">Reviewer</th>
+                <th scope="col">Review score</th>
+              </tr>
+            </thead>
+            <tbody>
+              {reviewers.slice(0, 20).map((reviewer) => (
+                <tr
+                  className="leader-row global-leader-row reviewer-leader-row"
+                  key={reviewer.actor.id}
+                >
+                  <td className="rank-cell">#{reviewer.rank}</td>
+                  <td className="person-cell">
+                    <Link
+                      className="person-link"
+                      href={`/contributors/${encodeURIComponent(reviewer.actor.login)}`}
+                    >
+                      <Avatar actor={reviewer.actor} />
+                      <span>
+                        <strong>{reviewer.actor.login}</strong>
+                        <small>
+                          {reviewer.reviewEventCount} scored review
+                          {reviewer.reviewEventCount === 1 ? "" : "s"}
+                        </small>
+                      </span>
+                    </Link>
+                  </td>
+                  <td data-label="Review score">
+                    <strong>{formatThirds(reviewer.reviewThirds)}</strong>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
 function GlobalLeaderboard({
   cycleIndex,
   snapshot,
@@ -787,6 +857,11 @@ function GlobalLeaderboard({
                       </tbody>
                     </table>
                   </div>
+                  <ReviewerLeaderboard
+                    caption={`${selectedView.project.name} ${cycleMonth} reviewer leaderboard`}
+                    cycleMonth={cycleMonth}
+                    ledger={selectedView.ledger}
+                  />
                   <Link
                     className="leaderboard-project-link"
                     href={`/projects/${selectedView.project.slug}`}
@@ -1228,6 +1303,11 @@ function ProjectLeaderboard({
           </table>
         </div>
       )}
+      <ReviewerLeaderboard
+        caption={`${view.project.name} ${formatCycleMonth(view.cycle.id)} reviewer leaderboard`}
+        cycleMonth={formatCycleMonth(view.cycle.id)}
+        ledger={view.ledger}
+      />
     </section>
   );
 }

--- a/src/lib/reviewer-leaders.test.ts
+++ b/src/lib/reviewer-leaders.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Exercises reviewer selection: category filtering, third aggregation across
+ * v2 and legacy events, deterministic ordering, and rejection of malformed
+ * third counts.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { GitHubActor, ScoreEvent } from "./leaderboard";
+import { formatThirds, selectReviewerLeaders } from "./reviewer-leaders";
+
+function actor(id: string, login: string): GitHubActor {
+  return {
+    id,
+    login,
+    avatarUrl: `https://avatars.githubusercontent.com/${login}?size=96`,
+    url: `https://github.com/${login}`,
+    kind: "User",
+  };
+}
+
+function event(overrides: Partial<ScoreEvent> & { id: string }): ScoreEvent {
+  return {
+    actor: actor("U_reviewer", "reviewer-one"),
+    category: "substantive-review",
+    points: 1,
+    scoreThirds: 3,
+    occurredAt: "2026-08-10T10:00:00.000Z",
+    repository: "elizaOS/eliza",
+    source: {
+      id: overrides.id,
+      kind: "review",
+      number: 25581,
+      title: "Independent review",
+      url: "https://github.com/elizaOS/eliza/pull/25581",
+    },
+    reason: "Substantive review of an accepted outcome.",
+    ...overrides,
+  };
+}
+
+describe("selectReviewerLeaders", () => {
+  it("ranks only substantive-review points and keeps ordering deterministic", () => {
+    const second = actor("U_second", "reviewer-two");
+    const leaders = selectReviewerLeaders([
+      event({ id: "rev_1" }),
+      event({ id: "rev_2", actor: second, scoreThirds: 6, points: 2 }),
+      event({ id: "rev_3", actor: second, scoreThirds: 3, points: 1 }),
+      event({
+        id: "pr_1",
+        category: "merged-pull-request",
+        scoreThirds: 30,
+        points: 10,
+      }),
+    ]);
+    expect(leaders).toHaveLength(2);
+    expect(leaders[0]).toMatchObject({
+      rank: 1,
+      actor: { login: "reviewer-two" },
+      reviewThirds: 9,
+      reviewEventCount: 2,
+    });
+    expect(leaders[1]).toMatchObject({
+      rank: 2,
+      actor: { login: "reviewer-one" },
+      reviewThirds: 3,
+      reviewEventCount: 1,
+    });
+  });
+
+  it("breaks exact ties by event count and then by login", () => {
+    const alpha = actor("U_alpha", "alpha-reviewer");
+    const beta = actor("U_beta", "beta-reviewer");
+    const leaders = selectReviewerLeaders([
+      event({ id: "rev_b", actor: beta, scoreThirds: 6, points: 2 }),
+      event({ id: "rev_a1", actor: alpha, scoreThirds: 3, points: 1 }),
+      event({ id: "rev_a2", actor: alpha, scoreThirds: 3, points: 1 }),
+    ]);
+    expect(leaders.map((leader) => leader.actor.login)).toEqual([
+      "alpha-reviewer",
+      "beta-reviewer",
+    ]);
+  });
+
+  it("falls back to rounded points for legacy events without thirds", () => {
+    const leaders = selectReviewerLeaders([
+      event({ id: "rev_legacy", scoreThirds: undefined, points: 2 }),
+    ]);
+    expect(leaders[0]).toMatchObject({ reviewThirds: 6, reviewEventCount: 1 });
+  });
+
+  it("returns no leaders when the ledger has no scored reviews", () => {
+    expect(
+      selectReviewerLeaders([
+        event({
+          id: "pr_only",
+          category: "merged-pull-request",
+          scoreThirds: 1,
+          points: 1 / 3,
+        }),
+      ]),
+    ).toEqual([]);
+  });
+
+  it("rejects malformed review third counts instead of ranking them", () => {
+    expect(() =>
+      selectReviewerLeaders([
+        event({ id: "rev_bad", scoreThirds: 2.5, points: 2.5 / 3 }),
+      ]),
+    ).toThrow(/non-integer third count/u);
+  });
+});
+
+describe("formatThirds", () => {
+  it("formats whole and fractional third counts", () => {
+    expect(formatThirds(0)).toBe("0");
+    expect(formatThirds(3)).toBe("1");
+    expect(formatThirds(1)).toBe("0.33");
+    expect(formatThirds(2)).toBe("0.67");
+    expect(formatThirds(28)).toBe("9.33");
+  });
+
+  it("rejects negative and non-integer third counts", () => {
+    expect(() => formatThirds(-3)).toThrow(RangeError);
+    expect(() => formatThirds(1.5)).toThrow(RangeError);
+  });
+});

--- a/src/lib/reviewer-leaders.ts
+++ b/src/lib/reviewer-leaders.ts
@@ -1,0 +1,70 @@
+/**
+ * Selects the reviewer slice of a project cycle from accepted score events.
+ * Review points currently share the single monthly pool with authored work;
+ * this view only makes the review contribution visible as its own ranking and
+ * never changes scoring, shares, or payouts.
+ */
+
+import type { GitHubActor, ScoreEvent } from "./leaderboard";
+
+export interface ReviewerLeader {
+  rank: number;
+  actor: GitHubActor;
+  reviewThirds: number;
+  reviewEventCount: number;
+}
+
+function compareActors(left: GitHubActor, right: GitHubActor): number {
+  const leftLogin = left.login.toLowerCase();
+  const rightLogin = right.login.toLowerCase();
+  return (
+    leftLogin.localeCompare(rightLogin) ||
+    left.login.localeCompare(right.login) ||
+    left.id.localeCompare(right.id)
+  );
+}
+
+/** Formats an integer third count as a score with at most two decimals. */
+export function formatThirds(thirds: number): string {
+  if (!Number.isSafeInteger(thirds) || thirds < 0) {
+    throw new RangeError(`Invalid third count: ${thirds}`);
+  }
+  if (thirds % 3 === 0) return String(thirds / 3);
+  return (thirds / 3).toFixed(2);
+}
+
+export function selectReviewerLeaders(
+  ledger: readonly ScoreEvent[],
+): ReviewerLeader[] {
+  const byActor = new Map<
+    string,
+    { actor: GitHubActor; reviewThirds: number; reviewEventCount: number }
+  >();
+  for (const event of ledger) {
+    if (event.category !== "substantive-review") continue;
+    const thirds = event.scoreThirds ?? Math.round(event.points * 3);
+    if (!Number.isSafeInteger(thirds) || thirds < 0) {
+      throw new TypeError(
+        `Review event ${event.id} has a non-integer third count`,
+      );
+    }
+    const current = byActor.get(event.actor.id) ?? {
+      actor: event.actor,
+      reviewThirds: 0,
+      reviewEventCount: 0,
+    };
+    current.actor = event.actor;
+    current.reviewThirds += thirds;
+    current.reviewEventCount += 1;
+    byActor.set(event.actor.id, current);
+  }
+  return [...byActor.values()]
+    .filter((entry) => entry.reviewThirds > 0)
+    .sort(
+      (left, right) =>
+        right.reviewThirds - left.reviewThirds ||
+        right.reviewEventCount - left.reviewEventCount ||
+        compareActors(left.actor, right.actor),
+    )
+    .map((entry, index) => ({ rank: index + 1, ...entry }));
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -495,6 +495,10 @@ p {
   font-weight: 700;
 }
 
+.reviewer-leaderboard {
+  margin-top: 22px;
+}
+
 .leaderboard-cycle-summary,
 .leaderboard-record-summary {
   display: flex;
@@ -1283,6 +1287,10 @@ small {
 .global-leader-head,
 .global-leader-row {
   grid-template-columns: 72px minmax(220px, 1.5fr) 0.6fr 0.8fr;
+}
+
+.reviewer-leader-row {
+  grid-template-columns: 72px minmax(220px, 1.5fr) 0.8fr;
 }
 
 .event-list,

--- a/tests/app.test.tsx
+++ b/tests/app.test.tsx
@@ -491,7 +491,16 @@ describe("discovery", () => {
     ).not.toBeInTheDocument();
     expect(screen.queryByText("THE GITARMY NETWORK")).not.toBeInTheDocument();
     expect(screen.queryByText("Work in. Money out.")).not.toBeInTheDocument();
-    expect(screen.getByText("finish-line")).toBeInTheDocument();
+    expect(screen.getAllByText("finish-line")).toHaveLength(2);
+    const reviewerTable = screen.getByRole("table", {
+      name: /reviewer leaderboard/u,
+    });
+    const reviewerRow = within(reviewerTable)
+      .getByText("finish-line")
+      .closest("tr");
+    expect(reviewerRow).not.toBeNull();
+    expect(reviewerRow).toHaveTextContent("1 scored review");
+    expect(reviewerRow).toHaveTextContent("3");
 
     fireEvent.click(screen.getByRole("tab", { name: "All-time record" }));
     const record = screen.getByRole("table", {


### PR DESCRIPTION
Closes #288.

## What

Adds a Reviewers table to the home current-cycle leaderboard panel and to each project cycle leaderboard, ranked by `substantive-review` thirds selected from the ledger the page already loads.

Scoring, shares, and payouts are untouched. The existing blended tables keep their exact semantics, because simulated shares reflect how the pool actually allocates today, review points included. The new table only makes the review slice visible, and its summary line says explicitly that review points currently share the monthly pool with authored work.

## How

- `src/lib/reviewer-leaders.ts`: pure selection over `ScoreEvent[]`. Aggregates integer thirds per actor (`scoreThirds`, with the same rounded fallback the generator uses for legacy events), fails closed on non-integer third counts, deterministic ordering by thirds, then scored-review count, then login. `formatThirds` renders thirds as a score with at most two decimals.
- `src/App.tsx`: one `ReviewerLeaderboard` component rendered in the home current-cycle panel and inside the project cycle leaderboard section. Three columns (rank, reviewer with scored-review count, review score), top 20, contributor profile links, and an explicit empty state distinct from the main table's.
- Reuses the existing `global-leader` table classes, so the mobile card layout and data-labels come from the current stylesheet; one new grid rule and one margin rule added.

## Tests

- New unit suite `src/lib/reviewer-leaders.test.ts` (7 tests): category filtering, aggregation across v2 and legacy events, deterministic tie-breaks, empty ledger, malformed thirds rejection, and `formatThirds` bounds.
- `tests/app.test.tsx` extended: the home test now asserts the reviewer table renders the fixture reviewer with its review score and scored-review count.
- Full local run: vitest 641 passed across 66 files; `bun run verify` chain green (typecheck, lint, format, projects/evaluations/funding/cycles/protocol checks, audit, build).
- Playwright e2e: 36 passed plus 1 wide-desktop artifact check, including the accessibility and viewport route sweeps.
- Known local-environment exception: one `skill-tests` ccusage case fails identically on a pristine `origin/develop` worktree on this machine; unrelated to this change.

## UI evidence

Verified against the live production snapshot (August window) served locally: home desktop 1440px and mobile 390px render the ranked table (top of board: lalalune, 806 scored reviews); project page renders the block below the cycle leaderboard; delta-star renders the empty state. Before/after screenshots at desktop and mobile widths are attached in a comment below. Zero application console errors during capture.

A green local test is not proof of merge or deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
