### PR TITLE
fix(scoring): reject replayed review bonuses

### DIFF
--- a/src/lib/leaderboard.test.ts
+++ b/src/lib/leaderboard.test.ts
@@ -2444,6 +2444,46 @@ describe("scoring and limits", () => {
         (event) => event.source.id === "REVIEW_ORDINARY_TRACE",
       )?.evidenceBonusBasisPoints ?? 0,
     ).toBe(0);
+
+    const replayedReview = structuredClone(merged);
+    replayedReview.id = "PR_ORDINARY_REVIEW_TRACE_REPLAY";
+    replayedReview.number = 79;
+    replayedReview.url = "https://github.com/elizaOS/eliza/pull/79";
+    replayedReview.createdAt = "2026-08-17T09:00:00.000Z";
+    replayedReview.updatedAt = "2026-08-18T23:30:00.000Z";
+    replayedReview.mergedAt = "2026-08-18T23:30:00.000Z";
+    replayedReview.reviews[0].id = "REVIEW_ORDINARY_TRACE_REPLAY";
+    replayedReview.reviews[0].url =
+      "https://github.com/elizaOS/eliza/pull/79#pullrequestreview-790";
+    const replayInput = v2Input([merged, replayedReview]);
+    replayInput.generatedAt = ordinaryInput.generatedAt;
+    replayInput.windowFrom = ordinaryInput.windowFrom;
+    replayInput.windowTo = ordinaryInput.windowTo;
+    replayInput.sourceUpdatedAt = replayedReview.updatedAt;
+    replayInput.source.fetchedAt = replayInput.generatedAt;
+    replayInput.source.cutoffAt = replayInput.windowTo;
+    replayInput.source.verificationWindow.from = replayInput.windowFrom;
+    replayInput.source.verificationWindow.to = replayInput.windowTo;
+    replayInput.verificationWindowFrom = replayInput.windowFrom;
+    const replayed = createLeaderboardSnapshot({
+      ...replayInput,
+      verifyRunReceipt: (value) => value as ProjectRunReceipt,
+    });
+    const replayEvents = replayed.ledger.filter(
+      (event) =>
+        event.source.id === "REVIEW_ORDINARY_TRACE" ||
+        event.source.id === "REVIEW_ORDINARY_TRACE_REPLAY",
+    );
+    expect(replayEvents).toHaveLength(2);
+    expect(
+      replayEvents.filter((event) => event.evidenceBonusBasisPoints === 1_500),
+    ).toHaveLength(1);
+    expect(replayed.invalidAttributionMarkers).toContainEqual(
+      expect.objectContaining({
+        sourceId: "REVIEW_ORDINARY_TRACE",
+        reason: expect.stringContaining("already claimed"),
+      }),
+    );
   });
 
   it("rejects a detail-eligible pull request that was not hydrated", () => {

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -642,6 +642,21 @@ export interface LeaderboardInput {
   verifyRunReceipt?: (value: unknown) => ProjectRunReceipt;
 }
 
+function exactEvidenceBonusRun(
+  event: ScoreEvent,
+  attributions: readonly ModelAttribution[],
+): ProjectRunReceipt | null {
+  return (
+    attributions.find(
+      (attribution) =>
+        attribution.actor?.id === event.actor.id &&
+        (attribution.artifactId === event.source.id ||
+          attribution.sourceId === event.source.id) &&
+        attribution.run !== null,
+    )?.run ?? null
+  );
+}
+
 const EVIDENCE_WEIGHTS: Record<EvidenceCategory, number> = {
   screenshot: 1,
   video: 2,
@@ -3664,6 +3679,19 @@ export function createLeaderboardSnapshot(
     },
   );
   const attributions = overallAttribution.declarations;
+  // A receipt can look valid when a review is assessed in isolation but be
+  // rejected by the snapshot-wide replay guard because another scored source
+  // already claimed the same client run, server run, or trace object. Preserve
+  // the base review credit while removing any bonus that has no surviving
+  // exact public attribution.
+  for (const event of ledger) {
+    if (
+      (event.evidenceBonusBasisPoints ?? 0) > 0 &&
+      exactEvidenceBonusRun(event, attributions) === null
+    ) {
+      delete event.evidenceBonusBasisPoints;
+    }
+  }
   for (const attribution of attributions) {
     if (attribution.actor && !isBotActor(attribution.actor)) {
       actorEntry(entries, attribution.actor).models.add(attribution.identifier);
@@ -5533,13 +5561,7 @@ export function assertLeaderboardSnapshot(
   for (const event of validatedLedger) {
     const publishedBonus = event.evidenceBonusBasisPoints ?? 0;
     if (publishedBonus === 0) continue;
-    const matchingRun = validatedAttributions.find(
-      (attribution) =>
-        attribution.actor?.id === event.actor.id &&
-        (attribution.artifactId === event.source.id ||
-          attribution.sourceId === event.source.id) &&
-        attribution.run !== null,
-    )?.run;
+    const matchingRun = exactEvidenceBonusRun(event, validatedAttributions);
     const legacyUsageBonusPolicy =
       Date.parse(snapshot.generatedAt) <
       Date.parse(USAGE_NEUTRAL_EVIDENCE_POLICY_AT);


### PR DESCRIPTION
## Summary
- preserve ordinary base review credit while removing a trace bonus if snapshot-wide replay validation rejects that source receipt
- share the exact bonus-to-attribution join between generation and published-snapshot validation
- add a regression with one signed trace replayed across two formal reviews

Follow-up to #315 / #280.

## Failure reproduced
Final post-merge develop run [33628914293](https://github.com/SlopDotCash/slopdotcash/actions/runs/33628914293) rejected event `PR_kwDOT23CXM7_oQS5:reviewer:MDQ6VXNlcjMxODE2MzUy` because the isolated review assessment granted a bonus before the global receipt-replay guard removed its attribution.

## Validation
- `bun test src/lib/leaderboard.test.ts` (101 passed)
- `git diff --check`
