### PR TITLE
fix(scoring): reverify retained review attribution

### DIFF
--- a/data/accepted-review-history.json
+++ b/data/accepted-review-history.json
@@ -1,5 +1,69 @@
 {
-  "schemaVersion": "1",
+  "schemaVersion": "2",
+  "attributions": [
+    {
+      "id": "PRR_kwDOMT5cIs8AAAABKiiDoA:machine-marker:0",
+      "sourceId": "PRR_kwDOMT5cIs8AAAABKiiDoA",
+      "sourceUrl": "https://github.com/elizaOS/eliza/pull/25197#pullrequestreview-5002265504",
+      "artifactId": "PR_kwDOMT5cIs8AAAABAr93Yg",
+      "actor": {
+        "id": "U_kgDOCzScNQ",
+        "login": "mashingaan",
+        "avatarUrl": "https://avatars.githubusercontent.com/u/187997237?v=4",
+        "url": "https://github.com/mashingaan",
+        "kind": "User"
+      },
+      "provider": "openai",
+      "model": "gpt-5.6-sol",
+      "identifier": "openai/gpt-5.6-sol",
+      "client": "codex",
+      "skillRevision": "SlopDotCash/slopdotcash@92d692518c3d832ac9b203076ef691a54e61a9fa:skills/contribute-to-eliza",
+      "run": {
+        "schemaVersion": "2",
+        "runId": "run_01M0Q56B36JGGEP1AZNVNH3C9T",
+        "projectId": "eliza",
+        "repositoryId": "elizaOS/eliza",
+        "startedAt": "2026-08-23T11:13:17.926Z",
+        "completedAt": "2026-08-23T11:21:02.652Z",
+        "provider": "openai",
+        "model": "gpt-5.6-sol",
+        "client": "codex",
+        "skillRevision": "SlopDotCash/slopdotcash@92d692518c3d832ac9b203076ef691a54e61a9fa:skills/contribute-to-eliza",
+        "skillSha256": "97666aac5e8039955e335470436f46557ee59dcf48201fe39c429c078e373a0b",
+        "policyAcknowledgement": {
+          "policyRevision": "2026-08-18.1",
+          "licenseSha256": "d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d",
+          "inboundTermsSha256": "15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469",
+          "prizeRulesSha256": null,
+          "acknowledgedAt": "2026-08-23T11:13:19.068Z"
+        },
+        "usage": {
+          "source": "ccusage-session-v20",
+          "confidence": "unavailable",
+          "inputTokens": 0,
+          "outputTokens": 0,
+          "cacheCreationTokens": 0,
+          "cacheReadTokens": 0,
+          "totalTokens": 0,
+          "costMicroUsd": "0",
+          "sessionCount": 0
+        },
+        "trajectorySha256": "d86f5dbf7ae1cfe6ce01e19fd11d30ec240ba4a378417901e3dca20c359a7c4c",
+        "traceUpload": {
+          "authority": "https://api.slop.cash",
+          "serverRunId": "18b86343-e8a6-44fc-b70c-8875aea9c126",
+          "objectId": "sha256:d86f5dbf7ae1cfe6ce01e19fd11d30ec240ba4a378417901e3dca20c359a7c4c",
+          "sha256": "d86f5dbf7ae1cfe6ce01e19fd11d30ec240ba4a378417901e3dca20c359a7c4c"
+        },
+        "signatureAlgorithm": "ed25519",
+        "devicePublicKey": "MCowBQYDK2VwAyEAM-QnG1GIrFCQc80xfVVCicm6NwnOconuAnNxqQ3dJw0",
+        "deviceKeyId": "89e303b0db92a7b63fb55d5e6fbf1be4dc2eff6f41e4520fb74ee0b238899486",
+        "deviceSignature": "jwrbyBDpaF94xHMx-Ek2VbEGs5orn-tic8TnLOSWY8WFN_eadC5_FJKye6zl1RImejmAw0MpRClsNHuhVEJiDA"
+      },
+      "format": "machine-marker",
+      "status": "self-reported"
+    }
+  ],
   "events": [
     {
       "id": "PR_kwDOMT5cIs8AAAABAr9NwA:reviewer:U_kgDOCzScNQ",

--- a/scripts/generate-leaderboard.ts
+++ b/scripts/generate-leaderboard.ts
@@ -28,6 +28,7 @@ import {
   type LeaderboardSourceMetadata,
   type MergedPullRequestOutcome,
   type MergedPullRequestReviewRecord,
+  type ModelAttribution,
   type PullRequestFile,
   type PullRequestRecord,
   type PullRequestReview,
@@ -83,7 +84,10 @@ const ACCEPTED_REVIEW_HISTORY_PATH = resolve(
   "../data/accepted-review-history.json",
 );
 
-function loadAcceptedReviewHistory(): ScoreEvent[] {
+function loadAcceptedReviewHistory(): {
+  events: ScoreEvent[];
+  attributions: ModelAttribution[];
+} {
   const value = JSON.parse(
     readFileSync(ACCEPTED_REVIEW_HISTORY_PATH, "utf8"),
   ) as unknown;
@@ -91,13 +95,15 @@ function loadAcceptedReviewHistory(): ScoreEvent[] {
     typeof value !== "object" ||
     value === null ||
     Array.isArray(value) ||
-    (value as { schemaVersion?: unknown }).schemaVersion !== "1" ||
+    (value as { schemaVersion?: unknown }).schemaVersion !== "2" ||
     !Array.isArray((value as { events?: unknown }).events) ||
-    Object.keys(value).sort().join("\0") !== "events\0schemaVersion"
+    !Array.isArray((value as { attributions?: unknown }).attributions) ||
+    Object.keys(value).sort().join("\0") !==
+      "attributions\0events\0schemaVersion"
   ) {
     throw new TypeError("accepted review history manifest is invalid");
   }
-  return (value as { events: ScoreEvent[] }).events;
+  return value as { events: ScoreEvent[]; attributions: ModelAttribution[] };
 }
 
 type JsonRecord = Record<string, unknown>;
@@ -247,6 +253,7 @@ export interface GenerateOptions {
   evidenceTimeoutMs?: number;
   evaluatedContributions?: ScoreEvent[];
   retainedReviewEvents?: ScoreEvent[];
+  retainedReviewAttributions?: ModelAttribution[];
 }
 
 export function collectEvaluatedReviewArtifactKeys(
@@ -3571,6 +3578,7 @@ export async function generateLeaderboardFromGitHub(
       actualNow,
     ),
     retainedReviewEvents: options.retainedReviewEvents,
+    retainedReviewAttributions: options.retainedReviewAttributions,
     verifyRunReceipt: verifyRunReceiptSignature,
   });
   return snapshot;
@@ -3619,11 +3627,13 @@ function progressLine(progress: GenerationProgress): string {
 
 if (import.meta.main) {
   const arguments_ = parseGenerationArguments(process.argv.slice(2));
+  const acceptedReviewHistory = loadAcceptedReviewHistory();
   let lastProgressPhase: GenerationProgress["phase"] | null = null;
   const snapshot = await runGenerator(DEFAULT_OUTPUT_PATH, undefined, {
     ...arguments_,
     evaluatedContributions: loadEvaluatorAwardEvents(),
-    retainedReviewEvents: loadAcceptedReviewHistory(),
+    retainedReviewEvents: acceptedReviewHistory.events,
+    retainedReviewAttributions: acceptedReviewHistory.attributions,
     onProgress: (progress) => {
       const phaseChanged = progress.phase !== lastProgressPhase;
       lastProgressPhase = progress.phase;

--- a/src/lib/leaderboard.test.ts
+++ b/src/lib/leaderboard.test.ts
@@ -2677,6 +2677,193 @@ describe("scoring and limits", () => {
     );
   });
 
+  it("re-verifies retained review attribution without trusting its stored bonus", () => {
+    const reviewer = actor("retained-attributed-reviewer");
+    const retained: ScoreEvent = {
+      id: "PR_deleted_attributed:reviewer:U_retained-attributed-reviewer",
+      actor: reviewer,
+      category: "substantive-review",
+      points: 1,
+      scoreThirds: 3,
+      workUnitId: "wu_eliza_prr_deleted_attributed",
+      occurredAt: "2026-08-23T11:00:00.000Z",
+      repository: "elizaOS/eliza",
+      source: {
+        id: "PRR_deleted_attributed",
+        kind: "review",
+        number: 79,
+        title: "Deleted accepted attributed contribution",
+        url: "https://github.com/elizaOS/eliza/pull/79#pullrequestreview-799",
+      },
+      reason: "Previously accepted review credit.",
+      continuity: {
+        sourceSnapshotSha256: "a".repeat(64),
+        decisionUrl: "https://github.com/SlopDotCash/slopdotcash/issues/313",
+      },
+    };
+    const source: GitHubTextSource = {
+      id: retained.source.id,
+      artifactId: "PR_deleted_attributed",
+      kind: "review",
+      body: reviewAttribution(
+        {
+          schemaVersion: "2",
+          startedAt: "2026-08-23T09:00:00.000Z",
+          completedAt: "2026-08-23T10:00:00.000Z",
+          policyAcknowledgement: {
+            policyRevision: "2026-08-18.1",
+            licenseSha256:
+              "d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d",
+            inboundTermsSha256:
+              "15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469",
+            prizeRulesSha256: null,
+            acknowledgedAt: "2026-08-23T09:00:00.000Z",
+          },
+        },
+        { artifactUrl: "https://github.com/elizaOS/eliza/pull/79" },
+      ),
+      url: retained.source.url,
+      createdAt: retained.occurredAt,
+      updatedAt: retained.occurredAt,
+      author: reviewer,
+      artifactUrl: "https://github.com/elizaOS/eliza/pull/79",
+      artifactHeadSha: "a".repeat(40),
+    };
+    const attributionAssessment = assessModelAttribution([source], {
+      requireEverySource: true,
+      verifyRunReceipt: (value) => value as ProjectRunReceipt,
+    });
+    expect(attributionAssessment.invalidMarkers).toEqual([]);
+    const attribution = attributionAssessment.declarations[0];
+    expect(attribution).toBeDefined();
+    const retainedInput = (
+      overrides: Partial<LeaderboardInput>,
+    ): LeaderboardInput => {
+      const result = input(overrides);
+      result.generatedAt = "2026-08-24T12:00:00.000Z";
+      result.windowFrom = "2026-07-20T12:00:00.000Z";
+      result.windowTo = "2026-08-24T12:00:00.000Z";
+      result.sourceUpdatedAt = result.generatedAt;
+      result.source.fetchedAt = result.generatedAt;
+      result.source.cutoffAt = result.windowTo;
+      result.source.verificationWindow.from = result.windowFrom;
+      result.source.verificationWindow.to = result.windowTo;
+      result.verificationWindowFrom = result.windowFrom;
+      return result;
+    };
+
+    const accepted = createLeaderboardSnapshot(
+      retainedInput({
+        retainedReviewEvents: [retained],
+        retainedReviewAttributions: [attribution],
+        verifyRunReceipt: (value) => value as ProjectRunReceipt,
+      }),
+    );
+    expect(
+      accepted.ledger.find((event) => event.id === retained.id),
+    ).toMatchObject({
+      scoreThirds: 3,
+      evidenceBonusBasisPoints: 1_500,
+    });
+    expect(accepted.attributions).toContainEqual(
+      expect.objectContaining({ id: attribution.id }),
+    );
+
+    for (const rejectedInput of [
+      {
+        retainedReviewAttributions: [
+          {
+            ...attribution,
+            actor: actor("wrong-retained-reviewer"),
+          },
+        ],
+        verifyRunReceipt: (value: unknown) => value as ProjectRunReceipt,
+      },
+      {
+        retainedReviewAttributions: [attribution],
+        verifyRunReceipt: (_value: unknown): ProjectRunReceipt => {
+          throw new TypeError("signature verification failed");
+        },
+      },
+      {
+        retainedReviewAttributions: [
+          {
+            ...attribution,
+            run: { ...attribution.run!, traceUpload: null },
+          },
+        ],
+        verifyRunReceipt: (value: unknown) => value as ProjectRunReceipt,
+      },
+      {
+        retainedReviewAttributions: [
+          {
+            ...attribution,
+            run: { ...attribution.run!, repositoryId: "elizaOS/asi" },
+          },
+        ],
+        verifyRunReceipt: (value: unknown) => value as ProjectRunReceipt,
+      },
+      {
+        retainedReviewAttributions: [
+          { ...attribution, sourceId: "PRR_wrong_retained_source" },
+        ],
+        verifyRunReceipt: (value: unknown) => value as ProjectRunReceipt,
+      },
+    ]) {
+      const rejected = createLeaderboardSnapshot(
+        retainedInput({
+          retainedReviewEvents: [retained],
+          ...rejectedInput,
+        }),
+      );
+      expect(
+        rejected.ledger.find((event) => event.id === retained.id),
+      ).toMatchObject({ scoreThirds: 3 });
+      expect(
+        rejected.ledger.find((event) => event.id === retained.id)
+          ?.evidenceBonusBasisPoints ?? 0,
+      ).toBe(0);
+    }
+
+    const livePullRequest = pullRequest({
+      id: "PR_deleted_attributed",
+      number: 79,
+      createdAt: "2026-08-22T09:00:00.000Z",
+      updatedAt: "2026-08-23T12:00:00.000Z",
+      mergedAt: "2026-08-23T12:00:00.000Z",
+      reviews: [
+        {
+          id: retained.source.id,
+          body: source.body,
+          state: "APPROVED",
+          submittedAt: retained.occurredAt,
+          url: retained.source.url,
+          author: reviewer,
+          inlineCommentCount: 0,
+        },
+      ],
+    });
+    const live = createLeaderboardSnapshot(
+      retainedInput({
+        mergedPullRequests: [livePullRequest],
+        retainedReviewEvents: [retained],
+        retainedReviewAttributions: [attribution],
+        verifyRunReceipt: (value) => value as ProjectRunReceipt,
+      }),
+    );
+    expect(
+      live.ledger.filter((event) => event.source.id === retained.source.id),
+    ).toHaveLength(1);
+    expect(
+      live.ledger.find((event) => event.source.id === retained.source.id),
+    ).toMatchObject({ evidenceBonusBasisPoints: 1_500 });
+    expect(
+      live.attributions.filter(
+        (declaration) => declaration.sourceId === retained.source.id,
+      ),
+    ).toHaveLength(1);
+  });
+
   it("lets current GitHub evidence replace retained review history", () => {
     const reviewer = actor("current-reviewer");
     const review = {

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -649,6 +649,8 @@ export interface LeaderboardInput {
    * are replayed, so live GitHub remains authoritative whenever it exists.
    */
   retainedReviewEvents?: ScoreEvent[];
+  /** Signed attributions recovered from the same accepted snapshot. */
+  retainedReviewAttributions?: ModelAttribution[];
   verifyRunReceipt?: (value: unknown) => ProjectRunReceipt;
 }
 
@@ -3665,6 +3667,7 @@ export function createLeaderboardSnapshot(
   const currentScoreSources = new Set(
     ledger.map((event) => `${event.repository}\0${event.source.id}`),
   );
+  const retainedAttributionCandidates = new Map<string, ModelAttribution>();
   for (const [index, event] of [...(input.retainedReviewEvents ?? [])]
     .sort(
       (left, right) =>
@@ -3706,6 +3709,12 @@ export function createLeaderboardSnapshot(
     if (addScore(entries, ledger, retained)) {
       currentLedgerIds.add(retained.id);
       currentScoreSources.add(`${retained.repository}\0${retained.source.id}`);
+      const candidates = (input.retainedReviewAttributions ?? []).filter(
+        (attribution) => attribution.sourceId === retained.source.id,
+      );
+      if (candidates.length === 1) {
+        retainedAttributionCandidates.set(retained.id, candidates[0]);
+      }
     }
   }
 
@@ -3736,7 +3745,80 @@ export function createLeaderboardSnapshot(
       verifyRunReceipt: input.verifyRunReceipt,
     },
   );
-  const attributions = overallAttribution.declarations;
+  const attributions = [...overallAttribution.declarations];
+  const receiptClaims = new Set(
+    attributions.flatMap((attribution) =>
+      attribution.run?.traceUpload
+        ? [
+            `client run:${attribution.run.runId}`,
+            `server run:${attribution.run.traceUpload.serverRunId}`,
+            `trace object:${attribution.run.traceUpload.objectId}`,
+          ]
+        : [],
+    ),
+  );
+  for (const event of ledger) {
+    const candidate = retainedAttributionCandidates.get(event.id);
+    if (!candidate || !input.verifyRunReceipt) continue;
+    try {
+      assertAttributionValue(candidate, `retained attribution ${candidate.id}`);
+      const verifiedRun = input.verifyRunReceipt(candidate.run);
+      const parentPullRequestId = event.id.split(":", 1)[0];
+      const claims = verifiedRun.traceUpload
+        ? [
+            `client run:${verifiedRun.runId}`,
+            `server run:${verifiedRun.traceUpload.serverRunId}`,
+            `trace object:${verifiedRun.traceUpload.objectId}`,
+          ]
+        : [];
+      if (
+        candidate.format !== "machine-marker" ||
+        candidate.actor?.id !== event.actor.id ||
+        candidate.sourceId !== event.source.id ||
+        candidate.sourceUrl !== event.source.url ||
+        candidate.artifactId !== parentPullRequestId ||
+        candidate.run === null ||
+        !verifiedRun.traceUpload ||
+        verifiedRun.repositoryId !== event.repository ||
+        verifiedRun.provider !== candidate.provider ||
+        verifiedRun.model !== candidate.model ||
+        verifiedRun.client !== candidate.client ||
+        verifiedRun.skillRevision !== candidate.skillRevision ||
+        Date.parse(verifiedRun.completedAt) > Date.parse(event.occurredAt) ||
+        claims.some((claim) => receiptClaims.has(claim))
+      ) {
+        continue;
+      }
+      for (const claim of claims) receiptClaims.add(claim);
+      event.evidenceBonusBasisPoints = 1_500;
+      attributions.push({ ...candidate, run: verifiedRun });
+    } catch {
+      // Historical attribution is optional. Invalid replay never removes the
+      // independently accepted base review credit.
+    }
+  }
+  const retainedValidSourceCount =
+    attributions.length - overallAttribution.declarations.length;
+  const eligibleSourceCount =
+    overallAttribution.coverage.eligibleSourceCount + retainedValidSourceCount;
+  const validSourceCount =
+    overallAttribution.coverage.validSourceCount + retainedValidSourceCount;
+  const invalidSourceCount = overallAttribution.coverage.invalidSourceCount;
+  const attributionCoverage: AttributionCoverage = {
+    ...overallAttribution.coverage,
+    status:
+      eligibleSourceCount > 0 &&
+      validSourceCount === eligibleSourceCount &&
+      invalidSourceCount === 0
+        ? "complete"
+        : validSourceCount > 0
+          ? "partial"
+          : invalidSourceCount > 0
+            ? "invalid"
+            : "missing",
+    eligibleSourceCount,
+    validSourceCount,
+  };
   // A receipt can look valid when a review is assessed in isolation but be
   // rejected by the snapshot-wide replay guard because another scored source
   // already claimed the same client run, server run, or trace object. Preserve
@@ -3831,7 +3913,7 @@ export function createLeaderboardSnapshot(
         left.sourceId.localeCompare(right.sourceId) ||
         left.reason.localeCompare(right.reason),
     ),
-    attributionCoverage: overallAttribution.coverage,
+    attributionCoverage,
     workQueue: {
       issues: issueQueue.map((result) => result.item).sort(compareWorkItems),
       pullRequests: pullRequestQueue


### PR DESCRIPTION
Closes #324.

## What changed

- upgrades the accepted-review continuity manifest to schema 2 and retains the original published machine attribution recovered from immutable Actions artifact `9646439665` / snapshot SHA-256 `5a76b7754a1522e19270814163bee78c39805a35cd0edb947f1418a9d306ddc9`
- re-runs the signed historical receipt through the current verifier before publishing it
- requires exact stable-actor, repository, review source URL, parent PR node, provider/model/client/skill revision, completion-time, finalized-trace, and snapshot-wide replay bindings
- derives the fixed 1,500 bp finalized-trace weight after verification; no stored historical bonus is trusted
- keeps accepted base review credit when attribution is missing, malformed, mismatched, replayed, unsigned, or lacks a finalized trace
- leaves current live GitHub evidence authoritative whenever it exists

## Validation

Exact head: `9d98740ae4d6bf76dc9cf4a9f92b76edbd7b264d`

- `bun run verify` — passed
  - 67 Vitest files / 680 tests
  - 103 skill tests
  - registry, evaluator, funding, cycle, protocol, dependency, type, format, lint, and production build checks
- `bun run test:e2e` — passed
  - 36/36 real-browser scenarios across wide desktop, desktop, tablet, and 320px mobile
  - 1/1 Pages-emulator byte-consistency contract
- focused retained-attribution and generator tests — 169/169 passed
- recovered receipt verified independently with the production Ed25519 verifier; run `run_01M0Q56B36JGGEP1AZNVNH3C9T`, repository `elizaOS/eliza`, trace digest `d86f5dbf7ae1cfe6ce01e19fd11d30ec240ba4a378417901e3dca20c359a7c4c`
- `bun run typecheck` — passed
- `git diff --check` — passed

The browser run used a generated ignored PR ledger derived from the current deployed public snapshot; no generated ledger or captured evidence is committed.

