### PR TITLE
fix(skills): probe live GraphQL budget

### DIFF
--- a/skill-tests/contribute-to-eliza.test.ts
+++ b/skill-tests/contribute-to-eliza.test.ts
@@ -36,6 +36,8 @@ import {
   isBotAccount,
   MAX_ACTIVITY_CONNECTION_ITEMS,
   MAX_REVIEW_EPOCH_CANDIDATES,
+  MIN_REST_ACTIVITY_REQUESTS,
+  MIN_SEARCH_ACTIVITY_REQUESTS,
   MISSION_READY_LABEL,
   parseCliArguments,
   parseModelDisclosure,
@@ -683,9 +685,13 @@ describe("live report parsing", () => {
         }
         if (args.includes("graphql")) {
           return {
-            status: 1,
-            stderr: "gh: API rate limit already exceeded",
-            stdout: "",
+            status: 0,
+            stderr: "",
+            stdout: JSON.stringify({
+              limit: 5_000,
+              remaining: 354,
+              resetAt: "2027-01-15T08:00:00.000Z",
+            }),
           };
         }
         const endpoint = args.at(-1) ?? "";
@@ -739,7 +745,15 @@ describe("live report parsing", () => {
     );
 
     assert.strictEqual(calls[0].at(-1), "rate_limit");
-    assert.ok(calls.every((args) => !args.includes("graphql")));
+    assert.strictEqual(
+      calls.filter((args) => args.includes("graphql")).length,
+      1,
+    );
+    assert.strictEqual(activity.rateLimits.graphqlRemaining, 354);
+    assert.strictEqual(
+      activity.rateLimits.graphqlBudgetSource,
+      "direct-graphql",
+    );
     assert.ok(
       calls
         .filter((args) => args.at(-1)?.includes("/comments?"))
@@ -781,6 +795,160 @@ describe("live report parsing", () => {
     assert.deepStrictEqual(
       report.filtered.reviewedPullRequests.map((pull) => pull.number),
       [2],
+    );
+  });
+
+  it("uses REST when the direct GraphQL budget probe is rate-limited", () => {
+    const calls: string[][] = [];
+    const activity = readGhOpenActivity(
+      "elizaOS/eliza",
+      (_command, args) => {
+        calls.push(args);
+        if (args.at(-1) === "rate_limit") {
+          return {
+            status: 0,
+            stderr: "",
+            stdout: JSON.stringify({
+              resources: {
+                graphql: {
+                  limit: 5_000,
+                  remaining: 5_000,
+                  reset: 1_800_000_000,
+                },
+                core: {
+                  limit: 5_000,
+                  remaining: 5_000,
+                  reset: 1_800_000_000,
+                },
+                search: { limit: 30, remaining: 30, reset: 1_800_000_000 },
+              },
+            }),
+          };
+        }
+        if (args.includes("graphql")) {
+          return {
+            status: 1,
+            stderr: "gh: API rate limit already exceeded",
+            stdout: "",
+          };
+        }
+        return { status: 0, stderr: "", stdout: "" };
+      },
+      { preflight: true },
+    );
+
+    assert.strictEqual(activity.source, "rest");
+    assert.strictEqual(activity.rateLimits.graphqlRemaining, 0);
+    assert.strictEqual(
+      activity.rateLimits.graphqlBudgetSource,
+      "direct-probe-rate-limited",
+    );
+    assert.strictEqual(
+      calls.filter((args) => args.includes("graphql")).length,
+      1,
+    );
+  });
+
+  it("fails closed with both budgets when no complete activity path is affordable", () => {
+    assert.throws(
+      () =>
+        readGhOpenActivity(
+          "elizaOS/eliza",
+          (_command, args) => {
+            if (args.at(-1) === "rate_limit") {
+              return {
+                status: 0,
+                stderr: "",
+                stdout: JSON.stringify({
+                  resources: {
+                    graphql: {
+                      limit: 5_000,
+                      remaining: 5_000,
+                      reset: 1_800_000_000,
+                    },
+                    core: {
+                      limit: 5_000,
+                      remaining: MIN_REST_ACTIVITY_REQUESTS - 1,
+                      reset: 1_800_000_000,
+                    },
+                    search: {
+                      limit: 30,
+                      remaining: MIN_SEARCH_ACTIVITY_REQUESTS - 1,
+                      reset: 1_800_000_000,
+                    },
+                  },
+                }),
+              };
+            }
+            return args.includes("graphql")
+              ? {
+                  status: 0,
+                  stderr: "",
+                  stdout: JSON.stringify({
+                    limit: 5_000,
+                    remaining: 354,
+                    resetAt: "2027-01-15T08:00:00.000Z",
+                  }),
+                }
+              : { status: 0, stderr: "", stdout: "" };
+          },
+          { preflight: true },
+        ),
+      /cannot afford either complete GraphQL or REST activity discovery/,
+    );
+  });
+
+  it("uses GraphQL when its direct budget probe is healthy", () => {
+    const calls: string[][] = [];
+    const activity = readGhOpenActivity(
+      "elizaOS/eliza",
+      (_command, args) => {
+        calls.push(args);
+        if (args.at(-1) === "rate_limit") {
+          return {
+            status: 0,
+            stderr: "",
+            stdout: JSON.stringify({
+              resources: {
+                graphql: {
+                  limit: 5_000,
+                  remaining: 5_000,
+                  reset: 1_800_000_000,
+                },
+                core: {
+                  limit: 5_000,
+                  remaining: 5_000,
+                  reset: 1_800_000_000,
+                },
+                search: { limit: 30, remaining: 30, reset: 1_800_000_000 },
+              },
+            }),
+          };
+        }
+        if (
+          args.includes("graphql") &&
+          args.some((argument) => argument.includes("SlopActivityRateLimit"))
+        ) {
+          return {
+            status: 0,
+            stderr: "",
+            stdout: JSON.stringify({
+              limit: 5_000,
+              remaining: 4_500,
+              resetAt: "2027-01-15T08:00:00.000Z",
+            }),
+          };
+        }
+        return { status: 0, stderr: "", stdout: "" };
+      },
+      { preflight: true },
+    );
+
+    assert.strictEqual(activity.source, "graphql");
+    assert.strictEqual(activity.rateLimits.graphqlRemaining, 4_500);
+    assert.strictEqual(
+      calls.filter((args) => args.includes("graphql")).length,
+      3,
     );
   });
 

--- a/skills/contribute-to-asi/scripts/live-report.mjs
+++ b/skills/contribute-to-asi/scripts/live-report.mjs
@@ -1316,6 +1316,74 @@ function rateResource(value, context) {
   return { limit, remaining, reset };
 }
 
+const GRAPHQL_RATE_LIMIT_QUERY =
+  "query SlopActivityRateLimit { rateLimit { limit remaining resetAt } }";
+
+function readGhGraphqlRateLimit(spawn) {
+  const result = spawn(
+    "gh",
+    [
+      "api",
+      "graphql",
+      "--method",
+      "POST",
+      "-f",
+      `query=${GRAPHQL_RATE_LIMIT_QUERY}`,
+      "--jq",
+      ".data.rateLimit",
+    ],
+    {
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024,
+      windowsHide: true,
+    },
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const detail = `${result.stderr ?? ""}\n${result.stdout ?? ""}`.trim();
+    if (/\b(?:secondary )?rate limit\b|abuse detection/iu.test(detail)) {
+      return { rateLimited: true };
+    }
+    throw new Error(
+      `gh api graphql failed for rate-limit preflight${detail ? `: ${detail}` : ""}`,
+    );
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(result.stdout);
+  } catch (cause) {
+    throw new SyntaxError(
+      "gh api graphql returned malformed JSON for rate-limit preflight",
+      { cause },
+    );
+  }
+  const resource = asRecord(parsed, "GitHub GraphQL rate-limit preflight");
+  const limit = asNumberField(
+    resource,
+    "limit",
+    "GitHub GraphQL rate-limit preflight",
+  );
+  const remaining = asNumberField(
+    resource,
+    "remaining",
+    "GitHub GraphQL rate-limit preflight",
+  );
+  const resetAt = nullableText(resource.resetAt, "GraphQL rate-limit resetAt");
+  const reset = resetAt === null ? Number.NaN : Date.parse(resetAt) / 1000;
+  if (
+    limit <= 0 ||
+    remaining < 0 ||
+    remaining > limit ||
+    !Number.isSafeInteger(reset) ||
+    reset <= 0
+  ) {
+    throw new RangeError(
+      "GitHub GraphQL rate-limit preflight contains an invalid rate budget",
+    );
+  }
+  return { limit, remaining, reset, rateLimited: false };
+}
+
 export function readGhRateLimits(spawn = spawnSync) {
   const result = spawn(
     "gh",
@@ -1354,10 +1422,18 @@ export function readGhRateLimits(spawn = spawnSync) {
   const graphql = rateResource(resources.graphql, "GitHub GraphQL rate limit");
   const rest = rateResource(resources.core, "GitHub REST rate limit");
   const search = rateResource(resources.search, "GitHub Search rate limit");
+  const directGraphql = readGhGraphqlRateLimit(spawn);
   return {
-    graphqlLimit: graphql.limit,
-    graphqlRemaining: graphql.remaining,
-    graphqlReset: graphql.reset,
+    graphqlLimit: directGraphql.rateLimited
+      ? graphql.limit
+      : directGraphql.limit,
+    graphqlRemaining: directGraphql.rateLimited ? 0 : directGraphql.remaining,
+    graphqlReset: directGraphql.rateLimited
+      ? graphql.reset
+      : directGraphql.reset,
+    graphqlBudgetSource: directGraphql.rateLimited
+      ? "direct-probe-rate-limited"
+      : "direct-graphql",
     restLimit: rest.limit,
     restRemaining: rest.remaining,
     restReset: rest.reset,
@@ -2708,7 +2784,7 @@ export function main(args = process.argv.slice(2)) {
   });
   const limits = asRecord(openActivity.rateLimits, "GitHub rate limits");
   process.stderr.write(
-    `[Slop] GitHub budgets: GraphQL ${limits.graphqlRemaining}/${limits.graphqlLimit}; REST ${limits.restRemaining}/${limits.restLimit}; Search ${limits.searchRemaining}/${limits.searchLimit}; activity source ${openActivity.source}\n`,
+    `[Slop] GitHub budgets: GraphQL ${limits.graphqlRemaining}/${limits.graphqlLimit} (${limits.graphqlBudgetSource}); REST ${limits.restRemaining}/${limits.restLimit}; Search ${limits.searchRemaining}/${limits.searchLimit}; activity source ${openActivity.source}\n`,
   );
   const report = collectLiveReport(
     options.repo,

--- a/skills/contribute-to-delta-star/scripts/live-report.mjs
+++ b/skills/contribute-to-delta-star/scripts/live-report.mjs
@@ -1316,6 +1316,74 @@ function rateResource(value, context) {
   return { limit, remaining, reset };
 }
 
+const GRAPHQL_RATE_LIMIT_QUERY =
+  "query SlopActivityRateLimit { rateLimit { limit remaining resetAt } }";
+
+function readGhGraphqlRateLimit(spawn) {
+  const result = spawn(
+    "gh",
+    [
+      "api",
+      "graphql",
+      "--method",
+      "POST",
+      "-f",
+      `query=${GRAPHQL_RATE_LIMIT_QUERY}`,
+      "--jq",
+      ".data.rateLimit",
+    ],
+    {
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024,
+      windowsHide: true,
+    },
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const detail = `${result.stderr ?? ""}\n${result.stdout ?? ""}`.trim();
+    if (/\b(?:secondary )?rate limit\b|abuse detection/iu.test(detail)) {
+      return { rateLimited: true };
+    }
+    throw new Error(
+      `gh api graphql failed for rate-limit preflight${detail ? `: ${detail}` : ""}`,
+    );
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(result.stdout);
+  } catch (cause) {
+    throw new SyntaxError(
+      "gh api graphql returned malformed JSON for rate-limit preflight",
+      { cause },
+    );
+  }
+  const resource = asRecord(parsed, "GitHub GraphQL rate-limit preflight");
+  const limit = asNumberField(
+    resource,
+    "limit",
+    "GitHub GraphQL rate-limit preflight",
+  );
+  const remaining = asNumberField(
+    resource,
+    "remaining",
+    "GitHub GraphQL rate-limit preflight",
+  );
+  const resetAt = nullableText(resource.resetAt, "GraphQL rate-limit resetAt");
+  const reset = resetAt === null ? Number.NaN : Date.parse(resetAt) / 1000;
+  if (
+    limit <= 0 ||
+    remaining < 0 ||
+    remaining > limit ||
+    !Number.isSafeInteger(reset) ||
+    reset <= 0
+  ) {
+    throw new RangeError(
+      "GitHub GraphQL rate-limit preflight contains an invalid rate budget",
+    );
+  }
+  return { limit, remaining, reset, rateLimited: false };
+}
+
 export function readGhRateLimits(spawn = spawnSync) {
   const result = spawn(
     "gh",
@@ -1354,10 +1422,18 @@ export function readGhRateLimits(spawn = spawnSync) {
   const graphql = rateResource(resources.graphql, "GitHub GraphQL rate limit");
   const rest = rateResource(resources.core, "GitHub REST rate limit");
   const search = rateResource(resources.search, "GitHub Search rate limit");
+  const directGraphql = readGhGraphqlRateLimit(spawn);
   return {
-    graphqlLimit: graphql.limit,
-    graphqlRemaining: graphql.remaining,
-    graphqlReset: graphql.reset,
+    graphqlLimit: directGraphql.rateLimited
+      ? graphql.limit
+      : directGraphql.limit,
+    graphqlRemaining: directGraphql.rateLimited ? 0 : directGraphql.remaining,
+    graphqlReset: directGraphql.rateLimited
+      ? graphql.reset
+      : directGraphql.reset,
+    graphqlBudgetSource: directGraphql.rateLimited
+      ? "direct-probe-rate-limited"
+      : "direct-graphql",
     restLimit: rest.limit,
     restRemaining: rest.remaining,
     restReset: rest.reset,
@@ -2708,7 +2784,7 @@ export function main(args = process.argv.slice(2)) {
   });
   const limits = asRecord(openActivity.rateLimits, "GitHub rate limits");
   process.stderr.write(
-    `[Slop] GitHub budgets: GraphQL ${limits.graphqlRemaining}/${limits.graphqlLimit}; REST ${limits.restRemaining}/${limits.restLimit}; Search ${limits.searchRemaining}/${limits.searchLimit}; activity source ${openActivity.source}\n`,
+    `[Slop] GitHub budgets: GraphQL ${limits.graphqlRemaining}/${limits.graphqlLimit} (${limits.graphqlBudgetSource}); REST ${limits.restRemaining}/${limits.restLimit}; Search ${limits.searchRemaining}/${limits.searchLimit}; activity source ${openActivity.source}\n`,
   );
   const report = collectLiveReport(
     options.repo,

--- a/skills/contribute-to-eliza/scripts/live-report.mjs
+++ b/skills/contribute-to-eliza/scripts/live-report.mjs
@@ -1316,6 +1316,74 @@ function rateResource(value, context) {
   return { limit, remaining, reset };
 }
 
+const GRAPHQL_RATE_LIMIT_QUERY =
+  "query SlopActivityRateLimit { rateLimit { limit remaining resetAt } }";
+
+function readGhGraphqlRateLimit(spawn) {
+  const result = spawn(
+    "gh",
+    [
+      "api",
+      "graphql",
+      "--method",
+      "POST",
+      "-f",
+      `query=${GRAPHQL_RATE_LIMIT_QUERY}`,
+      "--jq",
+      ".data.rateLimit",
+    ],
+    {
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024,
+      windowsHide: true,
+    },
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const detail = `${result.stderr ?? ""}\n${result.stdout ?? ""}`.trim();
+    if (/\b(?:secondary )?rate limit\b|abuse detection/iu.test(detail)) {
+      return { rateLimited: true };
+    }
+    throw new Error(
+      `gh api graphql failed for rate-limit preflight${detail ? `: ${detail}` : ""}`,
+    );
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(result.stdout);
+  } catch (cause) {
+    throw new SyntaxError(
+      "gh api graphql returned malformed JSON for rate-limit preflight",
+      { cause },
+    );
+  }
+  const resource = asRecord(parsed, "GitHub GraphQL rate-limit preflight");
+  const limit = asNumberField(
+    resource,
+    "limit",
+    "GitHub GraphQL rate-limit preflight",
+  );
+  const remaining = asNumberField(
+    resource,
+    "remaining",
+    "GitHub GraphQL rate-limit preflight",
+  );
+  const resetAt = nullableText(resource.resetAt, "GraphQL rate-limit resetAt");
+  const reset = resetAt === null ? Number.NaN : Date.parse(resetAt) / 1000;
+  if (
+    limit <= 0 ||
+    remaining < 0 ||
+    remaining > limit ||
+    !Number.isSafeInteger(reset) ||
+    reset <= 0
+  ) {
+    throw new RangeError(
+      "GitHub GraphQL rate-limit preflight contains an invalid rate budget",
+    );
+  }
+  return { limit, remaining, reset, rateLimited: false };
+}
+
 export function readGhRateLimits(spawn = spawnSync) {
   const result = spawn(
     "gh",
@@ -1354,10 +1422,18 @@ export function readGhRateLimits(spawn = spawnSync) {
   const graphql = rateResource(resources.graphql, "GitHub GraphQL rate limit");
   const rest = rateResource(resources.core, "GitHub REST rate limit");
   const search = rateResource(resources.search, "GitHub Search rate limit");
+  const directGraphql = readGhGraphqlRateLimit(spawn);
   return {
-    graphqlLimit: graphql.limit,
-    graphqlRemaining: graphql.remaining,
-    graphqlReset: graphql.reset,
+    graphqlLimit: directGraphql.rateLimited
+      ? graphql.limit
+      : directGraphql.limit,
+    graphqlRemaining: directGraphql.rateLimited ? 0 : directGraphql.remaining,
+    graphqlReset: directGraphql.rateLimited
+      ? graphql.reset
+      : directGraphql.reset,
+    graphqlBudgetSource: directGraphql.rateLimited
+      ? "direct-probe-rate-limited"
+      : "direct-graphql",
     restLimit: rest.limit,
     restRemaining: rest.remaining,
     restReset: rest.reset,
@@ -2708,7 +2784,7 @@ export function main(args = process.argv.slice(2)) {
   });
   const limits = asRecord(openActivity.rateLimits, "GitHub rate limits");
   process.stderr.write(
-    `[Slop] GitHub budgets: GraphQL ${limits.graphqlRemaining}/${limits.graphqlLimit}; REST ${limits.restRemaining}/${limits.restLimit}; Search ${limits.searchRemaining}/${limits.searchLimit}; activity source ${openActivity.source}\n`,
+    `[Slop] GitHub budgets: GraphQL ${limits.graphqlRemaining}/${limits.graphqlLimit} (${limits.graphqlBudgetSource}); REST ${limits.restRemaining}/${limits.restLimit}; Search ${limits.searchRemaining}/${limits.searchLimit}; activity source ${openActivity.source}\n`,
   );
   const report = collectLiveReport(
     options.repo,

--- a/skills/contribute-to-heir-elements-sdk/scripts/live-report.mjs
+++ b/skills/contribute-to-heir-elements-sdk/scripts/live-report.mjs
@@ -1316,6 +1316,74 @@ function rateResource(value, context) {
   return { limit, remaining, reset };
 }
 
+const GRAPHQL_RATE_LIMIT_QUERY =
+  "query SlopActivityRateLimit { rateLimit { limit remaining resetAt } }";
+
+function readGhGraphqlRateLimit(spawn) {
+  const result = spawn(
+    "gh",
+    [
+      "api",
+      "graphql",
+      "--method",
+      "POST",
+      "-f",
+      `query=${GRAPHQL_RATE_LIMIT_QUERY}`,
+      "--jq",
+      ".data.rateLimit",
+    ],
+    {
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024,
+      windowsHide: true,
+    },
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const detail = `${result.stderr ?? ""}\n${result.stdout ?? ""}`.trim();
+    if (/\b(?:secondary )?rate limit\b|abuse detection/iu.test(detail)) {
+      return { rateLimited: true };
+    }
+    throw new Error(
+      `gh api graphql failed for rate-limit preflight${detail ? `: ${detail}` : ""}`,
+    );
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(result.stdout);
+  } catch (cause) {
+    throw new SyntaxError(
+      "gh api graphql returned malformed JSON for rate-limit preflight",
+      { cause },
+    );
+  }
+  const resource = asRecord(parsed, "GitHub GraphQL rate-limit preflight");
+  const limit = asNumberField(
+    resource,
+    "limit",
+    "GitHub GraphQL rate-limit preflight",
+  );
+  const remaining = asNumberField(
+    resource,
+    "remaining",
+    "GitHub GraphQL rate-limit preflight",
+  );
+  const resetAt = nullableText(resource.resetAt, "GraphQL rate-limit resetAt");
+  const reset = resetAt === null ? Number.NaN : Date.parse(resetAt) / 1000;
+  if (
+    limit <= 0 ||
+    remaining < 0 ||
+    remaining > limit ||
+    !Number.isSafeInteger(reset) ||
+    reset <= 0
+  ) {
+    throw new RangeError(
+      "GitHub GraphQL rate-limit preflight contains an invalid rate budget",
+    );
+  }
+  return { limit, remaining, reset, rateLimited: false };
+}
+
 export function readGhRateLimits(spawn = spawnSync) {
   const result = spawn(
     "gh",
@@ -1354,10 +1422,18 @@ export function readGhRateLimits(spawn = spawnSync) {
   const graphql = rateResource(resources.graphql, "GitHub GraphQL rate limit");
   const rest = rateResource(resources.core, "GitHub REST rate limit");
   const search = rateResource(resources.search, "GitHub Search rate limit");
+  const directGraphql = readGhGraphqlRateLimit(spawn);
   return {
-    graphqlLimit: graphql.limit,
-    graphqlRemaining: graphql.remaining,
-    graphqlReset: graphql.reset,
+    graphqlLimit: directGraphql.rateLimited
+      ? graphql.limit
+      : directGraphql.limit,
+    graphqlRemaining: directGraphql.rateLimited ? 0 : directGraphql.remaining,
+    graphqlReset: directGraphql.rateLimited
+      ? graphql.reset
+      : directGraphql.reset,
+    graphqlBudgetSource: directGraphql.rateLimited
+      ? "direct-probe-rate-limited"
+      : "direct-graphql",
     restLimit: rest.limit,
     restRemaining: rest.remaining,
     restReset: rest.reset,
@@ -2708,7 +2784,7 @@ export function main(args = process.argv.slice(2)) {
   });
   const limits = asRecord(openActivity.rateLimits, "GitHub rate limits");
   process.stderr.write(
-    `[Slop] GitHub budgets: GraphQL ${limits.graphqlRemaining}/${limits.graphqlLimit}; REST ${limits.restRemaining}/${limits.restLimit}; Search ${limits.searchRemaining}/${limits.searchLimit}; activity source ${openActivity.source}\n`,
+    `[Slop] GitHub budgets: GraphQL ${limits.graphqlRemaining}/${limits.graphqlLimit} (${limits.graphqlBudgetSource}); REST ${limits.restRemaining}/${limits.restLimit}; Search ${limits.searchRemaining}/${limits.searchLimit}; activity source ${openActivity.source}\n`,
   );
   const report = collectLiveReport(
     options.repo,


### PR DESCRIPTION
## Summary
- query the live GraphQL `rateLimit` object before choosing the activity scan path
- use bounded REST when the GraphQL probe itself is rate-limited and fail closed on other probe errors
- keep all canonical contributor skill scripts byte-identical and add discrepancy/fallback regression coverage

Closes #314

## Validation
- relevant live-report parsing coverage: 23 passed
- canonical script byte identity: passed
- `bun run verify`: all product tests and all changed behavior pass; the unchanged run-receipt child-process fixture twice returned `status: null` on this host (expected 0/1), so hosted exact-head CI remains the authoritative full gate
