### PR TITLE
fix(trace): retry transient upload server failure

### DIFF
--- a/skill-tests/project-skills.test.ts
+++ b/skill-tests/project-skills.test.ts
@@ -1037,6 +1037,93 @@ describe("project run usage", () => {
     }
   });
 
+  it("retries one transient trace-upload server failure on the same capability", async () => {
+    const fixtureRoot = mkdtempSync(join(tmpdir(), "slop-trace-upload-retry-"));
+    try {
+      const trajectory = join(fixtureRoot, "trace.ndjson");
+      const contents = '{"event":"complete"}\n';
+      writeFileSync(trajectory, contents);
+      const digest = createHash("sha256").update(contents).digest("hex");
+      const uploadUrl = "https://api.slop.cash/api/v1/trace-uploads/retry-test";
+      let uploadAttempts = 0;
+      const fetchImpl = async (url: RequestInfo | URL) => {
+        const target = String(url);
+        if (target.endsWith("private-request-intake")) {
+          return Response.json({
+            enabled: true,
+            source: "github-public-status",
+            verifiedAt: "2026-08-25T12:00:00.000Z",
+          });
+        }
+        if (target.endsWith("auth/session")) {
+          return Response.json({
+            token: "s".repeat(32),
+            tokenType: "Bearer",
+            expiresAt: "2030-01-01T00:00:00.000Z",
+          });
+        }
+        if (target.endsWith("/runs")) {
+          return Response.json({
+            serverRunId: "srv_retry",
+            clientRunId: "run_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+            state: "awaiting_trace",
+          });
+        }
+        if (target.endsWith("trace-intents")) {
+          return Response.json({
+            serverRunId: "srv_retry",
+            uploadUrl,
+            expiresAt: "2030-01-01T00:00:00.000Z",
+            sha256: digest,
+            sizeBytes: Buffer.byteLength(contents),
+            contentType: "application/x-ndjson",
+          });
+        }
+        if (target === uploadUrl) {
+          uploadAttempts += 1;
+          if (uploadAttempts === 1)
+            return Response.json({ error: "internal_error" }, { status: 500 });
+          return Response.json({
+            serverRunId: "srv_retry",
+            clientRunId: "run_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+            traceObjectId: `sha256:${digest}`,
+            traceSha256: digest,
+            sizeBytes: Buffer.byteLength(contents),
+            state: "trace_uploaded",
+          });
+        }
+        return Response.json({
+          serverRunId: "srv_retry",
+          clientRunId: "run_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+          traceObjectId: `sha256:${digest}`,
+          traceSha256: digest,
+          state: "finalized",
+        });
+      };
+      await uploadPrivateTrace(
+        {
+          runId: "run_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+          projectId: "eliza",
+          repositoryId: "elizaOS/eliza",
+          revision: "a".repeat(40),
+          provider: "openai",
+          model: "gpt-5.6-sol",
+          client: "codex",
+        },
+        trajectory,
+        "1.2.3",
+        {
+          disclosure: () => {},
+          assertionProvider: () => "i".repeat(32),
+          fetchImpl,
+        },
+      );
+      assert.strictEqual(uploadAttempts, 2);
+    } finally {
+      rmSync(fixtureRoot, { force: true, recursive: true });
+    }
+  });
+
   it("reports private intake rate-limit reset before authorization", async () => {
     const fixtureRoot = mkdtempSync(join(tmpdir(), "slop-trace-intake-rate-"));
     try {

--- a/skills/contribute-to-asi/scripts/run-receipt.mjs
+++ b/skills/contribute-to-asi/scripts/run-receipt.mjs
@@ -1223,15 +1223,30 @@ async function boundedResponseText(response, field) {
   }
 }
 
-async function jsonRequest(fetchImpl, url, options, keys, field) {
+async function jsonRequest(
+  fetchImpl,
+  url,
+  options,
+  keys,
+  field,
+  retryServerErrors = 0,
+) {
   let response;
-  try {
-    response = await fetchImpl(url, {
-      ...options,
-      signal: AbortSignal.timeout(30_000),
-    });
-  } catch {
-    fail(`${field} request failed`);
+  for (let attempt = 0; attempt <= retryServerErrors; attempt += 1) {
+    try {
+      response = await fetchImpl(url, {
+        ...options,
+        signal: AbortSignal.timeout(30_000),
+      });
+    } catch {
+      fail(`${field} request failed`);
+    }
+    if (
+      response?.ok ||
+      (response?.status ?? 0) < 500 ||
+      attempt === retryServerErrors
+    )
+      break;
   }
   if (!response?.ok) fail(`${field} request returned HTTP ${response?.status}`);
   const source = await boundedResponseText(response, field);
@@ -1605,6 +1620,7 @@ export async function uploadPrivateTrace(
       "traceSha256",
     ],
     "trace upload",
+    1,
   );
   if (
     uploaded.clientRunId !== state.runId ||

--- a/skills/contribute-to-delta-star/scripts/run-receipt.mjs
+++ b/skills/contribute-to-delta-star/scripts/run-receipt.mjs
@@ -1223,15 +1223,30 @@ async function boundedResponseText(response, field) {
   }
 }
 
-async function jsonRequest(fetchImpl, url, options, keys, field) {
+async function jsonRequest(
+  fetchImpl,
+  url,
+  options,
+  keys,
+  field,
+  retryServerErrors = 0,
+) {
   let response;
-  try {
-    response = await fetchImpl(url, {
-      ...options,
-      signal: AbortSignal.timeout(30_000),
-    });
-  } catch {
-    fail(`${field} request failed`);
+  for (let attempt = 0; attempt <= retryServerErrors; attempt += 1) {
+    try {
+      response = await fetchImpl(url, {
+        ...options,
+        signal: AbortSignal.timeout(30_000),
+      });
+    } catch {
+      fail(`${field} request failed`);
+    }
+    if (
+      response?.ok ||
+      (response?.status ?? 0) < 500 ||
+      attempt === retryServerErrors
+    )
+      break;
   }
   if (!response?.ok) fail(`${field} request returned HTTP ${response?.status}`);
   const source = await boundedResponseText(response, field);
@@ -1605,6 +1620,7 @@ export async function uploadPrivateTrace(
       "traceSha256",
     ],
     "trace upload",
+    1,
   );
   if (
     uploaded.clientRunId !== state.runId ||

--- a/skills/contribute-to-eliza/scripts/run-receipt.mjs
+++ b/skills/contribute-to-eliza/scripts/run-receipt.mjs
@@ -1223,15 +1223,30 @@ async function boundedResponseText(response, field) {
   }
 }
 
-async function jsonRequest(fetchImpl, url, options, keys, field) {
+async function jsonRequest(
+  fetchImpl,
+  url,
+  options,
+  keys,
+  field,
+  retryServerErrors = 0,
+) {
   let response;
-  try {
-    response = await fetchImpl(url, {
-      ...options,
-      signal: AbortSignal.timeout(30_000),
-    });
-  } catch {
-    fail(`${field} request failed`);
+  for (let attempt = 0; attempt <= retryServerErrors; attempt += 1) {
+    try {
+      response = await fetchImpl(url, {
+        ...options,
+        signal: AbortSignal.timeout(30_000),
+      });
+    } catch {
+      fail(`${field} request failed`);
+    }
+    if (
+      response?.ok ||
+      (response?.status ?? 0) < 500 ||
+      attempt === retryServerErrors
+    )
+      break;
   }
   if (!response?.ok) fail(`${field} request returned HTTP ${response?.status}`);
   const source = await boundedResponseText(response, field);
@@ -1605,6 +1620,7 @@ export async function uploadPrivateTrace(
       "traceSha256",
     ],
     "trace upload",
+    1,
   );
   if (
     uploaded.clientRunId !== state.runId ||

--- a/skills/contribute-to-heir-elements-sdk/scripts/run-receipt.mjs
+++ b/skills/contribute-to-heir-elements-sdk/scripts/run-receipt.mjs
@@ -1223,15 +1223,30 @@ async function boundedResponseText(response, field) {
   }
 }
 
-async function jsonRequest(fetchImpl, url, options, keys, field) {
+async function jsonRequest(
+  fetchImpl,
+  url,
+  options,
+  keys,
+  field,
+  retryServerErrors = 0,
+) {
   let response;
-  try {
-    response = await fetchImpl(url, {
-      ...options,
-      signal: AbortSignal.timeout(30_000),
-    });
-  } catch {
-    fail(`${field} request failed`);
+  for (let attempt = 0; attempt <= retryServerErrors; attempt += 1) {
+    try {
+      response = await fetchImpl(url, {
+        ...options,
+        signal: AbortSignal.timeout(30_000),
+      });
+    } catch {
+      fail(`${field} request failed`);
+    }
+    if (
+      response?.ok ||
+      (response?.status ?? 0) < 500 ||
+      attempt === retryServerErrors
+    )
+      break;
   }
   if (!response?.ok) fail(`${field} request returned HTTP ${response?.status}`);
   const source = await boundedResponseText(response, field);
@@ -1605,6 +1620,7 @@ export async function uploadPrivateTrace(
       "traceSha256",
     ],
     "trace upload",
+    1,
   );
   if (
     uploaded.clientRunId !== state.runId ||


### PR DESCRIPTION
## Summary

- retry one explicit 5xx response from the private-trace upload PUT
- reuse the same bounded body and one-time upload capability
- keep every non-upload request and every 4xx response single-attempt/fail-closed
- apply the byte-identical receipt change to all four packaged project skills

## Reproduction

An Eliza review trace upload reached the upload PUT and returned HTTP 500. The receipt client immediately exited, discarded its process-local authorization state, and prevented the otherwise completed review from being submitted.

## Verification

- `bun test skill-tests/project-skills.test.ts` — 26 passed
- `bun run typecheck` — passed
- `bun run lint:check` — passed with pre-existing stylesheet specificity warnings

The new regression returns HTTP 500 for the first upload request and verifies that the second request uses the same capability and completes finalization.

This mitigates transient server failures; it does not hide a repeated 5xx or retry authentication, run creation, intent creation, finalization, network exceptions, or client errors.
