### PR TITLE
fix(scoring): apply verified review trace bonus

### DIFF
--- a/protocol/scoring-v2.md
+++ b/protocol/scoring-v2.md
@@ -65,7 +65,11 @@ private trace. Maintainers remain the sole scoring authority.
 ## Evidence bonuses
 
 A valid signed receipt with an outcome-matched finalized private trace adds a
-fixed 15% weight. Usage evidence remains diagnostic: token volume, confidence,
+fixed 15% weight. This applies equally to an ordinary qualifying formal review
+when its exact review source carries the same actor's valid receipt and the
+receipt is bound to the reviewed repository. A missing or invalid receipt
+removes only the bonus; it does not remove otherwise valid base review credit.
+Usage evidence remains diagnostic: token volume, confidence,
 cost, lines, commits, and account count never change score, rank, reward share,
 or payment. Missing pre-activation August traces do not reduce base credit. Runs
 after a project's receipt cutover must satisfy its active receipt policy or

--- a/src/lib/leaderboard.test.ts
+++ b/src/lib/leaderboard.test.ts
@@ -2361,6 +2361,91 @@ describe("scoring and limits", () => {
     );
   });
 
+  it("applies the finalized-trace bonus to an ordinary formal review", () => {
+    const reviewer = actor("legacy-receipt-reviewer");
+    const attributedBody = reviewAttribution({
+      schemaVersion: "2",
+      startedAt: "2026-08-18T21:00:00.000Z",
+      completedAt: "2026-08-18T22:00:00.000Z",
+      policyAcknowledgement: {
+        policyRevision: "2026-08-18.1",
+        licenseSha256:
+          "d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d",
+        inboundTermsSha256:
+          "15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469",
+        prizeRulesSha256: null,
+        acknowledgedAt: "2026-08-18T21:00:00.000Z",
+      },
+    }).replace(
+      /^Findings: none\.\n\n```slop-review\n[^\n]+\n```\n\n/u,
+      "This review reproduced the failure and verified the exact repair.\n\n",
+    );
+    const merged = pullRequest({
+      id: "PR_ORDINARY_REVIEW_TRACE",
+      number: 78,
+      createdAt: "2026-08-17T08:00:00.000Z",
+      updatedAt: "2026-08-18T23:00:00.000Z",
+      mergedAt: "2026-08-18T23:00:00.000Z",
+      reviews: [
+        {
+          id: "REVIEW_ORDINARY_TRACE",
+          body: attributedBody,
+          state: "APPROVED",
+          submittedAt: "2026-08-18T22:00:00.000Z",
+          url: "https://github.com/elizaOS/eliza/pull/78#pullrequestreview-780",
+          author: reviewer,
+          inlineCommentCount: 0,
+        },
+      ],
+    });
+    const ordinaryInput = v2Input([merged]);
+    ordinaryInput.generatedAt = "2026-08-19T00:01:00.000Z";
+    ordinaryInput.windowFrom = "2026-07-15T00:00:00.000Z";
+    ordinaryInput.windowTo = "2026-08-19T00:00:00.000Z";
+    ordinaryInput.sourceUpdatedAt = "2026-08-18T23:00:00.000Z";
+    ordinaryInput.source.fetchedAt = ordinaryInput.generatedAt;
+    ordinaryInput.source.cutoffAt = ordinaryInput.windowTo;
+    ordinaryInput.source.verificationWindow.from = ordinaryInput.windowFrom;
+    ordinaryInput.source.verificationWindow.to = ordinaryInput.windowTo;
+    ordinaryInput.verificationWindowFrom = ordinaryInput.windowFrom;
+    const accepted = createLeaderboardSnapshot({
+      ...ordinaryInput,
+      verifyRunReceipt: (value) => value as ProjectRunReceipt,
+    });
+    expect(accepted.invalidAttributionMarkers).toEqual([]);
+    expect(
+      accepted.ledger.find(
+        (event) => event.source.id === "REVIEW_ORDINARY_TRACE",
+      ),
+    ).toMatchObject({
+      category: "substantive-review",
+      scoreThirds: 3,
+      evidenceBonusBasisPoints: 1_500,
+    });
+    expect(accepted.attributions).toContainEqual(
+      expect.objectContaining({
+        sourceId: "REVIEW_ORDINARY_TRACE",
+        actor: reviewer,
+        run: expect.objectContaining({
+          runId: "run_01K3JZ6Y7E8M9N0P1Q2R3S4T5V",
+          traceUpload: expect.any(Object),
+        }),
+      }),
+    );
+
+    const rejectedReceipt = createLeaderboardSnapshot({
+      ...ordinaryInput,
+      verifyRunReceipt: () => {
+        throw new TypeError("signature verification failed");
+      },
+    });
+    expect(
+      rejectedReceipt.ledger.find(
+        (event) => event.source.id === "REVIEW_ORDINARY_TRACE",
+      )?.evidenceBonusBasisPoints ?? 0,
+    ).toBe(0);
+  });
+
   it("rejects a detail-eligible pull request that was not hydrated", () => {
     expect(() =>
       createLeaderboardSnapshot(

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -3547,12 +3547,29 @@ export function createLeaderboardSnapshot(
           `Qualifying review ${review.id} is missing its submitted timestamp`,
         );
       }
+      const reviewSource = sources.find(
+        (candidate) => candidate.id === review.id,
+      );
+      const reviewReceipt =
+        reviewSource && input.verifyRunReceipt
+          ? assessModelAttribution([reviewSource], {
+              requireEverySource: true,
+              verifyRunReceipt: input.verifyRunReceipt,
+            }).declarations.find(
+              (declaration) =>
+                declaration.sourceId === review.id &&
+                declaration.actor?.id === review.author?.id,
+            )?.run
+          : null;
       awardedReviewers.add(review.author.id);
       const scored = addScore(entries, ledger, {
         id: `${pullRequest.id}:reviewer:${review.author.id}`,
         actor: review.author,
         category: "substantive-review",
         points: 3,
+        ...(reviewReceipt?.traceUpload
+          ? { evidenceBonusBasisPoints: 1_500 as const }
+          : {}),
         occurredAt: review.submittedAt,
         repository: repositoryIdFromUrl(review.url),
         source: {
@@ -3566,9 +3583,8 @@ export function createLeaderboardSnapshot(
           "First qualifying substantive, non-self review submitted before merge.",
       });
       if (scored) {
-        const source = sources.find((candidate) => candidate.id === review.id);
-        if (source) {
-          recordScoredSources([source]);
+        if (reviewSource) {
+          recordScoredSources([reviewSource]);
         }
       } else {
         excludeReview(pullRequest, review, "reviewer-cycle-cap");


### PR DESCRIPTION
## Summary
- apply the published 15% evidence bonus to ordinary qualifying formal reviews only when a valid same-actor, exact-source, repository-bound finalized trace receipt exists
- preserve base review credit when attribution is missing or invalid
- document the eligibility boundary and add positive/negative regression coverage

Closes #280

## Validation
- `bun test src/lib/leaderboard.test.ts` (101 passed)
- `bun run verify` (passed)

Exact implementation commit: `bd370d4`