### PR TITLE
docs(evaluations): define review-led closure criteria

### DIFF
--- a/evaluations/README.md
+++ b/evaluations/README.md
@@ -19,6 +19,46 @@ sources, duplicate ids, symlinks, oversized files, awards outside the rolling
 window, and sources already rewarded by the ordinary GitHub ledger. The newest
 three valid awards per contributor and project can score in a window.
 
+## Reviews that lead to closing a pull request
+
+A substantiated review-led closure can be a useful evaluated outcome even when
+no replacement has landed yet. Examples include demonstrating that an approach
+cannot satisfy a required invariant or consolidating a duplicate implementation
+after comparing the alternatives. A landed repair is stronger evidence, but it
+is not a prerequisite when the closure decision itself prevents a concrete,
+well-supported project risk or avoids material duplicate work.
+
+Closure is never sufficient by itself. The evaluation pull request must let an
+independent maintainer assess all of the following:
+
+- the exact public review, recorded as a `source.kind` of `review` with its
+  canonical `#pullrequestreview-...` URL;
+- the specific technical finding or comparison that justified closure;
+- public evidence tying that finding to the decision, such as a maintainer's
+  closure explanation, a linked consolidation decision, or independently
+  reproduced failure evidence; and
+- why the outcome was useful enough for a discretionary 1–8 point award,
+  including any uncertainty or credit shared with earlier reviewers.
+
+Chronology, an author's acknowledgement, a matching closure reason, or the word
+`CLOSE` in review text does not establish causation or value on its own. GitHub
+has no `CLOSE` review state: a substantive `COMMENTED` review may be evaluated
+here when the public evidence establishes its outcome. This is distinct from
+ordinary formal-review scoring and does not change merge-based scoring.
+
+Submit the request through the same one-file evaluation pull request described
+above. The reviewing maintainer—not the reviewer, author, or an automated
+evaluator—decides whether the closure produced a useful outcome and selects the
+award, if any. Existing canonical-source deduplication, ordinary-ledger
+deduplication, rolling-window limits, and the three-award contributor/project
+cap still apply. Coordinated, repetitive, low-value, or unsupported closures
+receive no automatic credit.
+
+For example, a review that proves a proposed scheduler design loses queued work
+may support an award when the maintainer closes the pull request on that basis,
+links the exact review, and confirms the reproduced invariant failure. “The
+pull request was closed after this review” is not an adequate reason.
+
 Example (do not copy placeholder identities into a real award):
 
 ```json

--- a/src/lib/evaluator-awards.test.ts
+++ b/src/lib/evaluator-awards.test.ts
@@ -6,6 +6,7 @@
 import {
   mkdirSync,
   mkdtempSync,
+  readFileSync,
   rmSync,
   symlinkSync,
   writeFileSync,
@@ -70,6 +71,20 @@ afterEach(() => {
 });
 
 describe("evaluator award protocol", () => {
+  it("keeps review-led closure guidance narrow and non-automatic", () => {
+    const guide = readFileSync(
+      join(import.meta.dirname, "..", "..", "evaluations", "README.md"),
+      "utf8",
+    );
+
+    expect(guide).toMatch(/closure is never sufficient by itself/iu);
+    expect(guide).toMatch(/GitHub\s+has no `CLOSE` review state/iu);
+    expect(guide).toMatch(/substantive `COMMENTED` review may be evaluated/iu);
+    expect(guide).toMatch(/independent maintainer/iu);
+    expect(guide).toMatch(/ordinary-ledger\s+deduplication/iu);
+    expect(guide).toMatch(/receive no automatic credit/iu);
+  });
+
   it("turns a reviewed manifest into one digest-bound score event", () => {
     const root = fixtureRoot();
     writeFileSync(


### PR DESCRIPTION
Closes #292.

Documents the existing discretionary evaluated-contribution boundary for substantive reviews that lead to pull-request closure.

The guide now states that a closure decision can itself be a useful outcome without a landed replacement, but never scores automatically. It requires an exact canonical review receipt, a specific technical finding or comparison, public evidence tying that work to the closure decision, and independent maintainer judgment. It also clarifies that `CLOSE` is not a GitHub review state, a substantive `COMMENTED` review may be evaluated, chronology or author acknowledgement alone is insufficient, and ordinary scoring/deduplication/caps remain unchanged.

Verification at `ceb8a8b`:

- `bun x vitest run src/lib/evaluator-awards.test.ts` — 8 passed.
- `bun run evaluations:check` — 8 checked-in awards validated.
- `bun run typecheck` — pass.
- `bun run lint:check` — pass.
- `bun run format:check` — pass.
- `git diff --check` — pass.
