### PR TITLE
fix(ci): serialize trusted leaderboard refreshes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,6 +36,11 @@ jobs:
   quality:
     name: Skill, data, build, and browser checks
     runs-on: ubuntu-24.04
+    concurrency:
+      # A newer trusted revision supersedes stale live-data generation, while
+      # each pull request retains its own independently superseding lane.
+      group: slop-quality-${{ github.event.pull_request.number || 'trusted' }}
+      cancel-in-progress: true
     # The public elizaOS ledger can contain several thousand accepted outcomes.
     # Leave room for complete fail-closed hydration plus four browser projects.
     timeout-minutes: 180

--- a/scripts/deployment-contract.test.mjs
+++ b/scripts/deployment-contract.test.mjs
@@ -343,6 +343,10 @@ describe("slop.cash deployment contract", () => {
     expect(workflow).toContain(
       `group: slop-${"$"}{{ github.event.pull_request.number || github.run_id }}`,
     );
+    expect(qualityJob).toContain(
+      `group: slop-quality-${"$"}{{ github.event.pull_request.number || 'trusted' }}`,
+    );
+    expect(qualityJob).toContain("cancel-in-progress: true");
     expect(deployJob).toContain(
       "github.event_name == 'push' && github.ref == 'refs/heads/develop'",
     );

--- a/scripts/generate-leaderboard.test.ts
+++ b/scripts/generate-leaderboard.test.ts
@@ -1112,6 +1112,31 @@ describe("GitHub GraphQL boundary", () => {
     expect(client.getRateLimit().consumedDuringRun).toBe(1_350);
   });
 
+  it("uses the reported capacity of a 5,000-point Actions token", async () => {
+    let attempts = 0;
+    const fetcher = async () => {
+      attempts += 1;
+      return successResponse(
+        { viewer: { login: "eliza" } },
+        {
+          cost: 500,
+          limit: 5_000,
+          remaining: 5_000 - attempts * 500,
+          resetAt: "2026-07-30T13:00:00.000Z",
+        },
+      );
+    };
+    const client = new GitHubGraphqlClient("actions-token", fetcher);
+
+    await expect(
+      client.execute("query { viewer { login } }"),
+    ).resolves.toBeDefined();
+    await expect(
+      client.execute("query { viewer { login } }"),
+    ).resolves.toBeDefined();
+    expect(client.getRateLimit().consumedDuringRun).toBe(1_000);
+  });
+
   it("does not call the writer after live generation fails", async () => {
     const write = vi.fn(async (_snapshot: LeaderboardSnapshot) => undefined);
     const generate = vi.fn(async () => {

--- a/scripts/generate-leaderboard.ts
+++ b/scripts/generate-leaderboard.ts
@@ -60,9 +60,10 @@ export const MAX_GRAPHQL_REQUEST_ATTEMPTS = 5;
 // retries even though the successful query itself is inexpensive.
 export const GRAPHQL_REQUEST_TIMEOUT_MS = 60_000;
 export const MAX_GRAPHQL_RESPONSE_BYTES = 64 * 1024 * 1024;
-// Match the usable budget of GitHub Actions' 1,000-point repository token so a
-// local 5,000-point token cannot validate a query plan that production rejects.
-export const MAX_GENERATION_COST = 900;
+// Permit the usable portion of a 5,000-point token while preserving the same
+// 100-point reserve on lower-limit tokens. The effective cap is always bounded
+// by the limit GitHub reports, so a 1,000-point token still stops at 900.
+export const MAX_GENERATION_COST = 4_900;
 export const MINIMUM_RATE_LIMIT_RESERVE = 100;
 export const MINIMUM_STARTING_RATE_LIMIT = 900;
 export const MAX_EVIDENCE_ARTIFACTS_PER_SNAPSHOT = 64;


### PR DESCRIPTION
## Summary
- use the capacity GitHub reports for 5,000-point tokens while retaining the 100-point reserve and the existing 900-point effective cap for 1,000-point tokens
- serialize trusted quality jobs so a newer develop revision cancels stale live-data generation without canceling an older deployment that is already awaiting environment review
- lock both behaviors with generator and deployment-contract tests

## Evidence
Production run 33592890637 failed with `GitHub GraphQL safety budget exceeded (902/900 points consumed in the current window, 2968 remaining; reserve 100)` while hydrating the expanded 683-PR open inventory. Several trusted runs were crawling the same live inventory concurrently.

## Tests
- `bunx vitest run scripts/generate-leaderboard.test.ts scripts/deployment-contract.test.mjs --config vitest.config.ts` (79 passed)
- `bun run typecheck`
- `bun run format:check`
- `bun run lint:check`