### PR TITLE
Implement additive review budget accounting

### DIFF
--- a/protocol/review-budget-v1.md
+++ b/protocol/review-budget-v1.md
@@ -13,7 +13,9 @@ pledged, disabled, or underfunded review line is public context only and changes
 nothing. Allocation becomes operative only after a positive review amount has
 its own active, reviewed funding commitment and the manifest declares the line
 committed and enabled. Existing open and closed cycles are never changed
-retroactively.
+retroactively. `effectiveAt` must be the first instant of a future UTC month
+when the line is added or funded. The allocator applies the line only when that
+instant is at or before the cycle's opening boundary.
 
 Public surfaces show the committed amount and the monthly cap as separate
 values. Allocation may never exceed `committedMinor`, even when
@@ -27,6 +29,13 @@ The reward-level fee applies identically to approved review principal. Because
 both lines settle to the same registered wallet, the minimum-transfer rule is
 evaluated against each recipient's combined cycle total. Reporting must still
 publish shared-pool and additive-review amounts as distinct line items.
+
+Proposal and approved-allocation rows publish `lines.sharedPool` and
+`lines.reviewBudget`; aggregate fields remain their exact sum for backwards
+compatibility. The review line binds the accepted review event IDs used as its
+weights. Unsigned transfer plans and finalized settlement recipients preserve
+the same split while transferring the combined recipient total, so a line
+below the dust floor cannot strand an otherwise payable combined allocation.
 
 ## Evidence and settlement
 

--- a/scripts/check-project-transitions.d.mts
+++ b/scripts/check-project-transitions.d.mts
@@ -3,6 +3,7 @@ export type ProjectManifestEntry = readonly [path: string, bytes: string];
 export declare function validateProjectTransitions(
   previousEntries: readonly ProjectManifestEntry[],
   currentEntries: readonly ProjectManifestEntry[],
+  now?: number,
 ): { previous: number; current: number };
 
 export declare function checkProjectTransitions(

--- a/scripts/check-project-transitions.mjs
+++ b/scripts/check-project-transitions.mjs
@@ -77,7 +77,7 @@ function assertRootPublisherInventory(projects, label) {
   return true;
 }
 
-function assertReviewBudgetTransition(prior, next) {
+function assertReviewBudgetTransition(prior, next, now) {
   const priorBudget = prior.reward.reviewBudget;
   const nextBudget = next.reward.reviewBudget;
   if (!nextBudget) return;
@@ -94,9 +94,26 @@ function assertReviewBudgetTransition(prior, next) {
       `project ${next.id} cannot add or fund a review budget while reducing the contributor pool cap`,
     );
   }
+  if (addsReviewBudget || fundsReviewBudget) {
+    const instant = new Date(now);
+    const nextCycle = Date.UTC(
+      instant.getUTCFullYear(),
+      instant.getUTCMonth() + 1,
+      1,
+    );
+    if (Date.parse(nextBudget.effectiveAt) < nextCycle) {
+      throw new TypeError(
+        `project ${next.id} review budget cannot affect an open or past cycle`,
+      );
+    }
+  }
 }
 
-export function validateProjectTransitions(previousEntries, currentEntries) {
+export function validateProjectTransitions(
+  previousEntries,
+  currentEntries,
+  now = Date.now(),
+) {
   const previous = boundedProjectMap(previousEntries, { historical: true });
   const current = boundedProjectMap(currentEntries);
   const previousPublishesAtRoot = assertRootPublisherInventory(
@@ -115,7 +132,7 @@ export function validateProjectTransitions(previousEntries, currentEntries) {
       );
     }
     assertProjectPolicyTransition(prior, next);
-    assertReviewBudgetTransition(prior, next);
+    assertReviewBudgetTransition(prior, next, now);
   }
   if (previousPublishesAtRoot && !currentPublishesAtRoot) {
     throw new TypeError(

--- a/scripts/check-project-transitions.test.ts
+++ b/scripts/check-project-transitions.test.ts
@@ -109,6 +109,7 @@ describe("project transition gate", () => {
     const withPledgedReview = structuredClone(eliza) as typeof eliza & {
       reward: typeof eliza.reward & {
         reviewBudget: {
+          effectiveAt: string;
           monthlyCapMinor: string;
           monthlyCapDisplay: string;
           committedMinor: string;
@@ -119,6 +120,7 @@ describe("project transition gate", () => {
       };
     };
     withPledgedReview.reward.reviewBudget = {
+      effectiveAt: "2026-10-01T00:00:00.000Z",
       monthlyCapMinor: "50000000",
       monthlyCapDisplay: "$50",
       committedMinor: "0",
@@ -135,8 +137,22 @@ describe("project transition gate", () => {
     ).toThrow(/review budget.*reducing the contributor pool cap/u);
 
     expect(
-      validateProjectTransitions([entry(eliza)], [entry(withPledgedReview)]),
+      validateProjectTransitions(
+        [entry(eliza)],
+        [entry(withPledgedReview)],
+        Date.parse("2026-09-02T00:00:00.000Z"),
+      ),
     ).toEqual({ previous: 1, current: 1 });
+
+    const retroactive = structuredClone(withPledgedReview);
+    retroactive.reward.reviewBudget.effectiveAt = "2026-09-01T00:00:00.000Z";
+    expect(() =>
+      validateProjectTransitions(
+        [entry(eliza)],
+        [entry(retroactive)],
+        Date.parse("2026-09-02T00:00:00.000Z"),
+      ),
+    ).toThrow(/open or past cycle/u);
 
     const funded = structuredClone(withPledgedReview);
     funded.reward.paymentMode = "enabled";
@@ -166,7 +182,11 @@ describe("project transition gate", () => {
       },
     ];
     expect(() =>
-      validateProjectTransitions([entry(withPledgedReview)], [entry(funded)]),
+      validateProjectTransitions(
+        [entry(withPledgedReview)],
+        [entry(funded)],
+        Date.parse("2026-09-02T00:00:00.000Z"),
+      ),
     ).toThrow(/review budget.*reducing the contributor pool cap/u);
   });
 });

--- a/scripts/sync-cycle-index.ts
+++ b/scripts/sync-cycle-index.ts
@@ -175,6 +175,7 @@ async function verifyProposalAgainstSnapshot(
       allocation.actor.login !== expected.actor.login ||
       allocation.score !== expected.score ||
       allocation.suggestedMinor !== expected.suggestedMinor ||
+      canonical(allocation.lines) !== canonical(expected.lines) ||
       canonical(allocation.evidenceEventIds) !==
         canonical(expected.evidenceEventIds)
     ) {
@@ -189,6 +190,7 @@ async function verifyProposalAgainstSnapshot(
     proposal.contributionWindow.from !== baseline.contributionWindow.from ||
     proposal.contributionWindow.to !== baseline.contributionWindow.to ||
     proposal.capMinor !== baseline.capMinor ||
+    canonical(proposal.rewardLines) !== canonical(baseline.rewardLines) ||
     proposal.totals.suggestedMinor !== baseline.totals.suggestedMinor
   ) {
     throw new TypeError(
@@ -422,6 +424,20 @@ async function buildCycle(
   const settlementByIntent = new Map(
     settlement?.recipients.map((entry) => [entry.intentId, entry]) ?? [],
   );
+  const paidSharedPoolMinor = (
+    settlement?.recipients.reduce(
+      (total, entry) =>
+        total + BigInt(entry.rewardLines?.sharedPool.paidMinor ?? "0"),
+      0n,
+    ) ?? 0n
+  ).toString();
+  const paidReviewBudgetMinor = (
+    settlement?.recipients.reduce(
+      (total, entry) =>
+        total + BigInt(entry.rewardLines?.reviewBudget.paidMinor ?? "0"),
+      0n,
+    ) ?? 0n
+  ).toString();
   return {
     entry: {
       projectId,
@@ -441,6 +457,26 @@ async function buildCycle(
         paidMinor: settlement?.totals.paidMinor ?? "0",
         feeMinor: allocation?.totals.feeMinor ?? "0",
         sharePartsPerMillion: null,
+        ...(proposal.rewardLines
+          ? {
+              lines: {
+                sharedPool: {
+                  suggestedMinor:
+                    proposal.rewardLines.sharedPool.suggestedMinor,
+                  approvedMinor:
+                    allocation?.rewardLines?.sharedPool.approvedMinor ?? "0",
+                  paidMinor: paidSharedPoolMinor,
+                },
+                reviewBudget: {
+                  suggestedMinor:
+                    proposal.rewardLines.reviewBudget.suggestedMinor,
+                  approvedMinor:
+                    allocation?.rewardLines?.reviewBudget.approvedMinor ?? "0",
+                  paidMinor: paidReviewBudgetMinor,
+                },
+              },
+            }
+          : {}),
       },
       contributors: proposal.allocations.map((entry) => {
         const approved = allocationByIntent.get(entry.intentId);
@@ -455,6 +491,24 @@ async function buildCycle(
           paidMinor: paid?.paidMinor ?? "0",
           sharePartsPerMillion: null,
           wallet: approved?.wallet ?? entry.wallet,
+          ...(entry.lines
+            ? {
+                lines: {
+                  sharedPool: {
+                    suggestedMinor: entry.lines.sharedPool.suggestedMinor,
+                    approvedMinor:
+                      approved?.lines?.sharedPool.approvedMinor ?? "0",
+                    paidMinor: paid?.rewardLines?.sharedPool.paidMinor ?? "0",
+                  },
+                  reviewBudget: {
+                    suggestedMinor: entry.lines.reviewBudget.suggestedMinor,
+                    approvedMinor:
+                      approved?.lines?.reviewBudget.approvedMinor ?? "0",
+                    paidMinor: paid?.rewardLines?.reviewBudget.paidMinor ?? "0",
+                  },
+                },
+              }
+            : {}),
         };
       }),
       files: {

--- a/scripts/verify-settlement.ts
+++ b/scripts/verify-settlement.ts
@@ -276,6 +276,20 @@ export async function verifySettlement(
           approvedMinor: row.approvedMinor,
           paidMinor: row.approvedMinor,
           state: "paid",
+          ...(row.lines
+            ? {
+                rewardLines: {
+                  sharedPool: {
+                    approvedMinor: row.lines.sharedPool.approvedMinor,
+                    paidMinor: row.lines.sharedPool.approvedMinor,
+                  },
+                  reviewBudget: {
+                    approvedMinor: row.lines.reviewBudget.approvedMinor,
+                    paidMinor: row.lines.reviewBudget.approvedMinor,
+                  },
+                },
+              }
+            : {}),
         })),
       attempts: evidence.attempts.map((attempt) => ({
         ...attempt,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2744,10 +2744,50 @@ function ArchivedCycleLeaderboard({ cycle }: { cycle: CycleIndexEntry }) {
                     </Link>
                   </th>
                   <td>{contributor.score}</td>
-                  <td>{formatMicroUsdc(contributor.suggestedMinor)}</td>
-                  <td>{formatMicroUsdc(contributor.approvedMinor)}</td>
+                  <td>
+                    {formatMicroUsdc(contributor.suggestedMinor)}
+                    {contributor.lines ? (
+                      <small>
+                        Pool{" "}
+                        {formatMicroUsdc(
+                          contributor.lines.sharedPool.suggestedMinor,
+                        )}{" "}
+                        + review{" "}
+                        {formatMicroUsdc(
+                          contributor.lines.reviewBudget.suggestedMinor,
+                        )}
+                      </small>
+                    ) : null}
+                  </td>
+                  <td>
+                    {formatMicroUsdc(contributor.approvedMinor)}
+                    {contributor.lines ? (
+                      <small>
+                        Pool{" "}
+                        {formatMicroUsdc(
+                          contributor.lines.sharedPool.approvedMinor,
+                        )}{" "}
+                        + review{" "}
+                        {formatMicroUsdc(
+                          contributor.lines.reviewBudget.approvedMinor,
+                        )}
+                      </small>
+                    ) : null}
+                  </td>
                   <td>
                     <strong>{formatMicroUsdc(contributor.paidMinor)}</strong>
+                    {contributor.lines ? (
+                      <small>
+                        Pool{" "}
+                        {formatMicroUsdc(
+                          contributor.lines.sharedPool.paidMinor,
+                        )}{" "}
+                        + review{" "}
+                        {formatMicroUsdc(
+                          contributor.lines.reviewBudget.paidMinor,
+                        )}
+                      </small>
+                    ) : null}
                   </td>
                 </tr>
               ))}
@@ -2884,6 +2924,16 @@ function CyclePage({
           </span>
         </div>
       </section>
+      {record?.reward.lines ? (
+        <p className="cycle-line-summary">
+          Shared pool{" "}
+          {formatMicroUsdc(record.reward.lines.sharedPool.suggestedMinor)} +
+          additive review{" "}
+          {formatMicroUsdc(record.reward.lines.reviewBudget.suggestedMinor)}{" "}
+          suggested. The combined amount uses one wallet and one dust-floor
+          decision.
+        </p>
+      ) : null}
       {reminder ? (
         <div
           className={`data-notice cycle-reminder ${reminder.kind}`}
@@ -3464,6 +3514,13 @@ function ProjectProposalPage() {
         ...(includesReviewBudget
           ? {
               reviewBudget: {
+                effectiveAt: new Date(
+                  Date.UTC(
+                    new Date().getUTCFullYear(),
+                    new Date().getUTCMonth() + 1,
+                    1,
+                  ),
+                ).toISOString(),
                 monthlyCapMinor: reviewBudget.minor,
                 monthlyCapDisplay: reviewBudget.display,
                 committedMinor: "0",

--- a/src/lib/cycle-index.test.ts
+++ b/src/lib/cycle-index.test.ts
@@ -84,6 +84,49 @@ describe("public cycle index", () => {
     expect(() => assertCycleIndex(value)).not.toThrow();
   });
 
+  it("publishes additive review-budget money as reconciled line items", () => {
+    const additive = entry();
+    additive.reward.suggestedMinor = "10500000000";
+    additive.reward.lines = {
+      sharedPool: {
+        suggestedMinor: "10000000000",
+        approvedMinor: "0",
+        paidMinor: "0",
+      },
+      reviewBudget: {
+        suggestedMinor: "500000000",
+        approvedMinor: "0",
+        paidMinor: "0",
+      },
+    };
+    additive.contributors[0].suggestedMinor = "10500000000";
+    additive.contributors[0].lines = {
+      sharedPool: {
+        suggestedMinor: "10000000000",
+        approvedMinor: "0",
+        paidMinor: "0",
+      },
+      reviewBudget: {
+        suggestedMinor: "500000000",
+        approvedMinor: "0",
+        paidMinor: "0",
+      },
+    };
+
+    expect(() => assertCycleIndex(index([additive]))).not.toThrow();
+
+    const missingContributorLines = structuredClone(additive);
+    delete missingContributorLines.contributors[0].lines;
+    expect(() => assertCycleIndex(index([missingContributorLines]))).toThrow(
+      /line-item accounting/u,
+    );
+
+    additive.reward.lines.reviewBudget.suggestedMinor = "499999999";
+    expect(() => assertCycleIndex(index([additive]))).toThrow(
+      /reward lines do not reconcile/u,
+    );
+  });
+
   it("accepts an actor-bound Slop wallet claim issue", () => {
     const claimed = entry();
     claimed.contributors[0].wallet = {

--- a/src/lib/cycle-index.ts
+++ b/src/lib/cycle-index.ts
@@ -75,6 +75,18 @@ export interface CycleIndexEntry {
     paidMinor: string;
     feeMinor: string;
     sharePartsPerMillion: number | null;
+    lines?: {
+      sharedPool: {
+        suggestedMinor: string;
+        approvedMinor: string;
+        paidMinor: string;
+      };
+      reviewBudget: {
+        suggestedMinor: string;
+        approvedMinor: string;
+        paidMinor: string;
+      };
+    };
   };
   contributors: Array<{
     actor: { id: string; login: string };
@@ -93,6 +105,18 @@ export interface CycleIndexEntry {
     paidMinor: string;
     sharePartsPerMillion: number | null;
     wallet: CycleWalletProof | null;
+    lines?: {
+      sharedPool: {
+        suggestedMinor: string;
+        approvedMinor: string;
+        paidMinor: string;
+      };
+      reviewBudget: {
+        suggestedMinor: string;
+        approvedMinor: string;
+        paidMinor: string;
+      };
+    };
   }>;
   files: {
     sourceSnapshot: CycleFileReference;
@@ -186,6 +210,32 @@ function nullableFileReference(
   expectedUrl: string,
 ): CycleFileReference | null {
   return value === null ? null : fileReference(value, field, expectedUrl);
+}
+
+function cycleMoneyLines(value: unknown, field: string) {
+  const lines = record(value, field);
+  exact(lines, ["reviewBudget", "sharedPool"], field);
+  const parseLine = (value: unknown, lineField: string) => {
+    const line = record(value, lineField);
+    exact(line, ["approvedMinor", "paidMinor", "suggestedMinor"], lineField);
+    const suggestedMinor = minor(
+      line.suggestedMinor,
+      `${lineField}.suggestedMinor`,
+    );
+    const approvedMinor = minor(
+      line.approvedMinor,
+      `${lineField}.approvedMinor`,
+    );
+    const paidMinor = minor(line.paidMinor, `${lineField}.paidMinor`);
+    if (BigInt(paidMinor) > BigInt(approvedMinor)) {
+      throw new TypeError(`${lineField} money totals do not reconcile`);
+    }
+    return { suggestedMinor, approvedMinor, paidMinor };
+  };
+  return {
+    sharedPool: parseLine(lines.sharedPool, `${field}.sharedPool`),
+    reviewBudget: parseLine(lines.reviewBudget, `${field}.reviewBudget`),
+  };
 }
 
 function contributorWallet(
@@ -417,6 +467,7 @@ function cycleEntry(value: unknown, index: number): CycleIndexEntry {
     throw new TypeError(`${field}.contributionWindow is invalid`);
   }
   const reward = record(entry.reward, `${field}.reward`);
+  const hasRewardLines = "lines" in reward;
   exact(
     reward,
     [
@@ -427,6 +478,7 @@ function cycleEntry(value: unknown, index: number): CycleIndexEntry {
       "paidMinor",
       "sharePartsPerMillion",
       "suggestedMinor",
+      ...(hasRewardLines ? ["lines"] : []),
     ],
     `${field}.reward`,
   );
@@ -453,10 +505,33 @@ function cycleEntry(value: unknown, index: number): CycleIndexEntry {
     paidMinor: minor(reward.paidMinor, `${field}.reward.paidMinor`),
     feeMinor: minor(reward.feeMinor, `${field}.reward.feeMinor`),
     sharePartsPerMillion: share === null ? null : Number(share),
+    ...(hasRewardLines
+      ? {
+          lines: cycleMoneyLines(reward.lines, `${field}.reward.lines`),
+        }
+      : {}),
   };
   if (
-    BigInt(normalizedReward.approvedMinor) >
-      BigInt(normalizedReward.capMinor) ||
+    normalizedReward.lines &&
+    (BigInt(normalizedReward.lines.sharedPool.suggestedMinor) +
+      BigInt(normalizedReward.lines.reviewBudget.suggestedMinor) !==
+      BigInt(normalizedReward.suggestedMinor) ||
+      BigInt(normalizedReward.lines.sharedPool.approvedMinor) +
+        BigInt(normalizedReward.lines.reviewBudget.approvedMinor) !==
+        BigInt(normalizedReward.approvedMinor) ||
+      BigInt(normalizedReward.lines.sharedPool.paidMinor) +
+        BigInt(normalizedReward.lines.reviewBudget.paidMinor) !==
+        BigInt(normalizedReward.paidMinor))
+  ) {
+    throw new TypeError(`${field}.reward lines do not reconcile`);
+  }
+  if (
+    (!normalizedReward.lines &&
+      BigInt(normalizedReward.approvedMinor) >
+        BigInt(normalizedReward.capMinor)) ||
+    (normalizedReward.lines &&
+      BigInt(normalizedReward.lines.sharedPool.approvedMinor) >
+        BigInt(normalizedReward.capMinor)) ||
     BigInt(normalizedReward.paidMinor) > BigInt(normalizedReward.approvedMinor)
   ) {
     throw new TypeError(`${field}.reward money totals do not reconcile`);
@@ -477,6 +552,7 @@ function cycleEntry(value: unknown, index: number): CycleIndexEntry {
   const contributors = entry.contributors.map((value, contributorIndex) => {
     const contributorField = `${field}.contributors[${contributorIndex}]`;
     const contributor = record(value, contributorField);
+    const hasLines = "lines" in contributor;
     exact(
       contributor,
       [
@@ -488,6 +564,7 @@ function cycleEntry(value: unknown, index: number): CycleIndexEntry {
         "state",
         "suggestedMinor",
         "wallet",
+        ...(hasLines ? ["lines"] : []),
       ],
       contributorField,
     );
@@ -549,6 +626,23 @@ function cycleEntry(value: unknown, index: number): CycleIndexEntry {
     if (BigInt(paidMinor) > BigInt(approvedMinor)) {
       throw new TypeError(`${contributorField} money totals do not reconcile`);
     }
+    const lines = hasLines
+      ? cycleMoneyLines(contributor.lines, `${contributorField}.lines`)
+      : undefined;
+    if (
+      lines &&
+      (BigInt(lines.sharedPool.suggestedMinor) +
+        BigInt(lines.reviewBudget.suggestedMinor) !==
+        BigInt(suggestedMinor) ||
+        BigInt(lines.sharedPool.approvedMinor) +
+          BigInt(lines.reviewBudget.approvedMinor) !==
+          BigInt(approvedMinor) ||
+        BigInt(lines.sharedPool.paidMinor) +
+          BigInt(lines.reviewBudget.paidMinor) !==
+          BigInt(paidMinor))
+    ) {
+      throw new TypeError(`${contributorField}.lines do not reconcile`);
+    }
     return {
       actor: { id: actorId, login },
       score: Number(contributor.score),
@@ -558,6 +652,7 @@ function cycleEntry(value: unknown, index: number): CycleIndexEntry {
       paidMinor,
       sharePartsPerMillion: share === null ? null : Number(share),
       wallet,
+      ...(lines ? { lines } : {}),
     };
   });
   if (
@@ -565,6 +660,16 @@ function cycleEntry(value: unknown, index: number): CycleIndexEntry {
     contributors.length
   ) {
     throw new TypeError(`${field}.contributors repeats an actor`);
+  }
+  if (
+    (normalizedReward.lines &&
+      !contributors.every((contributor) => Boolean(contributor.lines))) ||
+    (!normalizedReward.lines &&
+      contributors.some((contributor) => Boolean(contributor.lines)))
+  ) {
+    throw new TypeError(
+      `${field}.reward and contributor line-item accounting differ`,
+    );
   }
   const contributorTotals = contributors.reduce(
     (totals, contributor) => ({

--- a/src/lib/project-schema.mjs
+++ b/src/lib/project-schema.mjs
@@ -769,6 +769,7 @@ function validateReviewBudget(value, field, poolPaymentMode) {
     budget,
     [
       "committedMinor",
+      "effectiveAt",
       "fundingState",
       "monthlyCapDisplay",
       "monthlyCapMinor",
@@ -781,6 +782,7 @@ function validateReviewBudget(value, field, poolPaymentMode) {
     budget.monthlyCapMinor,
     `${field}.monthlyCapMinor`,
   );
+  const effectiveAt = timestamp(budget.effectiveAt, `${field}.effectiveAt`);
   const committedMinor = minor(
     budget.committedMinor,
     `${field}.committedMinor`,
@@ -792,6 +794,7 @@ function validateReviewBudget(value, field, poolPaymentMode) {
   const paymentsDisabled = budget.paymentMode === "disabled";
   if (
     BigInt(monthlyCapMinor) <= 0n ||
+    !effectiveAt.endsWith("-01T00:00:00.000Z") ||
     budget.unusedFunds !== "rollover-without-cap-increase" ||
     (paymentsDisabled
       ? budget.fundingState !== "pledged" || committedMinor !== "0"

--- a/src/lib/project-schema.test.ts
+++ b/src/lib/project-schema.test.ts
@@ -186,6 +186,7 @@ describe("project proposal schema", () => {
 
   it("validates the optional review budget line", () => {
     const pledgedReviewBudget = {
+      effectiveAt: "2026-09-01T00:00:00.000Z",
       monthlyCapMinor: "50000000",
       monthlyCapDisplay: "$50",
       committedMinor: "0",

--- a/src/lib/projects.d.mts
+++ b/src/lib/projects.d.mts
@@ -21,6 +21,7 @@ export interface ProjectFundingPolicy {
 }
 
 export interface ProjectReviewBudgetPolicy {
+  readonly effectiveAt: string;
   readonly monthlyCapMinor: string;
   readonly monthlyCapDisplay: string;
   readonly committedMinor: string;

--- a/src/lib/reward-cycle.test.ts
+++ b/src/lib/reward-cycle.test.ts
@@ -2,7 +2,10 @@
 
 import { describe, expect, it } from "vitest";
 import { snapshotFixture } from "../../tests/fixtures";
-import { createRewardCycleProposal } from "./reward-cycle";
+import {
+  allocateReviewBudgetMinor,
+  createRewardCycleProposal,
+} from "./reward-cycle";
 import type { WalletProof } from "./rewards";
 
 const SOURCE_SHA = "a".repeat(64);
@@ -28,6 +31,36 @@ function wallet(): WalletProof {
 }
 
 describe("reward cycle proposals", () => {
+  it("allocates an additive review line with deterministic largest remainder", () => {
+    expect(
+      Object.fromEntries(
+        allocateReviewBudgetMinor(10n, [
+          { actorId: "actor-c", scoreThirds: 1 },
+          { actorId: "actor-a", scoreThirds: 1 },
+          { actorId: "actor-b", scoreThirds: 1 },
+        ]),
+      ),
+    ).toEqual({ "actor-a": 4n, "actor-b": 3n, "actor-c": 3n });
+    expect(
+      Object.fromEntries(
+        allocateReviewBudgetMinor(5n, [
+          { actorId: "light", scoreThirds: 1 },
+          { actorId: "deep", scoreThirds: 3 },
+        ]),
+      ),
+    ).toEqual({ deep: 4n, light: 1n });
+  });
+
+  it("leaves the additive line unused without accepted review evidence", () => {
+    expect(allocateReviewBudgetMinor(10n, [])).toEqual(new Map());
+    expect(() =>
+      allocateReviewBudgetMinor(10n, [
+        { actorId: "duplicate", scoreThirds: 1 },
+        { actorId: "duplicate", scoreThirds: 2 },
+      ]),
+    ).toThrow(/unique non-negative/u);
+  });
+
   it("proposes the exact Eliza pool without approving a payment", () => {
     const wallets = new Map([["U_fixture", wallet()]]);
     const proposal = createRewardCycleProposal({

--- a/src/lib/reward-cycle.ts
+++ b/src/lib/reward-cycle.ts
@@ -34,6 +34,58 @@ export interface CreateRewardCycleProposalInput {
   priorActorLogins?: ReadonlyMap<string, string>;
 }
 
+export function allocateReviewBudgetMinor(
+  totalMinor: bigint,
+  contributors: readonly { actorId: string; scoreThirds: number }[],
+): Map<string, bigint> {
+  if (totalMinor < 0n) throw new RangeError("review budget cannot be negative");
+  if (
+    contributors.some(
+      ({ actorId, scoreThirds }) =>
+        actorId.length === 0 ||
+        !Number.isSafeInteger(scoreThirds) ||
+        scoreThirds < 0,
+    ) ||
+    new Set(contributors.map(({ actorId }) => actorId)).size !==
+      contributors.length
+  ) {
+    throw new TypeError("review weights must be unique non-negative integers");
+  }
+  const eligible = contributors
+    .filter(
+      ({ scoreThirds }) => Number.isSafeInteger(scoreThirds) && scoreThirds > 0,
+    )
+    .sort((left, right) => left.actorId.localeCompare(right.actorId));
+  if (eligible.length === 0 || totalMinor === 0n) return new Map();
+  const totalWeight = eligible.reduce(
+    (total, contributor) => total + BigInt(contributor.scoreThirds),
+    0n,
+  );
+  const allocations = new Map<string, bigint>();
+  const remainders = eligible.map((contributor) => {
+    const numerator = totalMinor * BigInt(contributor.scoreThirds);
+    const amount = numerator / totalWeight;
+    allocations.set(contributor.actorId, amount);
+    return { actorId: contributor.actorId, remainder: numerator % totalWeight };
+  });
+  let unallocated =
+    totalMinor -
+    [...allocations.values()].reduce((total, amount) => total + amount, 0n);
+  remainders.sort((left, right) =>
+    left.remainder === right.remainder
+      ? left.actorId.localeCompare(right.actorId)
+      : left.remainder > right.remainder
+        ? -1
+        : 1,
+  );
+  for (let index = 0; unallocated > 0n; index += 1) {
+    const actorId = remainders[index % remainders.length].actorId;
+    allocations.set(actorId, (allocations.get(actorId) ?? 0n) + 1n);
+    unallocated -= 1n;
+  }
+  return allocations;
+}
+
 function cycleBounds(cycleId: string): { from: number; to: number } {
   if (!/^\d{4}-(?:0[1-9]|1[0-2])$/u.test(cycleId)) {
     throw new TypeError(`Invalid reward cycle id: ${cycleId}`);
@@ -168,6 +220,41 @@ export function createRewardCycleProposal(
       0n,
     ) + carriedOnlyMinor
   ).toString();
+  const reviewPolicy = view.project.reward.reviewBudget;
+  const reviewBudgetTotal =
+    reviewPolicy?.fundingState === "committed" &&
+    reviewPolicy.paymentMode === "enabled" &&
+    Date.parse(reviewPolicy.effectiveAt) <= Date.parse(view.cycle.from)
+      ? BigInt(reviewPolicy.committedMinor) <
+        BigInt(reviewPolicy.monthlyCapMinor)
+        ? BigInt(reviewPolicy.committedMinor)
+        : BigInt(reviewPolicy.monthlyCapMinor)
+      : 0n;
+  const reviewEvents = view.ledger.filter(
+    (event) => event.category === "substantive-review",
+  );
+  const reviewScoreThirds = new Map<string, number>();
+  for (const event of reviewEvents) {
+    reviewScoreThirds.set(
+      event.actor.id,
+      (reviewScoreThirds.get(event.actor.id) ?? 0) +
+        (event.scoreThirds ?? Math.round(event.points * 3)),
+    );
+  }
+  const reviewAllocations = allocateReviewBudgetMinor(
+    reviewBudgetTotal,
+    [...reviewScoreThirds].map(([actorId, scoreThirds]) => ({
+      actorId,
+      scoreThirds,
+    })),
+  );
+  const reviewSuggestedTotal = [...reviewAllocations.values()].reduce(
+    (total, amount) => total + amount,
+    0n,
+  );
+  const combinedSuggestedMinor = (
+    BigInt(suggestedMinor) + reviewSuggestedTotal
+  ).toString();
   const reviewEndsAt = new Date(
     Date.parse(input.generatedAt) + REVIEW_WINDOW_DAYS * 86_400_000,
   ).toISOString();
@@ -200,10 +287,11 @@ export function createRewardCycleProposal(
     allocations: view.leaders
       .map((leader, index) => {
         const wallet = input.wallets?.get(leader.actor.id) ?? null;
-        const accruedMinor = (
+        const sharedPoolMinor =
           BigInt(input.priorAccruedMinor?.get(leader.actor.id) ?? "0") +
-          BigInt(leader.projectedMinor ?? "0")
-        ).toString();
+          BigInt(leader.projectedMinor ?? "0");
+        const reviewMinor = reviewAllocations.get(leader.actor.id) ?? 0n;
+        const accruedMinor = (sharedPoolMinor + reviewMinor).toString();
         return {
           intentId: `pay_${intentComponent(input.projectId)}_${cycleComponent}_${String(index + 1).padStart(4, "0")}_${intentComponent(leader.actor.id)}`,
           actor: { id: leader.actor.id, login: leader.actor.login },
@@ -222,6 +310,23 @@ export function createRewardCycleProposal(
           relatedParty:
             input.relatedPartyActorIds?.has(leader.actor.id) ?? false,
           platformApproval: null,
+          ...(reviewBudgetTotal > 0n
+            ? {
+                lines: {
+                  sharedPool: {
+                    suggestedMinor: sharedPoolMinor.toString(),
+                    approvedMinor: "0",
+                  },
+                  reviewBudget: {
+                    suggestedMinor: reviewMinor.toString(),
+                    approvedMinor: "0",
+                    evidenceEventIds: reviewEvents
+                      .filter((event) => event.actor.id === leader.actor.id)
+                      .map((event) => event.id),
+                  },
+                },
+              }
+            : {}),
         };
       })
       .concat(
@@ -251,11 +356,40 @@ export function createRewardCycleProposal(
             adjustmentReason: null,
             relatedParty: input.relatedPartyActorIds?.has(actorId) ?? false,
             platformApproval: null,
+            ...(reviewBudgetTotal > 0n
+              ? {
+                  lines: {
+                    sharedPool: { suggestedMinor: minor, approvedMinor: "0" },
+                    reviewBudget: {
+                      suggestedMinor: "0",
+                      approvedMinor: "0",
+                      evidenceEventIds: [],
+                    },
+                  },
+                }
+              : {}),
           };
         }),
       ),
+    ...(reviewBudgetTotal > 0n && reviewPolicy
+      ? {
+          rewardLines: {
+            sharedPool: {
+              capMinor: view.project.reward.monthlyCapMinor,
+              suggestedMinor,
+              approvedMinor: "0",
+            },
+            reviewBudget: {
+              capMinor: reviewPolicy.monthlyCapMinor,
+              committedMinor: reviewPolicy.committedMinor,
+              suggestedMinor: reviewSuggestedTotal.toString(),
+              approvedMinor: "0",
+            },
+          },
+        }
+      : {}),
     totals: {
-      suggestedMinor,
+      suggestedMinor: combinedSuggestedMinor,
       approvedMinor: "0",
       feeMinor: feeForPrincipal("0", view.project.reward.feeBasisPoints),
     },

--- a/src/lib/rewards.test.ts
+++ b/src/lib/rewards.test.ts
@@ -66,6 +66,44 @@ function allocationManifest() {
 }
 
 describe("reward manifests", () => {
+  it("rejects an additive review line until its project funding is committed", () => {
+    const manifest = allocationManifest() as unknown as Record<
+      string,
+      unknown
+    > & { allocations: Array<Record<string, unknown>> };
+    manifest.allocations[0].suggestedMinor = "2000000";
+    manifest.allocations[0].approvedMinor = "2000000";
+    manifest.allocations[0].lines = {
+      sharedPool: { suggestedMinor: "2000000", approvedMinor: "2000000" },
+      reviewBudget: {
+        suggestedMinor: "0",
+        approvedMinor: "0",
+        evidenceEventIds: [],
+      },
+    };
+    manifest.rewardLines = {
+      sharedPool: {
+        capMinor: "10000000000",
+        suggestedMinor: "2000000",
+        approvedMinor: "2000000",
+      },
+      reviewBudget: {
+        capMinor: "500000",
+        committedMinor: "500000",
+        suggestedMinor: "0",
+        approvedMinor: "0",
+      },
+    };
+    manifest.totals = {
+      suggestedMinor: "2000000",
+      approvedMinor: "2000000",
+      feeMinor: "20000",
+    };
+    expect(() => assertRewardAllocationManifest(manifest)).toThrow(
+      /not funded and enabled/u,
+    );
+  });
+
   it("holds sub-$2 awards without discarding or redistributing them", () => {
     const manifest = allocationManifest() as ReturnType<
       typeof allocationManifest

--- a/src/lib/rewards.ts
+++ b/src/lib/rewards.ts
@@ -73,6 +73,14 @@ export interface RewardAllocation {
     reviewer: string;
     approvedAt: string;
   } | null;
+  lines?: {
+    sharedPool: { suggestedMinor: string; approvedMinor: string };
+    reviewBudget: {
+      suggestedMinor: string;
+      approvedMinor: string;
+      evidenceEventIds: string[];
+    };
+  };
 }
 
 export interface RewardAllocationManifest {
@@ -98,6 +106,19 @@ export interface RewardAllocationManifest {
   scoringRuleVersion: string;
   sourceSnapshotSha256: string;
   allocations: RewardAllocation[];
+  rewardLines?: {
+    sharedPool: {
+      capMinor: string;
+      suggestedMinor: string;
+      approvedMinor: string;
+    };
+    reviewBudget: {
+      capMinor: string;
+      committedMinor: string;
+      suggestedMinor: string;
+      approvedMinor: string;
+    };
+  };
   totals: {
     suggestedMinor: string;
     approvedMinor: string;
@@ -139,6 +160,10 @@ export interface RewardSettlementManifest {
     approvedMinor: string;
     paidMinor: string;
     state: "failed" | "paid" | "pending";
+    rewardLines?: {
+      sharedPool: { approvedMinor: string; paidMinor: string };
+      reviewBudget: { approvedMinor: string; paidMinor: string };
+    };
   }>;
   attempts: Array<{
     attemptId: string;
@@ -483,6 +508,7 @@ function assertAllocation(value: unknown, index: number): RewardAllocation {
   const path = `allocations[${index}]`;
   const allocation = record(value, path);
   const hasAccrual = "accruedMinor" in allocation;
+  const hasLines = "lines" in allocation;
   exactKeys(
     allocation,
     [
@@ -498,6 +524,7 @@ function assertAllocation(value: unknown, index: number): RewardAllocation {
       "suggestedMinor",
       "wallet",
       ...(hasAccrual ? ["accruedMinor"] : []),
+      ...(hasLines ? ["lines"] : []),
     ],
     path,
   );
@@ -530,6 +557,72 @@ function assertAllocation(value: unknown, index: number): RewardAllocation {
     allocation.approvedMinor,
     `${path}.approvedMinor`,
   );
+  let lines: RewardAllocation["lines"];
+  if (hasLines) {
+    const rawLines = record(allocation.lines, `${path}.lines`);
+    exactKeys(rawLines, ["reviewBudget", "sharedPool"], `${path}.lines`);
+    const sharedPool = record(rawLines.sharedPool, `${path}.lines.sharedPool`);
+    exactKeys(
+      sharedPool,
+      ["approvedMinor", "suggestedMinor"],
+      `${path}.lines.sharedPool`,
+    );
+    const reviewBudget = record(
+      rawLines.reviewBudget,
+      `${path}.lines.reviewBudget`,
+    );
+    exactKeys(
+      reviewBudget,
+      ["approvedMinor", "evidenceEventIds", "suggestedMinor"],
+      `${path}.lines.reviewBudget`,
+    );
+    lines = {
+      sharedPool: {
+        suggestedMinor: minor(
+          sharedPool.suggestedMinor,
+          `${path}.lines.sharedPool.suggestedMinor`,
+        ),
+        approvedMinor: minor(
+          sharedPool.approvedMinor,
+          `${path}.lines.sharedPool.approvedMinor`,
+        ),
+      },
+      reviewBudget: {
+        suggestedMinor: minor(
+          reviewBudget.suggestedMinor,
+          `${path}.lines.reviewBudget.suggestedMinor`,
+        ),
+        approvedMinor: minor(
+          reviewBudget.approvedMinor,
+          `${path}.lines.reviewBudget.approvedMinor`,
+        ),
+        evidenceEventIds: assertEvidenceIds(
+          reviewBudget.evidenceEventIds,
+          `${path}.lines.reviewBudget.evidenceEventIds`,
+        ),
+      },
+    };
+    if (
+      BigInt(lines.sharedPool.suggestedMinor) +
+        BigInt(lines.reviewBudget.suggestedMinor) !==
+        BigInt(suggestedMinor) ||
+      BigInt(lines.sharedPool.approvedMinor) +
+        BigInt(lines.reviewBudget.approvedMinor) !==
+        BigInt(approvedMinor)
+    ) {
+      throw new TypeError(`${path} reward lines do not reconcile`);
+    }
+    if (
+      (BigInt(lines.reviewBudget.suggestedMinor) > 0n &&
+        lines.reviewBudget.evidenceEventIds.length === 0) ||
+      lines.reviewBudget.evidenceEventIds.some(
+        (eventId) =>
+          !(allocation.evidenceEventIds as unknown[]).includes(eventId),
+      )
+    ) {
+      throw new TypeError(`${path} review line lacks accepted review evidence`);
+    }
+  }
   const adjustmentReason =
     allocation.adjustmentReason === null
       ? null
@@ -596,6 +689,15 @@ function assertAllocation(value: unknown, index: number): RewardAllocation {
   ) {
     throw new TypeError(`${path} approved payment is below the $2 minimum`);
   }
+  if (
+    hasLines &&
+    state === "approved" &&
+    BigInt(approvedMinor) < BigInt(MINIMUM_TRANSFER_MINOR)
+  ) {
+    throw new TypeError(
+      `${path} combined approved payment is below the $2 minimum`,
+    );
+  }
   if (state !== "approved" && BigInt(approvedMinor) !== 0n) {
     throw new TypeError(
       `${path} non-approved state must have zero approved amount`,
@@ -620,6 +722,7 @@ function assertAllocation(value: unknown, index: number): RewardAllocation {
     adjustmentReason,
     relatedParty: allocation.relatedParty,
     platformApproval,
+    ...(lines ? { lines } : {}),
   };
 }
 
@@ -630,6 +733,7 @@ export function assertRewardAllocationManifest(
   const manifest = record(value, "allocation manifest");
   const hasAccrual =
     "carriedMinor" in manifest || "minimumTransferMinor" in manifest;
+  const hasRewardLines = "rewardLines" in manifest;
   exactKeys(
     manifest,
     [
@@ -651,6 +755,7 @@ export function assertRewardAllocationManifest(
       "status",
       "totals",
       ...(hasAccrual ? ["carriedMinor", "minimumTransferMinor"] : []),
+      ...(hasRewardLines ? ["rewardLines"] : []),
     ],
     "allocation manifest",
   );
@@ -802,7 +907,108 @@ export function assertRewardAllocationManifest(
   const approvedMinor = sumMinor(
     allocations.map((allocation) => allocation.approvedMinor),
   );
-  if (BigInt(approvedMinor) > BigInt(capMinor) + BigInt(carriedMinor)) {
+  let rewardLines: RewardAllocationManifest["rewardLines"];
+  if (hasRewardLines) {
+    const policy = project.reward.reviewBudget;
+    if (
+      policy?.fundingState !== "committed" ||
+      policy.paymentMode !== "enabled"
+    ) {
+      throw new TypeError("allocation review line is not funded and enabled");
+    }
+    const rawLines = record(manifest.rewardLines, "allocation rewardLines");
+    exactKeys(
+      rawLines,
+      ["reviewBudget", "sharedPool"],
+      "allocation rewardLines",
+    );
+    const sharedPool = record(
+      rawLines.sharedPool,
+      "allocation rewardLines.sharedPool",
+    );
+    exactKeys(
+      sharedPool,
+      ["approvedMinor", "capMinor", "suggestedMinor"],
+      "allocation rewardLines.sharedPool",
+    );
+    const reviewBudget = record(
+      rawLines.reviewBudget,
+      "allocation rewardLines.reviewBudget",
+    );
+    exactKeys(
+      reviewBudget,
+      ["approvedMinor", "capMinor", "committedMinor", "suggestedMinor"],
+      "allocation rewardLines.reviewBudget",
+    );
+    rewardLines = {
+      sharedPool: {
+        capMinor: minor(sharedPool.capMinor, "shared-pool line capMinor"),
+        suggestedMinor: minor(
+          sharedPool.suggestedMinor,
+          "shared-pool line suggestedMinor",
+        ),
+        approvedMinor: minor(
+          sharedPool.approvedMinor,
+          "shared-pool line approvedMinor",
+        ),
+      },
+      reviewBudget: {
+        capMinor: minor(reviewBudget.capMinor, "review line capMinor"),
+        committedMinor: minor(
+          reviewBudget.committedMinor,
+          "review line committedMinor",
+        ),
+        suggestedMinor: minor(
+          reviewBudget.suggestedMinor,
+          "review line suggestedMinor",
+        ),
+        approvedMinor: minor(
+          reviewBudget.approvedMinor,
+          "review line approvedMinor",
+        ),
+      },
+    };
+    const allocationSharedSuggested = sumMinor(
+      allocations.map((entry) => entry.lines?.sharedPool.suggestedMinor ?? "0"),
+    );
+    const allocationSharedApproved = sumMinor(
+      allocations.map((entry) => entry.lines?.sharedPool.approvedMinor ?? "0"),
+    );
+    const allocationReviewSuggested = sumMinor(
+      allocations.map(
+        (entry) => entry.lines?.reviewBudget.suggestedMinor ?? "0",
+      ),
+    );
+    const allocationReviewApproved = sumMinor(
+      allocations.map(
+        (entry) => entry.lines?.reviewBudget.approvedMinor ?? "0",
+      ),
+    );
+    if (
+      allocations.some((entry) => !entry.lines) ||
+      rewardLines.sharedPool.capMinor !== capMinor ||
+      rewardLines.reviewBudget.capMinor !== policy.monthlyCapMinor ||
+      rewardLines.reviewBudget.committedMinor !== policy.committedMinor ||
+      rewardLines.sharedPool.suggestedMinor !== allocationSharedSuggested ||
+      rewardLines.sharedPool.approvedMinor !== allocationSharedApproved ||
+      rewardLines.reviewBudget.suggestedMinor !== allocationReviewSuggested ||
+      rewardLines.reviewBudget.approvedMinor !== allocationReviewApproved ||
+      BigInt(allocationSharedApproved) >
+        BigInt(capMinor) + BigInt(carriedMinor) ||
+      BigInt(allocationReviewApproved) > BigInt(policy.committedMinor) ||
+      BigInt(allocationReviewApproved) > BigInt(policy.monthlyCapMinor) ||
+      BigInt(allocationReviewSuggested) > BigInt(policy.committedMinor) ||
+      BigInt(allocationReviewSuggested) > BigInt(policy.monthlyCapMinor)
+    ) {
+      throw new TypeError(
+        "allocation reward lines do not reconcile with policy",
+      );
+    }
+  } else if (allocations.some((entry) => entry.lines)) {
+    throw new TypeError(
+      "allocation rows have reward lines without line totals",
+    );
+  } else if (BigInt(approvedMinor) > BigInt(capMinor) + BigInt(carriedMinor)) {
     throw new TypeError("allocation total exceeds the monthly cap");
   }
   const totals = record(manifest.totals, "allocation manifest.totals");
@@ -859,6 +1065,7 @@ export function assertRewardAllocationManifest(
       "allocation manifest.sourceSnapshotSha256",
     ),
     allocations,
+    ...(rewardLines ? { rewardLines } : {}),
     totals: { suggestedMinor, approvedMinor, feeMinor },
   };
 }
@@ -1046,15 +1253,26 @@ export function assertRewardSettlementManifest(
   const approvedByIntent = new Map(
     allocation.allocations
       .filter((entry) => entry.state === "approved")
-      .map((entry) => [entry.intentId, entry.approvedMinor]),
+      .map((entry) => [entry.intentId, entry]),
   );
   const recipients = array(manifest.recipients, "settlement recipients").map(
     (value, index) => {
       const path = `settlement recipients[${index}]`;
       const recipient = record(value, path);
+      const expectedAllocation =
+        typeof recipient.intentId === "string"
+          ? approvedByIntent.get(recipient.intentId)
+          : undefined;
+      const hasRewardLines = "rewardLines" in recipient;
       exactKeys(
         recipient,
-        ["approvedMinor", "intentId", "paidMinor", "state"],
+        [
+          "approvedMinor",
+          "intentId",
+          "paidMinor",
+          "state",
+          ...(hasRewardLines ? ["rewardLines"] : []),
+        ],
         path,
       );
       const intentId = text(recipient.intentId, `${path}.intentId`, {
@@ -1064,7 +1282,7 @@ export function assertRewardSettlementManifest(
         recipient.approvedMinor,
         `${path}.approvedMinor`,
       );
-      if (approvedByIntent.get(intentId) !== approvedMinor) {
+      if (expectedAllocation?.approvedMinor !== approvedMinor) {
         throw new TypeError(`${path} does not match an approved payout intent`);
       }
       const paidMinor = minor(recipient.paidMinor, `${path}.paidMinor`);
@@ -1084,7 +1302,59 @@ export function assertRewardSettlementManifest(
           `${path} non-paid state must have zero paid amount`,
         );
       }
-      return { intentId, approvedMinor, paidMinor, state };
+      let rewardLines: RewardSettlementManifest["recipients"][number]["rewardLines"];
+      if (expectedAllocation.lines) {
+        if (!hasRewardLines) {
+          throw new TypeError(`${path} must preserve reward line items`);
+        }
+        const rawLines = record(recipient.rewardLines, `${path}.rewardLines`);
+        exactKeys(
+          rawLines,
+          ["reviewBudget", "sharedPool"],
+          `${path}.rewardLines`,
+        );
+        const parseLine = (
+          value: unknown,
+          linePath: string,
+          expectedApprovedMinor: string,
+        ): { approvedMinor: string; paidMinor: string } => {
+          const line = record(value, linePath);
+          exactKeys(line, ["approvedMinor", "paidMinor"], linePath);
+          const lineApproved = minor(
+            line.approvedMinor,
+            `${linePath}.approvedMinor`,
+          );
+          const linePaid = minor(line.paidMinor, `${linePath}.paidMinor`);
+          if (
+            lineApproved !== expectedApprovedMinor ||
+            linePaid !== (state === "paid" ? lineApproved : "0")
+          ) {
+            throw new TypeError(`${linePath} does not reconcile`);
+          }
+          return { approvedMinor: lineApproved, paidMinor: linePaid };
+        };
+        rewardLines = {
+          sharedPool: parseLine(
+            rawLines.sharedPool,
+            `${path}.rewardLines.sharedPool`,
+            expectedAllocation.lines.sharedPool.approvedMinor,
+          ),
+          reviewBudget: parseLine(
+            rawLines.reviewBudget,
+            `${path}.rewardLines.reviewBudget`,
+            expectedAllocation.lines.reviewBudget.approvedMinor,
+          ),
+        };
+      } else if (hasRewardLines) {
+        throw new TypeError(`${path} has reward lines absent from allocation`);
+      }
+      return {
+        intentId,
+        approvedMinor,
+        paidMinor,
+        state,
+        ...(rewardLines ? { rewardLines } : {}),
+      };
     },
   );
   unique(

--- a/src/lib/settlement-plan.ts
+++ b/src/lib/settlement-plan.ts
@@ -22,6 +22,10 @@ export interface SettlementPlanTransfer {
   intentIds: string[];
   recipientOwner: string;
   amountMinor: string;
+  rewardLines?: {
+    sharedPoolMinor: string;
+    reviewBudgetMinor: string;
+  };
 }
 
 export interface SettlementExecutionPlan {
@@ -148,6 +152,14 @@ export function createSettlementExecutionPlan(input: {
       intentIds: [row.intentId],
       recipientOwner,
       amountMinor: row.approvedMinor,
+      ...(row.lines
+        ? {
+            rewardLines: {
+              sharedPoolMinor: row.lines.sharedPool.approvedMinor,
+              reviewBudgetMinor: row.lines.reviewBudget.approvedMinor,
+            },
+          }
+        : {}),
     };
   });
   const platformFeeMinor = allocation.totals.feeMinor;

--- a/tests/app.test.tsx
+++ b/tests/app.test.tsx
@@ -52,6 +52,7 @@ describe("review budget display", () => {
   it("distinguishes the committed amount from the monthly cap", () => {
     expect(
       reviewBudgetLabel({
+        effectiveAt: "2026-10-01T00:00:00.000Z",
         monthlyCapMinor: "50000000",
         monthlyCapDisplay: "$50",
         committedMinor: "1000000",
@@ -62,6 +63,7 @@ describe("review budget display", () => {
     ).toBe("$1 committed of $50 cap · additive review line");
     expect(
       reviewBudgetLabel({
+        effectiveAt: "2026-10-01T00:00:00.000Z",
         monthlyCapMinor: "50000000",
         monthlyCapDisplay: "$50",
         committedMinor: "0",


### PR DESCRIPTION
Closes #303.

## Outcome

Implements the RFC's additive-only review budget as a real, separately auditable cash line while preserving the existing shared-pool allocation byte-for-byte.

- Activates a funded review line only for cycles beginning on or after its reviewed `effectiveAt` month boundary.
- Allocates committed review funds deterministically by accepted substantive-review score thirds, with exact evidence event IDs.
- Carries shared-pool and review-budget amounts through proposal, approval, unsigned settlement planning, finalized settlement, cycle-index publication, and archived public UI.
- Applies the transfer floor to each recipient's combined amount and the normal fee to combined approved principal.
- Rejects cap substitution, unfunded lines, missing evidence, mismatched line totals, partial settlement accounting, and retroactive activation.

The settlement plan keeps one recipient transfer because both lines go to the same registered wallet; the immutable transfer and settlement records retain the exact two-line split. This avoids extra on-chain dust/fees while preserving public accounting.

## Exact-head verification

Head: `322c7097213c9542b6ba1db90e7aa208fd503a1d`, rebased onto `origin/develop` after #320.

- `bun run verify`
  - 67 Vitest files / 679 tests passed
  - 103 executable skill tests passed
  - project, funding, cycle, protocol, dependency, type, format, lint, and production-build gates passed
- Focused review-budget/schema/transition/cycle-index suite: 56 tests passed before the full gate.
- `git diff --check` passed.

Hosted browser and release-input validation must pass for this exact head before merge.
