### PR TITLE
fix(installer): retry slow authenticated downloads

### DIFF
--- a/src/lib/install-command.test.ts
+++ b/src/lib/install-command.test.ts
@@ -1208,6 +1208,68 @@ describe("authenticated skill installer lifecycle", () => {
     );
   });
 
+  it("retries a transient timeout while reading an authenticated response", () => {
+    const root = freshRoot("read-timeout-retry");
+    const installRoot = join(root, "install");
+    const files = baseFiles("read-timeout-retry");
+    const artifact = writeArtifact(root, revisionA, files);
+    const authority = configureAuthority(root, {
+      developHead: revisionA,
+      revisions: { [revisionA]: { files } },
+    });
+    const pythonPath = join(root, "python-path");
+    const marker = join(root, "read-timeout-triggered");
+    mkdirSync(pythonPath);
+    writeFileSync(
+      join(pythonPath, "sitecustomize.py"),
+      `import os
+import urllib.request
+
+_original_urlopen = urllib.request.urlopen
+_failed = False
+
+class _TimeoutOnceResponse:
+    def __init__(self, response):
+        self._response = response
+
+    def __enter__(self):
+        self._response.__enter__()
+        return self
+
+    def __exit__(self, *args):
+        return self._response.__exit__(*args)
+
+    def __getattr__(self, name):
+        return getattr(self._response, name)
+
+    def read(self, *args, **kwargs):
+        global _failed
+        if not _failed:
+            _failed = True
+            with open(os.environ["SLOP_TIMEOUT_MARKER"], "w", encoding="utf-8") as output:
+                output.write("triggered\\n")
+            raise TimeoutError("simulated authenticated response read timeout")
+        return self._response.read(*args, **kwargs)
+
+def _urlopen(*args, **kwargs):
+    return _TimeoutOnceResponse(_original_urlopen(*args, **kwargs))
+
+urllib.request.urlopen = _urlopen
+`,
+    );
+
+    const result = run(command(artifact, authority), installRoot, {
+      PYTHONPATH: pythonPath,
+      SLOP_TIMEOUT_MARKER: marker,
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(readFileSync(marker, "utf8")).toBe("triggered\n");
+    expect(currentLink(installRoot)).toBe(
+      `.contribute-to-eliza-versions/${revisionA}`,
+    );
+  });
+
   it("uses the current Slop repository for GitHub authority and local provenance", () => {
     const production = createInstallCommand(
       "https://slop.cash",

--- a/src/lib/install-command.test.ts
+++ b/src/lib/install-command.test.ts
@@ -1191,6 +1191,23 @@ describe("authenticated skill installer lifecycle", () => {
     ).toThrow("must be an unparameterized file:// origin");
   });
 
+  it("bounds transient authenticated download retries and reports their budget", () => {
+    const production = createInstallCommand(
+      "https://slop.cash",
+      `\${HOME}/.codex/skills`,
+      primaryInstallOptions,
+    );
+    expect(production).toContain("request_timeout_seconds = 45");
+    expect(production).toContain("request_attempts = 3");
+    expect(production).toContain(
+      "retryable = error.code in (408, 429) or 500 <= error.code <= 599",
+    );
+    expect(production).toContain("time.sleep(attempt)");
+    expect(production).toContain(
+      "authenticated download failed after {attempt} attempts",
+    );
+  });
+
   it("uses the current Slop repository for GitHub authority and local provenance", () => {
     const production = createInstallCommand(
       "https://slop.cash",

--- a/src/lib/install-command.ts
+++ b/src/lib/install-command.ts
@@ -104,6 +104,7 @@ import stat
 import struct
 import sys
 import tempfile
+import time
 import unicodedata
 import urllib.error
 import urllib.parse
@@ -134,7 +135,8 @@ max_total_bytes = 4_194_304
 max_api_bytes = 2_097_152
 max_pull_pages = 10
 max_timeline_pages = 10
-request_timeout_seconds = 20
+request_timeout_seconds = 45
+request_attempts = 3
 sha_pattern = re.compile(r"[0-9a-f]{40}")
 digest_pattern = re.compile(r"[0-9a-f]{64}")
 local_header = struct.Struct("<IHHHHHIIIHH")
@@ -184,8 +186,27 @@ def fetch_bytes(url, limit, expected_origin):
         },
         method="GET",
     )
+    for attempt in range(1, request_attempts + 1):
+        try:
+            response = urllib.request.urlopen(request, timeout=request_timeout_seconds)
+            break
+        except urllib.error.HTTPError as error:
+            retryable = error.code in (408, 429) or 500 <= error.code <= 599
+            if not retryable or attempt == request_attempts:
+                raise ValueError(
+                    f"authenticated download failed after {attempt} attempt(s): "
+                    f"HTTP {error.code} from {url}"
+                ) from error
+        except (OSError, urllib.error.URLError) as error:
+            if attempt == request_attempts:
+                detail = getattr(error, "reason", error)
+                raise ValueError(
+                    f"authenticated download failed after {attempt} attempts "
+                    f"of {request_timeout_seconds}s: {url} ({detail})"
+                ) from error
+        time.sleep(attempt)
     try:
-        with urllib.request.urlopen(request, timeout=request_timeout_seconds) as response:
+        with response:
             final_url = response.geturl()
             expected = urllib.parse.urlsplit(expected_origin)
             final = urllib.parse.urlsplit(final_url)
@@ -206,7 +227,7 @@ def fetch_bytes(url, limit, expected_origin):
                     raise ValueError("remote response exceeds its declared size limit")
             contents = response.read(limit + 1)
     except (OSError, urllib.error.URLError) as error:
-        raise ValueError(f"authenticated download failed: {url}") from error
+        raise ValueError(f"authenticated response read failed: {url}") from error
     if len(contents) > limit:
         raise ValueError("remote response exceeds its actual size limit")
     return contents

--- a/src/lib/install-command.ts
+++ b/src/lib/install-command.ts
@@ -188,7 +188,26 @@ def fetch_bytes(url, limit, expected_origin):
     )
     for attempt in range(1, request_attempts + 1):
         try:
-            response = urllib.request.urlopen(request, timeout=request_timeout_seconds)
+            with urllib.request.urlopen(request, timeout=request_timeout_seconds) as response:
+                final_url = response.geturl()
+                expected = urllib.parse.urlsplit(expected_origin)
+                final = urllib.parse.urlsplit(final_url)
+                if expected.scheme == "file":
+                    expected_root = os.path.realpath(urllib.request.url2pathname(expected.path))
+                    final_path = os.path.realpath(urllib.request.url2pathname(final.path))
+                    if os.path.commonpath((expected_root, final_path)) != expected_root:
+                        raise ValueError("file authority escaped its injected fixture root")
+                elif origin_identity(final_url) != origin_identity(expected_origin):
+                    raise ValueError("authenticated request redirected to another authority")
+                content_length = response.headers.get("Content-Length")
+                if content_length is not None:
+                    try:
+                        declared_length = int(content_length)
+                    except ValueError as error:
+                        raise ValueError("remote response has an invalid Content-Length") from error
+                    if declared_length < 0 or declared_length > limit:
+                        raise ValueError("remote response exceeds its declared size limit")
+                contents = response.read(limit + 1)
             break
         except urllib.error.HTTPError as error:
             retryable = error.code in (408, 429) or 500 <= error.code <= 599
@@ -205,29 +224,6 @@ def fetch_bytes(url, limit, expected_origin):
                     f"of {request_timeout_seconds}s: {url} ({detail})"
                 ) from error
         time.sleep(attempt)
-    try:
-        with response:
-            final_url = response.geturl()
-            expected = urllib.parse.urlsplit(expected_origin)
-            final = urllib.parse.urlsplit(final_url)
-            if expected.scheme == "file":
-                expected_root = os.path.realpath(urllib.request.url2pathname(expected.path))
-                final_path = os.path.realpath(urllib.request.url2pathname(final.path))
-                if os.path.commonpath((expected_root, final_path)) != expected_root:
-                    raise ValueError("file authority escaped its injected fixture root")
-            elif origin_identity(final_url) != origin_identity(expected_origin):
-                raise ValueError("authenticated request redirected to another authority")
-            content_length = response.headers.get("Content-Length")
-            if content_length is not None:
-                try:
-                    declared_length = int(content_length)
-                except ValueError as error:
-                    raise ValueError("remote response has an invalid Content-Length") from error
-                if declared_length < 0 or declared_length > limit:
-                    raise ValueError("remote response exceeds its declared size limit")
-            contents = response.read(limit + 1)
-    except (OSError, urllib.error.URLError) as error:
-        raise ValueError(f"authenticated response read failed: {url}") from error
     if len(contents) > limit:
         raise ValueError("remote response exceeds its actual size limit")
     return contents


### PR DESCRIPTION
Closes #294.

Raises the per-request deadline to cover the observed slow GitHub compare response, retries transient network/408/429/5xx failures within a fixed three-attempt budget, and reports the exhausted timeout/attempt budget in the installer diagnostic. The retry boundary covers both connection setup and response-body reads; integrity and authority failures remain non-retryable.

Verification:
- `bun test src/lib/install-command.test.ts` (19 passed)
- deterministic `sitecustomize` fault injection raises `TimeoutError` during authenticated `response.read`; the retry completes and activates the verified revision
- `bun run typecheck`
- `bun run format:check`

Exact verified head: `872c6f7689b9e4ec48c8ffb7fb082dc7db12eecb`