### PR TITLE
Fix production evidence after reviewer leaderboard

### DIFF
--- a/scripts/record-evidence.mjs
+++ b/scripts/record-evidence.mjs
@@ -540,7 +540,10 @@ try {
       .filter({ hasText: /^SHIPPING OPEN SOURCE\.$/u })
       .waitFor({ state: "visible", timeout: 10_000 });
     await page.locator("#projects").waitFor({ state: "visible" });
-    await page.locator("#leaderboard table").waitFor({ state: "visible" });
+    await page
+      .locator("#leaderboard table")
+      .first()
+      .waitFor({ state: "visible" });
     if (previewServer && previewState) {
       assertPreviewRunning(previewServer, previewState);
     }


### PR DESCRIPTION
## What

Make the production evidence recorder wait for the first visible leaderboard table after the reviewer leaderboard added a second table to the same section.

## Why

PR #289 correctly added the reviewer ranking, but the recorder's strict `#leaderboard table` locator began resolving to two elements and failed before capturing exact-head production evidence.

## Verification

- `bun test scripts/deployment-contract.test.mjs`: 15 passed
- `bun run format:check`: passed
- `bun run test:e2e:record:production`: passed against deployed `f784f8b0c64731c1aa2cc1e60e2247cf41f4e29d`
- Production browser evidence: zero console errors and zero request failures
