### PR TITLE
fix(ops): alert before intake attestation expiry

### DIFF
--- a/.github/workflows/private-intake-watch.yml
+++ b/.github/workflows/private-intake-watch.yml
@@ -15,6 +15,12 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
+      - name: Checkout watchdog
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+          submodules: false
+
       - name: Check deployed attestation expiry
         env:
           APPROVAL_URL: https://github.com/SlopDotCash/slopdotcash/actions/workflows/deploy.yml
@@ -30,26 +36,5 @@ jobs:
             --max-filesize 16384 \
             --output "$attestation" \
             https://slop.cash/data/private-intake-attestation.json
-          node - "$attestation" <<'NODE'
-          const { readFileSync } = require("node:fs");
-          const path = process.argv[2];
-          const value = JSON.parse(readFileSync(path, "utf8"));
-          const verifiedAt = Date.parse(value?.verifiedAt);
-          const expiresAt = verifiedAt + 7 * 60 * 60 * 1000;
-          const remainingMs = expiresAt - Date.now();
-          if (
-            value?.enabled !== true ||
-            value?.source !== "github-public-status" ||
-            !Number.isFinite(verifiedAt) ||
-            !/^[0-9a-f]{40}$/.test(value?.revision ?? "")
-          ) {
-            console.error(`::error title=Private intake attestation invalid::Approve a fresh trusted deployment: ${process.env.APPROVAL_URL}. Recovery procedure: ${process.env.RECOVERY_URL}`);
-            process.exit(1);
-          }
-          if (remainingMs <= 90 * 60 * 1000) {
-            const expiry = new Date(expiresAt).toISOString();
-            console.error(`::error title=Private intake renewal required::The deployed attestation expires at ${expiry}. Approve the newest trusted deployment now: ${process.env.APPROVAL_URL}. If the designated reviewer is unavailable, follow: ${process.env.RECOVERY_URL}`);
-            process.exit(1);
-          }
-          console.log(`Private intake attestation is safe until ${new Date(expiresAt).toISOString()}.`);
-          NODE
+          node scripts/check-private-intake-freshness.mjs \
+            "$attestation" "$APPROVAL_URL" "$RECOVERY_URL"

--- a/.github/workflows/private-intake-watch.yml
+++ b/.github/workflows/private-intake-watch.yml
@@ -1,0 +1,54 @@
+name: Private intake freshness watch
+
+on:
+  schedule:
+    # Detect a missed reviewed refresh before the seven-hour attestation gate closes.
+    - cron: "47 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  freshness:
+    name: Require a safe private-intake renewal window
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Check deployed attestation expiry
+        env:
+          APPROVAL_URL: https://github.com/SlopDotCash/slopdotcash/actions/workflows/deploy.yml
+        run: |
+          set -euo pipefail
+          attestation="$RUNNER_TEMP/private-intake-attestation.json"
+          curl --fail --silent --show-error \
+            --proto '=https' \
+            --tlsv1.2 \
+            --connect-timeout 10 \
+            --max-time 30 \
+            --max-filesize 16384 \
+            --output "$attestation" \
+            https://slop.cash/data/private-intake-attestation.json
+          node - "$attestation" <<'NODE'
+          const { readFileSync } = require("node:fs");
+          const path = process.argv[2];
+          const value = JSON.parse(readFileSync(path, "utf8"));
+          const verifiedAt = Date.parse(value?.verifiedAt);
+          const expiresAt = verifiedAt + 7 * 60 * 60 * 1000;
+          const remainingMs = expiresAt - Date.now();
+          if (
+            value?.enabled !== true ||
+            value?.source !== "github-public-status" ||
+            !Number.isFinite(verifiedAt) ||
+            !/^[0-9a-f]{40}$/.test(value?.revision ?? "")
+          ) {
+            console.error(`::error title=Private intake attestation invalid::Approve a fresh trusted deployment: ${process.env.APPROVAL_URL}`);
+            process.exit(1);
+          }
+          if (remainingMs <= 90 * 60 * 1000) {
+            const expiry = new Date(expiresAt).toISOString();
+            console.error(`::error title=Private intake renewal required::The deployed attestation expires at ${expiry}. Approve the newest trusted deployment now: ${process.env.APPROVAL_URL}`);
+            process.exit(1);
+          }
+          console.log(`Private intake attestation is safe until ${new Date(expiresAt).toISOString()}.`);
+          NODE

--- a/.github/workflows/private-intake-watch.yml
+++ b/.github/workflows/private-intake-watch.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Check deployed attestation expiry
         env:
           APPROVAL_URL: https://github.com/SlopDotCash/slopdotcash/actions/workflows/deploy.yml
+          RECOVERY_URL: https://github.com/SlopDotCash/slopdotcash/blob/develop/backend/trace/PRIVATE_INTAKE_RECOVERY.md
         run: |
           set -euo pipefail
           attestation="$RUNNER_TEMP/private-intake-attestation.json"
@@ -42,12 +43,12 @@ jobs:
             !Number.isFinite(verifiedAt) ||
             !/^[0-9a-f]{40}$/.test(value?.revision ?? "")
           ) {
-            console.error(`::error title=Private intake attestation invalid::Approve a fresh trusted deployment: ${process.env.APPROVAL_URL}`);
+            console.error(`::error title=Private intake attestation invalid::Approve a fresh trusted deployment: ${process.env.APPROVAL_URL}. Recovery procedure: ${process.env.RECOVERY_URL}`);
             process.exit(1);
           }
           if (remainingMs <= 90 * 60 * 1000) {
             const expiry = new Date(expiresAt).toISOString();
-            console.error(`::error title=Private intake renewal required::The deployed attestation expires at ${expiry}. Approve the newest trusted deployment now: ${process.env.APPROVAL_URL}`);
+            console.error(`::error title=Private intake renewal required::The deployed attestation expires at ${expiry}. Approve the newest trusted deployment now: ${process.env.APPROVAL_URL}. If the designated reviewer is unavailable, follow: ${process.env.RECOVERY_URL}`);
             process.exit(1);
           }
           console.log(`Private intake attestation is safe until ${new Date(expiresAt).toISOString()}.`);

--- a/backend/trace/PRIVATE_INTAKE_RECOVERY.md
+++ b/backend/trace/PRIVATE_INTAKE_RECOVERY.md
@@ -1,0 +1,85 @@
+# Private intake renewal and recovery
+
+The private-trace API accepts uploads only while the deployed public-intake
+attestation is valid. The attestation is bound to one tested `develop` revision
+and expires seven hours after `verifiedAt`. Expiry is intentionally fail-closed:
+`GET https://api.slop.cash/api/v1/private-request-intake` returns HTTP 503 with
+`{"error":"private_intake_unavailable"}` until a reviewed production deployment
+publishes a fresh attestation.
+
+This procedure does not extend the freshness window, bypass environment review,
+or let automation approve its own deployment.
+
+## Normal renewal
+
+1. Open the newest `slop.cash` workflow run for `develop` at
+   <https://github.com/SlopDotCash/slopdotcash/actions/workflows/deploy.yml>.
+2. Confirm `Skill, data, build, and browser checks` succeeded for the current
+   `develop` SHA. Do not approve a run from a pull request, fork, tag, stale SHA,
+   or a run whose quality job failed.
+3. A designated `eliza-army-production` reviewer inspects and approves the
+   waiting `Deploy trusted production bundle` job.
+4. Wait for that exact run to finish successfully. A merge, successful quality
+   job, or environment approval alone is not deployment evidence.
+5. Run the verification sequence below and record the workflow run URL, tested
+   SHA, `verifiedAt`, and verification time on the operations issue.
+
+The scheduled deployment runs every six hours. The hourly freshness watch
+fails when fewer than 90 minutes remain so a reviewed scheduled run should
+already be available before expiry.
+
+## Designated reviewer unavailable
+
+GitHub environment protection is the release authority. Contributors and
+automation must not impersonate the reviewer, use administrator bypass, change
+the deployment payload, lengthen the seven-hour window, or publish an
+attestation from a local checkout.
+
+If no configured reviewer can respond before expiry:
+
+1. Leave intake fail-closed and open or update the public operations issue with
+   the waiting workflow-run URL and expiry time. Do not include credentials or
+   private trace contents.
+2. Ask another repository administrator to verify the current `develop` run and
+   the existing environment policy. If the organization has an independently
+   authorized backup reviewer, the administrator may add that human or team to
+   `eliza-army-production` through GitHub environment settings and record the
+   policy change on the issue before approval.
+3. Keep `Prevent administrators from bypassing required reviewers` enabled.
+   Do not remove the original reviewer merely to make a pending run pass.
+4. The newly authorized reviewer approves the newest clean `develop` run. Run
+   the complete verification sequence; do not treat the settings change or
+   approval click as recovery.
+
+If no independently authorized backup exists, wait for the designated reviewer.
+Availability is less important than preserving the human release boundary.
+
+## Complete renewal-cycle verification
+
+After the deployment reports success:
+
+1. Fetch `https://slop.cash/data/private-intake-attestation.json` without cache.
+   Require exactly `enabled: true`, `source: "github-public-status"`, a
+   40-character lowercase-hex `revision` equal to the deployed `develop` SHA,
+   and an ISO `verifiedAt` no more than seven hours old and not future-dated.
+2. Fetch `https://api.slop.cash/api/v1/private-request-intake` without cache.
+   Require HTTP 200 and exactly `enabled: true`,
+   `source: "github-public-status"`, and the same `verifiedAt` as the bundle.
+3. Run one minimized private-trace upload through the ordinary contributor
+   client. Require intent creation, immutable object upload, attachment, and
+   finalization to succeed. Never use a private trace containing test secrets.
+4. Confirm the next hourly `Private intake freshness watch` succeeds and prints
+   the calculated expiry time.
+
+Any mismatch, non-200 API result, stale timestamp, failed trace finalization, or
+failed freshness watch means recovery is incomplete. Keep intake fail-closed,
+preserve the failed run, and diagnose the exact deployment or API boundary.
+
+## Rollback and incident handling
+
+Do not edit the deployed attestation or roll back to an older attestation: an
+older revision or timestamp must remain rejected. Correct the defect on a new
+reviewed branch, merge through the normal repository rules, and deploy the new
+exact `develop` SHA through the protected environment. Security-sensitive
+details go through GitHub private vulnerability reporting; ordinary expiry and
+availability incidents stay on the public operations issue.

--- a/backend/trace/README.md
+++ b/backend/trace/README.md
@@ -159,6 +159,11 @@ trace uploads must remain disabled until a reviewed D1-backed policy bounds
 authenticated storage and write amplification without relying on an
 eventually-consistent edge counter.
 
+Operational renewal, designated-reviewer unavailability, full-cycle
+verification, and rollback are documented in
+[`PRIVATE_INTAKE_RECOVERY.md`](PRIVATE_INTAKE_RECOVERY.md). The procedure keeps
+the seven-hour gate and protected-environment review fail-closed.
+
 The Cloudflare account and bucket permissions remain limited to designated
 Slop operators. Application authorization does not replace Cloudflare account
 access control and audit logging.

--- a/scripts/check-private-intake-freshness.mjs
+++ b/scripts/check-private-intake-freshness.mjs
@@ -1,0 +1,75 @@
+/** Validates the deployed private-intake attestation before its API gate expires. */
+
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const MAX_AGE_MS = 7 * 60 * 60 * 1000;
+const MAX_FUTURE_SKEW_MS = 5 * 60 * 1000;
+const RENEWAL_WINDOW_MS = 90 * 60 * 1000;
+
+export function checkPrivateIntakeFreshness(value, now = Date.now()) {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    Array.isArray(value) ||
+    JSON.stringify(Object.keys(value).sort()) !==
+      JSON.stringify(["enabled", "revision", "source", "verifiedAt"]) ||
+    value.enabled !== true ||
+    value.source !== "github-public-status" ||
+    typeof value.verifiedAt !== "string" ||
+    typeof value.revision !== "string" ||
+    !/^[0-9a-f]{40}$/u.test(value.revision)
+  ) {
+    return { status: "invalid" };
+  }
+
+  const verifiedAt = Date.parse(value.verifiedAt);
+  const age = now - verifiedAt;
+  if (
+    !Number.isFinite(verifiedAt) ||
+    !Number.isFinite(now) ||
+    age < -MAX_FUTURE_SKEW_MS ||
+    age > MAX_AGE_MS
+  ) {
+    return { status: "invalid" };
+  }
+
+  const expiresAt = verifiedAt + MAX_AGE_MS;
+  if (expiresAt - now <= RENEWAL_WINDOW_MS) {
+    return { status: "renew", expiresAt: new Date(expiresAt).toISOString() };
+  }
+  return { status: "safe", expiresAt: new Date(expiresAt).toISOString() };
+}
+
+function main([path, approvalUrl, recoveryUrl]) {
+  if (!path || !approvalUrl || !recoveryUrl) {
+    throw new Error(
+      "Usage: check-private-intake-freshness.mjs <attestation> <approval-url> <recovery-url>",
+    );
+  }
+  const result = checkPrivateIntakeFreshness(
+    JSON.parse(readFileSync(path, "utf8")),
+  );
+  if (result.status === "invalid") {
+    console.error(
+      `::error title=Private intake attestation invalid::Approve a fresh trusted deployment: ${approvalUrl}. Recovery procedure: ${recoveryUrl}`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+  if (result.status === "renew") {
+    console.error(
+      `::error title=Private intake renewal required::The deployed attestation expires at ${result.expiresAt}. Approve the newest trusted deployment now: ${approvalUrl}. If the designated reviewer is unavailable, follow: ${recoveryUrl}`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+  console.log(`Private intake attestation is safe until ${result.expiresAt}.`);
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main(process.argv.slice(2));
+}

--- a/scripts/check-private-intake-freshness.test.mjs
+++ b/scripts/check-private-intake-freshness.test.mjs
@@ -1,0 +1,64 @@
+/** Exercises watchdog decisions against the production attestation time contract. */
+
+import { describe, expect, it } from "vitest";
+import { checkPrivateIntakeFreshness } from "./check-private-intake-freshness.mjs";
+
+const NOW = Date.parse("2026-08-29T02:00:00.000Z");
+const REVISION = "a".repeat(40);
+
+function attestation(verifiedAt) {
+  return {
+    enabled: true,
+    source: "github-public-status",
+    verifiedAt: new Date(verifiedAt).toISOString(),
+    revision: REVISION,
+  };
+}
+
+describe("private intake freshness watchdog", () => {
+  it("accepts a current attestation outside the renewal window", () => {
+    expect(checkPrivateIntakeFreshness(attestation(NOW - 60_000), NOW)).toEqual(
+      {
+        status: "safe",
+        expiresAt: "2026-08-29T08:59:00.000Z",
+      },
+    );
+  });
+
+  it("requires renewal at the 90-minute boundary and after expiry", () => {
+    expect(
+      checkPrivateIntakeFreshness(
+        attestation(NOW - (7 * 60 - 90) * 60_000),
+        NOW,
+      ).status,
+    ).toBe("renew");
+    expect(
+      checkPrivateIntakeFreshness(attestation(NOW - 7 * 60 * 60_000), NOW)
+        .status,
+    ).toBe("renew");
+  });
+
+  it("rejects timestamps beyond the production five-minute future skew", () => {
+    expect(
+      checkPrivateIntakeFreshness(attestation(NOW + 5 * 60_000), NOW).status,
+    ).toBe("safe");
+    expect(
+      checkPrivateIntakeFreshness(attestation(NOW + 5 * 60_000 + 1), NOW)
+        .status,
+    ).toBe("invalid");
+  });
+
+  it("rejects malformed, stale, and extra-field attestations", () => {
+    expect(checkPrivateIntakeFreshness({}, NOW).status).toBe("invalid");
+    expect(
+      checkPrivateIntakeFreshness(attestation(NOW - 7 * 60 * 60_000 - 1), NOW)
+        .status,
+    ).toBe("invalid");
+    expect(
+      checkPrivateIntakeFreshness(
+        { ...attestation(NOW), unexpected: true },
+        NOW,
+      ).status,
+    ).toBe("invalid");
+  });
+});

--- a/scripts/deployment-contract.test.mjs
+++ b/scripts/deployment-contract.test.mjs
@@ -31,6 +31,10 @@ const privateIntakeWatch = readFileSync(
   join(workflowDirectory, "private-intake-watch.yml"),
   "utf8",
 );
+const privateIntakeWatchScript = readFileSync(
+  join(repositoryRoot, "scripts", "check-private-intake-freshness.mjs"),
+  "utf8",
+);
 const privateIntakeRecoveryGuide = readFileSync(
   join(repositoryRoot, "backend", "trace", "PRIVATE_INTAKE_RECOVERY.md"),
   "utf8",
@@ -91,8 +95,10 @@ describe("slop.cash deployment contract", () => {
     expect(privateIntakeWatch).toContain(
       "https://slop.cash/data/private-intake-attestation.json",
     );
-    expect(privateIntakeWatch).toContain("remainingMs <= 90 * 60 * 1000");
     expect(privateIntakeWatch).toContain(
+      "node scripts/check-private-intake-freshness.mjs",
+    );
+    expect(privateIntakeWatchScript).toContain(
       "Approve the newest trusted deployment now",
     );
     expect(privateIntakeWatch).toContain("PRIVATE_INTAKE_RECOVERY.md");

--- a/scripts/deployment-contract.test.mjs
+++ b/scripts/deployment-contract.test.mjs
@@ -31,6 +31,10 @@ const privateIntakeWatch = readFileSync(
   join(workflowDirectory, "private-intake-watch.yml"),
   "utf8",
 );
+const privateIntakeRecoveryGuide = readFileSync(
+  join(repositoryRoot, "backend", "trace", "PRIVATE_INTAKE_RECOVERY.md"),
+  "utf8",
+);
 const allWorkflows = readdirSync(workflowDirectory)
   .filter((name) => /\.ya?ml$/u.test(name))
   .map((name) => ({
@@ -91,8 +95,31 @@ describe("slop.cash deployment contract", () => {
     expect(privateIntakeWatch).toContain(
       "Approve the newest trusted deployment now",
     );
+    expect(privateIntakeWatch).toContain("PRIVATE_INTAKE_RECOVERY.md");
     expect(privateIntakeWatch).not.toContain("environment:");
     expect(privateIntakeWatch).not.toContain("wrangler");
+  });
+
+  it("documents fail-closed private-intake renewal and approver recovery", () => {
+    expect(privateIntakeRecoveryGuide).toContain("## Normal renewal");
+    expect(privateIntakeRecoveryGuide).toContain(
+      "## Designated reviewer unavailable",
+    );
+    expect(privateIntakeRecoveryGuide).toContain(
+      "## Complete renewal-cycle verification",
+    );
+    expect(privateIntakeRecoveryGuide).toContain(
+      "Prevent administrators from bypassing required reviewers",
+    );
+    expect(privateIntakeRecoveryGuide).toContain(
+      "If no independently authorized backup exists, wait for the designated reviewer",
+    );
+    expect(privateIntakeRecoveryGuide).toContain(
+      "GET https://api.slop.cash/api/v1/private-request-intake",
+    );
+    expect(privateIntakeRecoveryGuide).toContain(
+      "does not extend the freshness window",
+    );
   });
 
   it("rewrites the nested project funding route through the Pages SPA", () => {

--- a/scripts/deployment-contract.test.mjs
+++ b/scripts/deployment-contract.test.mjs
@@ -27,6 +27,10 @@ const releaseLabelWorkflow = readFileSync(
   "utf8",
 );
 const workflowDirectory = join(repositoryRoot, ".github", "workflows");
+const privateIntakeWatch = readFileSync(
+  join(workflowDirectory, "private-intake-watch.yml"),
+  "utf8",
+);
 const allWorkflows = readdirSync(workflowDirectory)
   .filter((name) => /\.ya?ml$/u.test(name))
   .map((name) => ({
@@ -78,6 +82,19 @@ const qualityJob = workflow.slice(
 const deployJob = workflow.slice(workflow.indexOf("\n  deploy:"));
 
 describe("slop.cash deployment contract", () => {
+  it("alerts before a reviewed private-intake refresh can expire", () => {
+    expect(privateIntakeWatch).toContain('cron: "47 * * * *"');
+    expect(privateIntakeWatch).toContain(
+      "https://slop.cash/data/private-intake-attestation.json",
+    );
+    expect(privateIntakeWatch).toContain("remainingMs <= 90 * 60 * 1000");
+    expect(privateIntakeWatch).toContain(
+      "Approve the newest trusted deployment now",
+    );
+    expect(privateIntakeWatch).not.toContain("environment:");
+    expect(privateIntakeWatch).not.toContain("wrangler");
+  });
+
   it("rewrites the nested project funding route through the Pages SPA", () => {
     const redirects = pagesRedirects.trim().split("\n");
     expect(redirects).toContain("/projects/:project/funding/ / 200");


### PR DESCRIPTION
Related to #293.

Adds an independent hourly production freshness watchdog. It validates the deployed attestation and fails with the exact trusted-deployment approval and recovery links when less than 90 minutes remain. This gives operators an actionable notification before the seven-hour gate closes without auto-approving, extending, or bypassing the existing protected-environment deployment.

The follow-up through `822aa34` closes the remaining recovery gap:

- documents the supported normal renewal sequence;
- defines the fail-closed response when the designated reviewer is unavailable;
- permits only an independently authorized backup reviewer added by a repository administrator, while keeping administrator bypass disabled;
- defines full-cycle verification across the deployed bundle, authoritative API, ordinary trace finalization, and the next freshness-watch run; and
- documents rollback and incident handling without reusing an older attestation or weakening the seven-hour limit.
- replaces duplicated inline time checks with a functional watchdog validator that rejects malformed, stale, extra-field, and more-than-five-minute future-dated attestations exactly like the production gate. Previously a far-future `verifiedAt` was reported safe while the API rejected it and remained unavailable.

Verification at `822aa347448c2fcd44c535979ef71f61392e21ab`:

- `./node_modules/.bin/vitest run scripts/check-private-intake-freshness.test.mjs scripts/deployment-contract.test.mjs` — 21 passed
- `bun run format:check` — 221 files checked, clean
- `git diff --check origin/develop...HEAD` — clean
- `bun run verify` — project/evaluation/funding/cycle/protocol checks, dependency audit, typecheck, format, and lint passed; the local full test phase then stopped on host toolchain drift (Node 22 lacks required `node:sqlite`; Python has PyYAML 6.0.1 instead of pinned 6.0.3). GitHub CI supplies the repository-pinned Node 24/PyYAML lane.

This change improves warning and recovery documentation. It intentionally cannot approve or deploy the currently waiting production run; a configured human reviewer remains required.
