### PR TITLE
feat(site): official X, LinkedIn, and Telegram links in the footer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -68,6 +68,9 @@ import { formatThirds, selectReviewerLeaders } from "./lib/reviewer-leaders";
 import { feeForPrincipal, PLATFORM_FEE_BASIS_POINTS } from "./lib/rewards";
 
 const SOURCE_REPOSITORY = "https://github.com/SlopDotCash/slopdotcash";
+const SOCIAL_X = "https://x.com/SlopCash";
+const SOCIAL_LINKEDIN = "https://www.linkedin.com/company/slop-cash";
+const SOCIAL_TELEGRAM = "https://t.me/slopcashofficial";
 const PROJECT_PROPOSAL_ROOT = `${SOURCE_REPOSITORY}/new/develop`;
 const SNAPSHOT_TIMEOUT_MS = 12_000;
 const FUNDING_TIMEOUT_MS = 12_000;
@@ -513,6 +516,13 @@ function Footer() {
           <Link href="/projects/new">Add a project</Link>
           <ExternalLinkAnchor href={SOURCE_REPOSITORY}>
             GitHub
+          </ExternalLinkAnchor>
+          <ExternalLinkAnchor href={SOCIAL_X}>X</ExternalLinkAnchor>
+          <ExternalLinkAnchor href={SOCIAL_LINKEDIN}>
+            LinkedIn
+          </ExternalLinkAnchor>
+          <ExternalLinkAnchor href={SOCIAL_TELEGRAM}>
+            Telegram
           </ExternalLinkAnchor>
         </div>
         <p className="footer-fine">

--- a/src/styles.css
+++ b/src/styles.css
@@ -961,6 +961,7 @@ small {
 
 .footer-links {
   display: flex;
+  flex-wrap: wrap;
   gap: 24px;
   font-size: 12px;
   font-weight: 600;


### PR DESCRIPTION
Adds the three official Slop Cash social profiles to the footer links column next to the existing GitHub link, on every page including the home page:

- X: https://x.com/SlopCash
- LinkedIn: https://www.linkedin.com/company/slop-cash
- Telegram: https://t.me/slopcashofficial

Links use the existing `ExternalLinkAnchor` (new tab, `rel=noreferrer`). `footer-links` gains `flex-wrap` so the longer row cannot overflow at narrow desktop widths; the existing mobile breakpoint already stacks the column. 11 lines, no logic changes.

## Verification

- `bun run typecheck`, `bun run lint:check`, `bun run format:check`: pass
- `bun x vitest run tests/`: 69 pass
- Dev-server DOM check: all six footer links present with exact hrefs, zero console errors
- Screenshots (hosted on fork branch `evidence/footer-social-links`, same pattern as #289):

Desktop:

![footer desktop](https://raw.githubusercontent.com/drew-dot-com/slopdotcash/0cf90acad356ff0fd5f481331de995dc7e3c9118/footer-desktop.png)

Mobile (375px):

![footer mobile](https://raw.githubusercontent.com/drew-dot-com/slopdotcash/0cf90acad356ff0fd5f481331de995dc7e3c9118/footer-mobile.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
