### PR TITLE
fix: retry transient authenticated download failures with classified errors

### DIFF
--- a/src/lib/install-command.test.ts
+++ b/src/lib/install-command.test.ts
@@ -17,7 +17,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   type AuthorityFixtureOptions,
@@ -1188,7 +1188,45 @@ describe("authenticated skill installer lifecycle", () => {
           rawOrigin: "https://attacker.example",
         },
       }),
-    ).toThrow("must be an unparameterized file:// origin");
+    ).toThrow(
+      "must be an unparameterized file:// or loopback http://127.0.0.1 origin",
+    );
+    expect(() =>
+      createInstallCommand("https://slop.cash", `\${HOME}/.codex/skills`, {
+        ...primaryInstallOptions,
+        testAuthority: {
+          apiOrigin: "http://attacker.example:8080",
+          rawOrigin: "file:///tmp/raw",
+        },
+      }),
+    ).toThrow(
+      "must be an unparameterized file:// or loopback http://127.0.0.1 origin",
+    );
+    expect(() =>
+      createInstallCommand("https://slop.cash", `\${HOME}/.codex/skills`, {
+        ...primaryInstallOptions,
+        testAuthority: {
+          apiOrigin: "http://127.0.0.1:8080",
+          rawOrigin: "file:///tmp/raw",
+          requestTimeoutSeconds: 0,
+        },
+      }),
+    ).toThrow("requestTimeoutSeconds must be between 0.1 and 300 seconds");
+    const loopback = createInstallCommand(
+      "https://slop.cash",
+      `\${HOME}/.codex/skills`,
+      {
+        ...primaryInstallOptions,
+        testAuthority: {
+          apiOrigin: "http://127.0.0.1:8080",
+          rawOrigin: "file:///tmp/raw",
+          requestTimeoutSeconds: 0.5,
+        },
+      },
+    );
+    expect(loopback).toContain("'http://127.0.0.1:8080'");
+    expect(loopback).toContain("'0.5'");
+    expect(production).toContain("'60'");
   });
 
   it("uses the current Slop repository for GitHub authority and local provenance", () => {
@@ -1319,5 +1357,188 @@ time.sleep(60)
     expect(readFileSync(unmanagedTarget, "utf8")).toBe(
       "must remain untouched\n",
     );
+  });
+
+  const stallServerScript = `
+    const http = require("node:http");
+    const fs = require("node:fs");
+    const [responsesPath, pattern, stallMsRaw, stallCountRaw, logPath] =
+      process.argv.slice(1);
+    const responses = JSON.parse(fs.readFileSync(responsesPath, "utf8"));
+    const stallMs = Number(stallMsRaw);
+    const stallCount = Number(stallCountRaw);
+    let stalled = 0;
+    const server = http.createServer((request, response) => {
+      fs.appendFileSync(logPath, request.url + "\\n");
+      const respond = () => {
+        try {
+          if (!(request.url in responses)) {
+            response.statusCode = 404;
+            response.end("{}");
+            return;
+          }
+          response.setHeader("content-type", "application/json");
+          response.end(JSON.stringify(responses[request.url]));
+        } catch {}
+      };
+      if (request.url.includes(pattern) && stalled < stallCount) {
+        stalled += 1;
+        setTimeout(respond, stallMs);
+      } else {
+        respond();
+      }
+    });
+    server.listen(0, "127.0.0.1", () => {
+      console.log("PORT " + server.address().port);
+    });
+  `;
+
+  async function startStallServer(options: {
+    responsesPath: string;
+    requestLog: string;
+    stallPattern: string;
+    stallMs: number;
+    stallCount: number;
+  }): Promise<{ port: number; kill: () => void }> {
+    const child = spawn(
+      process.execPath,
+      [
+        "-e",
+        stallServerScript,
+        options.responsesPath,
+        options.stallPattern,
+        String(options.stallMs),
+        String(options.stallCount),
+        options.requestLog,
+      ],
+      { stdio: ["ignore", "pipe", "inherit"] },
+    );
+    const port = await new Promise<number>((resolvePort, rejectPort) => {
+      let buffered = "";
+      child.stdout.on("data", (chunk: Buffer) => {
+        buffered += chunk.toString("utf8");
+        const match = buffered.match(/PORT (\d+)/u);
+        if (match) resolvePort(Number(match[1]));
+      });
+      child.once("exit", () =>
+        rejectPort(new Error("stall server exited before listening")),
+      );
+    });
+    return { port, kill: () => child.kill("SIGKILL") };
+  }
+
+  function timeoutUpdateFixture(root: string) {
+    const installRoot = join(root, "install");
+    const filesA = baseFiles("revision-a");
+    const filesB = baseFiles("revision-b");
+    const artifactA = writeArtifact(root, revisionA, filesA);
+    const artifactB = writeArtifact(root, revisionB, filesB);
+    const initialAuthority = configureAuthority(root, {
+      developHead: revisionA,
+      revisions: { [revisionA]: { files: filesA } },
+    });
+    const initial = run(command(artifactA, initialAuthority), installRoot);
+    expect(initial.status, initial.stderr).toBe(0);
+    const updateAuthority = configureAuthority(root, {
+      comparisons: {
+        [`${revisionA}...${revisionB}`]: aheadComparison(revisionA, revisionB),
+      },
+      developHead: revisionB,
+      revisions: {
+        [revisionA]: { files: filesA },
+        [revisionB]: { files: filesB },
+      },
+    });
+    return { artifactB, installRoot, updateAuthority };
+  }
+
+  function loopbackCommand(
+    artifactRoot: string,
+    apiPort: number,
+    rawOrigin: string,
+  ): string {
+    return createInstallCommand(
+      pathToFileURL(artifactRoot).href.replace(/\/$/u, ""),
+      `\${CODEX_HOME:-\${HOME}/.codex}/skills`,
+      {
+        ...primaryInstallOptions,
+        testAuthority: {
+          apiOrigin: `http://127.0.0.1:${apiPort}`,
+          rawOrigin,
+          requestTimeoutSeconds: 0.5,
+        },
+      },
+    );
+  }
+
+  it("recovers a valid update from one slow comparison within bounded attempts", async () => {
+    const root = freshRoot("timeout-recover");
+    const { artifactB, installRoot, updateAuthority } =
+      timeoutUpdateFixture(root);
+    const requestLog = join(root, "requests.log");
+    writeFileSync(requestLog, "");
+    const server = await startStallServer({
+      responsesPath: join(
+        fileURLToPath(updateAuthority.apiOrigin),
+        "responses.json",
+      ),
+      requestLog,
+      stallPattern: "/compare/",
+      stallMs: 1500,
+      stallCount: 1,
+    });
+    try {
+      const update = run(
+        loopbackCommand(artifactB, server.port, updateAuthority.rawOrigin),
+        installRoot,
+      );
+      expect(update.status, update.stderr).toBe(0);
+      expect(currentLink(installRoot)).toBe(
+        `.contribute-to-eliza-versions/${revisionB}`,
+      );
+      const compareRequests = readFileSync(requestLog, "utf8")
+        .split("\n")
+        .filter((line) => line.includes("/compare/"));
+      expect(compareRequests).toHaveLength(2);
+    } finally {
+      server.kill();
+    }
+  });
+
+  it("fails closed with a timeout-classified error after bounded attempts", async () => {
+    const root = freshRoot("timeout-exhaust");
+    const { artifactB, installRoot, updateAuthority } =
+      timeoutUpdateFixture(root);
+    const requestLog = join(root, "requests.log");
+    writeFileSync(requestLog, "");
+    const server = await startStallServer({
+      responsesPath: join(
+        fileURLToPath(updateAuthority.apiOrigin),
+        "responses.json",
+      ),
+      requestLog,
+      stallPattern: "/compare/",
+      stallMs: 1500,
+      stallCount: 99,
+    });
+    try {
+      const update = run(
+        loopbackCommand(artifactB, server.port, updateAuthority.rawOrigin),
+        installRoot,
+      );
+      expect(update.status).not.toBe(0);
+      expect(update.stderr).toContain(
+        "authenticated download failed after 3 attempts (timed out after 0.5s)",
+      );
+      const compareRequests = readFileSync(requestLog, "utf8")
+        .split("\n")
+        .filter((line) => line.includes("/compare/"));
+      expect(compareRequests).toHaveLength(3);
+      expect(currentLink(installRoot)).toBe(
+        `.contribute-to-eliza-versions/${revisionA}`,
+      );
+    } finally {
+      server.kill();
+    }
   });
 });

--- a/src/lib/install-command.ts
+++ b/src/lib/install-command.ts
@@ -9,6 +9,12 @@
 interface TestAuthorityOrigins {
   apiOrigin: string;
   rawOrigin: string;
+  /**
+   * Test-only per-attempt download timeout. Production always uses the
+   * default; this exists so a deterministic test can reproduce a response
+   * exceeding the per-attempt timeout without waiting minutes.
+   */
+  requestTimeoutSeconds?: number;
 }
 
 interface InstallCommandOptions {
@@ -19,6 +25,9 @@ interface InstallCommandOptions {
 
 const PRODUCTION_API_ORIGIN = "https://api.github.com";
 const PRODUCTION_RAW_ORIGIN = "https://raw.githubusercontent.com";
+// GitHub compare responses on large ranges have been observed taking ~34s
+// while still succeeding; the per-attempt timeout must exceed that.
+const DEFAULT_REQUEST_TIMEOUT_SECONDS = 60;
 
 function shellQuote(value: string): string {
   return `'${value.replaceAll("'", `'"'"'`)}'`;
@@ -37,27 +46,45 @@ function validateArtifactOrigin(origin: string): string {
   return origin.replace(/\/$/u, "");
 }
 
-function resolveAuthorityOrigins(
-  options: InstallCommandOptions,
-): TestAuthorityOrigins {
+function validateTestOrigin(name: string, origin: string): void {
+  const parsed = new URL(origin);
+  const isFile = parsed.protocol === "file:";
+  const isLoopbackHttp =
+    parsed.protocol === "http:" && parsed.hostname === "127.0.0.1";
+  if ((!isFile && !isLoopbackHttp) || parsed.search || parsed.hash) {
+    throw new TypeError(
+      `[Slop] test ${name} must be an unparameterized file:// or loopback http://127.0.0.1 origin`,
+    );
+  }
+}
+
+function resolveAuthorityOrigins(options: InstallCommandOptions): {
+  apiOrigin: string;
+  rawOrigin: string;
+} {
   if (!options.testAuthority) {
     return {
       apiOrigin: PRODUCTION_API_ORIGIN,
       rawOrigin: PRODUCTION_RAW_ORIGIN,
     };
   }
-  for (const [name, origin] of Object.entries(options.testAuthority)) {
-    const parsed = new URL(origin);
-    if (parsed.protocol !== "file:" || parsed.search || parsed.hash) {
-      throw new TypeError(
-        `[Slop] test ${name} must be an unparameterized file:// origin`,
-      );
-    }
-  }
+  validateTestOrigin("apiOrigin", options.testAuthority.apiOrigin);
+  validateTestOrigin("rawOrigin", options.testAuthority.rawOrigin);
   return {
     apiOrigin: options.testAuthority.apiOrigin.replace(/\/$/u, ""),
     rawOrigin: options.testAuthority.rawOrigin.replace(/\/$/u, ""),
   };
+}
+
+function resolveRequestTimeoutSeconds(options: InstallCommandOptions): number {
+  const override = options.testAuthority?.requestTimeoutSeconds;
+  if (override === undefined) return DEFAULT_REQUEST_TIMEOUT_SECONDS;
+  if (!Number.isFinite(override) || override < 0.1 || override > 300) {
+    throw new TypeError(
+      "[Slop] test requestTimeoutSeconds must be between 0.1 and 300 seconds",
+    );
+  }
+  return override;
 }
 
 export function createInstallCommand(
@@ -67,6 +94,7 @@ export function createInstallCommand(
 ): string {
   const artifactOrigin = validateArtifactOrigin(origin);
   const authority = resolveAuthorityOrigins(options);
+  const requestTimeoutSeconds = resolveRequestTimeoutSeconds(options);
   const { skillName, skillRepositoryPath } = options;
   if (!/^[a-z0-9][a-z0-9-]{0,63}$/u.test(skillName)) {
     throw new TypeError("[Slop] skill name must be canonical kebab-case");
@@ -90,20 +118,23 @@ export function createInstallCommand(
     exit 1
   fi
   trap 'exit 1' HUP INT TERM
-  python3 - ${shellQuote(artifactOrigin)} ${shellQuote(authority.apiOrigin)} ${shellQuote(authority.rawOrigin)} "$SKILLS_ROOT" "$OPERATION" "$ROLLBACK_REVISION" ${shellQuote(skillName)} ${shellQuote(skillRepositoryPath)} <<'PY'
+  python3 - ${shellQuote(artifactOrigin)} ${shellQuote(authority.apiOrigin)} ${shellQuote(authority.rawOrigin)} "$SKILLS_ROOT" "$OPERATION" "$ROLLBACK_REVISION" ${shellQuote(skillName)} ${shellQuote(skillRepositoryPath)} ${shellQuote(String(requestTimeoutSeconds))} <<'PY'
 import binascii
 import ctypes
 import hashlib
 import io
 import json
+import math
 import os
 import re
 import secrets
 import shutil
+import socket
 import stat
 import struct
 import sys
 import tempfile
+import time
 import unicodedata
 import urllib.error
 import urllib.parse
@@ -112,7 +143,7 @@ import zipfile
 import zlib
 from pathlib import Path, PurePosixPath
 
-artifact_origin, api_origin, raw_origin, skills_root, operation, rollback_revision, skill_name, skill_repository_path = sys.argv[1:]
+artifact_origin, api_origin, raw_origin, skills_root, operation, rollback_revision, skill_name, skill_repository_path, request_timeout_argument = sys.argv[1:]
 repository = "SlopDotCash/slopdotcash"
 github_repository = "SlopDotCash/slopdotcash"
 legacy_repository = "elizaOS/slopdotcash"
@@ -134,7 +165,14 @@ max_total_bytes = 4_194_304
 max_api_bytes = 2_097_152
 max_pull_pages = 10
 max_timeline_pages = 10
-request_timeout_seconds = 20
+try:
+    request_timeout_seconds = float(request_timeout_argument)
+except ValueError as error:
+    raise ValueError("request timeout argument is not a number") from error
+if not math.isfinite(request_timeout_seconds) or request_timeout_seconds <= 0:
+    raise ValueError("request timeout argument must be a positive finite number")
+download_attempts = 3
+retry_backoff_seconds = (2.0, 4.0)
 sha_pattern = re.compile(r"[0-9a-f]{40}")
 digest_pattern = re.compile(r"[0-9a-f]{64}")
 local_header = struct.Struct("<IHHHHHIIIHH")
@@ -174,7 +212,15 @@ def origin_identity(url):
     return (parsed.scheme, parsed.hostname, parsed.port)
 
 
-def fetch_bytes(url, limit, expected_origin):
+class RetryableDownloadError(Exception):
+    """A transient transport failure eligible for one bounded retry cycle."""
+
+    def __init__(self, reason):
+        super().__init__(reason)
+        self.reason = reason
+
+
+def fetch_bytes_once(url, limit, expected_origin):
     request = urllib.request.Request(
         url,
         headers={
@@ -205,11 +251,45 @@ def fetch_bytes(url, limit, expected_origin):
                 if declared_length < 0 or declared_length > limit:
                     raise ValueError("remote response exceeds its declared size limit")
             contents = response.read(limit + 1)
-    except (OSError, urllib.error.URLError) as error:
-        raise ValueError(f"authenticated download failed: {url}") from error
+    except urllib.error.HTTPError as error:
+        if error.code >= 500:
+            raise RetryableDownloadError(f"HTTP {error.code}") from error
+        raise ValueError(f"authenticated download failed: HTTP {error.code}: {url}") from error
+    except (TimeoutError, socket.timeout) as error:
+        raise RetryableDownloadError(
+            f"timed out after {request_timeout_seconds}s"
+        ) from error
+    except urllib.error.URLError as error:
+        if isinstance(error.reason, (TimeoutError, socket.timeout)):
+            raise RetryableDownloadError(
+                f"timed out after {request_timeout_seconds}s"
+            ) from error
+        raise ValueError(
+            f"authenticated download failed ({type(error.reason).__name__}): {url}"
+        ) from error
+    except OSError as error:
+        raise ValueError(
+            f"authenticated download failed ({type(error).__name__}): {url}"
+        ) from error
     if len(contents) > limit:
         raise ValueError("remote response exceeds its actual size limit")
     return contents
+
+
+def fetch_bytes(url, limit, expected_origin):
+    # Integrity, authority, and size violations above raise ValueError and are
+    # never retried; only per-attempt timeouts and HTTP 5xx repeat, bounded.
+    last_reason = None
+    for attempt in range(1, download_attempts + 1):
+        try:
+            return fetch_bytes_once(url, limit, expected_origin)
+        except RetryableDownloadError as error:
+            last_reason = error.reason
+            if attempt < download_attempts:
+                time.sleep(retry_backoff_seconds[attempt - 1])
+    raise ValueError(
+        f"authenticated download failed after {download_attempts} attempts ({last_reason}): {url}"
+    )
 
 
 def decode_json(contents, context):


### PR DESCRIPTION
Fixes #294.

**Environment Variables**

No environment variable changes.

**Overview**

The authenticated skill installer made one download attempt per request with a fixed 20-second `urllib` timeout and collapsed every failure into `authenticated download failed: <url>`. GitHub compare responses on large ranges have been observed taking ~34 seconds while succeeding (see #294), so a valid fast-forward update failed closed before queue inspection — blocking all contribution work — and the diagnostic could not distinguish timeout from HTTP, DNS, or integrity failure.

**Change Summary**

- **Fixes** (embedded installer in `src/lib/install-command.ts`):
  - per-attempt timeout raised 20s → 60s (observed valid responses exceed the old cap, so retry alone cannot fix the reported incident);
  - bounded deterministic retry — 3 attempts, 2s then 4s backoff — for exactly two transient classes: per-attempt timeout and HTTP 5xx;
  - terminal diagnostics now classify the failure: `HTTP <code>`, `timed out after <t>s` (with attempt count), or the underlying `OSError`/`URLError` reason class. No credentials or headers appear in any message.
  - **Fail-closed boundaries are unchanged and never retried**: authority-redirect detection, `file://` fixture-root escape, declared/actual size limits, and non-5xx HTTP statuses all still raise immediately.
- **Tests** (acceptance criterion 4 — deterministic timeout reproduction):
  - test authorities may now be loopback `http://127.0.0.1` origins in addition to `file://`, plus a test-only `requestTimeoutSeconds` override (0.1–300s). Production origins and the production timeout are untouched — verified by the updated authority-pinning test, which also rejects non-loopback http.
  - new end-to-end test: a child-process HTTP authority serves the standard fixture map but stalls the compare response past the per-attempt timeout once — the update succeeds with exactly 2 compare requests (bounded recovery proven by server-side request log);
  - new fail-closed test: a persistent stall exhausts exactly 3 attempts, emits `authenticated download failed after 3 attempts (timed out after 0.5s)`, and leaves the active version symlink on the retained revision.

**Technical Impact**

- Generated installer bytes change (argv gains the timeout parameter), so the published checksum and downloadable `.skill` archives regenerate on deploy as usual. No schema, API, or state-layout changes.

**Testing Evidence**

- `vitest run src/lib/install-command.test.ts` — 19 pass (2 new).
- `vitest run scripts/prepare-site.test.ts` — 9 pass.
- Full `vitest run` — 640 pass; the only 5 failures are the known macOS-local `scripts/skill-validation.test.ts` cases (`os.tmpdir()` under the `/var → /private/var` symlink), present on unmodified `develop` and unrelated to this change.
- `bun run typecheck`, `biome check`, `bun run format:check` — clean.

**Migration / Deployment Notes**

No special deployment steps.

**Provenance**

Authored by `wbaxterh` using Claude Code (model `claude-fable-5`, client `claude-code`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)