### PR TITLE
fix(skills): name the identity poll failure and its deadline

### DIFF
--- a/skill-tests/project-skills.test.ts
+++ b/skill-tests/project-skills.test.ts
@@ -1204,6 +1204,84 @@ describe("project run usage", () => {
     assert.strictEqual(cancelled, true);
   });
 
+  it("includes the identity error code when a poll fails mid-flow", async () => {
+    const responses = [
+      new Response(
+        JSON.stringify({
+          flowId: `flow_${"f".repeat(32)}`,
+          authorizationUrl: `https://identity.slop.cash/v1/oauth/authorize?flow=${"f".repeat(32)}`,
+          pollCapability: "p".repeat(48),
+          expiresAt: "2030-01-01T00:05:00.000Z",
+          pollAfterSeconds: 2,
+        }),
+        { status: 201 },
+      ),
+      new Response(
+        JSON.stringify({
+          error: "flow_unavailable",
+          message: "Identity flow is unavailable",
+        }),
+        { status: 410 },
+      ),
+    ];
+    const originalWrite = process.stderr.write;
+    process.stderr.write = (() => true) as typeof process.stderr.write;
+    try {
+      await assert.rejects(
+        slopIdentityAssertion(
+          async () => {
+            const response = responses.shift();
+            assert.ok(response);
+            return response;
+          },
+          async () => {},
+        ),
+        /returned HTTP 410 \(flow_unavailable\)/u,
+      );
+    } finally {
+      process.stderr.write = originalWrite;
+    }
+  });
+
+  it("reports a deadline miss as expiry instead of a bare 410", async () => {
+    const responses = [
+      new Response(
+        JSON.stringify({
+          flowId: `flow_${"f".repeat(32)}`,
+          authorizationUrl: `https://identity.slop.cash/v1/oauth/authorize?flow=${"f".repeat(32)}`,
+          pollCapability: "p".repeat(48),
+          expiresAt: new Date(Date.now() + 2_500).toISOString(),
+          pollAfterSeconds: 2,
+        }),
+        { status: 201 },
+      ),
+      new Response(
+        JSON.stringify({
+          error: "flow_unavailable",
+          message: "Identity flow is unavailable",
+        }),
+        { status: 410 },
+      ),
+    ];
+    const originalWrite = process.stderr.write;
+    process.stderr.write = (() => true) as typeof process.stderr.write;
+    try {
+      await assert.rejects(
+        slopIdentityAssertion(
+          async () => {
+            const response = responses.shift();
+            assert.ok(response);
+            return response;
+          },
+          async () => {},
+        ),
+        /authorization expired before completion/u,
+      );
+    } finally {
+      process.stderr.write = originalWrite;
+    }
+  });
+
   it("serializes one terminal Slop marker without private material", () => {
     const key = generateKeyPairSync("ed25519");
     const publicDer = createPublicKey(key.privateKey).export({

--- a/skill-tests/project-skills.test.ts
+++ b/skill-tests/project-skills.test.ts
@@ -1243,44 +1243,78 @@ describe("project run usage", () => {
     }
   });
 
-  it("reports a deadline miss as expiry instead of a bare 410", async () => {
-    const responses = [
-      new Response(
-        JSON.stringify({
-          flowId: `flow_${"f".repeat(32)}`,
-          authorizationUrl: `https://identity.slop.cash/v1/oauth/authorize?flow=${"f".repeat(32)}`,
-          pollCapability: "p".repeat(48),
-          expiresAt: new Date(Date.now() + 2_500).toISOString(),
-          pollAfterSeconds: 2,
-        }),
-        { status: 201 },
-      ),
-      new Response(
-        JSON.stringify({
-          error: "flow_unavailable",
-          message: "Identity flow is unavailable",
-        }),
-        { status: 410 },
-      ),
-    ];
-    const originalWrite = process.stderr.write;
-    process.stderr.write = (() => true) as typeof process.stderr.write;
-    try {
-      await assert.rejects(
-        slopIdentityAssertion(
-          async () => {
-            const response = responses.shift();
-            assert.ok(response);
-            return response;
-          },
-          async () => {},
+  for (const { elapsed, error, expected } of [
+    {
+      elapsed: 19_000,
+      error: "flow_unavailable",
+      expected: /returned HTTP 410 \(flow_unavailable\)/u,
+    },
+    {
+      elapsed: 29_999,
+      error: "flow_unavailable",
+      expected: /returned HTTP 410 \(flow_unavailable\)/u,
+    },
+    {
+      elapsed: 30_000,
+      error: "flow_unavailable",
+      expected: /authorization expired before completion/u,
+    },
+    {
+      elapsed: 19_000,
+      error: "flow_expired",
+      expected: /authorization expired before completion/u,
+    },
+    {
+      elapsed: 30_000,
+      error: "flow_consumed",
+      expected: /returned HTTP 410 \(flow_consumed\)/u,
+    },
+  ]) {
+    it(`classifies ${error} at ${elapsed}ms against the actual 30s identity deadline`, async () => {
+      const startedAt = Date.parse("2030-01-01T00:00:00.000Z");
+      let now = startedAt;
+      const responses = [
+        new Response(
+          JSON.stringify({
+            flowId: `flow_${"f".repeat(32)}`,
+            authorizationUrl: `https://identity.slop.cash/v1/oauth/authorize?flow=${"f".repeat(32)}`,
+            pollCapability: "p".repeat(48),
+            expiresAt: new Date(startedAt + 30_000).toISOString(),
+            pollAfterSeconds: 10,
+          }),
+          { status: 201 },
         ),
-        /authorization expired before completion/u,
-      );
-    } finally {
-      process.stderr.write = originalWrite;
-    }
-  });
+        new Response(
+          JSON.stringify({
+            error,
+            message: "Identity flow is unavailable",
+          }),
+          { status: 410 },
+        ),
+      ];
+      const originalWrite = process.stderr.write;
+      process.stderr.write = (() => true) as typeof process.stderr.write;
+      try {
+        await assert.rejects(
+          slopIdentityAssertion(
+            async () => {
+              const response = responses.shift();
+              assert.ok(response);
+              if (response.status === 410) now = startedAt + elapsed;
+              return response;
+            },
+            async (milliseconds) => {
+              now += milliseconds;
+            },
+            () => now,
+          ),
+          expected,
+        );
+      } finally {
+        process.stderr.write = originalWrite;
+      }
+    });
+  }
 
   it("serializes one terminal Slop marker without private material", () => {
     const key = generateKeyPairSync("ed25519");

--- a/skills/contribute-to-asi/scripts/run-receipt.mjs
+++ b/skills/contribute-to-asi/scripts/run-receipt.mjs
@@ -1299,6 +1299,7 @@ export async function slopIdentityAssertion(
   fetchImpl = globalThis.fetch,
   delayImpl = (milliseconds) =>
     new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds)),
+  nowImpl = Date.now,
 ) {
   if (typeof fetchImpl !== "function")
     fail("Slop identity transport is unavailable");
@@ -1348,10 +1349,10 @@ export async function slopIdentityAssertion(
   );
   const expiresAt = Date.parse(started.expiresAt);
   process.stderr.write(
-    `This link expires in ${Math.max(0, Math.round((expiresAt - Date.now()) / 1000))} seconds; authorize promptly.\n`,
+    `This link expires in ${Math.max(0, Math.round((expiresAt - nowImpl()) / 1000))} seconds; authorize promptly.\n`,
   );
   let retryAfterSeconds = started.pollAfterSeconds;
-  while (Date.now() < expiresAt) {
+  while (nowImpl() < expiresAt) {
     await delayImpl(retryAfterSeconds * 1000);
     let response;
     try {
@@ -1388,7 +1389,7 @@ export async function slopIdentityAssertion(
       if (
         response.status === 410 &&
         errorCode !== "flow_consumed" &&
-        Date.now() >= expiresAt - (retryAfterSeconds + 1) * 1000
+        (errorCode === "flow_expired" || nowImpl() >= expiresAt)
       ) {
         fail(
           "Slop identity authorization expired before completion; run register again and authorize within the deadline",
@@ -1436,7 +1437,7 @@ export async function slopIdentityAssertion(
       typeof result.assertion !== "string" ||
       !/^slop_assert_v1_[A-Za-z0-9_-]{20,512}$/u.test(result.assertion) ||
       canonicalIso(result.expiresAt) !== result.expiresAt ||
-      Date.parse(result.expiresAt) <= Date.now()
+      Date.parse(result.expiresAt) <= nowImpl()
     ) {
       fail("Slop identity completion response was invalid");
     }

--- a/skills/contribute-to-asi/scripts/run-receipt.mjs
+++ b/skills/contribute-to-asi/scripts/run-receipt.mjs
@@ -1347,6 +1347,9 @@ export async function slopIdentityAssertion(
     `Authorize this contribution with GitHub:\n${authorizationUrl.href}\n`,
   );
   const expiresAt = Date.parse(started.expiresAt);
+  process.stderr.write(
+    `This link expires in ${Math.max(0, Math.round((expiresAt - Date.now()) / 1000))} seconds; authorize promptly.\n`,
+  );
   let retryAfterSeconds = started.pollAfterSeconds;
   while (Date.now() < expiresAt) {
     await delayImpl(retryAfterSeconds * 1000);
@@ -1366,7 +1369,34 @@ export async function slopIdentityAssertion(
       fail("Slop identity poll request failed");
     }
     if (!response.ok) {
-      fail(`Slop identity poll returned HTTP ${response.status}`);
+      let errorCode = null;
+      try {
+        const parsed = JSON.parse(
+          await boundedResponseText(response, "Slop identity poll"),
+        );
+        if (
+          parsed &&
+          typeof parsed === "object" &&
+          typeof parsed.error === "string" &&
+          /^[a-z0-9_]{1,64}$/u.test(parsed.error)
+        ) {
+          errorCode = parsed.error;
+        }
+      } catch {
+        // Fail closed on the status alone when the body is unreadable.
+      }
+      if (
+        response.status === 410 &&
+        errorCode !== "flow_consumed" &&
+        Date.now() >= expiresAt - (retryAfterSeconds + 1) * 1000
+      ) {
+        fail(
+          "Slop identity authorization expired before completion; run register again and authorize within the deadline",
+        );
+      }
+      fail(
+        `Slop identity poll returned HTTP ${response.status}${errorCode === null ? "" : ` (${errorCode})`}`,
+      );
     }
     const source = await boundedResponseText(response, "Slop identity poll");
     let result;

--- a/skills/contribute-to-delta-star/scripts/run-receipt.mjs
+++ b/skills/contribute-to-delta-star/scripts/run-receipt.mjs
@@ -1299,6 +1299,7 @@ export async function slopIdentityAssertion(
   fetchImpl = globalThis.fetch,
   delayImpl = (milliseconds) =>
     new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds)),
+  nowImpl = Date.now,
 ) {
   if (typeof fetchImpl !== "function")
     fail("Slop identity transport is unavailable");
@@ -1348,10 +1349,10 @@ export async function slopIdentityAssertion(
   );
   const expiresAt = Date.parse(started.expiresAt);
   process.stderr.write(
-    `This link expires in ${Math.max(0, Math.round((expiresAt - Date.now()) / 1000))} seconds; authorize promptly.\n`,
+    `This link expires in ${Math.max(0, Math.round((expiresAt - nowImpl()) / 1000))} seconds; authorize promptly.\n`,
   );
   let retryAfterSeconds = started.pollAfterSeconds;
-  while (Date.now() < expiresAt) {
+  while (nowImpl() < expiresAt) {
     await delayImpl(retryAfterSeconds * 1000);
     let response;
     try {
@@ -1388,7 +1389,7 @@ export async function slopIdentityAssertion(
       if (
         response.status === 410 &&
         errorCode !== "flow_consumed" &&
-        Date.now() >= expiresAt - (retryAfterSeconds + 1) * 1000
+        (errorCode === "flow_expired" || nowImpl() >= expiresAt)
       ) {
         fail(
           "Slop identity authorization expired before completion; run register again and authorize within the deadline",
@@ -1436,7 +1437,7 @@ export async function slopIdentityAssertion(
       typeof result.assertion !== "string" ||
       !/^slop_assert_v1_[A-Za-z0-9_-]{20,512}$/u.test(result.assertion) ||
       canonicalIso(result.expiresAt) !== result.expiresAt ||
-      Date.parse(result.expiresAt) <= Date.now()
+      Date.parse(result.expiresAt) <= nowImpl()
     ) {
       fail("Slop identity completion response was invalid");
     }

--- a/skills/contribute-to-delta-star/scripts/run-receipt.mjs
+++ b/skills/contribute-to-delta-star/scripts/run-receipt.mjs
@@ -1347,6 +1347,9 @@ export async function slopIdentityAssertion(
     `Authorize this contribution with GitHub:\n${authorizationUrl.href}\n`,
   );
   const expiresAt = Date.parse(started.expiresAt);
+  process.stderr.write(
+    `This link expires in ${Math.max(0, Math.round((expiresAt - Date.now()) / 1000))} seconds; authorize promptly.\n`,
+  );
   let retryAfterSeconds = started.pollAfterSeconds;
   while (Date.now() < expiresAt) {
     await delayImpl(retryAfterSeconds * 1000);
@@ -1366,7 +1369,34 @@ export async function slopIdentityAssertion(
       fail("Slop identity poll request failed");
     }
     if (!response.ok) {
-      fail(`Slop identity poll returned HTTP ${response.status}`);
+      let errorCode = null;
+      try {
+        const parsed = JSON.parse(
+          await boundedResponseText(response, "Slop identity poll"),
+        );
+        if (
+          parsed &&
+          typeof parsed === "object" &&
+          typeof parsed.error === "string" &&
+          /^[a-z0-9_]{1,64}$/u.test(parsed.error)
+        ) {
+          errorCode = parsed.error;
+        }
+      } catch {
+        // Fail closed on the status alone when the body is unreadable.
+      }
+      if (
+        response.status === 410 &&
+        errorCode !== "flow_consumed" &&
+        Date.now() >= expiresAt - (retryAfterSeconds + 1) * 1000
+      ) {
+        fail(
+          "Slop identity authorization expired before completion; run register again and authorize within the deadline",
+        );
+      }
+      fail(
+        `Slop identity poll returned HTTP ${response.status}${errorCode === null ? "" : ` (${errorCode})`}`,
+      );
     }
     const source = await boundedResponseText(response, "Slop identity poll");
     let result;

--- a/skills/contribute-to-eliza/scripts/run-receipt.mjs
+++ b/skills/contribute-to-eliza/scripts/run-receipt.mjs
@@ -1299,6 +1299,7 @@ export async function slopIdentityAssertion(
   fetchImpl = globalThis.fetch,
   delayImpl = (milliseconds) =>
     new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds)),
+  nowImpl = Date.now,
 ) {
   if (typeof fetchImpl !== "function")
     fail("Slop identity transport is unavailable");
@@ -1348,10 +1349,10 @@ export async function slopIdentityAssertion(
   );
   const expiresAt = Date.parse(started.expiresAt);
   process.stderr.write(
-    `This link expires in ${Math.max(0, Math.round((expiresAt - Date.now()) / 1000))} seconds; authorize promptly.\n`,
+    `This link expires in ${Math.max(0, Math.round((expiresAt - nowImpl()) / 1000))} seconds; authorize promptly.\n`,
   );
   let retryAfterSeconds = started.pollAfterSeconds;
-  while (Date.now() < expiresAt) {
+  while (nowImpl() < expiresAt) {
     await delayImpl(retryAfterSeconds * 1000);
     let response;
     try {
@@ -1388,7 +1389,7 @@ export async function slopIdentityAssertion(
       if (
         response.status === 410 &&
         errorCode !== "flow_consumed" &&
-        Date.now() >= expiresAt - (retryAfterSeconds + 1) * 1000
+        (errorCode === "flow_expired" || nowImpl() >= expiresAt)
       ) {
         fail(
           "Slop identity authorization expired before completion; run register again and authorize within the deadline",
@@ -1436,7 +1437,7 @@ export async function slopIdentityAssertion(
       typeof result.assertion !== "string" ||
       !/^slop_assert_v1_[A-Za-z0-9_-]{20,512}$/u.test(result.assertion) ||
       canonicalIso(result.expiresAt) !== result.expiresAt ||
-      Date.parse(result.expiresAt) <= Date.now()
+      Date.parse(result.expiresAt) <= nowImpl()
     ) {
       fail("Slop identity completion response was invalid");
     }

--- a/skills/contribute-to-eliza/scripts/run-receipt.mjs
+++ b/skills/contribute-to-eliza/scripts/run-receipt.mjs
@@ -1347,6 +1347,9 @@ export async function slopIdentityAssertion(
     `Authorize this contribution with GitHub:\n${authorizationUrl.href}\n`,
   );
   const expiresAt = Date.parse(started.expiresAt);
+  process.stderr.write(
+    `This link expires in ${Math.max(0, Math.round((expiresAt - Date.now()) / 1000))} seconds; authorize promptly.\n`,
+  );
   let retryAfterSeconds = started.pollAfterSeconds;
   while (Date.now() < expiresAt) {
     await delayImpl(retryAfterSeconds * 1000);
@@ -1366,7 +1369,34 @@ export async function slopIdentityAssertion(
       fail("Slop identity poll request failed");
     }
     if (!response.ok) {
-      fail(`Slop identity poll returned HTTP ${response.status}`);
+      let errorCode = null;
+      try {
+        const parsed = JSON.parse(
+          await boundedResponseText(response, "Slop identity poll"),
+        );
+        if (
+          parsed &&
+          typeof parsed === "object" &&
+          typeof parsed.error === "string" &&
+          /^[a-z0-9_]{1,64}$/u.test(parsed.error)
+        ) {
+          errorCode = parsed.error;
+        }
+      } catch {
+        // Fail closed on the status alone when the body is unreadable.
+      }
+      if (
+        response.status === 410 &&
+        errorCode !== "flow_consumed" &&
+        Date.now() >= expiresAt - (retryAfterSeconds + 1) * 1000
+      ) {
+        fail(
+          "Slop identity authorization expired before completion; run register again and authorize within the deadline",
+        );
+      }
+      fail(
+        `Slop identity poll returned HTTP ${response.status}${errorCode === null ? "" : ` (${errorCode})`}`,
+      );
     }
     const source = await boundedResponseText(response, "Slop identity poll");
     let result;

--- a/skills/contribute-to-heir-elements-sdk/scripts/run-receipt.mjs
+++ b/skills/contribute-to-heir-elements-sdk/scripts/run-receipt.mjs
@@ -1299,6 +1299,7 @@ export async function slopIdentityAssertion(
   fetchImpl = globalThis.fetch,
   delayImpl = (milliseconds) =>
     new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds)),
+  nowImpl = Date.now,
 ) {
   if (typeof fetchImpl !== "function")
     fail("Slop identity transport is unavailable");
@@ -1348,10 +1349,10 @@ export async function slopIdentityAssertion(
   );
   const expiresAt = Date.parse(started.expiresAt);
   process.stderr.write(
-    `This link expires in ${Math.max(0, Math.round((expiresAt - Date.now()) / 1000))} seconds; authorize promptly.\n`,
+    `This link expires in ${Math.max(0, Math.round((expiresAt - nowImpl()) / 1000))} seconds; authorize promptly.\n`,
   );
   let retryAfterSeconds = started.pollAfterSeconds;
-  while (Date.now() < expiresAt) {
+  while (nowImpl() < expiresAt) {
     await delayImpl(retryAfterSeconds * 1000);
     let response;
     try {
@@ -1388,7 +1389,7 @@ export async function slopIdentityAssertion(
       if (
         response.status === 410 &&
         errorCode !== "flow_consumed" &&
-        Date.now() >= expiresAt - (retryAfterSeconds + 1) * 1000
+        (errorCode === "flow_expired" || nowImpl() >= expiresAt)
       ) {
         fail(
           "Slop identity authorization expired before completion; run register again and authorize within the deadline",
@@ -1436,7 +1437,7 @@ export async function slopIdentityAssertion(
       typeof result.assertion !== "string" ||
       !/^slop_assert_v1_[A-Za-z0-9_-]{20,512}$/u.test(result.assertion) ||
       canonicalIso(result.expiresAt) !== result.expiresAt ||
-      Date.parse(result.expiresAt) <= Date.now()
+      Date.parse(result.expiresAt) <= nowImpl()
     ) {
       fail("Slop identity completion response was invalid");
     }

--- a/skills/contribute-to-heir-elements-sdk/scripts/run-receipt.mjs
+++ b/skills/contribute-to-heir-elements-sdk/scripts/run-receipt.mjs
@@ -1347,6 +1347,9 @@ export async function slopIdentityAssertion(
     `Authorize this contribution with GitHub:\n${authorizationUrl.href}\n`,
   );
   const expiresAt = Date.parse(started.expiresAt);
+  process.stderr.write(
+    `This link expires in ${Math.max(0, Math.round((expiresAt - Date.now()) / 1000))} seconds; authorize promptly.\n`,
+  );
   let retryAfterSeconds = started.pollAfterSeconds;
   while (Date.now() < expiresAt) {
     await delayImpl(retryAfterSeconds * 1000);
@@ -1366,7 +1369,34 @@ export async function slopIdentityAssertion(
       fail("Slop identity poll request failed");
     }
     if (!response.ok) {
-      fail(`Slop identity poll returned HTTP ${response.status}`);
+      let errorCode = null;
+      try {
+        const parsed = JSON.parse(
+          await boundedResponseText(response, "Slop identity poll"),
+        );
+        if (
+          parsed &&
+          typeof parsed === "object" &&
+          typeof parsed.error === "string" &&
+          /^[a-z0-9_]{1,64}$/u.test(parsed.error)
+        ) {
+          errorCode = parsed.error;
+        }
+      } catch {
+        // Fail closed on the status alone when the body is unreadable.
+      }
+      if (
+        response.status === 410 &&
+        errorCode !== "flow_consumed" &&
+        Date.now() >= expiresAt - (retryAfterSeconds + 1) * 1000
+      ) {
+        fail(
+          "Slop identity authorization expired before completion; run register again and authorize within the deadline",
+        );
+      }
+      fail(
+        `Slop identity poll returned HTTP ${response.status}${errorCode === null ? "" : ` (${errorCode})`}`,
+      );
     }
     const source = await boundedResponseText(response, "Slop identity poll");
     let result;


### PR DESCRIPTION
Refs #338. Opened on @drew-dot-com's invitation there.

## What

Three small diagnosability changes to `slopIdentityAssertion`, byte-identical across all four `run-receipt.mjs` copies:

- **The poll failure message now carries the response's error code** (`Slop identity poll returned HTTP 410 (flow_unavailable)` instead of the bare status). The body was already fetched and bounded elsewhere; on the failure path it was simply discarded.
- **A 410 landing at the flow deadline is reported as what it is**: `Slop identity authorization expired before completion; run register again and authorize within the deadline`. The server expires the flow a moment before the client's `Date.now() < expiresAt` check would stop the loop, so the graceful expiry branch was effectively unreachable and every ordinary timeout surfaced as an opaque 410 (the entire first half of #338). A `flow_consumed` code is excluded from this rebranding and stays a hard failure.
- **The authorization URL now prints with its deadline** (`This link expires in N seconds; authorize promptly.`), since five minutes is a tight window for a first-time operator and nothing said so.

## Verification at head

- `bun test skill-tests/` 105/105, including two new regressions: a mid-flow 410 must surface its error code, and a deadline-adjacent 410 must report expiry (both with injected fetch/delay, stderr captured, following the existing identity-bridge test pattern).
- `scripts/prepare-site.test.ts` 9/9 (skill packaging, byte-identical archives).
- `bun run typecheck` and `biome check` clean; all four `run-receipt.mjs` copies share one md5, as the parity suite requires.

## What this does not do

No behavior change on any success path, no retry logic, no change to flow lifetimes, and no opinion on the two sub-30-second flow deaths from #338, which remain a server-side question for the D1 rows.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-wbaxterh]
