### PR TITLE
feat(projects): opt-in reviewBudget line in the reward schema (RFC #303)

### DIFF
--- a/src/lib/project-schema.mjs
+++ b/src/lib/project-schema.mjs
@@ -763,6 +763,47 @@ function validateSkill(
   return skill;
 }
 
+function validateReviewBudget(value, field, poolPaymentMode) {
+  const budget = record(value, field);
+  exactKeys(
+    budget,
+    [
+      "committedMinor",
+      "fundingState",
+      "monthlyCapDisplay",
+      "monthlyCapMinor",
+      "paymentMode",
+      "unusedFunds",
+    ],
+    field,
+  );
+  const monthlyCapMinor = minor(
+    budget.monthlyCapMinor,
+    `${field}.monthlyCapMinor`,
+  );
+  const committedMinor = minor(
+    budget.committedMinor,
+    `${field}.committedMinor`,
+  );
+  if (budget.paymentMode !== "disabled" && budget.paymentMode !== "enabled") {
+    throw new TypeError(`${field}.paymentMode is invalid`);
+  }
+  text(budget.monthlyCapDisplay, `${field}.monthlyCapDisplay`, { max: 80 });
+  const paymentsDisabled = budget.paymentMode === "disabled";
+  if (
+    BigInt(monthlyCapMinor) <= 0n ||
+    budget.unusedFunds !== "rollover-without-cap-increase" ||
+    (paymentsDisabled
+      ? budget.fundingState !== "pledged" || committedMinor !== "0"
+      : budget.fundingState !== "committed" || BigInt(committedMinor) <= 0n) ||
+    (budget.paymentMode === "enabled" && poolPaymentMode !== "enabled") ||
+    budget.monthlyCapDisplay !== formatMonthlyCapDisplay(monthlyCapMinor)
+  ) {
+    throw new TypeError(`${field} review budget policy is inconsistent`);
+  }
+  return budget;
+}
+
 function validateReward(
   value,
   field,
@@ -770,6 +811,7 @@ function validateReward(
 ) {
   const reward = record(value, field);
   const hasExternal = Object.hasOwn(reward, "externalOpportunity");
+  const hasReviewBudget = Object.hasOwn(reward, "reviewBudget");
   exactKeys(
     reward,
     [
@@ -784,6 +826,7 @@ function validateReward(
       "monthlyCapDisplay",
       "monthlyCapMinor",
       "paymentMode",
+      ...(hasReviewBudget ? ["reviewBudget"] : []),
       "rewardStartAt",
       "unusedFunds",
     ],
@@ -830,8 +873,16 @@ function validateReward(
     ) {
       throw new TypeError(`${field} monthly pool policy is inconsistent`);
     }
+    if (hasReviewBudget) {
+      validateReviewBudget(
+        reward.reviewBudget,
+        `${field}.reviewBudget`,
+        reward.paymentMode,
+      );
+    }
   } else if (reward.kind === "external-prize-share") {
     if (
+      hasReviewBudget ||
       !hasExternal ||
       reward.currency !== null ||
       reward.chain !== null ||
@@ -972,7 +1023,8 @@ function validateProjectDefinition(
   });
   validateFunding(project.funding, id);
   if (
-    project.reward.fundingState === "committed" &&
+    (project.reward.fundingState === "committed" ||
+      project.reward.reviewBudget?.fundingState === "committed") &&
     !hasActiveFundingCommitment(project.funding.commitments)
   ) {
     throw new TypeError(

--- a/src/lib/project-schema.test.ts
+++ b/src/lib/project-schema.test.ts
@@ -184,6 +184,74 @@ describe("project proposal schema", () => {
     expect(() => assertProjectDefinition(overlargeCap)).toThrow(/at most/u);
   });
 
+  it("validates the optional review budget line", () => {
+    const pledgedReviewBudget = {
+      monthlyCapMinor: "50000000",
+      monthlyCapDisplay: "$50",
+      committedMinor: "0",
+      paymentMode: "disabled",
+      unusedFunds: "rollover-without-cap-increase",
+      fundingState: "pledged",
+    };
+    const withBudget = structuredClone(eliza) as unknown as {
+      reward: Record<string, unknown>;
+    };
+    withBudget.reward.reviewBudget = structuredClone(pledgedReviewBudget);
+    expect(
+      assertProjectDefinition(withBudget).reward.reviewBudget
+        ?.monthlyCapDisplay,
+    ).toBe("$50");
+
+    const zeroCap = structuredClone(withBudget);
+    (zeroCap.reward.reviewBudget as Record<string, unknown>).monthlyCapMinor =
+      "0";
+    (zeroCap.reward.reviewBudget as Record<string, unknown>).monthlyCapDisplay =
+      "$0";
+    expect(() => assertProjectDefinition(zeroCap)).toThrow(/inconsistent/u);
+
+    const misleadingDisplay = structuredClone(withBudget);
+    (
+      misleadingDisplay.reward.reviewBudget as Record<string, unknown>
+    ).monthlyCapDisplay = "$5,000";
+    expect(() => assertProjectDefinition(misleadingDisplay)).toThrow(
+      /inconsistent/u,
+    );
+
+    const smuggledField = structuredClone(withBudget);
+    (smuggledField.reward.reviewBudget as Record<string, unknown>).payoutHook =
+      "https://example.com";
+    expect(() => assertProjectDefinition(smuggledField)).toThrow(
+      /unexpected or missing fields/u,
+    );
+
+    const fakeCommitted = structuredClone(withBudget);
+    (
+      fakeCommitted.reward.reviewBudget as Record<string, unknown>
+    ).committedMinor = "1000000";
+    expect(() => assertProjectDefinition(fakeCommitted)).toThrow(
+      /inconsistent/u,
+    );
+
+    const enabledAheadOfPool = structuredClone(withBudget);
+    Object.assign(enabledAheadOfPool.reward.reviewBudget as object, {
+      paymentMode: "enabled",
+      fundingState: "committed",
+      committedMinor: "50000000",
+    });
+    expect(() => assertProjectDefinition(enabledAheadOfPool)).toThrow(
+      /inconsistent/u,
+    );
+
+    const externalPrizeBudget = structuredClone(deltaStar) as unknown as {
+      reward: Record<string, unknown>;
+    };
+    externalPrizeBudget.reward.reviewBudget =
+      structuredClone(pledgedReviewBudget);
+    expect(() => assertProjectDefinition(externalPrizeBudget)).toThrow(
+      /unexpected or missing fields|inconsistent/u,
+    );
+  });
+
   it("rejects repository and skill collisions across project folders", () => {
     const copy = structuredClone(deltaStar);
     copy.status = "paused";

--- a/src/lib/projects.d.mts
+++ b/src/lib/projects.d.mts
@@ -20,6 +20,15 @@ export interface ProjectFundingPolicy {
   readonly commitments?: readonly FundingCommitmentInstrument[];
 }
 
+export interface ProjectReviewBudgetPolicy {
+  readonly monthlyCapMinor: string;
+  readonly monthlyCapDisplay: string;
+  readonly committedMinor: string;
+  readonly paymentMode: "disabled" | "enabled";
+  readonly unusedFunds: "rollover-without-cap-increase";
+  readonly fundingState: "committed" | "pledged";
+}
+
 export interface ProjectRewardPolicy {
   readonly kind: RewardKind;
   readonly currency: "USDC" | null;
@@ -33,6 +42,7 @@ export interface ProjectRewardPolicy {
   readonly feeBasisPoints: 100 | 1000;
   readonly unusedFunds: "not-applicable" | "rollover-without-cap-increase";
   readonly fundingState: "committed" | "external-opportunity" | "pledged";
+  readonly reviewBudget?: ProjectReviewBudgetPolicy;
   readonly externalOpportunity?: {
     readonly name: string;
     readonly advertisedAmountDisplay: string;


### PR DESCRIPTION
Implements the manifest half of RFC #303: a project funding a monthly pool may declare a second, named cash line for review work. Schema and validation only; no manifest opts in yet, and allocation, settlement, and UI surfaces are follow-ups.

**Additive invariant (added 2026-09-01, per the [amended RFC](https://github.com/SlopDotCash/slopdotcash/issues/303)):** this schema is not license for moving review events out of the shared pool. Review events remain in the shared pool, scored and allocated exactly as today; the `reviewBudget` line pays on top of that treatment, and only when `fundingState` is `committed`. The allocation follow-up must implement the line as additive, with the dust floor applied to a recipient's combined total across both lines. Nothing in this PR's schema needs to change for that: the block already carries no allocation semantics.

## What changes

`project.reward` accepts an optional `reviewBudget` block on `monthly-pool` policies:

```json
"reviewBudget": {
  "monthlyCapMinor": "50000000",
  "monthlyCapDisplay": "$50",
  "committedMinor": "0",
  "paymentMode": "disabled",
  "unusedFunds": "rollover-without-cap-increase",
  "fundingState": "pledged"
}
```

An absent block keeps current behavior byte for byte. The block reuses the pool's own rules so there is nothing new to audit:

- exact keys, cent-precise integer minor units, display string must equal the canonical formatting of the cap
- `pledged` requires disabled payments and zero committed; `committed` requires enabled payments, positive committed, and an active funding commitment instrument
- the cap must be positive; a zero-cap block is rejected rather than silently meaningless
- fail-closed extras: the review line cannot enable payments while the author pool is disabled, and `external-prize-share` policies reject the block entirely

## Positions taken on the RFC's open questions

Stated here so they are reviewable decisions, not silent defaults:

1. **Fee**: the existing reward-level `feeBasisPoints` applies to the review line identically. No separate fee field.
2. **Dust floor**: per the amended RFC, `minimumTransferMinor` applies to a recipient's combined cycle total across both lines, since both settle to the same registered wallet. Nothing to encode in this schema; binds the allocation follow-up.
3. **Shape**: `fundingState` was added to the RFC's sketched block so the pledged/committed coupling stays symmetric with the pool.

No retroactive effect on any open or past cycle, including eliza 2026-07. Non-custodial settlement is unchanged: two transfers instead of one, both signed by the creator externally.

## Verification

- `bun run projects:check`: registry current
- `bun run typecheck`, `bun run lint:check`, `bun run format:check`: pass
- `bun x vitest run` project schema, projects, policy, and view suites: 39 pass, including new coverage for accept, zero cap, display mismatch, smuggled field, fake commitment, enabled-ahead-of-pool, and external-prize-share rejection
- `bun run test`: 95 pass, 1 fail. The failure is the pre-existing skill-tests ccusage case that fails on pristine `develop` in my environment, disclosed previously in #287 and #289.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
