### PR TITLE
fix(profile): show current wallet registration

### DIFF
--- a/backend/trace/handler.ts
+++ b/backend/trace/handler.ts
@@ -159,6 +159,42 @@ function pathParts(request: Request): string[] {
   return path.slice("/api/v1/".length).split("/").filter(Boolean);
 }
 
+const PUBLIC_WALLET_BROWSER_ORIGINS = new Set([
+  "https://slop.cash",
+  "https://www.slop.cash",
+  "https://slop.tech",
+  "https://www.slop.tech",
+]);
+
+function publicWalletBrowserResponse(
+  request: Request,
+  response: Response,
+): Response {
+  const origin = request.headers.get("origin");
+  if (origin === null || !PUBLIC_WALLET_BROWSER_ORIGINS.has(origin)) {
+    return response;
+  }
+  response.headers.set("access-control-allow-origin", origin);
+  response.headers.append("vary", "Origin");
+  return response;
+}
+
+function isPublicWalletRead(
+  request: Request,
+  parts: readonly string[],
+): boolean {
+  return (
+    request.method === "GET" &&
+    ((parts.length === 4 &&
+      parts[0] === "wallet-claims" &&
+      parts[1] === "actors" &&
+      parts[3] === "current") ||
+      (parts.length === 2 &&
+        parts[0] === "wallet-claims" &&
+        parts[1] !== "current"))
+  );
+}
+
 function publicWalletClaim(claim: WalletClaim): Record<string, unknown> {
   return {
     schemaVersion: 1,
@@ -942,6 +978,7 @@ export async function handleTraceApi(
   if (requestUrl.host !== "api.slop.cash" && !isLocal) {
     return json(404, { error: "not_found" });
   }
+  const publicWalletRead = isPublicWalletRead(request, parts);
   try {
     if (
       request.method === "GET" &&
@@ -957,7 +994,10 @@ export async function handleTraceApi(
       parts[1] === "actors" &&
       parts[3] === "current"
     ) {
-      return await readCurrentWalletClaim(deps, parts[2]);
+      return publicWalletBrowserResponse(
+        request,
+        await readCurrentWalletClaim(deps, parts[2]),
+      );
     }
     if (
       request.method === "GET" &&
@@ -965,7 +1005,10 @@ export async function handleTraceApi(
       parts[0] === "wallet-claims" &&
       parts[1] !== "current"
     ) {
-      return await readPublicWalletClaim(deps, parts[1]);
+      return publicWalletBrowserResponse(
+        request,
+        await readPublicWalletClaim(deps, parts[1]),
+      );
     }
     if (
       request.method === "PUT" &&
@@ -1005,7 +1048,7 @@ export async function handleTraceApi(
         ? Number(error.status)
         : 500;
     if (status >= 500) console.error("private trace API failure");
-    return json(status, {
+    const response = json(status, {
       error:
         typeof error.code === "string" &&
         /^[a-z][a-z0-9_]{1,63}$/u.test(error.code)
@@ -1016,6 +1059,9 @@ export async function handleTraceApi(
           ? "Internal error"
           : error.message,
     });
+    return publicWalletRead
+      ? publicWalletBrowserResponse(request, response)
+      : response;
   }
 }
 

--- a/functions/api/v1/trace-api.test.ts
+++ b/functions/api/v1/trace-api.test.ts
@@ -893,6 +893,67 @@ describe("private trace API", () => {
     }
   });
 
+  it("permits browser reads of public wallet claims only from public site origins", async () => {
+    const deps = dependencies();
+    const contributor = await token("42", "octocat", ["contributor"]);
+    const created = await handleTraceApi(
+      request(
+        "wallet-claims",
+        "POST",
+        contributor,
+        JSON.stringify({ address: "11111111111111111111111111111111" }),
+        { "content-type": "application/json" },
+      ),
+      deps,
+    );
+    expect(created.status).toBe(201);
+    const { claimId } = (await created.json()) as { claimId: string };
+
+    for (const origin of ["https://slop.cash", "https://slop.tech"]) {
+      const current = await handleTraceApi(
+        new Request(
+          "https://api.slop.cash/api/v1/wallet-claims/actors/42/current",
+          { headers: { origin } },
+        ),
+        deps,
+      );
+      expect(current.status).toBe(200);
+      expect(current.headers.get("access-control-allow-origin")).toBe(origin);
+      expect(current.headers.get("vary")).toContain("Origin");
+
+      const immutable = await handleTraceApi(
+        new Request(`https://api.slop.cash/api/v1/wallet-claims/${claimId}`, {
+          headers: { origin },
+        }),
+        deps,
+      );
+      expect(immutable.status).toBe(200);
+      expect(immutable.headers.get("access-control-allow-origin")).toBe(origin);
+    }
+
+    const missing = await handleTraceApi(
+      new Request(
+        "https://api.slop.cash/api/v1/wallet-claims/actors/999/current",
+        { headers: { origin: "https://slop.cash" } },
+      ),
+      deps,
+    );
+    expect(missing.status).toBe(404);
+    expect(missing.headers.get("access-control-allow-origin")).toBe(
+      "https://slop.cash",
+    );
+
+    const untrusted = await handleTraceApi(
+      new Request(
+        "https://api.slop.cash/api/v1/wallet-claims/actors/42/current",
+        { headers: { origin: "https://attacker.example" } },
+      ),
+      deps,
+    );
+    expect(untrusted.status).toBe(200);
+    expect(untrusted.headers.get("access-control-allow-origin")).toBeNull();
+  });
+
   it("rejects non-canonical body lengths and releases oversized streams", async () => {
     for (const value of ["2e0", "+2"]) {
       await expect(

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -74,10 +74,12 @@ const SOCIAL_TELEGRAM = "https://t.me/slopcashofficial";
 const PROJECT_PROPOSAL_ROOT = `${SOURCE_REPOSITORY}/new/develop`;
 const SNAPSHOT_TIMEOUT_MS = 12_000;
 const FUNDING_TIMEOUT_MS = 12_000;
+const WALLET_CLAIM_TIMEOUT_MS = 12_000;
 const SNAPSHOT_RETRIES = 1;
 const MAX_LEADERBOARD_BYTES = 32 * 1024 * 1024;
 const MAX_CYCLE_INDEX_BYTES = 8 * 1024 * 1024;
 const MAX_FUNDING_INDEX_BYTES = 8 * 1024 * 1024;
+const MAX_WALLET_CLAIM_BYTES = 16 * 1024;
 const PROFILE_EVENT_PREVIEW_LIMIT = 10;
 
 export function rootPublishedTemplateProject(
@@ -1600,6 +1602,107 @@ function useFundingIndex(): FundingDataState {
   return funding;
 }
 
+type CurrentWalletState =
+  | { status: "loading" }
+  | { status: "none" }
+  | { status: "error" }
+  | { status: "ready"; address: string; sourceUrl: string };
+
+function useCurrentWallet(state: DataState, login: string): CurrentWalletState {
+  const [wallet, setWallet] = useState<CurrentWalletState>({
+    status: "loading",
+  });
+  useEffect(() => {
+    if (state.status !== "ready") return;
+    const normalizedLogin = login.toLowerCase();
+    const actors: Array<{ id: string; login: string; avatarUrl?: string }> = [
+      ...state.views.flatMap((view) => [
+        ...view.leaders.map((leader) => leader.actor),
+        ...view.opportunities.map((opportunity) => opportunity.actor),
+      ]),
+      ...state.cycleIndex.cycles.flatMap((cycle) =>
+        cycle.contributors.map((contributor) => contributor.actor),
+      ),
+    ];
+    const actor = actors.find(
+      (candidate) => candidate.login.toLowerCase() === normalizedLogin,
+    );
+    const avatarActorId = actor?.avatarUrl
+      ? /^https:\/\/avatars\.githubusercontent\.com\/u\/(\d+)(?:\?|$)/u.exec(
+          actor.avatarUrl,
+        )?.[1]
+      : undefined;
+    const githubActorId =
+      actor && /^\d+$/u.test(actor.id) ? actor.id : avatarActorId;
+    if (!githubActorId) {
+      setWallet({ status: "none" });
+      return;
+    }
+    let active = true;
+    const controller = new AbortController();
+    const timeout = window.setTimeout(
+      () => controller.abort(new Error("wallet claim request timed out")),
+      WALLET_CLAIM_TIMEOUT_MS,
+    );
+    void fetch(
+      `https://api.slop.cash/api/v1/wallet-claims/actors/${githubActorId}/current`,
+      {
+        cache: "no-store",
+        headers: { Accept: "application/json" },
+        signal: controller.signal,
+      },
+    )
+      .then(async (response) => {
+        if (response.status === 404) return null;
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        return readBoundedJson(
+          response,
+          MAX_WALLET_CLAIM_BYTES,
+          "Wallet claim",
+        );
+      })
+      .then((value) => {
+        if (!active) return;
+        if (value === null) {
+          setWallet({ status: "none" });
+          return;
+        }
+        if (
+          typeof value !== "object" ||
+          value === null ||
+          Array.isArray(value)
+        ) {
+          throw new TypeError("Wallet claim must be an object");
+        }
+        const claim = value as Record<string, unknown>;
+        if (
+          typeof claim.claimId !== "string" ||
+          !/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/u.test(claim.claimId) ||
+          claim.githubActorId !== githubActorId ||
+          typeof claim.address !== "string" ||
+          !isFundingAddress("solana", claim.address)
+        ) {
+          throw new TypeError("Wallet claim has invalid actor-bound metadata");
+        }
+        setWallet({
+          status: "ready",
+          address: claim.address,
+          sourceUrl: `https://api.slop.cash/api/v1/wallet-claims/${claim.claimId}`,
+        });
+      })
+      .catch(() => {
+        if (active) setWallet({ status: "error" });
+      })
+      .finally(() => window.clearTimeout(timeout));
+    return () => {
+      active = false;
+      controller.abort();
+      window.clearTimeout(timeout);
+    };
+  }, [state, login]);
+  return wallet;
+}
+
 function ProjectFundingPage({ project }: { project: ProjectDefinition }) {
   const funding = useFundingIndex();
   const records =
@@ -1894,6 +1997,7 @@ function ProfilePage({
   retry: () => void;
 }) {
   const funding = useFundingIndex();
+  const currentWallet = useCurrentWallet(state, login);
   if (state.status !== "ready")
     return (
       <main className="shell route-main">
@@ -1983,7 +2087,7 @@ function ProfilePage({
     (total, { contributor }) => total + BigInt(contributor.paidMinor),
     0n,
   );
-  const wallet = history.find(({ contributor }) => contributor.wallet)
+  const historicalWallet = history.find(({ contributor }) => contributor.wallet)
     ?.contributor.wallet;
   const featuredEvents = events.slice(0, PROFILE_EVENT_PREVIEW_LIMIT);
   const remainingEvents = events.slice(PROFILE_EVENT_PREVIEW_LIMIT);
@@ -2001,13 +2105,22 @@ function ProfilePage({
             <ExternalLinkAnchor href={actor.url}>
               GitHub <ExternalLink aria-hidden="true" size={15} />
             </ExternalLinkAnchor>
-            {wallet ? (
-              <ExternalLinkAnchor href={wallet.sourceUrl}>
-                Payout wallet · {wallet.address}{" "}
+            {currentWallet.status === "ready" ? (
+              <ExternalLinkAnchor href={currentWallet.sourceUrl}>
+                Current payout wallet · {currentWallet.address}{" "}
                 <ExternalLink aria-hidden="true" size={15} />
               </ExternalLinkAnchor>
+            ) : historicalWallet ? (
+              <ExternalLinkAnchor href={historicalWallet.sourceUrl}>
+                Historical payout wallet · {historicalWallet.address}{" "}
+                <ExternalLink aria-hidden="true" size={15} />
+              </ExternalLinkAnchor>
+            ) : currentWallet.status === "loading" ? (
+              <span>Checking current payout wallet…</span>
+            ) : currentWallet.status === "error" ? (
+              <span>Current payout wallet status unavailable</span>
             ) : (
-              <span>No payout wallet registered</span>
+              <span>No current payout wallet registered</span>
             )}
           </div>
         </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1604,9 +1604,9 @@ function useFundingIndex(): FundingDataState {
 
 type CurrentWalletState =
   | { status: "loading" }
-  | { status: "none" }
-  | { status: "error" }
-  | { status: "ready"; address: string; sourceUrl: string };
+  | { status: "none"; login: string }
+  | { status: "error"; login: string }
+  | { status: "ready"; address: string; login: string; sourceUrl: string };
 
 function useCurrentWallet(state: DataState, login: string): CurrentWalletState {
   const [wallet, setWallet] = useState<CurrentWalletState>({
@@ -1615,6 +1615,7 @@ function useCurrentWallet(state: DataState, login: string): CurrentWalletState {
   useEffect(() => {
     if (state.status !== "ready") return;
     const normalizedLogin = login.toLowerCase();
+    setWallet({ status: "loading" });
     const actors: Array<{ id: string; login: string; avatarUrl?: string }> = [
       ...state.views.flatMap((view) => [
         ...view.leaders.map((leader) => leader.actor),
@@ -1635,7 +1636,7 @@ function useCurrentWallet(state: DataState, login: string): CurrentWalletState {
     const githubActorId =
       actor && /^\d+$/u.test(actor.id) ? actor.id : avatarActorId;
     if (!githubActorId) {
-      setWallet({ status: "none" });
+      setWallet({ status: "none", login: normalizedLogin });
       return;
     }
     let active = true;
@@ -1664,7 +1665,7 @@ function useCurrentWallet(state: DataState, login: string): CurrentWalletState {
       .then((value) => {
         if (!active) return;
         if (value === null) {
-          setWallet({ status: "none" });
+          setWallet({ status: "none", login: normalizedLogin });
           return;
         }
         if (
@@ -1687,11 +1688,12 @@ function useCurrentWallet(state: DataState, login: string): CurrentWalletState {
         setWallet({
           status: "ready",
           address: claim.address,
+          login: normalizedLogin,
           sourceUrl: `https://api.slop.cash/api/v1/wallet-claims/${claim.claimId}`,
         });
       })
       .catch(() => {
-        if (active) setWallet({ status: "error" });
+        if (active) setWallet({ status: "error", login: normalizedLogin });
       })
       .finally(() => window.clearTimeout(timeout));
     return () => {
@@ -1700,6 +1702,9 @@ function useCurrentWallet(state: DataState, login: string): CurrentWalletState {
       window.clearTimeout(timeout);
     };
   }, [state, login]);
+  if (wallet.status !== "loading" && wallet.login !== login.toLowerCase()) {
+    return { status: "loading" };
+  }
   return wallet;
 }
 

--- a/tests/app.test.tsx
+++ b/tests/app.test.tsx
@@ -839,6 +839,63 @@ describe("public records", () => {
     );
   });
 
+  it("does not show the previous contributor's wallet during navigation", async () => {
+    route("/contributors/finish-line");
+    const snapshot = snapshotFixture();
+    const secondActor: (typeof snapshot.leaders)[number]["actor"] = {
+      id: "U_second",
+      login: "second-profile",
+      avatarUrl: "https://avatars.githubusercontent.com/u/99?v=4",
+      url: "https://github.com/second-profile",
+      kind: "User",
+    };
+    snapshot.opportunities = [
+      {
+        ...snapshot.opportunities[0],
+        id: "PR_second:opportunity:partial-evidence",
+        actor: secondActor,
+      },
+    ];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.includes("/wallet-claims/actors/1/current")) {
+        return Response.json({
+          schemaVersion: 1,
+          claimId: "wc_first",
+          githubActorId: "1",
+          address: "11111111111111111111111111111111",
+        });
+      }
+      if (url.includes("/wallet-claims/actors/99/current")) {
+        return new Promise<Response>(() => {});
+      }
+      return Response.json(
+        url.includes("/data/cycles/") ? cycleIndexFixture() : snapshot,
+      );
+    });
+    render(<App />);
+    expect(
+      await screen.findByRole("link", {
+        name: /Current payout wallet · 11111111111111111111111111111111/i,
+      }),
+    ).toBeVisible();
+
+    act(() => {
+      window.history.pushState({}, "", "/contributors/second-profile");
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    });
+
+    expect(
+      await screen.findByRole("heading", { name: "second-profile" }),
+    ).toBeVisible();
+    expect(
+      screen.queryByRole("link", {
+        name: /Current payout wallet · 11111111111111111111111111111111/i,
+      }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Checking current payout wallet…")).toBeVisible();
+  });
+
   it("keeps rolling-window contributors reachable outside the active cycle", async () => {
     route("/contributors/finish-line");
     mockSnapshot(augustRollingSnapshot());

--- a/tests/app.test.tsx
+++ b/tests/app.test.tsx
@@ -810,6 +810,35 @@ describe("project routes", () => {
 });
 
 describe("public records", () => {
+  it("shows the actor-bound current wallet claim independently of cycle history", async () => {
+    route("/contributors/finish-line");
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.includes("/wallet-claims/actors/1/current")) {
+        return Response.json({
+          schemaVersion: 1,
+          claimId: "wc_current01",
+          githubActorId: "1",
+          address: "11111111111111111111111111111111",
+        });
+      }
+      return Response.json(
+        url.includes("/data/cycles/")
+          ? archivedPaidCycleIndex()
+          : snapshotFixture(),
+      );
+    });
+    render(<App />);
+
+    const wallet = await screen.findByRole("link", {
+      name: /Current payout wallet · 11111111111111111111111111111111/i,
+    });
+    expect(wallet).toHaveAttribute(
+      "href",
+      "https://api.slop.cash/api/v1/wallet-claims/wc_current01",
+    );
+  });
+
   it("keeps rolling-window contributors reachable outside the active cycle", async () => {
     route("/contributors/finish-line");
     mockSnapshot(augustRollingSnapshot());
@@ -1011,7 +1040,7 @@ describe("public records", () => {
     render(<App />);
 
     const wallet = await screen.findByRole("link", {
-      name: /Payout wallet · 11111111111111111111111111111111/i,
+      name: /Historical payout wallet · 11111111111111111111111111111111/i,
     });
     expect(wallet).toHaveAttribute("href", expect.stringContaining("/blob/"));
   });

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -464,12 +464,21 @@ test("renders contributor and cycle records from validated public data", async (
 
   await page.route(
     "https://api.slop.cash/api/v1/wallet-claims/actors/*/current",
-    async (route) =>
+    async (route) => {
+      const githubActorId = new URL(route.request().url()).pathname
+        .split("/")
+        .at(-2);
+      expect(githubActorId).toMatch(/^\d+$/u);
       route.fulfill({
-        status: 404,
+        status: 200,
         contentType: "application/json",
-        body: JSON.stringify({ error: "not_found" }),
-      }),
+        body: JSON.stringify({
+          claimId: "e2e-wallet-claim",
+          githubActorId,
+          address: "11111111111111111111111111111111",
+        }),
+      });
+    },
   );
 
   await page.goto(`/contributors/${encodeURIComponent(actor.login)}`, {

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -462,6 +462,16 @@ test("renders contributor and cycle records from validated public data", async (
     return;
   }
 
+  await page.route(
+    "https://api.slop.cash/api/v1/wallet-claims/actors/*/current",
+    async (route) =>
+      route.fulfill({
+        status: 404,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "not_found" }),
+      }),
+  );
+
   await page.goto(`/contributors/${encodeURIComponent(actor.login)}`, {
     waitUntil: "networkidle",
   });


### PR DESCRIPTION
Closes #284.

Contributor profiles now query the public actor-bound current-wallet endpoint, validate the actor and Solana address before rendering it, and distinguish current registration, historical payout evidence, no registration, loading, and unavailable API state. Historical evidence remains visible without being mistaken for current registration.

Wallet lookup results are bound to the normalized contributor login. Navigating between profiles immediately returns to loading, so a previous contributor's wallet cannot be rendered while the next actor-bound request is pending.

Verification:
- `bun x vitest run tests/app.test.tsx` (45 passed)
- deterministic navigation regression holds contributor B's request pending and proves contributor A's wallet disappears
- `bun run typecheck`
- `bun run format:check`
- `bun run lint:check`

Exact verified head: `a7af08cc8b0d4742896e64f0d46517fcc3ec35fd`
