### PR TITLE
fix: isolate monthly reward project refusals

### DIFF
--- a/scripts/prepare-monthly-rewards.test.ts
+++ b/scripts/prepare-monthly-rewards.test.ts
@@ -6,6 +6,7 @@ import {
   prepareMonthlyRewards,
   previousUtcCycleId,
 } from "./prepare-monthly-rewards";
+import { PriorCycleNotReadyError } from "./prior-cycle-accrual";
 
 describe("monthly reward close", () => {
   const activeProjects = PROJECTS.map((project) => ({
@@ -106,5 +107,67 @@ describe("monthly reward close", () => {
         generatedAt: "2026-08-31T23:59:59.999Z",
       }),
     ).rejects.toThrow(/has not closed/u);
+  });
+
+  it.each([
+    ["under-review" as const, "is still under review"],
+    ["unresolved-proposals" as const, "has unresolved proposals"],
+  ])(
+    "records an %s prior-cycle refusal and prepares unaffected projects",
+    async (reason, message) => {
+      const prepare = vi.fn().mockImplementation(async (arguments_) => {
+        if (arguments_.projectId === "eliza") {
+          throw new PriorCycleNotReadyError({
+            cycleId: "2026-07",
+            message: `Prior cycle eliza/2026-07 ${message}`,
+            projectId: "eliza",
+            reason,
+          });
+        }
+      });
+      const validateCycles = vi.fn().mockResolvedValue({});
+
+      const result = await prepareMonthlyRewards(
+        {
+          cycleId: "2026-08",
+          generatedAt: "2026-09-05T00:11:00.000Z",
+        },
+        {
+          inspectPath: vi.fn().mockResolvedValue("missing"),
+          prepare,
+          projects: activeProjects,
+          validateCycles,
+        },
+      );
+
+      expect(result.prepared).toEqual(["asi", "delta-star"]);
+      expect(result.refused).toEqual([
+        {
+          projectId: "eliza",
+          priorCycleId: "2026-07",
+          reason,
+          message: `Prior cycle eliza/2026-07 ${message}`,
+        },
+      ]);
+      expect(prepare).toHaveBeenCalledTimes(3);
+      expect(validateCycles).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("keeps unrelated project preparation failures fatal", async () => {
+    await expect(
+      prepareMonthlyRewards(
+        {
+          cycleId: "2026-08",
+          generatedAt: "2026-09-05T00:11:00.000Z",
+        },
+        {
+          inspectPath: vi.fn().mockResolvedValue("missing"),
+          prepare: vi.fn().mockRejectedValue(new Error("snapshot invalid")),
+          projects: activeProjects,
+          validateCycles: vi.fn(),
+        },
+      ),
+    ).rejects.toThrow("snapshot invalid");
   });
 });

--- a/scripts/prepare-monthly-rewards.ts
+++ b/scripts/prepare-monthly-rewards.ts
@@ -12,6 +12,10 @@ import {
   parsePrepareRewardCycleArguments,
   prepareRewardCycle,
 } from "./prepare-reward-cycle";
+import {
+  PriorCycleNotReadyError,
+  type PriorCycleNotReadyReason,
+} from "./prior-cycle-accrual";
 import { syncCycleIndex } from "./sync-cycle-index";
 
 type ExistingPath = "file" | "missing";
@@ -19,6 +23,12 @@ type ExistingPath = "file" | "missing";
 export interface MonthlyRewardResult {
   cycleId: string;
   prepared: string[];
+  refused: Array<{
+    message: string;
+    priorCycleId: string;
+    projectId: string;
+    reason: PriorCycleNotReadyReason;
+  }>;
   skippedExisting: string[];
   skippedPrelaunch: string[];
 }
@@ -102,6 +112,7 @@ export async function prepareMonthlyRewards(
   const result: MonthlyRewardResult = {
     cycleId,
     prepared: [],
+    refused: [],
     skippedExisting: [],
     skippedPrelaunch: [],
   };
@@ -137,10 +148,27 @@ export async function prepareMonthlyRewards(
       result.skippedExisting.push(project.id);
       continue;
     }
-    await dependencies.prepare(arguments_, {
-      generatedAt,
-      githubToken: options.githubToken,
-    });
+    try {
+      await dependencies.prepare(arguments_, {
+        generatedAt,
+        githubToken: options.githubToken,
+      });
+    } catch (error) {
+      if (!(error instanceof PriorCycleNotReadyError)) throw error;
+      if (error.projectId !== project.id) {
+        throw new TypeError(
+          `Prior-cycle refusal project ${error.projectId} does not match ${project.id}`,
+          { cause: error },
+        );
+      }
+      result.refused.push({
+        message: error.message,
+        priorCycleId: error.cycleId,
+        projectId: error.projectId,
+        reason: error.reason,
+      });
+      continue;
+    }
     result.prepared.push(project.id);
   }
   await dependencies.validateCycles();
@@ -182,7 +210,7 @@ if (import.meta.main) {
       githubToken: process.env.GH_TOKEN ?? process.env.GITHUB_TOKEN,
     });
     process.stdout.write(
-      `[Slop] closed ${result.cycleId}: prepared ${result.prepared.join(", ") || "none"}; already present ${result.skippedExisting.join(", ") || "none"}\n`,
+      `[Slop] closed ${result.cycleId}: prepared ${result.prepared.join(", ") || "none"}; already present ${result.skippedExisting.join(", ") || "none"}; refused ${result.refused.map((entry) => `${entry.projectId} (${entry.reason}: ${entry.message})`).join(", ") || "none"}\n`,
     );
   } catch (error) {
     // error-policy:J1 command boundary exposes a non-zero, actionable failure.

--- a/scripts/prior-cycle-accrual.ts
+++ b/scripts/prior-cycle-accrual.ts
@@ -15,6 +15,27 @@ export interface PriorCycleAccrual {
   accruedMinor: ReadonlyMap<string, string>;
 }
 
+export type PriorCycleNotReadyReason = "under-review" | "unresolved-proposals";
+
+export class PriorCycleNotReadyError extends Error {
+  readonly cycleId: string;
+  readonly projectId: ProjectId;
+  readonly reason: PriorCycleNotReadyReason;
+
+  constructor(input: {
+    cycleId: string;
+    message: string;
+    projectId: ProjectId;
+    reason: PriorCycleNotReadyReason;
+  }) {
+    super(input.message);
+    this.name = "PriorCycleNotReadyError";
+    this.cycleId = input.cycleId;
+    this.projectId = input.projectId;
+    this.reason = input.reason;
+  }
+}
+
 export function previousCycleId(cycleId: string): string {
   if (!/^\d{4}-(?:0[1-9]|1[0-2])$/u.test(cycleId)) {
     throw new TypeError("Cycle id must be YYYY-MM");
@@ -109,14 +130,20 @@ export async function loadPriorCycleAccrual(input: {
   }
   if (!allocation) {
     if (Date.parse(input.asOf) < Date.parse(proposal.review.endsAt)) {
-      throw new RangeError(
-        `Prior cycle ${input.projectId}/${priorId} is still under review`,
-      );
+      throw new PriorCycleNotReadyError({
+        cycleId: priorId,
+        message: `Prior cycle ${input.projectId}/${priorId} is still under review`,
+        projectId: input.projectId,
+        reason: "under-review",
+      });
     }
     if (proposal.allocations.some((row) => row.state === "proposed")) {
-      throw new TypeError(
-        `Prior cycle ${input.projectId}/${priorId} has unresolved proposals`,
-      );
+      throw new PriorCycleNotReadyError({
+        cycleId: priorId,
+        message: `Prior cycle ${input.projectId}/${priorId} has unresolved proposals`,
+        projectId: input.projectId,
+        reason: "unresolved-proposals",
+      });
     }
   }
 


### PR DESCRIPTION
Closes #301.

The monthly close now distinguishes a prior cycle that is not ready from an integrity or execution failure:

- prior-cycle under-review and unresolved-proposal states produce a typed refusal for that project;
- the refusal records project, prior cycle, reason, and the existing actionable message;
- unaffected projects continue through proposal preparation and the complete cycle validation still runs;
- mismatched refusal identity, malformed snapshots, partial state, and every unrelated preparation error remain fatal.

This does not alter, approve, or resolve the existing Eliza allocation. It only prevents that human decision from discarding valid ASI and Delta Star close work.

Verification at head 9200930b2387f7f6b7fbfc1c233d63b8830cebc3:

- focused reward suites: 12 passed;
- typecheck, dependency audit, lint, formatting, project/evaluation/funding/cycle/protocol checks: passed;
- production build: passed with SLOP_PYTHON=/root/asi/.venv/bin/python (PyYAML 6.0.3);
- full Vitest run: 633 passed, but the repository-wide command remained nonzero for two runner prerequisites unrelated to this diff: default Python lacked PyYAML 6.0.3/uv, and Node 22 could not bundle the existing node:sqlite test (the repository requires Node >=24).

No UI, deployment, wallet, allocation, settlement, or generated public artifact changes.
