### PR TITLE
perf(skills): cache verified immutable policy documents

### DIFF
--- a/skill-tests/terms-preflight.test.ts
+++ b/skill-tests/terms-preflight.test.ts
@@ -1,10 +1,17 @@
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { preflight } from "../skills/contribute-to-eliza/scripts/terms-preflight.mjs";
 
 const license = Buffer.from("immutable license bytes\n");
@@ -42,8 +49,20 @@ const policy = {
 };
 
 const originalFetch = globalThis.fetch;
+const originalCacheHome = process.env.XDG_CACHE_HOME;
+let cacheHome = "";
+beforeEach(() => {
+  cacheHome = mkdtempSync(join(tmpdir(), "terms-preflight-cache-"));
+  process.env.XDG_CACHE_HOME = cacheHome;
+});
 afterEach(() => {
   globalThis.fetch = originalFetch;
+  if (originalCacheHome === undefined) {
+    delete process.env.XDG_CACHE_HOME;
+  } else {
+    process.env.XDG_CACHE_HOME = originalCacheHome;
+  }
+  rmSync(cacheHome, { recursive: true, force: true });
 });
 
 function responses(...values: Response[]): typeof fetch {
@@ -66,6 +85,94 @@ describe("project terms preflight", () => {
       inboundTermsSha256: null,
       prizeRulesSha256: null,
     });
+  });
+
+  it("reuses rehashed commit-pinned bytes while refetching live policy", async () => {
+    const requested: string[] = [];
+    globalThis.fetch = (async (input) => {
+      const url = String(input);
+      requested.push(url);
+      if (url === "https://slop.cash/projects/eliza/terms.json") {
+        return new Response(JSON.stringify(policy));
+      }
+      if (url.includes("raw.githubusercontent.com")) {
+        return new Response(license);
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    await preflight("eliza");
+    await preflight("eliza");
+
+    expect(
+      requested.filter((url) => url.endsWith("/projects/eliza/terms.json")),
+    ).toHaveLength(2);
+    expect(
+      requested.filter((url) => url.includes("raw.githubusercontent.com")),
+    ).toHaveLength(1);
+  });
+
+  it("does not reuse cached bytes for a changed source and digest", async () => {
+    const changed = Buffer.from("replacement immutable license bytes\n");
+    const changedPolicy = structuredClone(policy);
+    changedPolicy.terms.repositoryLicense.url = `https://github.com/elizaOS/eliza/blob/${"b".repeat(40)}/LICENSE`;
+    changedPolicy.terms.repositoryLicense.fileSha256 = createHash("sha256")
+      .update(changed)
+      .digest("hex");
+    globalThis.fetch = responses(
+      new Response(JSON.stringify(policy)),
+      new Response(license),
+      new Response(JSON.stringify(changedPolicy)),
+      new Response(changed),
+    );
+
+    await preflight("eliza");
+    await expect(preflight("eliza")).resolves.toMatchObject({
+      licenseSha256: changedPolicy.terms.repositoryLicense.fileSha256,
+    });
+  });
+
+  it("refetches and repairs a corrupted immutable-document cache entry", async () => {
+    globalThis.fetch = responses(
+      new Response(JSON.stringify(policy)),
+      new Response(license),
+    );
+    await preflight("eliza");
+    const cacheRoot = join(cacheHome, "slop", "policy-documents-v1");
+    const [entry] = readdirSync(cacheRoot);
+    expect(entry).toMatch(/^[0-9a-f]{64}\.bin$/u);
+    writeFileSync(join(cacheRoot, entry), "corrupted cache bytes");
+    globalThis.fetch = responses(
+      new Response(JSON.stringify(policy)),
+      new Response(license),
+    );
+
+    await expect(preflight("eliza")).resolves.toMatchObject({
+      licenseSha256,
+    });
+  });
+
+  it("bounds the persistent immutable-document cache", async () => {
+    const cacheRoot = join(cacheHome, "slop", "policy-documents-v1");
+    mkdirSync(cacheRoot, { recursive: true });
+    for (let index = 0; index < 33; index += 1) {
+      writeFileSync(
+        join(cacheRoot, `${index.toString(16).padStart(64, "0")}.bin`),
+        "x",
+      );
+    }
+    globalThis.fetch = responses(
+      new Response(JSON.stringify(policy)),
+      new Response(license),
+    );
+
+    await preflight("eliza");
+
+    expect(
+      readdirSync(cacheRoot).filter((name) =>
+        /^[0-9a-f]{64}\.bin$/u.test(name),
+      ),
+    ).toHaveLength(32);
   });
 
   it("allows disclosed unknowns and legacy paused status but stops on byte drift", async () => {

--- a/skills/contribute-to-asi/scripts/terms-preflight.mjs
+++ b/skills/contribute-to-asi/scripts/terms-preflight.mjs
@@ -1,11 +1,25 @@
 #!/usr/bin/env node
-import { createHash } from "node:crypto";
-import { existsSync, realpathSync } from "node:fs";
-import { readFile } from "node:fs/promises";
+import { createHash, randomUUID } from "node:crypto";
+import { constants, existsSync, realpathSync } from "node:fs";
+import {
+  mkdir,
+  open,
+  readdir,
+  readFile,
+  rename,
+  stat,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
+import { homedir } from "node:os";
+import { isAbsolute, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const MAX_POLICY_BYTES = 1024 * 1024;
 const MAX_TERMS_BYTES = 4 * 1024 * 1024;
+const MAX_CACHE_BYTES = 32 * 1024 * 1024;
+const MAX_CACHE_ENTRIES = 32;
+const CACHE_FILE_PATTERN = /^[0-9a-f]{64}\.bin$/u;
 const ALLOWED_TERMS_HOSTS = new Set([
   "github.com",
   "proximityprize.org",
@@ -29,6 +43,85 @@ function exact(value, keys, field) {
 
 function digest(bytes) {
   return createHash("sha256").update(bytes).digest("hex");
+}
+
+function cacheRoot() {
+  const base = process.env.XDG_CACHE_HOME || join(homedir(), ".cache");
+  if (!base || !isAbsolute(base)) return null;
+  return join(base, "slop", "policy-documents-v1");
+}
+
+function immutableCachePath(source, expected) {
+  const parsed = new URL(source);
+  if (
+    parsed.hostname !== "raw.githubusercontent.com" ||
+    !/^\/[^/]+\/[^/]+\/[0-9a-f]{40}\/.+/u.test(parsed.pathname)
+  ) {
+    return null;
+  }
+  const root = cacheRoot();
+  return root === null
+    ? null
+    : {
+        root,
+        path: join(root, `${digest(`${source}\0${expected}`)}.bin`),
+      };
+}
+
+async function cachedVerifiedBytes(cache, expected) {
+  if (cache === null) return null;
+  let handle;
+  try {
+    handle = await open(cache.path, constants.O_RDONLY | constants.O_NOFOLLOW);
+    const metadata = await handle.stat();
+    if (!metadata.isFile() || metadata.size > MAX_TERMS_BYTES) return null;
+    const bytes = await handle.readFile();
+    return digest(bytes) === expected ? bytes : null;
+  } catch {
+    return null;
+  } finally {
+    await handle?.close();
+  }
+}
+
+async function pruneCache(root) {
+  const entries = [];
+  for (const name of await readdir(root)) {
+    if (!CACHE_FILE_PATTERN.test(name)) continue;
+    try {
+      const metadata = await stat(join(root, name));
+      if (metadata.isFile()) {
+        entries.push({ name, mtimeMs: metadata.mtimeMs, size: metadata.size });
+      }
+    } catch {
+      // Concurrent cache cleanup is harmless; keep inspecting other entries.
+    }
+  }
+  entries.sort((left, right) => right.mtimeMs - left.mtimeMs);
+  let retainedBytes = 0;
+  for (const [index, entry] of entries.entries()) {
+    retainedBytes += entry.size;
+    if (index >= MAX_CACHE_ENTRIES || retainedBytes > MAX_CACHE_BYTES) {
+      await unlink(join(root, entry.name)).catch(() => {});
+    }
+  }
+}
+
+async function publishCache(cache, bytes) {
+  if (cache === null) return;
+  try {
+    await mkdir(cache.root, { mode: 0o700, recursive: true });
+    const temporary = `${cache.path}.${process.pid}.${randomUUID()}.tmp`;
+    try {
+      await writeFile(temporary, bytes, { flag: "wx", mode: 0o600 });
+      await rename(temporary, cache.path);
+    } finally {
+      await unlink(temporary).catch(() => {});
+    }
+    await pruneCache(cache.root);
+  } catch {
+    // The cache is an availability optimization, never a policy authority.
+  }
 }
 
 function rawUrl(value) {
@@ -95,13 +188,20 @@ async function verifiedBytes(url, expected, field, allowFile) {
       fail(`${field} exceeds the byte limit`);
     }
   } else {
-    const response = await fetch(allowedRemoteSource(source, field), {
+    const allowedSource = allowedRemoteSource(source, field);
+    const cache = immutableCachePath(allowedSource, expected);
+    bytes = await cachedVerifiedBytes(cache, expected);
+    if (bytes !== null) return;
+    const response = await fetch(allowedSource, {
       headers: { accept: "application/octet-stream" },
       redirect: "error",
       signal: AbortSignal.timeout(30_000),
     });
     if (!response.ok) fail(`${field} could not be fetched`);
     bytes = await boundedResponseBytes(response, MAX_TERMS_BYTES, field);
+    if (digest(bytes) !== expected) fail(`${field} digest drifted`);
+    await publishCache(cache, bytes);
+    return;
   }
   if (digest(bytes) !== expected) fail(`${field} digest drifted`);
 }

--- a/skills/contribute-to-delta-star/scripts/terms-preflight.mjs
+++ b/skills/contribute-to-delta-star/scripts/terms-preflight.mjs
@@ -1,11 +1,25 @@
 #!/usr/bin/env node
-import { createHash } from "node:crypto";
-import { existsSync, realpathSync } from "node:fs";
-import { readFile } from "node:fs/promises";
+import { createHash, randomUUID } from "node:crypto";
+import { constants, existsSync, realpathSync } from "node:fs";
+import {
+  mkdir,
+  open,
+  readdir,
+  readFile,
+  rename,
+  stat,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
+import { homedir } from "node:os";
+import { isAbsolute, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const MAX_POLICY_BYTES = 1024 * 1024;
 const MAX_TERMS_BYTES = 4 * 1024 * 1024;
+const MAX_CACHE_BYTES = 32 * 1024 * 1024;
+const MAX_CACHE_ENTRIES = 32;
+const CACHE_FILE_PATTERN = /^[0-9a-f]{64}\.bin$/u;
 const ALLOWED_TERMS_HOSTS = new Set([
   "github.com",
   "proximityprize.org",
@@ -29,6 +43,85 @@ function exact(value, keys, field) {
 
 function digest(bytes) {
   return createHash("sha256").update(bytes).digest("hex");
+}
+
+function cacheRoot() {
+  const base = process.env.XDG_CACHE_HOME || join(homedir(), ".cache");
+  if (!base || !isAbsolute(base)) return null;
+  return join(base, "slop", "policy-documents-v1");
+}
+
+function immutableCachePath(source, expected) {
+  const parsed = new URL(source);
+  if (
+    parsed.hostname !== "raw.githubusercontent.com" ||
+    !/^\/[^/]+\/[^/]+\/[0-9a-f]{40}\/.+/u.test(parsed.pathname)
+  ) {
+    return null;
+  }
+  const root = cacheRoot();
+  return root === null
+    ? null
+    : {
+        root,
+        path: join(root, `${digest(`${source}\0${expected}`)}.bin`),
+      };
+}
+
+async function cachedVerifiedBytes(cache, expected) {
+  if (cache === null) return null;
+  let handle;
+  try {
+    handle = await open(cache.path, constants.O_RDONLY | constants.O_NOFOLLOW);
+    const metadata = await handle.stat();
+    if (!metadata.isFile() || metadata.size > MAX_TERMS_BYTES) return null;
+    const bytes = await handle.readFile();
+    return digest(bytes) === expected ? bytes : null;
+  } catch {
+    return null;
+  } finally {
+    await handle?.close();
+  }
+}
+
+async function pruneCache(root) {
+  const entries = [];
+  for (const name of await readdir(root)) {
+    if (!CACHE_FILE_PATTERN.test(name)) continue;
+    try {
+      const metadata = await stat(join(root, name));
+      if (metadata.isFile()) {
+        entries.push({ name, mtimeMs: metadata.mtimeMs, size: metadata.size });
+      }
+    } catch {
+      // Concurrent cache cleanup is harmless; keep inspecting other entries.
+    }
+  }
+  entries.sort((left, right) => right.mtimeMs - left.mtimeMs);
+  let retainedBytes = 0;
+  for (const [index, entry] of entries.entries()) {
+    retainedBytes += entry.size;
+    if (index >= MAX_CACHE_ENTRIES || retainedBytes > MAX_CACHE_BYTES) {
+      await unlink(join(root, entry.name)).catch(() => {});
+    }
+  }
+}
+
+async function publishCache(cache, bytes) {
+  if (cache === null) return;
+  try {
+    await mkdir(cache.root, { mode: 0o700, recursive: true });
+    const temporary = `${cache.path}.${process.pid}.${randomUUID()}.tmp`;
+    try {
+      await writeFile(temporary, bytes, { flag: "wx", mode: 0o600 });
+      await rename(temporary, cache.path);
+    } finally {
+      await unlink(temporary).catch(() => {});
+    }
+    await pruneCache(cache.root);
+  } catch {
+    // The cache is an availability optimization, never a policy authority.
+  }
 }
 
 function rawUrl(value) {
@@ -95,13 +188,20 @@ async function verifiedBytes(url, expected, field, allowFile) {
       fail(`${field} exceeds the byte limit`);
     }
   } else {
-    const response = await fetch(allowedRemoteSource(source, field), {
+    const allowedSource = allowedRemoteSource(source, field);
+    const cache = immutableCachePath(allowedSource, expected);
+    bytes = await cachedVerifiedBytes(cache, expected);
+    if (bytes !== null) return;
+    const response = await fetch(allowedSource, {
       headers: { accept: "application/octet-stream" },
       redirect: "error",
       signal: AbortSignal.timeout(30_000),
     });
     if (!response.ok) fail(`${field} could not be fetched`);
     bytes = await boundedResponseBytes(response, MAX_TERMS_BYTES, field);
+    if (digest(bytes) !== expected) fail(`${field} digest drifted`);
+    await publishCache(cache, bytes);
+    return;
   }
   if (digest(bytes) !== expected) fail(`${field} digest drifted`);
 }

--- a/skills/contribute-to-eliza/scripts/terms-preflight.mjs
+++ b/skills/contribute-to-eliza/scripts/terms-preflight.mjs
@@ -1,11 +1,25 @@
 #!/usr/bin/env node
-import { createHash } from "node:crypto";
-import { existsSync, realpathSync } from "node:fs";
-import { readFile } from "node:fs/promises";
+import { createHash, randomUUID } from "node:crypto";
+import { constants, existsSync, realpathSync } from "node:fs";
+import {
+  mkdir,
+  open,
+  readdir,
+  readFile,
+  rename,
+  stat,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
+import { homedir } from "node:os";
+import { isAbsolute, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const MAX_POLICY_BYTES = 1024 * 1024;
 const MAX_TERMS_BYTES = 4 * 1024 * 1024;
+const MAX_CACHE_BYTES = 32 * 1024 * 1024;
+const MAX_CACHE_ENTRIES = 32;
+const CACHE_FILE_PATTERN = /^[0-9a-f]{64}\.bin$/u;
 const ALLOWED_TERMS_HOSTS = new Set([
   "github.com",
   "proximityprize.org",
@@ -29,6 +43,85 @@ function exact(value, keys, field) {
 
 function digest(bytes) {
   return createHash("sha256").update(bytes).digest("hex");
+}
+
+function cacheRoot() {
+  const base = process.env.XDG_CACHE_HOME || join(homedir(), ".cache");
+  if (!base || !isAbsolute(base)) return null;
+  return join(base, "slop", "policy-documents-v1");
+}
+
+function immutableCachePath(source, expected) {
+  const parsed = new URL(source);
+  if (
+    parsed.hostname !== "raw.githubusercontent.com" ||
+    !/^\/[^/]+\/[^/]+\/[0-9a-f]{40}\/.+/u.test(parsed.pathname)
+  ) {
+    return null;
+  }
+  const root = cacheRoot();
+  return root === null
+    ? null
+    : {
+        root,
+        path: join(root, `${digest(`${source}\0${expected}`)}.bin`),
+      };
+}
+
+async function cachedVerifiedBytes(cache, expected) {
+  if (cache === null) return null;
+  let handle;
+  try {
+    handle = await open(cache.path, constants.O_RDONLY | constants.O_NOFOLLOW);
+    const metadata = await handle.stat();
+    if (!metadata.isFile() || metadata.size > MAX_TERMS_BYTES) return null;
+    const bytes = await handle.readFile();
+    return digest(bytes) === expected ? bytes : null;
+  } catch {
+    return null;
+  } finally {
+    await handle?.close();
+  }
+}
+
+async function pruneCache(root) {
+  const entries = [];
+  for (const name of await readdir(root)) {
+    if (!CACHE_FILE_PATTERN.test(name)) continue;
+    try {
+      const metadata = await stat(join(root, name));
+      if (metadata.isFile()) {
+        entries.push({ name, mtimeMs: metadata.mtimeMs, size: metadata.size });
+      }
+    } catch {
+      // Concurrent cache cleanup is harmless; keep inspecting other entries.
+    }
+  }
+  entries.sort((left, right) => right.mtimeMs - left.mtimeMs);
+  let retainedBytes = 0;
+  for (const [index, entry] of entries.entries()) {
+    retainedBytes += entry.size;
+    if (index >= MAX_CACHE_ENTRIES || retainedBytes > MAX_CACHE_BYTES) {
+      await unlink(join(root, entry.name)).catch(() => {});
+    }
+  }
+}
+
+async function publishCache(cache, bytes) {
+  if (cache === null) return;
+  try {
+    await mkdir(cache.root, { mode: 0o700, recursive: true });
+    const temporary = `${cache.path}.${process.pid}.${randomUUID()}.tmp`;
+    try {
+      await writeFile(temporary, bytes, { flag: "wx", mode: 0o600 });
+      await rename(temporary, cache.path);
+    } finally {
+      await unlink(temporary).catch(() => {});
+    }
+    await pruneCache(cache.root);
+  } catch {
+    // The cache is an availability optimization, never a policy authority.
+  }
 }
 
 function rawUrl(value) {
@@ -95,13 +188,20 @@ async function verifiedBytes(url, expected, field, allowFile) {
       fail(`${field} exceeds the byte limit`);
     }
   } else {
-    const response = await fetch(allowedRemoteSource(source, field), {
+    const allowedSource = allowedRemoteSource(source, field);
+    const cache = immutableCachePath(allowedSource, expected);
+    bytes = await cachedVerifiedBytes(cache, expected);
+    if (bytes !== null) return;
+    const response = await fetch(allowedSource, {
       headers: { accept: "application/octet-stream" },
       redirect: "error",
       signal: AbortSignal.timeout(30_000),
     });
     if (!response.ok) fail(`${field} could not be fetched`);
     bytes = await boundedResponseBytes(response, MAX_TERMS_BYTES, field);
+    if (digest(bytes) !== expected) fail(`${field} digest drifted`);
+    await publishCache(cache, bytes);
+    return;
   }
   if (digest(bytes) !== expected) fail(`${field} digest drifted`);
 }

--- a/skills/contribute-to-heir-elements-sdk/scripts/terms-preflight.mjs
+++ b/skills/contribute-to-heir-elements-sdk/scripts/terms-preflight.mjs
@@ -1,11 +1,25 @@
 #!/usr/bin/env node
-import { createHash } from "node:crypto";
-import { existsSync, realpathSync } from "node:fs";
-import { readFile } from "node:fs/promises";
+import { createHash, randomUUID } from "node:crypto";
+import { constants, existsSync, realpathSync } from "node:fs";
+import {
+  mkdir,
+  open,
+  readdir,
+  readFile,
+  rename,
+  stat,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
+import { homedir } from "node:os";
+import { isAbsolute, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const MAX_POLICY_BYTES = 1024 * 1024;
 const MAX_TERMS_BYTES = 4 * 1024 * 1024;
+const MAX_CACHE_BYTES = 32 * 1024 * 1024;
+const MAX_CACHE_ENTRIES = 32;
+const CACHE_FILE_PATTERN = /^[0-9a-f]{64}\.bin$/u;
 const ALLOWED_TERMS_HOSTS = new Set([
   "github.com",
   "proximityprize.org",
@@ -29,6 +43,85 @@ function exact(value, keys, field) {
 
 function digest(bytes) {
   return createHash("sha256").update(bytes).digest("hex");
+}
+
+function cacheRoot() {
+  const base = process.env.XDG_CACHE_HOME || join(homedir(), ".cache");
+  if (!base || !isAbsolute(base)) return null;
+  return join(base, "slop", "policy-documents-v1");
+}
+
+function immutableCachePath(source, expected) {
+  const parsed = new URL(source);
+  if (
+    parsed.hostname !== "raw.githubusercontent.com" ||
+    !/^\/[^/]+\/[^/]+\/[0-9a-f]{40}\/.+/u.test(parsed.pathname)
+  ) {
+    return null;
+  }
+  const root = cacheRoot();
+  return root === null
+    ? null
+    : {
+        root,
+        path: join(root, `${digest(`${source}\0${expected}`)}.bin`),
+      };
+}
+
+async function cachedVerifiedBytes(cache, expected) {
+  if (cache === null) return null;
+  let handle;
+  try {
+    handle = await open(cache.path, constants.O_RDONLY | constants.O_NOFOLLOW);
+    const metadata = await handle.stat();
+    if (!metadata.isFile() || metadata.size > MAX_TERMS_BYTES) return null;
+    const bytes = await handle.readFile();
+    return digest(bytes) === expected ? bytes : null;
+  } catch {
+    return null;
+  } finally {
+    await handle?.close();
+  }
+}
+
+async function pruneCache(root) {
+  const entries = [];
+  for (const name of await readdir(root)) {
+    if (!CACHE_FILE_PATTERN.test(name)) continue;
+    try {
+      const metadata = await stat(join(root, name));
+      if (metadata.isFile()) {
+        entries.push({ name, mtimeMs: metadata.mtimeMs, size: metadata.size });
+      }
+    } catch {
+      // Concurrent cache cleanup is harmless; keep inspecting other entries.
+    }
+  }
+  entries.sort((left, right) => right.mtimeMs - left.mtimeMs);
+  let retainedBytes = 0;
+  for (const [index, entry] of entries.entries()) {
+    retainedBytes += entry.size;
+    if (index >= MAX_CACHE_ENTRIES || retainedBytes > MAX_CACHE_BYTES) {
+      await unlink(join(root, entry.name)).catch(() => {});
+    }
+  }
+}
+
+async function publishCache(cache, bytes) {
+  if (cache === null) return;
+  try {
+    await mkdir(cache.root, { mode: 0o700, recursive: true });
+    const temporary = `${cache.path}.${process.pid}.${randomUUID()}.tmp`;
+    try {
+      await writeFile(temporary, bytes, { flag: "wx", mode: 0o600 });
+      await rename(temporary, cache.path);
+    } finally {
+      await unlink(temporary).catch(() => {});
+    }
+    await pruneCache(cache.root);
+  } catch {
+    // The cache is an availability optimization, never a policy authority.
+  }
 }
 
 function rawUrl(value) {
@@ -95,13 +188,20 @@ async function verifiedBytes(url, expected, field, allowFile) {
       fail(`${field} exceeds the byte limit`);
     }
   } else {
-    const response = await fetch(allowedRemoteSource(source, field), {
+    const allowedSource = allowedRemoteSource(source, field);
+    const cache = immutableCachePath(allowedSource, expected);
+    bytes = await cachedVerifiedBytes(cache, expected);
+    if (bytes !== null) return;
+    const response = await fetch(allowedSource, {
       headers: { accept: "application/octet-stream" },
       redirect: "error",
       signal: AbortSignal.timeout(30_000),
     });
     if (!response.ok) fail(`${field} could not be fetched`);
     bytes = await boundedResponseBytes(response, MAX_TERMS_BYTES, field);
+    if (digest(bytes) !== expected) fail(`${field} digest drifted`);
+    await publishCache(cache, bytes);
+    return;
   }
   if (digest(bytes) !== expected) fail(`${field} digest drifted`);
 }


### PR DESCRIPTION
Closes #281.

Keeps every live project-policy fetch intact while reusing only verified immutable documents whose canonical `raw.githubusercontent.com` path contains a full commit SHA. Persistent entries are keyed by canonical source plus expected digest and rehashed on every read. A changed source or digest cannot reuse an old entry; corrupt entries trigger a fresh bounded download and are replaced only after digest verification.

The cache uses `$XDG_CACHE_HOME/slop/policy-documents-v1` (or the platform home cache fallback), publishes files atomically with private modes, rejects symlinked cache entries, and prunes to at most 32 entries and 32 MiB. Cache failures do not weaken policy validation or block a valid fresh download.

Availability semantics: after a fresh live policy has named the same commit-pinned source and digest, a locally cached copy may satisfy the immutable-document check even if that immutable host is temporarily unavailable. Its bytes are rehashed for every preflight; live policy itself is never cached.

Verification at `a169e28`:

- `bun test skill-tests/terms-preflight.test.ts skill-tests/project-skills.test.ts`: 33 passed; one pre-existing host-specific symlinked-CLI assertion failed identically on clean `develop` because spawned Node exited 1 with empty stderr. Direct symlinked CLI invocation produces the expected diagnostic.
- New deterministic coverage proves two live policy reads cause one immutable-document download, changed source/digest fetches new bytes, corrupt cache refetches and repairs, and pruning retains at most 32 entries.
- `bun run typecheck`: pass.
- `bun run lint:check`: pass.
- `bun run format:check`: pass.
- All four packaged contributor preflight scripts are byte-identical.
