### PR TITLE
fix(skills): harden live reports for large changing queues

### DIFF
--- a/skill-tests/contribute-to-eliza.test.ts
+++ b/skill-tests/contribute-to-eliza.test.ts
@@ -34,6 +34,7 @@ import {
   createGhCommandBudget,
   createReviewEpoch,
   isBotAccount,
+  LiveInventoryChangedError,
   MAX_ACTIVITY_CONNECTION_ITEMS,
   MAX_REVIEW_EPOCH_CANDIDATES,
   MIN_REST_ACTIVITY_REQUESTS,
@@ -49,6 +50,7 @@ import {
   readProjectSelectionPolicy,
   recheckReviewEpochCandidate,
   renderMarkdown,
+  retryChangedLiveInventory,
 } from "../skills/contribute-to-eliza/scripts/live-report.mjs";
 import {
   isRepositoryRoot,
@@ -589,31 +591,40 @@ describe("live report parsing", () => {
         nodes: [{ comments: { totalCount: 1, nodes: [graphqlComment] } }],
       },
     };
-    const calls: string[][] = [];
-    const activity = readGhOpenActivity("elizaOS/eliza", (command, args) => {
-      assert.strictEqual(command, "gh");
-      calls.push(args);
-      const selector = args.at(-1);
-      return {
-        status: 0,
-        stderr: "",
-        stdout: `${JSON.stringify(
-          selector?.includes(".issues.") ? issueNode : pullNode,
-        )}\n`,
-      };
-    });
+    const calls: Array<{
+      args: string[];
+      options: import("node:child_process").SpawnSyncOptionsWithStringEncoding;
+    }> = [];
+    const activity = readGhOpenActivity(
+      "elizaOS/eliza",
+      (command, args, options) => {
+        assert.strictEqual(command, "gh");
+        calls.push({ args, options });
+        const selector = args.at(-1);
+        return {
+          status: 0,
+          stderr: "",
+          stdout: `${JSON.stringify(
+            selector?.includes(".issues.") ? issueNode : pullNode,
+          )}\n`,
+        };
+      },
+    );
 
     assert.strictEqual(calls.length, 2);
-    assert.ok(calls.every((args) => args.includes("graphql")));
-    assert.ok(calls.every((args) => args.includes("--paginate")));
+    assert.ok(calls.every(({ args }) => args.includes("graphql")));
+    assert.ok(calls.every(({ args }) => args.includes("--paginate")));
     assert.ok(
-      calls.every((args) => args[args.indexOf("--method") + 1] === "POST"),
+      calls.every(({ args }) => args[args.indexOf("--method") + 1] === "POST"),
     );
     assert.ok(
-      calls.every((args) => {
+      calls.every(({ args }) => {
         const query = args.find((argument) => argument.startsWith("query="));
         return query?.includes("query(") && !/\bmutation\b/i.test(query);
       }),
+    );
+    assert.ok(
+      calls.every(({ options }) => options.maxBuffer === 256 * 1024 * 1024),
     );
     assert.strictEqual(activity.issues.get(1)?.[0].user.id, 42);
     assert.strictEqual(activity.pulls.get(2)?.reviews[0].commit_id, HEAD_SHA);
@@ -1728,6 +1739,37 @@ describe("live report parsing", () => {
 });
 
 describe("live report behavior", () => {
+  it("retries one changed inventory snapshot without weakening other failures", () => {
+    let attempts = 0;
+    const retries: number[] = [];
+    const report = retryChangedLiveInventory(
+      () => {
+        attempts += 1;
+        if (attempts === 1) throw new LiveInventoryChangedError();
+        return { coherent: true };
+      },
+      ({ attempt }) => retries.push(attempt),
+    );
+
+    assert.deepStrictEqual(report, { coherent: true });
+    assert.strictEqual(attempts, 2);
+    assert.deepStrictEqual(retries, [1]);
+    assert.throws(
+      () =>
+        retryChangedLiveInventory(() => {
+          throw new TypeError("malformed GitHub response");
+        }),
+      /malformed GitHub response/,
+    );
+    assert.throws(
+      () =>
+        retryChangedLiveInventory(() => {
+          throw new LiveInventoryChangedError();
+        }),
+      /changed while collecting the live report after 2 attempts/,
+    );
+  });
+
   it("freezes a finite oldest-first epoch and defers arrivals and overflow", () => {
     const candidates = Array.from(
       { length: MAX_REVIEW_EPOCH_CANDIDATES + 3 },
@@ -2013,6 +2055,7 @@ describe("live report behavior", () => {
     assert.ok(
       !invocation?.args.some((argument) => /POST|PATCH|DELETE/.test(argument)),
     );
+    assert.strictEqual(invocation?.options.maxBuffer, 256 * 1024 * 1024);
   });
 
   it("keeps issues with open closing PRs out of the first-priority queue", () => {

--- a/skill-tests/contribute-to-eliza.test.ts
+++ b/skill-tests/contribute-to-eliza.test.ts
@@ -36,6 +36,7 @@ import {
   isBotAccount,
   LiveInventoryChangedError,
   MAX_ACTIVITY_CONNECTION_ITEMS,
+  MAX_API_READS,
   MAX_REVIEW_EPOCH_CANDIDATES,
   MIN_REST_ACTIVITY_REQUESTS,
   MIN_SEARCH_ACTIVITY_REQUESTS,
@@ -1768,6 +1769,32 @@ describe("live report behavior", () => {
         }),
       /changed while collecting the live report after 2 attempts/,
     );
+  });
+
+  it("gives each changed-inventory attempt its own command budget", () => {
+    const attemptBudgets: number[] = [];
+    const report = retryChangedLiveInventory(
+      ({ attempt, commandBudget }) => {
+        for (let index = 0; index < MAX_API_READS; index += 1) {
+          commandBudget.run("gh", ["api", `attempt-${attempt}-${index}`], {
+            encoding: "utf8",
+          });
+        }
+        attemptBudgets.push(commandBudget.count);
+        if (attempt === 1) throw new LiveInventoryChangedError();
+        return { coherent: true };
+      },
+      () => {},
+      () =>
+        createGhCommandBudget(() => ({
+          status: 0,
+          stdout: "",
+          stderr: "",
+        })),
+    );
+
+    assert.deepStrictEqual(report, { coherent: true });
+    assert.deepStrictEqual(attemptBudgets, [MAX_API_READS, MAX_API_READS]);
   });
 
   it("freezes a finite oldest-first epoch and defers arrivals and overflow", () => {

--- a/skills/contribute-to-asi/scripts/live-report.mjs
+++ b/skills/contribute-to-asi/scripts/live-report.mjs
@@ -31,9 +31,24 @@ export const REVIEW_EPOCH_SCHEMA_VERSION = 1;
 export const MAX_REVIEW_EPOCH_FILE_BYTES = 262_144;
 export const MAX_API_READS = 16;
 export const MAX_ACTIVITY_CONNECTION_ITEMS = 1_000;
+// Large repositories can legitimately exceed Node's 64 MiB spawnSync default
+// after gh concatenates bounded pages. Keep one explicit ceiling high enough
+// for the 10,000-item inventory while still failing closed on runaway output.
+export const MAX_GH_REPORT_BYTES = 256 * 1024 * 1024;
 export const MIN_GRAPHQL_ACTIVITY_POINTS = 1_000;
 export const MIN_REST_ACTIVITY_REQUESTS = 100;
 export const MIN_SEARCH_ACTIVITY_REQUESTS = 2;
+export const MAX_LIVE_INVENTORY_ATTEMPTS = 2;
+
+export class LiveInventoryChangedError extends Error {
+  constructor(
+    message = "batched activity does not exactly match the live open-item inventory",
+    options,
+  ) {
+    super(message, options);
+    this.name = "LiveInventoryChangedError";
+  }
+}
 
 const REPOSITORY_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const PLACEHOLDER_RE =
@@ -748,7 +763,7 @@ export function readGhPages(endpoint, spawn = spawnSync) {
   ];
   const result = spawn("gh", args, {
     encoding: "utf8",
-    maxBuffer: 64 * 1024 * 1024,
+    maxBuffer: MAX_GH_REPORT_BYTES,
     windowsHide: true,
   });
   if (result.error) throw result.error;
@@ -959,7 +974,7 @@ function readGhActivityPage(endpoint, pageNumber, context, spawn) {
     ["api", "--method", "GET", "--jq", ".[]", pagedEndpoint],
     {
       encoding: "utf8",
-      maxBuffer: 64 * 1024 * 1024,
+      maxBuffer: MAX_GH_REPORT_BYTES,
       windowsHide: true,
     },
   );
@@ -1051,7 +1066,7 @@ function readGhSearchPullNumbers(repo, qualifier, spawn) {
     ],
     {
       encoding: "utf8",
-      maxBuffer: 64 * 1024 * 1024,
+      maxBuffer: MAX_GH_REPORT_BYTES,
       windowsHide: true,
     },
   );
@@ -1274,7 +1289,7 @@ function readGraphqlActivityNodes(repo, query, selector, spawn, context) {
     ],
     {
       encoding: "utf8",
-      maxBuffer: 64 * 1024 * 1024,
+      maxBuffer: MAX_GH_REPORT_BYTES,
       windowsHide: true,
     },
   );
@@ -2239,9 +2254,7 @@ export function collectLiveReport(
       [...issueNumbers].some((number) => !activity.issues.has(number)) ||
       [...pullNumbers].some((number) => !activity.pulls.has(number))
     ) {
-      throw new TypeError(
-        "batched activity does not exactly match the live open-item inventory",
-      );
+      throw new LiveInventoryChangedError();
     }
   }
   onProgress({ phase: "issues", current: 0, total: issueItems.length });
@@ -2744,6 +2757,25 @@ Options:
 `;
 }
 
+/** Repeats one complete read when GitHub changes its open-item inventory mid-snapshot. */
+export function retryChangedLiveInventory(collect, onRetry = () => {}) {
+  for (let attempt = 1; attempt <= MAX_LIVE_INVENTORY_ATTEMPTS; attempt += 1) {
+    try {
+      return collect(attempt);
+    } catch (cause) {
+      if (!(cause instanceof LiveInventoryChangedError)) throw cause;
+      if (attempt === MAX_LIVE_INVENTORY_ATTEMPTS) {
+        throw new LiveInventoryChangedError(
+          `Open GitHub inventory changed while collecting the live report after ${MAX_LIVE_INVENTORY_ATTEMPTS} attempts`,
+          { cause },
+        );
+      }
+      onRetry({ attempt, cause });
+    }
+  }
+  throw new Error("unreachable live inventory retry state");
+}
+
 export function main(args = process.argv.slice(2)) {
   const selectionPolicy = readProjectSelectionPolicy();
   const options = parseCliArguments(args, selectionPolicy.repositoryId);
@@ -2779,26 +2811,40 @@ export function main(args = process.argv.slice(2)) {
   const boundedRead = (endpoint) => {
     return readGhPages(endpoint, commandBudget.run);
   };
-  const openActivity = readGhOpenActivity(options.repo, commandBudget.run, {
-    preflight: true,
-  });
-  const limits = asRecord(openActivity.rateLimits, "GitHub rate limits");
-  process.stderr.write(
-    `[Slop] GitHub budgets: GraphQL ${limits.graphqlRemaining}/${limits.graphqlLimit} (${limits.graphqlBudgetSource}); REST ${limits.restRemaining}/${limits.restLimit}; Search ${limits.searchRemaining}/${limits.searchLimit}; activity source ${openActivity.source}\n`,
-  );
-  const report = collectLiveReport(
-    options.repo,
-    boundedRead,
-    new Date(),
-    ({ phase, current, total }) => {
-      if (current === 0 || current === total || current % 10 === 0) {
-        process.stderr.write(
-          `[Slop] scanning ${phase}: ${current}/${total} (${commandBudget.count} bounded GitHub commands)\n`,
-        );
-      }
+  let rateLimits = { preflight: true };
+  const { report } = retryChangedLiveInventory(
+    () => {
+      const openActivity = readGhOpenActivity(
+        options.repo,
+        commandBudget.run,
+        rateLimits,
+      );
+      rateLimits = openActivity.rateLimits;
+      const limits = asRecord(openActivity.rateLimits, "GitHub rate limits");
+      process.stderr.write(
+        `[Slop] GitHub budgets: GraphQL ${limits.graphqlRemaining}/${limits.graphqlLimit} (${limits.graphqlBudgetSource}); REST ${limits.restRemaining}/${limits.restLimit}; Search ${limits.searchRemaining}/${limits.searchLimit}; activity source ${openActivity.source}\n`,
+      );
+      return {
+        report: collectLiveReport(
+          options.repo,
+          boundedRead,
+          new Date(),
+          ({ phase, current, total }) => {
+            if (current === 0 || current === total || current % 10 === 0) {
+              process.stderr.write(
+                `[Slop] scanning ${phase}: ${current}/${total} (${commandBudget.count} bounded GitHub commands)\n`,
+              );
+            }
+          },
+          openActivity,
+          selectionPolicy.eligibleIssueLabels,
+        ),
+      };
     },
-    openActivity,
-    selectionPolicy.eligibleIssueLabels,
+    ({ attempt }) =>
+      process.stderr.write(
+        `[Slop] open-item inventory changed during snapshot attempt ${attempt}; retrying one complete read\n`,
+      ),
   );
   process.stdout.write(
     options.epochOnly

--- a/skills/contribute-to-asi/scripts/live-report.mjs
+++ b/skills/contribute-to-asi/scripts/live-report.mjs
@@ -2758,10 +2758,15 @@ Options:
 }
 
 /** Repeats one complete read when GitHub changes its open-item inventory mid-snapshot. */
-export function retryChangedLiveInventory(collect, onRetry = () => {}) {
+export function retryChangedLiveInventory(
+  collect,
+  onRetry = () => {},
+  createCommandBudget = createGhCommandBudget,
+) {
   for (let attempt = 1; attempt <= MAX_LIVE_INVENTORY_ATTEMPTS; attempt += 1) {
+    const commandBudget = createCommandBudget();
     try {
-      return collect(attempt);
+      return collect({ attempt, commandBudget });
     } catch (cause) {
       if (!(cause instanceof LiveInventoryChangedError)) throw cause;
       if (attempt === MAX_LIVE_INVENTORY_ATTEMPTS) {
@@ -2794,8 +2799,8 @@ export function main(args = process.argv.slice(2)) {
     if (!result.complete) process.exitCode = 2;
     return;
   }
-  const commandBudget = createGhCommandBudget();
   if (options.recheckPr !== undefined) {
+    const commandBudget = createGhCommandBudget();
     const result = recheckLivePullHead(
       options.repo,
       {
@@ -2808,12 +2813,12 @@ export function main(args = process.argv.slice(2)) {
     if (!result.publishable) process.exitCode = 2;
     return;
   }
-  const boundedRead = (endpoint) => {
-    return readGhPages(endpoint, commandBudget.run);
-  };
   let rateLimits = { preflight: true };
   const { report } = retryChangedLiveInventory(
-    () => {
+    ({ commandBudget }) => {
+      const boundedRead = (endpoint) => {
+        return readGhPages(endpoint, commandBudget.run);
+      };
       const openActivity = readGhOpenActivity(
         options.repo,
         commandBudget.run,

--- a/skills/contribute-to-delta-star/scripts/live-report.mjs
+++ b/skills/contribute-to-delta-star/scripts/live-report.mjs
@@ -31,9 +31,24 @@ export const REVIEW_EPOCH_SCHEMA_VERSION = 1;
 export const MAX_REVIEW_EPOCH_FILE_BYTES = 262_144;
 export const MAX_API_READS = 16;
 export const MAX_ACTIVITY_CONNECTION_ITEMS = 1_000;
+// Large repositories can legitimately exceed Node's 64 MiB spawnSync default
+// after gh concatenates bounded pages. Keep one explicit ceiling high enough
+// for the 10,000-item inventory while still failing closed on runaway output.
+export const MAX_GH_REPORT_BYTES = 256 * 1024 * 1024;
 export const MIN_GRAPHQL_ACTIVITY_POINTS = 1_000;
 export const MIN_REST_ACTIVITY_REQUESTS = 100;
 export const MIN_SEARCH_ACTIVITY_REQUESTS = 2;
+export const MAX_LIVE_INVENTORY_ATTEMPTS = 2;
+
+export class LiveInventoryChangedError extends Error {
+  constructor(
+    message = "batched activity does not exactly match the live open-item inventory",
+    options,
+  ) {
+    super(message, options);
+    this.name = "LiveInventoryChangedError";
+  }
+}
 
 const REPOSITORY_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const PLACEHOLDER_RE =
@@ -748,7 +763,7 @@ export function readGhPages(endpoint, spawn = spawnSync) {
   ];
   const result = spawn("gh", args, {
     encoding: "utf8",
-    maxBuffer: 64 * 1024 * 1024,
+    maxBuffer: MAX_GH_REPORT_BYTES,
     windowsHide: true,
   });
   if (result.error) throw result.error;
@@ -959,7 +974,7 @@ function readGhActivityPage(endpoint, pageNumber, context, spawn) {
     ["api", "--method", "GET", "--jq", ".[]", pagedEndpoint],
     {
       encoding: "utf8",
-      maxBuffer: 64 * 1024 * 1024,
+      maxBuffer: MAX_GH_REPORT_BYTES,
       windowsHide: true,
     },
   );
@@ -1051,7 +1066,7 @@ function readGhSearchPullNumbers(repo, qualifier, spawn) {
     ],
     {
       encoding: "utf8",
-      maxBuffer: 64 * 1024 * 1024,
+      maxBuffer: MAX_GH_REPORT_BYTES,
       windowsHide: true,
     },
   );
@@ -1274,7 +1289,7 @@ function readGraphqlActivityNodes(repo, query, selector, spawn, context) {
     ],
     {
       encoding: "utf8",
-      maxBuffer: 64 * 1024 * 1024,
+      maxBuffer: MAX_GH_REPORT_BYTES,
       windowsHide: true,
     },
   );
@@ -2239,9 +2254,7 @@ export function collectLiveReport(
       [...issueNumbers].some((number) => !activity.issues.has(number)) ||
       [...pullNumbers].some((number) => !activity.pulls.has(number))
     ) {
-      throw new TypeError(
-        "batched activity does not exactly match the live open-item inventory",
-      );
+      throw new LiveInventoryChangedError();
     }
   }
   onProgress({ phase: "issues", current: 0, total: issueItems.length });
@@ -2744,6 +2757,25 @@ Options:
 `;
 }
 
+/** Repeats one complete read when GitHub changes its open-item inventory mid-snapshot. */
+export function retryChangedLiveInventory(collect, onRetry = () => {}) {
+  for (let attempt = 1; attempt <= MAX_LIVE_INVENTORY_ATTEMPTS; attempt += 1) {
+    try {
+      return collect(attempt);
+    } catch (cause) {
+      if (!(cause instanceof LiveInventoryChangedError)) throw cause;
+      if (attempt === MAX_LIVE_INVENTORY_ATTEMPTS) {
+        throw new LiveInventoryChangedError(
+          `Open GitHub inventory changed while collecting the live report after ${MAX_LIVE_INVENTORY_ATTEMPTS} attempts`,
+          { cause },
+        );
+      }
+      onRetry({ attempt, cause });
+    }
+  }
+  throw new Error("unreachable live inventory retry state");
+}
+
 export function main(args = process.argv.slice(2)) {
   const selectionPolicy = readProjectSelectionPolicy();
   const options = parseCliArguments(args, selectionPolicy.repositoryId);
@@ -2779,26 +2811,40 @@ export function main(args = process.argv.slice(2)) {
   const boundedRead = (endpoint) => {
     return readGhPages(endpoint, commandBudget.run);
   };
-  const openActivity = readGhOpenActivity(options.repo, commandBudget.run, {
-    preflight: true,
-  });
-  const limits = asRecord(openActivity.rateLimits, "GitHub rate limits");
-  process.stderr.write(
-    `[Slop] GitHub budgets: GraphQL ${limits.graphqlRemaining}/${limits.graphqlLimit} (${limits.graphqlBudgetSource}); REST ${limits.restRemaining}/${limits.restLimit}; Search ${limits.searchRemaining}/${limits.searchLimit}; activity source ${openActivity.source}\n`,
-  );
-  const report = collectLiveReport(
-    options.repo,
-    boundedRead,
-    new Date(),
-    ({ phase, current, total }) => {
-      if (current === 0 || current === total || current % 10 === 0) {
-        process.stderr.write(
-          `[Slop] scanning ${phase}: ${current}/${total} (${commandBudget.count} bounded GitHub commands)\n`,
-        );
-      }
+  let rateLimits = { preflight: true };
+  const { report } = retryChangedLiveInventory(
+    () => {
+      const openActivity = readGhOpenActivity(
+        options.repo,
+        commandBudget.run,
+        rateLimits,
+      );
+      rateLimits = openActivity.rateLimits;
+      const limits = asRecord(openActivity.rateLimits, "GitHub rate limits");
+      process.stderr.write(
+        `[Slop] GitHub budgets: GraphQL ${limits.graphqlRemaining}/${limits.graphqlLimit} (${limits.graphqlBudgetSource}); REST ${limits.restRemaining}/${limits.restLimit}; Search ${limits.searchRemaining}/${limits.searchLimit}; activity source ${openActivity.source}\n`,
+      );
+      return {
+        report: collectLiveReport(
+          options.repo,
+          boundedRead,
+          new Date(),
+          ({ phase, current, total }) => {
+            if (current === 0 || current === total || current % 10 === 0) {
+              process.stderr.write(
+                `[Slop] scanning ${phase}: ${current}/${total} (${commandBudget.count} bounded GitHub commands)\n`,
+              );
+            }
+          },
+          openActivity,
+          selectionPolicy.eligibleIssueLabels,
+        ),
+      };
     },
-    openActivity,
-    selectionPolicy.eligibleIssueLabels,
+    ({ attempt }) =>
+      process.stderr.write(
+        `[Slop] open-item inventory changed during snapshot attempt ${attempt}; retrying one complete read\n`,
+      ),
   );
   process.stdout.write(
     options.epochOnly

--- a/skills/contribute-to-delta-star/scripts/live-report.mjs
+++ b/skills/contribute-to-delta-star/scripts/live-report.mjs
@@ -2758,10 +2758,15 @@ Options:
 }
 
 /** Repeats one complete read when GitHub changes its open-item inventory mid-snapshot. */
-export function retryChangedLiveInventory(collect, onRetry = () => {}) {
+export function retryChangedLiveInventory(
+  collect,
+  onRetry = () => {},
+  createCommandBudget = createGhCommandBudget,
+) {
   for (let attempt = 1; attempt <= MAX_LIVE_INVENTORY_ATTEMPTS; attempt += 1) {
+    const commandBudget = createCommandBudget();
     try {
-      return collect(attempt);
+      return collect({ attempt, commandBudget });
     } catch (cause) {
       if (!(cause instanceof LiveInventoryChangedError)) throw cause;
       if (attempt === MAX_LIVE_INVENTORY_ATTEMPTS) {
@@ -2794,8 +2799,8 @@ export function main(args = process.argv.slice(2)) {
     if (!result.complete) process.exitCode = 2;
     return;
   }
-  const commandBudget = createGhCommandBudget();
   if (options.recheckPr !== undefined) {
+    const commandBudget = createGhCommandBudget();
     const result = recheckLivePullHead(
       options.repo,
       {
@@ -2808,12 +2813,12 @@ export function main(args = process.argv.slice(2)) {
     if (!result.publishable) process.exitCode = 2;
     return;
   }
-  const boundedRead = (endpoint) => {
-    return readGhPages(endpoint, commandBudget.run);
-  };
   let rateLimits = { preflight: true };
   const { report } = retryChangedLiveInventory(
-    () => {
+    ({ commandBudget }) => {
+      const boundedRead = (endpoint) => {
+        return readGhPages(endpoint, commandBudget.run);
+      };
       const openActivity = readGhOpenActivity(
         options.repo,
         commandBudget.run,

--- a/skills/contribute-to-eliza/scripts/live-report.mjs
+++ b/skills/contribute-to-eliza/scripts/live-report.mjs
@@ -31,9 +31,24 @@ export const REVIEW_EPOCH_SCHEMA_VERSION = 1;
 export const MAX_REVIEW_EPOCH_FILE_BYTES = 262_144;
 export const MAX_API_READS = 16;
 export const MAX_ACTIVITY_CONNECTION_ITEMS = 1_000;
+// Large repositories can legitimately exceed Node's 64 MiB spawnSync default
+// after gh concatenates bounded pages. Keep one explicit ceiling high enough
+// for the 10,000-item inventory while still failing closed on runaway output.
+export const MAX_GH_REPORT_BYTES = 256 * 1024 * 1024;
 export const MIN_GRAPHQL_ACTIVITY_POINTS = 1_000;
 export const MIN_REST_ACTIVITY_REQUESTS = 100;
 export const MIN_SEARCH_ACTIVITY_REQUESTS = 2;
+export const MAX_LIVE_INVENTORY_ATTEMPTS = 2;
+
+export class LiveInventoryChangedError extends Error {
+  constructor(
+    message = "batched activity does not exactly match the live open-item inventory",
+    options,
+  ) {
+    super(message, options);
+    this.name = "LiveInventoryChangedError";
+  }
+}
 
 const REPOSITORY_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const PLACEHOLDER_RE =
@@ -748,7 +763,7 @@ export function readGhPages(endpoint, spawn = spawnSync) {
   ];
   const result = spawn("gh", args, {
     encoding: "utf8",
-    maxBuffer: 64 * 1024 * 1024,
+    maxBuffer: MAX_GH_REPORT_BYTES,
     windowsHide: true,
   });
   if (result.error) throw result.error;
@@ -959,7 +974,7 @@ function readGhActivityPage(endpoint, pageNumber, context, spawn) {
     ["api", "--method", "GET", "--jq", ".[]", pagedEndpoint],
     {
       encoding: "utf8",
-      maxBuffer: 64 * 1024 * 1024,
+      maxBuffer: MAX_GH_REPORT_BYTES,
       windowsHide: true,
     },
   );
@@ -1051,7 +1066,7 @@ function readGhSearchPullNumbers(repo, qualifier, spawn) {
     ],
     {
       encoding: "utf8",
-      maxBuffer: 64 * 1024 * 1024,
+      maxBuffer: MAX_GH_REPORT_BYTES,
       windowsHide: true,
     },
   );
@@ -1274,7 +1289,7 @@ function readGraphqlActivityNodes(repo, query, selector, spawn, context) {
     ],
     {
       encoding: "utf8",
-      maxBuffer: 64 * 1024 * 1024,
+      maxBuffer: MAX_GH_REPORT_BYTES,
       windowsHide: true,
     },
   );
@@ -2239,9 +2254,7 @@ export function collectLiveReport(
       [...issueNumbers].some((number) => !activity.issues.has(number)) ||
       [...pullNumbers].some((number) => !activity.pulls.has(number))
     ) {
-      throw new TypeError(
-        "batched activity does not exactly match the live open-item inventory",
-      );
+      throw new LiveInventoryChangedError();
     }
   }
   onProgress({ phase: "issues", current: 0, total: issueItems.length });
@@ -2744,6 +2757,25 @@ Options:
 `;
 }
 
+/** Repeats one complete read when GitHub changes its open-item inventory mid-snapshot. */
+export function retryChangedLiveInventory(collect, onRetry = () => {}) {
+  for (let attempt = 1; attempt <= MAX_LIVE_INVENTORY_ATTEMPTS; attempt += 1) {
+    try {
+      return collect(attempt);
+    } catch (cause) {
+      if (!(cause instanceof LiveInventoryChangedError)) throw cause;
+      if (attempt === MAX_LIVE_INVENTORY_ATTEMPTS) {
+        throw new LiveInventoryChangedError(
+          `Open GitHub inventory changed while collecting the live report after ${MAX_LIVE_INVENTORY_ATTEMPTS} attempts`,
+          { cause },
+        );
+      }
+      onRetry({ attempt, cause });
+    }
+  }
+  throw new Error("unreachable live inventory retry state");
+}
+
 export function main(args = process.argv.slice(2)) {
   const selectionPolicy = readProjectSelectionPolicy();
   const options = parseCliArguments(args, selectionPolicy.repositoryId);
@@ -2779,26 +2811,40 @@ export function main(args = process.argv.slice(2)) {
   const boundedRead = (endpoint) => {
     return readGhPages(endpoint, commandBudget.run);
   };
-  const openActivity = readGhOpenActivity(options.repo, commandBudget.run, {
-    preflight: true,
-  });
-  const limits = asRecord(openActivity.rateLimits, "GitHub rate limits");
-  process.stderr.write(
-    `[Slop] GitHub budgets: GraphQL ${limits.graphqlRemaining}/${limits.graphqlLimit} (${limits.graphqlBudgetSource}); REST ${limits.restRemaining}/${limits.restLimit}; Search ${limits.searchRemaining}/${limits.searchLimit}; activity source ${openActivity.source}\n`,
-  );
-  const report = collectLiveReport(
-    options.repo,
-    boundedRead,
-    new Date(),
-    ({ phase, current, total }) => {
-      if (current === 0 || current === total || current % 10 === 0) {
-        process.stderr.write(
-          `[Slop] scanning ${phase}: ${current}/${total} (${commandBudget.count} bounded GitHub commands)\n`,
-        );
-      }
+  let rateLimits = { preflight: true };
+  const { report } = retryChangedLiveInventory(
+    () => {
+      const openActivity = readGhOpenActivity(
+        options.repo,
+        commandBudget.run,
+        rateLimits,
+      );
+      rateLimits = openActivity.rateLimits;
+      const limits = asRecord(openActivity.rateLimits, "GitHub rate limits");
+      process.stderr.write(
+        `[Slop] GitHub budgets: GraphQL ${limits.graphqlRemaining}/${limits.graphqlLimit} (${limits.graphqlBudgetSource}); REST ${limits.restRemaining}/${limits.restLimit}; Search ${limits.searchRemaining}/${limits.searchLimit}; activity source ${openActivity.source}\n`,
+      );
+      return {
+        report: collectLiveReport(
+          options.repo,
+          boundedRead,
+          new Date(),
+          ({ phase, current, total }) => {
+            if (current === 0 || current === total || current % 10 === 0) {
+              process.stderr.write(
+                `[Slop] scanning ${phase}: ${current}/${total} (${commandBudget.count} bounded GitHub commands)\n`,
+              );
+            }
+          },
+          openActivity,
+          selectionPolicy.eligibleIssueLabels,
+        ),
+      };
     },
-    openActivity,
-    selectionPolicy.eligibleIssueLabels,
+    ({ attempt }) =>
+      process.stderr.write(
+        `[Slop] open-item inventory changed during snapshot attempt ${attempt}; retrying one complete read\n`,
+      ),
   );
   process.stdout.write(
     options.epochOnly

--- a/skills/contribute-to-eliza/scripts/live-report.mjs
+++ b/skills/contribute-to-eliza/scripts/live-report.mjs
@@ -2758,10 +2758,15 @@ Options:
 }
 
 /** Repeats one complete read when GitHub changes its open-item inventory mid-snapshot. */
-export function retryChangedLiveInventory(collect, onRetry = () => {}) {
+export function retryChangedLiveInventory(
+  collect,
+  onRetry = () => {},
+  createCommandBudget = createGhCommandBudget,
+) {
   for (let attempt = 1; attempt <= MAX_LIVE_INVENTORY_ATTEMPTS; attempt += 1) {
+    const commandBudget = createCommandBudget();
     try {
-      return collect(attempt);
+      return collect({ attempt, commandBudget });
     } catch (cause) {
       if (!(cause instanceof LiveInventoryChangedError)) throw cause;
       if (attempt === MAX_LIVE_INVENTORY_ATTEMPTS) {
@@ -2794,8 +2799,8 @@ export function main(args = process.argv.slice(2)) {
     if (!result.complete) process.exitCode = 2;
     return;
   }
-  const commandBudget = createGhCommandBudget();
   if (options.recheckPr !== undefined) {
+    const commandBudget = createGhCommandBudget();
     const result = recheckLivePullHead(
       options.repo,
       {
@@ -2808,12 +2813,12 @@ export function main(args = process.argv.slice(2)) {
     if (!result.publishable) process.exitCode = 2;
     return;
   }
-  const boundedRead = (endpoint) => {
-    return readGhPages(endpoint, commandBudget.run);
-  };
   let rateLimits = { preflight: true };
   const { report } = retryChangedLiveInventory(
-    () => {
+    ({ commandBudget }) => {
+      const boundedRead = (endpoint) => {
+        return readGhPages(endpoint, commandBudget.run);
+      };
       const openActivity = readGhOpenActivity(
         options.repo,
         commandBudget.run,

--- a/skills/contribute-to-heir-elements-sdk/scripts/live-report.mjs
+++ b/skills/contribute-to-heir-elements-sdk/scripts/live-report.mjs
@@ -31,9 +31,24 @@ export const REVIEW_EPOCH_SCHEMA_VERSION = 1;
 export const MAX_REVIEW_EPOCH_FILE_BYTES = 262_144;
 export const MAX_API_READS = 16;
 export const MAX_ACTIVITY_CONNECTION_ITEMS = 1_000;
+// Large repositories can legitimately exceed Node's 64 MiB spawnSync default
+// after gh concatenates bounded pages. Keep one explicit ceiling high enough
+// for the 10,000-item inventory while still failing closed on runaway output.
+export const MAX_GH_REPORT_BYTES = 256 * 1024 * 1024;
 export const MIN_GRAPHQL_ACTIVITY_POINTS = 1_000;
 export const MIN_REST_ACTIVITY_REQUESTS = 100;
 export const MIN_SEARCH_ACTIVITY_REQUESTS = 2;
+export const MAX_LIVE_INVENTORY_ATTEMPTS = 2;
+
+export class LiveInventoryChangedError extends Error {
+  constructor(
+    message = "batched activity does not exactly match the live open-item inventory",
+    options,
+  ) {
+    super(message, options);
+    this.name = "LiveInventoryChangedError";
+  }
+}
 
 const REPOSITORY_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const PLACEHOLDER_RE =
@@ -748,7 +763,7 @@ export function readGhPages(endpoint, spawn = spawnSync) {
   ];
   const result = spawn("gh", args, {
     encoding: "utf8",
-    maxBuffer: 64 * 1024 * 1024,
+    maxBuffer: MAX_GH_REPORT_BYTES,
     windowsHide: true,
   });
   if (result.error) throw result.error;
@@ -959,7 +974,7 @@ function readGhActivityPage(endpoint, pageNumber, context, spawn) {
     ["api", "--method", "GET", "--jq", ".[]", pagedEndpoint],
     {
       encoding: "utf8",
-      maxBuffer: 64 * 1024 * 1024,
+      maxBuffer: MAX_GH_REPORT_BYTES,
       windowsHide: true,
     },
   );
@@ -1051,7 +1066,7 @@ function readGhSearchPullNumbers(repo, qualifier, spawn) {
     ],
     {
       encoding: "utf8",
-      maxBuffer: 64 * 1024 * 1024,
+      maxBuffer: MAX_GH_REPORT_BYTES,
       windowsHide: true,
     },
   );
@@ -1274,7 +1289,7 @@ function readGraphqlActivityNodes(repo, query, selector, spawn, context) {
     ],
     {
       encoding: "utf8",
-      maxBuffer: 64 * 1024 * 1024,
+      maxBuffer: MAX_GH_REPORT_BYTES,
       windowsHide: true,
     },
   );
@@ -2239,9 +2254,7 @@ export function collectLiveReport(
       [...issueNumbers].some((number) => !activity.issues.has(number)) ||
       [...pullNumbers].some((number) => !activity.pulls.has(number))
     ) {
-      throw new TypeError(
-        "batched activity does not exactly match the live open-item inventory",
-      );
+      throw new LiveInventoryChangedError();
     }
   }
   onProgress({ phase: "issues", current: 0, total: issueItems.length });
@@ -2744,6 +2757,25 @@ Options:
 `;
 }
 
+/** Repeats one complete read when GitHub changes its open-item inventory mid-snapshot. */
+export function retryChangedLiveInventory(collect, onRetry = () => {}) {
+  for (let attempt = 1; attempt <= MAX_LIVE_INVENTORY_ATTEMPTS; attempt += 1) {
+    try {
+      return collect(attempt);
+    } catch (cause) {
+      if (!(cause instanceof LiveInventoryChangedError)) throw cause;
+      if (attempt === MAX_LIVE_INVENTORY_ATTEMPTS) {
+        throw new LiveInventoryChangedError(
+          `Open GitHub inventory changed while collecting the live report after ${MAX_LIVE_INVENTORY_ATTEMPTS} attempts`,
+          { cause },
+        );
+      }
+      onRetry({ attempt, cause });
+    }
+  }
+  throw new Error("unreachable live inventory retry state");
+}
+
 export function main(args = process.argv.slice(2)) {
   const selectionPolicy = readProjectSelectionPolicy();
   const options = parseCliArguments(args, selectionPolicy.repositoryId);
@@ -2779,26 +2811,40 @@ export function main(args = process.argv.slice(2)) {
   const boundedRead = (endpoint) => {
     return readGhPages(endpoint, commandBudget.run);
   };
-  const openActivity = readGhOpenActivity(options.repo, commandBudget.run, {
-    preflight: true,
-  });
-  const limits = asRecord(openActivity.rateLimits, "GitHub rate limits");
-  process.stderr.write(
-    `[Slop] GitHub budgets: GraphQL ${limits.graphqlRemaining}/${limits.graphqlLimit} (${limits.graphqlBudgetSource}); REST ${limits.restRemaining}/${limits.restLimit}; Search ${limits.searchRemaining}/${limits.searchLimit}; activity source ${openActivity.source}\n`,
-  );
-  const report = collectLiveReport(
-    options.repo,
-    boundedRead,
-    new Date(),
-    ({ phase, current, total }) => {
-      if (current === 0 || current === total || current % 10 === 0) {
-        process.stderr.write(
-          `[Slop] scanning ${phase}: ${current}/${total} (${commandBudget.count} bounded GitHub commands)\n`,
-        );
-      }
+  let rateLimits = { preflight: true };
+  const { report } = retryChangedLiveInventory(
+    () => {
+      const openActivity = readGhOpenActivity(
+        options.repo,
+        commandBudget.run,
+        rateLimits,
+      );
+      rateLimits = openActivity.rateLimits;
+      const limits = asRecord(openActivity.rateLimits, "GitHub rate limits");
+      process.stderr.write(
+        `[Slop] GitHub budgets: GraphQL ${limits.graphqlRemaining}/${limits.graphqlLimit} (${limits.graphqlBudgetSource}); REST ${limits.restRemaining}/${limits.restLimit}; Search ${limits.searchRemaining}/${limits.searchLimit}; activity source ${openActivity.source}\n`,
+      );
+      return {
+        report: collectLiveReport(
+          options.repo,
+          boundedRead,
+          new Date(),
+          ({ phase, current, total }) => {
+            if (current === 0 || current === total || current % 10 === 0) {
+              process.stderr.write(
+                `[Slop] scanning ${phase}: ${current}/${total} (${commandBudget.count} bounded GitHub commands)\n`,
+              );
+            }
+          },
+          openActivity,
+          selectionPolicy.eligibleIssueLabels,
+        ),
+      };
     },
-    openActivity,
-    selectionPolicy.eligibleIssueLabels,
+    ({ attempt }) =>
+      process.stderr.write(
+        `[Slop] open-item inventory changed during snapshot attempt ${attempt}; retrying one complete read\n`,
+      ),
   );
   process.stdout.write(
     options.epochOnly

--- a/skills/contribute-to-heir-elements-sdk/scripts/live-report.mjs
+++ b/skills/contribute-to-heir-elements-sdk/scripts/live-report.mjs
@@ -2758,10 +2758,15 @@ Options:
 }
 
 /** Repeats one complete read when GitHub changes its open-item inventory mid-snapshot. */
-export function retryChangedLiveInventory(collect, onRetry = () => {}) {
+export function retryChangedLiveInventory(
+  collect,
+  onRetry = () => {},
+  createCommandBudget = createGhCommandBudget,
+) {
   for (let attempt = 1; attempt <= MAX_LIVE_INVENTORY_ATTEMPTS; attempt += 1) {
+    const commandBudget = createCommandBudget();
     try {
-      return collect(attempt);
+      return collect({ attempt, commandBudget });
     } catch (cause) {
       if (!(cause instanceof LiveInventoryChangedError)) throw cause;
       if (attempt === MAX_LIVE_INVENTORY_ATTEMPTS) {
@@ -2794,8 +2799,8 @@ export function main(args = process.argv.slice(2)) {
     if (!result.complete) process.exitCode = 2;
     return;
   }
-  const commandBudget = createGhCommandBudget();
   if (options.recheckPr !== undefined) {
+    const commandBudget = createGhCommandBudget();
     const result = recheckLivePullHead(
       options.repo,
       {
@@ -2808,12 +2813,12 @@ export function main(args = process.argv.slice(2)) {
     if (!result.publishable) process.exitCode = 2;
     return;
   }
-  const boundedRead = (endpoint) => {
-    return readGhPages(endpoint, commandBudget.run);
-  };
   let rateLimits = { preflight: true };
   const { report } = retryChangedLiveInventory(
-    () => {
+    ({ commandBudget }) => {
+      const boundedRead = (endpoint) => {
+        return readGhPages(endpoint, commandBudget.run);
+      };
       const openActivity = readGhOpenActivity(
         options.repo,
         commandBudget.run,


### PR DESCRIPTION
## Summary

Make contributor live reports complete reliably on large, actively changing repositories.

- Raise the bounded `gh` subprocess output ceiling from 64 MiB to 256 MiB so the complete Eliza activity response does not fail with `spawnSync gh ENOBUFS`.
- Detect the specific open-inventory reconciliation race with a typed error and retry one complete snapshot.
- Preserve fail-closed behavior for malformed data, resource bounds, and repositories that change during both attempts.
- Keep the live-report implementation byte-identical across all four contributor skills.

## Reproduction

The installed Eliza report repeatedly failed while reading the live repository:

```text
Slop live report failed: spawnSync gh ENOBUFS
```

After increasing the output bound, the next reachable failure was:

```text
Slop live report failed: batched activity does not exactly match the live open-item inventory
```

That mismatch occurs when the GraphQL activity snapshot and subsequent REST open-item inventory straddle an open/close event. The data is not accepted; the command now retries the entire snapshot once, then fails explicitly if churn repeats.

## Verification

- Failing-first output-bound assertions observed the old 64 MiB value.
- Deterministic inventory-race regression proves first mismatch → full retry → coherent result.
- The same regression proves malformed responses are not retried and two consecutive mismatches fail closed.
- `bun test skill-tests/contribute-to-eliza.test.ts skill-tests/project-skills.test.ts` — 73 passed.
- `bun run format:check` — passed.
- `bun run typecheck` — passed.
- `bun run lint:check` — passed with 50 existing warnings and no errors.
- Real `--epoch-only` Eliza report completed against 946 issues and 739 pull requests using 8 bounded GitHub commands.

## Scope

Five files: the shared Eliza regression suite and the byte-identical live-report script in the Eliza, ASI, Delta Star, and Heir Elements SDK contributor skills. No API writes, dependency changes, or relaxed validation.
