### PR TITLE
fix(intake): extend reviewed attestation window

### DIFF
--- a/.github/workflows/private-intake-watch.yml
+++ b/.github/workflows/private-intake-watch.yml
@@ -2,7 +2,7 @@ name: Private intake freshness watch
 
 on:
   schedule:
-    # Detect a missed reviewed refresh before the seven-hour attestation gate closes.
+    # Detect a missed reviewed refresh before the 49-hour attestation gate closes.
     - cron: "47 * * * *"
   workflow_dispatch:
 

--- a/backend/trace/PRIVATE_INTAKE_RECOVERY.md
+++ b/backend/trace/PRIVATE_INTAKE_RECOVERY.md
@@ -2,7 +2,7 @@
 
 The private-trace API accepts uploads only while the deployed public-intake
 attestation is valid. The attestation is bound to one tested `develop` revision
-and expires seven hours after `verifiedAt`. Expiry is intentionally fail-closed:
+and expires 49 hours after `verifiedAt`. Expiry is intentionally fail-closed:
 `GET https://api.slop.cash/api/v1/private-request-intake` returns HTTP 503 with
 `{"error":"private_intake_unavailable"}` until a reviewed production deployment
 publishes a fresh attestation.
@@ -25,14 +25,14 @@ or let automation approve its own deployment.
    SHA, `verifiedAt`, and verification time on the operations issue.
 
 The scheduled deployment runs every six hours. The hourly freshness watch
-fails when fewer than 90 minutes remain so a reviewed scheduled run should
-already be available before expiry.
+fails when fewer than nine hours remain, so at least one reviewed scheduled
+run is available inside the renewal window before expiry.
 
 ## Designated reviewer unavailable
 
 GitHub environment protection is the release authority. Contributors and
 automation must not impersonate the reviewer, use administrator bypass, change
-the deployment payload, lengthen the seven-hour window, or publish an
+the deployment payload, change the reviewed 49-hour window, or publish an
 attestation from a local checkout.
 
 If no configured reviewer can respond before expiry:
@@ -61,7 +61,7 @@ After the deployment reports success:
 1. Fetch `https://slop.cash/data/private-intake-attestation.json` without cache.
    Require exactly `enabled: true`, `source: "github-public-status"`, a
    40-character lowercase-hex `revision` equal to the deployed `develop` SHA,
-   and an ISO `verifiedAt` no more than seven hours old and not future-dated.
+   and an ISO `verifiedAt` no more than 49 hours old and not future-dated.
 2. Fetch `https://api.slop.cash/api/v1/private-request-intake` without cache.
    Require HTTP 200 and exactly `enabled: true`,
    `source: "github-public-status"`, and the same `verifiedAt` as the bundle.

--- a/backend/trace/README.md
+++ b/backend/trace/README.md
@@ -140,7 +140,7 @@ revision, and verification time into the tested Pages bundle. The deploy job
 checks GitHub again before publishing those exact bytes. The public
 `GET /api/v1/private-request-intake` route reads that bundle attestation and
 exposes only the verified boolean and timestamp. Missing, disabled, malformed,
-future-dated, or more-than-seven-hour-old attestations fail closed. No
+future-dated, or more-than-49-hour-old attestations fail closed. No
 contributor or runtime GitHub credential is involved.
 `TRACE_AUTH_SECRET` is opaque HMAC key material and must contain 32-128
 high-entropy printable ASCII characters. It must never be configured as a
@@ -162,7 +162,7 @@ eventually-consistent edge counter.
 Operational renewal, designated-reviewer unavailability, full-cycle
 verification, and rollback are documented in
 [`PRIVATE_INTAKE_RECOVERY.md`](PRIVATE_INTAKE_RECOVERY.md). The procedure keeps
-the seven-hour gate and protected-environment review fail-closed.
+the 49-hour gate and protected-environment review fail-closed.
 
 The Cloudflare account and bucket permissions remain limited to designated
 Slop operators. Application authorization does not replace Cloudflare account

--- a/protocol/private-trace-v1.md
+++ b/protocol/private-trace-v1.md
@@ -100,7 +100,7 @@ issue.
 The protected quality and deploy jobs query GitHub's public
 private-vulnerability-reporting status endpoint. The tested Pages bundle carries
 their bounded revision-bound attestation, and Slop's server-authoritative
-preflight accepts it for at most seven hours. Trace upload and production
+preflight accepts it for at most 49 hours. Trace upload and production
 activation fail closed if the attestation is missing, stale, malformed, or does
 not report exactly `enabled: true`; the preflight reports only safe state and
 never becomes an enabled result. The advisory URL alone is not evidence that

--- a/scripts/check-private-intake-freshness.mjs
+++ b/scripts/check-private-intake-freshness.mjs
@@ -3,9 +3,11 @@
 import { readFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
-const MAX_AGE_MS = 7 * 60 * 60 * 1000;
+const MAX_AGE_MS = 49 * 60 * 60 * 1000;
 const MAX_FUTURE_SKEW_MS = 5 * 60 * 1000;
-const RENEWAL_WINDOW_MS = 90 * 60 * 1000;
+// One six-hour scheduled refresh plus three hours of approval slack, so at
+// least one reviewed run lands inside the window before expiry.
+const RENEWAL_WINDOW_MS = 9 * 60 * 60 * 1000;
 
 export function checkPrivateIntakeFreshness(value, now = Date.now()) {
   if (

--- a/scripts/check-private-intake-freshness.test.mjs
+++ b/scripts/check-private-intake-freshness.test.mjs
@@ -20,20 +20,20 @@ describe("private intake freshness watchdog", () => {
     expect(checkPrivateIntakeFreshness(attestation(NOW - 60_000), NOW)).toEqual(
       {
         status: "safe",
-        expiresAt: "2026-08-29T08:59:00.000Z",
+        expiresAt: "2026-08-31T02:59:00.000Z",
       },
     );
   });
 
-  it("requires renewal at the 90-minute boundary and after expiry", () => {
+  it("requires renewal at the nine-hour boundary and after expiry", () => {
     expect(
       checkPrivateIntakeFreshness(
-        attestation(NOW - (7 * 60 - 90) * 60_000),
+        attestation(NOW - (49 * 60 - 9 * 60) * 60_000),
         NOW,
       ).status,
     ).toBe("renew");
     expect(
-      checkPrivateIntakeFreshness(attestation(NOW - 7 * 60 * 60_000), NOW)
+      checkPrivateIntakeFreshness(attestation(NOW - 49 * 60 * 60_000), NOW)
         .status,
     ).toBe("renew");
   });
@@ -51,7 +51,7 @@ describe("private intake freshness watchdog", () => {
   it("rejects malformed, stale, and extra-field attestations", () => {
     expect(checkPrivateIntakeFreshness({}, NOW).status).toBe("invalid");
     expect(
-      checkPrivateIntakeFreshness(attestation(NOW - 7 * 60 * 60_000 - 1), NOW)
+      checkPrivateIntakeFreshness(attestation(NOW - 49 * 60 * 60_000 - 1), NOW)
         .status,
     ).toBe("invalid");
     expect(

--- a/src/lib/private-intake-attestation.ts
+++ b/src/lib/private-intake-attestation.ts
@@ -1,6 +1,9 @@
 export const PRIVATE_INTAKE_ATTESTATION_PATH =
   "/data/private-intake-attestation.json";
-export const PRIVATE_INTAKE_ATTESTATION_MAX_AGE_MS = 7 * 60 * 60 * 1000;
+// Two full scheduled-refresh days. Every production refresh needs a human
+// environment approval, so a window shorter than a night plus one missed day
+// guarantees a recurring fail-closed intake outage (issue #302).
+export const PRIVATE_INTAKE_ATTESTATION_MAX_AGE_MS = 49 * 60 * 60 * 1000;
 
 export type PrivateIntakeAttestation = {
   enabled: true;


### PR DESCRIPTION
Addresses the practical private-intake outage branch of #302 after the maintainer explicitly authorized updating the deadline.

## Change

- Extend the exact-revision GitHub public-status attestation from 7 hours to 49 hours: two scheduled-refresh days plus one hour.
- Move the hourly watchdog renewal threshold from 90 minutes to 9 hours, covering one six-hour refresh interval plus approval slack.
- Update the protocol and recovery documentation to the same reviewed contract.
- Preserve exact `develop` revision binding, five-minute future-skew rejection, strict field validation, protected-environment review, and fail-closed expiry.
- Exclude the unrelated machine-specific `.claude/launch.json` that appeared in closed PR #323.

This deliberately accepts the maintainer-authorized availability/freshness tradeoff. It does not claim that scheduled leaderboard publishing is unattended; #302 should remain open for that separate acceptance criterion unless maintainers decide the longer reviewed window is the intended terminal policy.

## Exact-head validation

Head: `24510b464be24ec7659cae9c5b6b5c3759cdb626`

- `bunx vitest run src/lib/private-intake-attestation.test.ts scripts/check-private-intake-freshness.test.mjs scripts/deployment-contract.test.mjs functions`: 7 files / 70 tests passed.
- `bun run verify`: passed, including 67 files / 679 Vitest tests, 103 skill tests, registry/funding/cycle/protocol validation, dependency audit, typecheck, formatting, lint, and production build.
- `bun run test:e2e`: 36/36 desktop, tablet, and narrow-mobile browser tests passed after preparing the current live schema-6 ledger with the checked-in PR-ledger converter; the Pages artifact contract also passed 1/1.
- `git diff --check`: passed.

The first browser attempt was invalid because the detached worktree lacked ignored `public/data/leaderboard.json`, producing only expected 404/HTML-as-JSON failures. The complete rerun above used the current production ledger through `scripts/prepare-pr-ledger.ts` and passed without retries.