### PR TITLE
Show unfunded pool state instead of overdue settlement reminders

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2340,6 +2340,7 @@ function CyclePage({
         ? "external-prize-share"
         : "monthly-pool"),
     now: new Date().toISOString(),
+    paymentMode: project.reward.paymentMode,
     settledAt: record?.settledAt ?? null,
     state: record?.state ?? (view?.cycle.status === "live" ? "live" : "review"),
   });

--- a/src/lib/funding-reminders.test.ts
+++ b/src/lib/funding-reminders.test.ts
@@ -42,6 +42,7 @@ describe("funding cycle reminders", () => {
         closesAt: close,
         kind,
         now: "2026-08-05T00:00:00.000Z",
+        paymentMode: "enabled",
         settledAt: null,
         state,
       });
@@ -53,10 +54,39 @@ describe("funding cycle reminders", () => {
         closesAt: close,
         kind: "monthly-pool",
         now: "2026-08-05T00:00:00.000Z",
+        paymentMode: "enabled",
         settledAt: null,
         state: "payment-ready",
       })?.kind,
     ).toBe("overdue");
+  });
+
+  it("replaces settler deadlines with the unfunded state while payments are disabled", () => {
+    const unfunded = (now: string) =>
+      cycleSettlementReminder({
+        closesAt: close,
+        kind: "monthly-pool",
+        now,
+        paymentMode: "disabled",
+        settledAt: null,
+        state: "review",
+      });
+    expect(unfunded("2026-07-20T00:00:00.000Z")).toBeNull();
+    expect(unfunded("2026-07-25T00:00:00.000Z")?.kind).toBe("unfunded");
+    expect(unfunded("2026-08-05T00:00:00.000Z")?.kind).toBe("unfunded");
+    expect(unfunded("2026-08-05T00:00:00.000Z")?.message).toMatch(
+      /remain projected/u,
+    );
+    expect(
+      cycleSettlementReminder({
+        closesAt: close,
+        kind: "monthly-pool",
+        now: "2026-08-05T00:00:00.000Z",
+        paymentMode: "disabled",
+        settledAt: "2026-08-03T00:00:00.000Z",
+        state: "review",
+      }),
+    ).toBeNull();
   });
 
   it("rejects malformed settlement timestamps instead of hiding reminders", () => {

--- a/src/lib/funding-reminders.ts
+++ b/src/lib/funding-reminders.ts
@@ -4,7 +4,8 @@ export type SettlementReminder =
   | { kind: "cycle-close"; message: string }
   | { kind: "overdue"; message: string }
   | { kind: "ready-to-sign"; message: string }
-  | { kind: "settler-seven-day"; message: string };
+  | { kind: "settler-seven-day"; message: string }
+  | { kind: "unfunded"; message: string };
 
 export type SettlementReminderLifecycle =
   | "closed-no-awards"
@@ -71,11 +72,17 @@ export function settlementReminder(
   };
 }
 
-/** Suppresses signing language for cycles that never enter platform settlement. */
+/**
+ * Suppresses signing language for cycles that never enter platform settlement
+ * and replaces settler-deadline copy with the unfunded state while the pool
+ * has no committed funding: a settlement can only be late once payments are
+ * enabled.
+ */
 export function cycleSettlementReminder(input: {
   closesAt: string;
   kind: "external-prize-share" | "monthly-pool";
   now: string;
+  paymentMode: "disabled" | "enabled";
   settledAt: string | null;
   state: SettlementReminderLifecycle;
 }): SettlementReminder | null {
@@ -87,5 +94,18 @@ export function cycleSettlementReminder(input: {
   ) {
     return null;
   }
-  return settlementReminder(input.closesAt, input.now, input.settledAt);
+  const reminder = settlementReminder(
+    input.closesAt,
+    input.now,
+    input.settledAt,
+  );
+  if (reminder === null) return null;
+  if (input.paymentMode === "disabled") {
+    return {
+      kind: "unfunded",
+      message:
+        "Unfunded pool reminder: no funding is committed and payments are disabled. Allocations remain projected; settlement deadlines begin once the project commits funding.",
+    };
+  }
+  return reminder;
 }

--- a/tests/app.test.tsx
+++ b/tests/app.test.tsx
@@ -1026,9 +1026,10 @@ describe("public records", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("Review")).toBeInTheDocument();
     expect(screen.getByText("Settlement")).toBeInTheDocument();
+    expect(screen.getByText(/Unfunded pool reminder/u)).toBeInTheDocument();
     expect(
-      screen.getByText(/Overdue settlement reminder/u),
-    ).toBeInTheDocument();
+      screen.queryByText(/Overdue settlement reminder/u),
+    ).not.toBeInTheDocument();
     expect(
       screen.getByRole("heading", { name: "July 2026 leaderboard." }),
     ).toBeInTheDocument();


### PR DESCRIPTION
## What

The cycle page reminder banner currently walks every monthly-pool cycle through the settler deadline ladder (seven-day, cycle-close, ready-to-sign, overdue) regardless of whether the pool has any committed funding. On `cycles/eliza/2026-07` today that means the flagship proposal page opens with "Overdue settlement reminder: more than 72 hours have passed since UTC cycle close without reconciled settlement evidence" while the eliza manifest says `paymentMode: disabled`, `committedMinor: 0`, `fundingState: pledged`.

That copy asserts a settler missed a deadline that never existed. Per the product principles, projected and scheduled are different states, and the UI should keep them distinct: a settlement can only be late once payments are enabled.

## How

- `cycleSettlementReminder` now takes the manifest `paymentMode`. While payments are disabled it replaces whichever time-based reminder would have fired with a distinct `unfunded` notice: "Unfunded pool reminder: no funding is committed and payments are disabled. Allocations remain projected; settlement deadlines begin once the project commits funding."
- Cadence is unchanged: the notice appears exactly when a reminder would have appeared (from seven days before close onward), and disappears the same ways (settled evidence, paid or zero-award lifecycle, external-prize cycles).
- Funded pools (`paymentMode: enabled`) keep the existing ladder byte for byte, including overdue. The pressure on a funded, unsettled cycle is the point and is untouched.
- `settlementReminder` itself is unchanged; the funding gate lives only in the cycle-level wrapper.

## Verification

- `bun run projects:check`, `evaluations:check`, `funding:check`, `cycles:check`, `protocol:check`: pass
- `bun run typecheck`, `format:check`, `lint:check`: pass
- `vitest run`: 635/635 pass, including new unit coverage for the unfunded substitution, its cadence bounds, and settled suppression, plus the updated cycle-page render test asserting the unfunded banner and the absence of the overdue banner for the unfunded eliza fixture
- `bun run build`: clean
- `bun test ./skill-tests`: 95/96; the one failure (`run receipt CLI > starts and finishes a measured run without passing --project to ccusage`) also fails on clean `develop` in this environment and is unrelated
- Manual desktop and mobile (375px) review of `/cycles/eliza/2026-07` on the dev server: banner renders as the unfunded notice, zero console errors, zero first-party request failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)