### PR TITLE
fix(scoring): hydrate evaluated review sources

### DIFF
--- a/scripts/generate-leaderboard.test.ts
+++ b/scripts/generate-leaderboard.test.ts
@@ -18,6 +18,7 @@ import {
 import {
   assertOpenEvidenceReferencesCurrent,
   assertReviewCensusStable,
+  collectEvaluatedReviewArtifactKeys,
   collectReviewedPullRequestIds,
   collectSearchReferences,
   deriveCurrentHeadReviewDecision,
@@ -68,6 +69,36 @@ describe("generation arguments", () => {
 });
 
 describe("historical evaluator awards", () => {
+  it("selects reviewed pull requests that need exact evaluated-source hydration", () => {
+    const source = {
+      id: "PRR_1",
+      kind: "review" as const,
+      number: 25372,
+      title: "Durable cancellation",
+      url: "https://github.com/elizaOS/eliza/pull/25372#pullrequestreview-1",
+    };
+
+    expect(
+      collectEvaluatedReviewArtifactKeys([
+        {
+          category: "evaluated-contribution",
+          repository: "elizaOS/eliza",
+          source,
+        },
+        {
+          category: "substantive-review",
+          repository: "elizaOS/eliza",
+          source,
+        },
+        {
+          category: "evaluated-contribution",
+          repository: "elizaOS/eliza",
+          source: { ...source, kind: "comment" },
+        },
+      ]),
+    ).toEqual(new Set(["elizaos/eliza\u000025372"]));
+  });
+
   it("selects only awards in the cutoff's rolling window", () => {
     const events = [
       {

--- a/scripts/generate-leaderboard.ts
+++ b/scripts/generate-leaderboard.ts
@@ -226,6 +226,23 @@ export interface GenerateOptions {
   evaluatedContributions?: ScoreEvent[];
 }
 
+export function collectEvaluatedReviewArtifactKeys(
+  events: ReadonlyArray<Pick<ScoreEvent, "category" | "repository" | "source">>,
+): Set<string> {
+  return new Set(
+    events
+      .filter(
+        (event) =>
+          event.category === "evaluated-contribution" &&
+          event.source.kind === "review",
+      )
+      .map(
+        (event) =>
+          `${event.repository.toLowerCase()}\u0000${event.source.number}`,
+      ),
+  );
+}
+
 export interface GeneratorDependencies {
   getToken: () => Promise<string>;
   createClient: (token: string) => GraphqlExecutor;
@@ -3311,17 +3328,28 @@ export async function generateLeaderboardFromGitHub(
     hydrationCandidates,
     verificationWindowFrom,
   );
+  const evaluatedReviewArtifactKeys = collectEvaluatedReviewArtifactKeys(
+    options.evaluatedContributions ?? [],
+  );
   const finalReviewCensusCost = Math.ceil(
     hydrationCandidates.length / REVIEW_DETAIL_BATCH_SIZE,
   );
   for (const collection of collections) {
     const detailedReferences = collection.mergedPullRequestReferences.filter(
-      (reference) => hydrationPlan.detailEligibleIds.has(reference.id),
+      (reference) =>
+        hydrationPlan.detailEligibleIds.has(reference.id) ||
+        (reference.outcome !== null &&
+          evaluatedReviewArtifactKeys.has(
+            `${collection.repository.id.toLowerCase()}\u0000${reference.outcome.number}`,
+          )),
+    );
+    const detailedReferenceIds = new Set(
+      detailedReferences.map((reference) => reference.id),
     );
     const reviewedReferences = collection.mergedPullRequestReferences.filter(
       (reference) =>
         hydrationPlan.hydratedIds.has(reference.id) &&
-        !hydrationPlan.detailEligibleIds.has(reference.id),
+        !detailedReferenceIds.has(reference.id),
     );
     await ensureEstimatedBudget(
       client,


### PR DESCRIPTION
## Summary
- fully hydrate only merged pull requests referenced by evaluated review awards
- keep ordinary review ingestion on the formal-decision fast path
- ensure evaluated `COMMENTED` reviews can be matched to their exact immutable GitHub source

## Evidence
Protected develop run 33595454799 completed the full crawl and then failed closed with `Evaluated contribution award_andreolf_review_25372 does not match its exact GitHub review`. Review #25372 is a valid GitHub `COMMENTED` review, which the optimized formal-review hydration path intentionally omitted.

## Tests
- `bunx vitest run scripts/generate-leaderboard.test.ts --config vitest.config.ts` (65 passed)
- `bun run typecheck`
- `bun run format:check`
- `bun run lint:check`