### PR TITLE
Preserve accepted review history after GitHub deletion

### DIFF
--- a/data/accepted-review-history.json
+++ b/data/accepted-review-history.json
@@ -1,0 +1,61 @@
+{
+  "schemaVersion": "1",
+  "events": [
+    {
+      "id": "PR_kwDOMT5cIs8AAAABAr9NwA:reviewer:U_kgDOCzScNQ",
+      "actor": {
+        "id": "U_kgDOCzScNQ",
+        "login": "mashingaan",
+        "avatarUrl": "https://avatars.githubusercontent.com/u/187997237?v=4",
+        "url": "https://github.com/mashingaan",
+        "kind": "User"
+      },
+      "category": "substantive-review",
+      "points": 1,
+      "occurredAt": "2026-08-23T11:10:49Z",
+      "repository": "elizaOS/eliza",
+      "source": {
+        "id": "PRR_kwDOMT5cIs8AAAABKig2Kw",
+        "kind": "review",
+        "number": 25187,
+        "title": "test(app-core): cover electrobun window construction",
+        "url": "https://github.com/elizaOS/eliza/pull/25187#pullrequestreview-5002245675"
+      },
+      "reason": "First qualifying substantive, non-self review submitted before merge.",
+      "continuity": {
+        "sourceSnapshotSha256": "5a76b7754a1522e19270814163bee78c39805a35cd0edb947f1418a9d306ddc9",
+        "decisionUrl": "https://github.com/SlopDotCash/slopdotcash/issues/313"
+      },
+      "scoreThirds": 3,
+      "workUnitId": "wu_eliza_prr_kwdomt5cis8aaaabkig2kw"
+    },
+    {
+      "id": "PR_kwDOMT5cIs8AAAABAr93Yg:reviewer:U_kgDOCzScNQ",
+      "actor": {
+        "id": "U_kgDOCzScNQ",
+        "login": "mashingaan",
+        "avatarUrl": "https://avatars.githubusercontent.com/u/187997237?v=4",
+        "url": "https://github.com/mashingaan",
+        "kind": "User"
+      },
+      "category": "substantive-review",
+      "points": 1,
+      "occurredAt": "2026-08-23T11:22:35Z",
+      "repository": "elizaOS/eliza",
+      "source": {
+        "id": "PRR_kwDOMT5cIs8AAAABKiiDoA",
+        "kind": "review",
+        "number": 25197,
+        "title": "test(core): cover canonical model capability gating",
+        "url": "https://github.com/elizaOS/eliza/pull/25197#pullrequestreview-5002265504"
+      },
+      "reason": "First qualifying substantive, non-self review submitted before merge.",
+      "continuity": {
+        "sourceSnapshotSha256": "5a76b7754a1522e19270814163bee78c39805a35cd0edb947f1418a9d306ddc9",
+        "decisionUrl": "https://github.com/SlopDotCash/slopdotcash/issues/313"
+      },
+      "scoreThirds": 3,
+      "workUnitId": "wu_eliza_prr_kwdomt5cis8aaaabkiidoa"
+    }
+  ]
+}

--- a/scripts/generate-leaderboard.ts
+++ b/scripts/generate-leaderboard.ts
@@ -5,6 +5,7 @@
  * becoming a plausible-looking empty snapshot.
  */
 
+import { readFileSync } from "node:fs";
 import { mkdir, rename, rm } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -77,6 +78,27 @@ export const DEFAULT_OUTPUT_PATH = resolve(
   dirname(fileURLToPath(import.meta.url)),
   "../public/data/leaderboard.json",
 );
+const ACCEPTED_REVIEW_HISTORY_PATH = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../data/accepted-review-history.json",
+);
+
+function loadAcceptedReviewHistory(): ScoreEvent[] {
+  const value = JSON.parse(
+    readFileSync(ACCEPTED_REVIEW_HISTORY_PATH, "utf8"),
+  ) as unknown;
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    Array.isArray(value) ||
+    (value as { schemaVersion?: unknown }).schemaVersion !== "1" ||
+    !Array.isArray((value as { events?: unknown }).events) ||
+    Object.keys(value).sort().join("\0") !== "events\0schemaVersion"
+  ) {
+    throw new TypeError("accepted review history manifest is invalid");
+  }
+  return (value as { events: ScoreEvent[] }).events;
+}
 
 type JsonRecord = Record<string, unknown>;
 type GraphqlVariables = Record<
@@ -224,6 +246,7 @@ export interface GenerateOptions {
   evidenceToken?: string;
   evidenceTimeoutMs?: number;
   evaluatedContributions?: ScoreEvent[];
+  retainedReviewEvents?: ScoreEvent[];
 }
 
 export function collectEvaluatedReviewArtifactKeys(
@@ -3547,6 +3570,7 @@ export async function generateLeaderboardFromGitHub(
       now,
       actualNow,
     ),
+    retainedReviewEvents: options.retainedReviewEvents,
     verifyRunReceipt: verifyRunReceiptSignature,
   });
   return snapshot;
@@ -3599,6 +3623,7 @@ if (import.meta.main) {
   const snapshot = await runGenerator(DEFAULT_OUTPUT_PATH, undefined, {
     ...arguments_,
     evaluatedContributions: loadEvaluatorAwardEvents(),
+    retainedReviewEvents: loadAcceptedReviewHistory(),
     onProgress: (progress) => {
       const phaseChanged = progress.phase !== lastProgressPhase;
       lastProgressPhase = progress.phase;

--- a/src/lib/leaderboard.test.ts
+++ b/src/lib/leaderboard.test.ts
@@ -2640,6 +2640,94 @@ describe("scoring and limits", () => {
     );
   });
 
+  it("retains accepted formal review credit when GitHub deletes the parent pull request", () => {
+    const reviewer = actor("retained-reviewer");
+    const retained: ScoreEvent = {
+      id: "PR_deleted:reviewer:U_retained-reviewer",
+      actor: reviewer,
+      category: "substantive-review",
+      points: 3,
+      occurredAt: "2026-07-27T10:00:00.000Z",
+      repository: "elizaOS/eliza",
+      source: {
+        id: "PRR_deleted",
+        kind: "review",
+        number: 79,
+        title: "Deleted accepted contribution",
+        url: "https://github.com/elizaOS/eliza/pull/79#pullrequestreview-799",
+      },
+      reason: "Previously accepted review credit.",
+      continuity: {
+        sourceSnapshotSha256: "a".repeat(64),
+        decisionUrl: "https://github.com/SlopDotCash/slopdotcash/issues/313",
+      },
+    };
+
+    const snapshot = createLeaderboardSnapshot(
+      input({ retainedReviewEvents: [retained] }),
+    );
+
+    expect(snapshot.ledger).toContainEqual(retained);
+    expect(snapshot.leaders).toContainEqual(
+      expect.objectContaining({
+        actor: reviewer,
+        scoreThirds: 9,
+        pointThirds: expect.objectContaining({ substantiveReviews: 9 }),
+      }),
+    );
+  });
+
+  it("lets current GitHub evidence replace retained review history", () => {
+    const reviewer = actor("current-reviewer");
+    const review = {
+      id: "PRR_current",
+      body: "This review identifies a concrete release-blocking regression.",
+      state: "CHANGES_REQUESTED",
+      submittedAt: "2026-07-27T10:00:00.000Z",
+      url: "https://github.com/elizaOS/eliza/pull/79#pullrequestreview-799",
+      author: reviewer,
+      inlineCommentCount: 0,
+    };
+    const merged = pullRequest({
+      id: "PR_current",
+      number: 79,
+      reviews: [review],
+    });
+    const retained: ScoreEvent = {
+      id: `${merged.id}:reviewer:${reviewer.id}`,
+      actor: reviewer,
+      category: "substantive-review",
+      points: 3,
+      occurredAt: review.submittedAt,
+      repository: "elizaOS/eliza",
+      source: {
+        id: review.id,
+        kind: "review",
+        number: merged.number,
+        title: merged.title,
+        url: review.url,
+      },
+      reason: "Stale retained value.",
+    };
+
+    const snapshot = createLeaderboardSnapshot(
+      input({
+        mergedPullRequests: [merged],
+        retainedReviewEvents: [retained],
+      }),
+    );
+
+    expect(
+      snapshot.ledger.filter((event) => event.source.id === review.id),
+    ).toHaveLength(1);
+    expect(
+      snapshot.ledger.find((event) => event.source.id === review.id)?.points,
+    ).toBe(3);
+    expect(
+      snapshot.ledger.find((event) => event.source.id === review.id)?.reason,
+    ).not.toBe("Stale retained value.");
+  });
+
   it("scores accepted outcomes while capping evidence and reviews", () => {
     const reviewer = actor("reviewer");
     const evidenceBody = [

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -383,6 +383,10 @@ export interface ScoreEvent {
     url: string;
   };
   reason: string;
+  continuity?: {
+    sourceSnapshotSha256: string;
+    decisionUrl: string;
+  };
   evaluation?: {
     decisionUrl: string;
     reviewedAt: string;
@@ -639,6 +643,12 @@ export interface LeaderboardInput {
   verificationWindowFrom: string;
   verifiedEvidence: VerifiedEvidenceArtifact[];
   evaluatedContributions?: ScoreEvent[];
+  /**
+   * Previously published accepted review events. GitHub may delete a merged
+   * pull request and its reviews; only events whose parent outcome is absent
+   * are replayed, so live GitHub remains authoritative whenever it exists.
+   */
+  retainedReviewEvents?: ScoreEvent[];
   verifyRunReceipt?: (value: unknown) => ProjectRunReceipt;
 }
 
@@ -3651,6 +3661,54 @@ export function createLeaderboardSnapshot(
     }
   }
 
+  const currentLedgerIds = new Set(ledger.map((event) => event.id));
+  const currentScoreSources = new Set(
+    ledger.map((event) => `${event.repository}\0${event.source.id}`),
+  );
+  for (const [index, event] of [...(input.retainedReviewEvents ?? [])]
+    .sort(
+      (left, right) =>
+        parseIsoTime(right.occurredAt) - parseIsoTime(left.occurredAt) ||
+        left.id.localeCompare(right.id),
+    )
+    .entries()) {
+    assertLedgerValue(event, `retainedReviewEvents[${index}]`);
+    if (
+      event.category !== "substantive-review" ||
+      !isRecord(event.source) ||
+      (event.source as Record<string, unknown>).kind !== "review"
+    ) {
+      throw new TypeError(
+        `retainedReviewEvents[${index}] must be a formal substantive review`,
+      );
+    }
+    const parentPullRequestId = event.id.split(":", 1)[0];
+    if (!parentPullRequestId.startsWith("PR_")) {
+      throw new TypeError(
+        `retainedReviewEvents[${index}] does not bind a pull request node`,
+      );
+    }
+    const occurredAt = parseIsoTime(event.occurredAt);
+    if (
+      occurredAt < parseIsoTime(input.windowFrom) ||
+      occurredAt >= windowTo ||
+      outcomeIds.has(parentPullRequestId) ||
+      currentLedgerIds.has(event.id) ||
+      currentScoreSources.has(`${event.repository}\0${event.source.id}`)
+    ) {
+      continue;
+    }
+    const retained = { ...event };
+    // The historical event proves accepted base review credit. A trace bonus
+    // survives only when its attribution is independently present and replay
+    // checked in the current snapshot.
+    delete retained.evidenceBonusBasisPoints;
+    if (addScore(entries, ledger, retained)) {
+      currentLedgerIds.add(retained.id);
+      currentScoreSources.add(`${retained.repository}\0${retained.source.id}`);
+    }
+  }
+
   const issueQueue = openIssues.map((record) =>
     issueWorkItem(record, input.generatedAt),
   );
@@ -4811,6 +4869,44 @@ function assertLedgerValue(
   }
   assertIsoTimestamp(event.occurredAt, `${path}.occurredAt`);
   assertString(event.reason, `${path}.reason`);
+  if ("continuity" in event) {
+    if (
+      event.category !== "substantive-review" ||
+      !isRecord(event.source) ||
+      (event.source as Record<string, unknown>).kind !== "review"
+    ) {
+      throw new Error(`${path}.continuity is reserved for retained reviews`);
+    }
+    const continuity = assertObject(event.continuity, `${path}.continuity`);
+    if (
+      Object.keys(continuity).sort().join("\0") !==
+      "decisionUrl\0sourceSnapshotSha256"
+    ) {
+      throw new Error(`${path}.continuity has unexpected or missing fields`);
+    }
+    assertString(
+      continuity.sourceSnapshotSha256,
+      `${path}.continuity.sourceSnapshotSha256`,
+    );
+    if (!/^[0-9a-f]{64}$/u.test(continuity.sourceSnapshotSha256)) {
+      throw new Error(`${path}.continuity source digest is invalid`);
+    }
+    assertString(continuity.decisionUrl, `${path}.continuity.decisionUrl`);
+    const decisionUrl = secureUrl(
+      continuity.decisionUrl,
+      `${path}.continuity.decisionUrl`,
+    );
+    if (
+      decisionUrl.hostname !== "github.com" ||
+      !/^\/SlopDotCash\/slopdotcash\/issues\/[1-9]\d*$/u.test(
+        decisionUrl.pathname,
+      ) ||
+      decisionUrl.search ||
+      decisionUrl.hash
+    ) {
+      throw new Error(`${path}.continuity decision URL is invalid`);
+    }
+  }
   assertEnum(
     event.repository,
     TARGET_REPOSITORIES.map((repository) => repository.id),
@@ -5763,7 +5859,9 @@ export function assertLeaderboardSnapshot(
   );
   const reviewedPullRequestIds = new Set(
     validatedLedger
-      .filter((event) => event.category === "substantive-review")
+      .filter(
+        (event) => event.category === "substantive-review" && !event.continuity,
+      )
       .map(
         (event) =>
           event.id.split(/:(?:automated-review|ratifier|reviewer):/u)[0],


### PR DESCRIPTION
Closes #313.

## What changed
- adds an append-only, digest-bound continuity manifest for the two previously published accepted reviews whose upstream PR/review objects were deleted
- replays only formal substantive-review events whose parent PR is absent from the complete live GitHub outcome set
- gives current GitHub evidence precedence, deduplicates event/source IDs, strips unsupported historical trace bonuses, and marks retained rows with their source snapshot digest and public decision URL
- extends snapshot validation so retained history is transparent without pretending deleted parents were collected live
- adds regression tests for deletion recovery and live-source precedence

## Exact-head verification
Head: `1c5cfc658a5d`

- `bun run verify` — passed (67 files / 675 Vitest tests; 103 skill tests; build succeeded)
- focused generator + leaderboard suite — 168 passed
- `bun run typecheck` — passed
- `bun run lint:check` — passed with the repository's existing CSS specificity warnings only
- `bun run format:check` — passed
- `git diff --check` — passed
- `bun run test:e2e` — attempted; the local suite failed across unrelated baseline routes after the generated test server did not serve expected app state, so hosted exact-head E2E remains the authoritative browser gate

No current review award is replaced and no new award is created; this restores the exact one-point/three-thirds records that were already accepted and published in snapshot SHA-256 `5a76b7754a1522e19270814163bee78c39805a35cd0edb947f1418a9d306ddc9`.

AI provider/model: openai / gpt-5.6-sol
Client: codex
