### PR TITLE
fix(scoring): keep review ingestion stable during PR updates

### DIFF
--- a/scripts/generate-leaderboard.test.ts
+++ b/scripts/generate-leaderboard.test.ts
@@ -1266,6 +1266,44 @@ describe("rate-efficient query plan", () => {
     });
   });
 
+  it("keeps a pull request absent from the baseline census fatal", async () => {
+    const client: GraphqlExecutor = {
+      execute: async () => {
+        throw new Error("an absent baseline entry must not be re-read");
+      },
+      getRequestCount: () => 0,
+      getRateLimit: () => ({
+        cost: 0,
+        consumedDuringRun: 0,
+        limit: 5_000,
+        remaining: 5_000,
+        resetAt: "2026-08-25T18:00:00.000Z",
+      }),
+    };
+
+    await expect(
+      reconcileHydratedReviewCensus(client, new Map(), [
+        {
+          id: "PR_NEVER_IN_CENSUS",
+          updatedAt: "2026-08-25T18:01:00.000Z",
+          reviews: [
+            {
+              id: "PRR_1",
+              body: "Substantive review",
+              state: "APPROVED",
+              submittedAt: "2026-08-25T17:59:00.000Z",
+              url: "https://github.com/elizaOS/eliza/pull/1#pullrequestreview-1",
+              author: null,
+              inlineCommentCount: 0,
+            },
+          ],
+        },
+      ]),
+    ).rejects.toThrow(
+      "Review census missing PR_NEVER_IN_CENSUS before detail reconciliation",
+    );
+  });
+
   it("fails closed when a hydrated formal-review set is still moving", async () => {
     const client: GraphqlExecutor = {
       execute: async () => ({

--- a/scripts/generate-leaderboard.test.ts
+++ b/scripts/generate-leaderboard.test.ts
@@ -31,6 +31,7 @@ import {
   OpenSetChangedError,
   parseGenerationArguments,
   planMergedPullRequestHydration,
+  reconcileHydratedReviewCensus,
   resolveGitHubToken,
   retryOpenBatch,
   retryOpenReferenceListing,
@@ -1214,6 +1215,109 @@ describe("rate-efficient query plan", () => {
         ]),
       ),
     ).toThrow("Review census changed for PR_CHANGED");
+  });
+
+  it("reconciles an unrelated PR update after complete review hydration", async () => {
+    const client: GraphqlExecutor = {
+      execute: async () => ({
+        nodes: [
+          {
+            __typename: "PullRequest",
+            id: "PR_UPDATED",
+            updatedAt: "2026-08-25T18:01:00.000Z",
+            reviews: { totalCount: 1 },
+          },
+        ],
+      }),
+      getRequestCount: () => 1,
+      getRateLimit: () => ({
+        cost: 1,
+        consumedDuringRun: 1,
+        limit: 5_000,
+        remaining: 4_999,
+        resetAt: "2026-08-25T18:00:00.000Z",
+      }),
+    };
+    const reviewCounts = new Map([
+      ["PR_UPDATED", { reviewCount: 1, updatedAt: "2026-08-25T18:00:00.000Z" }],
+    ]);
+
+    await reconcileHydratedReviewCensus(client, reviewCounts, [
+      {
+        id: "PR_UPDATED",
+        updatedAt: "2026-08-25T18:01:00.000Z",
+        reviews: [
+          {
+            id: "PRR_1",
+            body: "Substantive review",
+            state: "APPROVED",
+            submittedAt: "2026-08-25T17:59:00.000Z",
+            url: "https://github.com/elizaOS/eliza/pull/1#pullrequestreview-1",
+            author: null,
+            inlineCommentCount: 0,
+          },
+        ],
+      },
+    ]);
+
+    expect(reviewCounts.get("PR_UPDATED")).toEqual({
+      reviewCount: 1,
+      updatedAt: "2026-08-25T18:01:00.000Z",
+    });
+  });
+
+  it("fails closed when a hydrated formal-review set is still moving", async () => {
+    const client: GraphqlExecutor = {
+      execute: async () => ({
+        nodes: [
+          {
+            __typename: "PullRequest",
+            id: "PR_MOVING",
+            updatedAt: "2026-08-25T18:02:00.000Z",
+            reviews: { totalCount: 2 },
+          },
+        ],
+      }),
+      getRequestCount: () => 1,
+      getRateLimit: () => ({
+        cost: 1,
+        consumedDuringRun: 1,
+        limit: 5_000,
+        remaining: 4_999,
+        resetAt: "2026-08-25T18:00:00.000Z",
+      }),
+    };
+
+    await expect(
+      reconcileHydratedReviewCensus(
+        client,
+        new Map([
+          [
+            "PR_MOVING",
+            { reviewCount: 1, updatedAt: "2026-08-25T18:00:00.000Z" },
+          ],
+        ]),
+        [
+          {
+            id: "PR_MOVING",
+            updatedAt: "2026-08-25T18:01:00.000Z",
+            reviews: [
+              {
+                id: "PRR_1",
+                body: "Substantive review",
+                state: "APPROVED",
+                submittedAt: "2026-08-25T17:59:00.000Z",
+                url: "https://github.com/elizaOS/eliza/pull/1#pullrequestreview-1",
+                author: null,
+                inlineCommentCount: 0,
+              },
+            ],
+          },
+        ],
+      ),
+    ).rejects.toThrow(
+      "Review census changed for PR_MOVING during detail hydration",
+    );
   });
 
   it("parses every production GraphQL document", () => {

--- a/scripts/generate-leaderboard.ts
+++ b/scripts/generate-leaderboard.ts
@@ -2715,8 +2715,12 @@ export async function reconcileHydratedReviewCensus(
 ): Promise<void> {
   const changed = pullRequests.filter((pullRequest) => {
     const census = reviewCounts.get(pullRequest.id);
+    if (census === undefined) {
+      throw new Error(
+        `Review census missing ${pullRequest.id} before detail reconciliation`,
+      );
+    }
     return (
-      census === undefined ||
       formalDecisionReviewCount(pullRequest.reviews) !== census.reviewCount ||
       pullRequest.updatedAt !== census.updatedAt
     );

--- a/scripts/generate-leaderboard.ts
+++ b/scripts/generate-leaderboard.ts
@@ -2699,6 +2699,49 @@ export function assertReviewCensusStable(
   }
 }
 
+/**
+ * Re-checks only pull requests that changed between the scalar census and
+ * detail hydration. A comment or other unrelated PR update advances
+ * `updatedAt`; when the freshly hydrated formal-review set and an immediate
+ * scalar re-read agree, the detail is a complete current snapshot and the
+ * global closing census can safely use the refreshed checkpoint.
+ */
+export async function reconcileHydratedReviewCensus(
+  client: GraphqlExecutor,
+  reviewCounts: Map<string, ReviewCensusEntry>,
+  pullRequests: ReadonlyArray<
+    Pick<MergedPullRequestReviewRecord, "id" | "reviews" | "updatedAt">
+  >,
+): Promise<void> {
+  const changed = pullRequests.filter((pullRequest) => {
+    const census = reviewCounts.get(pullRequest.id);
+    return (
+      census === undefined ||
+      formalDecisionReviewCount(pullRequest.reviews) !== census.reviewCount ||
+      pullRequest.updatedAt !== census.updatedAt
+    );
+  });
+  if (changed.length === 0) return;
+
+  const refreshed = await collectPullRequestReviewCounts(
+    client,
+    changed.map(({ id }) => ({ id })),
+  );
+  for (const pullRequest of changed) {
+    const current = refreshed.get(pullRequest.id);
+    if (
+      current === undefined ||
+      formalDecisionReviewCount(pullRequest.reviews) !== current.reviewCount ||
+      pullRequest.updatedAt !== current.updatedAt
+    ) {
+      throw new Error(
+        `Review census changed for ${pullRequest.id} during detail hydration`,
+      );
+    }
+    reviewCounts.set(pullRequest.id, current);
+  }
+}
+
 async function collectOpenIssues(
   client: GraphqlExecutor,
   targetRepository: TargetRepository,
@@ -3294,22 +3337,10 @@ export async function generateLeaderboardFromGitHub(
       reviewedReferences,
       onProgress,
     );
-    for (const pullRequest of [
+    await reconcileHydratedReviewCensus(client, hydrationPlan.reviewCounts, [
       ...detailedPullRequests,
       ...reviewedPullRequests,
-    ]) {
-      const censusCount = hydrationPlan.reviewCounts.get(pullRequest.id);
-      if (
-        censusCount === undefined ||
-        formalDecisionReviewCount(pullRequest.reviews) !==
-          censusCount.reviewCount ||
-        pullRequest.updatedAt !== censusCount.updatedAt
-      ) {
-        throw new Error(
-          `Review census changed for ${pullRequest.id} during detail hydration`,
-        );
-      }
-    }
+    ]);
     mergedPullRequests.push(...detailedPullRequests);
     reviewedMergedPullRequests.push(...reviewedPullRequests);
 

--- a/skill-tests/contribute-to-eliza.test.ts
+++ b/skill-tests/contribute-to-eliza.test.ts
@@ -214,6 +214,12 @@ describe("contribute-to-eliza skill structure", () => {
     assert.match(source, /marker name is outside the signed\s+payload/i);
     assert.match(source, /Do not remove the `run` object/i);
     assert.match(source, /generate the unsigned\s+legacy marker/i);
+    assert.match(source, /formal `APPROVE` or `REQUEST_CHANGES` event/);
+    assert.match(source, /`submittedAt` is after `mergedAt`/);
+    assert.match(
+      source,
+      /does not\s+require the reviewed commit to become the final merged head/,
+    );
     assert.match(source, /Do not put both markers in the same\s+source/i);
     assert.doesNotMatch(source, /ss251 gets \+50|give ss251 extra points/i);
   });

--- a/skills/contribute-to-eliza/SKILL.md
+++ b/skills/contribute-to-eliza/SKILL.md
@@ -410,6 +410,16 @@ blocking defects, repairs, commands run, evidence inspected, and remaining
 human checks. A rejected or unmerged artifact may still be useful, but only the
 project evaluator can award it partial credit.
 
+Publish an ordinary score-eligible review only while GitHub still reports the
+pull request open, using the formal `APPROVE` or `REQUEST_CHANGES` event. A
+`COMMENT` event and any review whose GitHub `submittedAt` is after `mergedAt`
+remain useful discussion but do not receive automatic review credit; do not
+repost either after merge. The mandatory current-head recheck protects review
+quality, while ordinary scoring binds the immutable review event and does not
+require the reviewed commit to become the final merged head. Unscored useful
+diagnosis may be proposed once through the public maintainer-evaluation path;
+never request an evaluation for a source that already appears in the ledger.
+
 ## Finish the measured run
 
 After all work and proof, prepare the minimized contribution-specific UTF-8


### PR DESCRIPTION
## Summary\n\n- re-check only merged PRs whose scalar review census changed during detail hydration\n- accept the refreshed checkpoint only when the fully hydrated formal-review set, count, and current `updatedAt` all agree\n- continue to fail closed when the formal review set is still moving\n- document the actual ordinary-review eligibility contract: formal pre-merge decision, no reposting, legacy marker compatibility, and no final-merged-head requirement for scoring\n\n## Why\n\nScheduled production run [33310328068](https://github.com/SlopDotCash/slopdotcash/actions/runs/33310328068) failed on `Review census changed ... during detail hydration` after elizaOS/eliza#29694 received an unrelated update while the long collection was running. This preserves the fail-closed census boundary without throwing away a complete current detail read.\n\nThe documentation clarification addresses the andreolf scoring report directly: eight of the original eleven reviews were submitted after GitHub recorded the merge, while three qualifying pre-merge decisions already score automatically. `eliza-computer-attribution:v1` is already accepted and reposting cannot repair chronology.\n\n## Verification\n\n- `bunx vitest run scripts/generate-leaderboard.test.ts --config vitest.config.ts` — 62 passed\n- focused skill contract assertion — 1 passed\n- `bun run typecheck` — pass\n- `bun run format:check` — pass\n- `bun run lint:check` — pass\n- `git diff --check` — pass\n\nThe full 44-test contributor-skill file reached 42 passes but two existing subprocess tests exceeded their 5-second timeout in this isolated worktree; the changed contract assertion passes independently.