### PR TITLE
fix(trace): renew expired upload intents

### DIFF
--- a/backend/trace/README.md
+++ b/backend/trace/README.md
@@ -64,9 +64,11 @@ repository, projectPolicyRevision, provider, model, client, clientVersion }`.
 4. `POST /api/v1/runs/{serverRunId}/finalize` with `Idempotency-Key`.
 
 Upload URLs are HMAC-derived, one-time write capabilities. Consumption is an
-atomic D1 update. A failed, expired, or already-used capability cannot be
-retried; the authenticated client creates a new intent. Finalization fails
-closed unless the trace is attached.
+atomic D1 update. Failed or already-used capabilities cannot be retried
+directly. An authenticated client may renew an expired, unconsumed intent only
+by repeating the exact idempotent request for the same run, digest, size, and
+content type; mismatched retries fail closed. Finalization fails closed unless
+the trace is attached.
 
 The public contribution receipt keeps its client `run_id` and includes the
 private join fields `server_run_id`, trace object ID, authority, and digest.

--- a/backend/trace/cloudflare-persistence.ts
+++ b/backend/trace/cloudflare-persistence.ts
@@ -545,6 +545,37 @@ export class CloudflareTracePersistence implements TracePersistence {
       .first<UploadIntentRow>();
     if (existing !== null) {
       const mapped = mapUploadIntent(existing);
+      if (
+        mapped.runId !== intent.runId ||
+        mapped.sha256 !== intent.sha256 ||
+        mapped.sizeBytes !== intent.sizeBytes ||
+        mapped.contentType !== intent.contentType
+      ) {
+        return { status: "conflict" };
+      }
+      if (mapped.consumedAt === null && mapped.expiresAt <= intent.createdAt) {
+        await this.db
+          .prepare(
+            `UPDATE trace_upload_intents SET expires_at = ?
+             WHERE token_hash = ? AND consumed_at IS NULL AND expires_at <= ?`,
+          )
+          .bind(intent.expiresAt, mapped.tokenHash, intent.createdAt)
+          .run();
+        const renewed = await this.db
+          .prepare("SELECT * FROM trace_upload_intents WHERE token_hash = ?")
+          .bind(mapped.tokenHash)
+          .first<UploadIntentRow>();
+        if (renewed === null) return { status: "conflict" };
+        const renewedIntent = mapUploadIntent(renewed);
+        return renewedIntent.runId === intent.runId &&
+          renewedIntent.sha256 === intent.sha256 &&
+          renewedIntent.sizeBytes === intent.sizeBytes &&
+          renewedIntent.contentType === intent.contentType &&
+          renewedIntent.consumedAt === null &&
+          renewedIntent.expiresAt > intent.createdAt
+          ? { status: "existing", value: renewedIntent }
+          : { status: "conflict" };
+      }
       return mapped.runId === intent.runId &&
         mapped.sha256 === intent.sha256 &&
         mapped.sizeBytes === intent.sizeBytes &&

--- a/functions/api/v1/cloudflare-persistence.test.ts
+++ b/functions/api/v1/cloudflare-persistence.test.ts
@@ -26,6 +26,67 @@ function body(text: string): ReadableStream<Uint8Array> {
 }
 
 describe("Cloudflare trace object persistence", () => {
+  it("renews an expired unconsumed upload intent without changing its capability", async () => {
+    const expired = {
+      token_hash: "a".repeat(64),
+      run_id: "run-1",
+      github_user_id: "42",
+      trace_sha256: object.sha256,
+      size_bytes: object.sizeBytes,
+      content_type: object.contentType,
+      idempotency_key: "intent-key-0001",
+      created_at: "2026-08-15T12:00:00.000Z",
+      expires_at: "2026-08-15T12:05:00.000Z",
+      consumed_at: null,
+    };
+    let renewed = false;
+    const db: D1Database = {
+      batch: async () => [],
+      prepare(query) {
+        const statement = {
+          bind() {
+            return statement;
+          },
+          async first<T>() {
+            return {
+              ...expired,
+              ...(renewed
+                ? {
+                    expires_at: "2026-08-15T12:11:00.000Z",
+                  }
+                : {}),
+            } as T;
+          },
+          async run() {
+            expect(query).toContain("UPDATE trace_upload_intents");
+            renewed = true;
+            return { success: true };
+          },
+        };
+        return statement;
+      },
+    };
+    const result = await new CloudflareTracePersistence(
+      db,
+      {} as R2Bucket,
+    ).createUploadIntent({
+      tokenHash: expired.token_hash,
+      runId: expired.run_id,
+      githubId: expired.github_user_id,
+      sha256: expired.trace_sha256,
+      sizeBytes: expired.size_bytes,
+      contentType: expired.content_type,
+      idempotencyKey: expired.idempotency_key,
+      createdAt: "2026-08-15T12:06:00.000Z",
+      expiresAt: "2026-08-15T12:11:00.000Z",
+      consumedAt: null,
+    });
+    expect(result.status).toBe("existing");
+    expect(result.status === "existing" && result.value.expiresAt).toBe(
+      "2026-08-15T12:11:00.000Z",
+    );
+  });
+
   it("does not disguise a missing atomic-attachment migration as replay", async () => {
     const db: D1Database = {
       batch: async () => {

--- a/functions/api/v1/trace-api.test.ts
+++ b/functions/api/v1/trace-api.test.ts
@@ -202,6 +202,14 @@ class MemoryPersistence implements TracePersistence {
       ) {
         return { status: "conflict" };
       }
+      if (prior.consumedAt === null && prior.expiresAt <= intent.createdAt) {
+        const renewed = {
+          ...prior,
+          expiresAt: intent.expiresAt,
+        };
+        this.intents.set(priorHash, renewed);
+        return { status: "existing", value: renewed };
+      }
       return { status: "existing", value: prior };
     }
     this.intents.set(intent.tokenHash, { ...intent });
@@ -432,6 +440,64 @@ async function uploadTrace(
 }
 
 describe("private trace API", () => {
+  it("renews an expired unconsumed upload intent on an idempotent retry", async () => {
+    const store = new MemoryPersistence();
+    let current = new Date(NOW);
+    const deps = { ...dependencies(store), now: () => new Date(current) };
+    const bearer = await token("42", "octocat", ["contributor"]);
+    const runResponse = await createRun(deps, bearer);
+    const { serverRunId } = (await runResponse.json()) as {
+      serverRunId: string;
+    };
+    const bytes = new TextEncoder().encode("recoverable trace");
+    const digest = await sha256Hex(bytes);
+    const intentRequest = () =>
+      request(
+        `runs/${serverRunId}/trace-intents`,
+        "POST",
+        bearer,
+        JSON.stringify({
+          sha256: digest,
+          sizeBytes: bytes.byteLength,
+          contentType: "text/plain",
+        }),
+        {
+          "content-type": "application/json",
+          "idempotency-key": "expired_intent_retry_key_0001",
+        },
+      );
+    const first = await handleTraceApi(intentRequest(), deps);
+    const firstIntent = (await first.json()) as {
+      expiresAt: string;
+      uploadUrl: string;
+    };
+
+    current = new Date(NOW.getTime() + 6 * 60 * 1000);
+    const retried = await handleTraceApi(intentRequest(), deps);
+    const renewedIntent = (await retried.json()) as {
+      expiresAt: string;
+      uploadUrl: string;
+    };
+
+    expect(retried.status).toBe(200);
+    expect(renewedIntent.uploadUrl).toBe(firstIntent.uploadUrl);
+    expect(renewedIntent.expiresAt).toBe(
+      new Date(current.getTime() + 5 * 60 * 1000).toISOString(),
+    );
+    const uploaded = await handleTraceApi(
+      new Request(renewedIntent.uploadUrl, {
+        method: "PUT",
+        body: bytes,
+        headers: {
+          "content-type": "text/plain",
+          digest: `sha-256=${digest}`,
+        },
+      }),
+      deps,
+    );
+    expect(uploaded.status).toBe(201);
+  });
+
   it("serves the fresh private intake attestation from the exact Pages bundle", async () => {
     let requestedUrl = "";
     const verifiedAt = new Date().toISOString();


### PR DESCRIPTION
## Summary

- renew an expired, unconsumed private-trace upload intent on an exact idempotent retry
- preserve the deterministic upload capability and original creation time
- keep consumed intents and mismatched idempotency replays fail-closed

## Reproduction

If a trace upload command failed and the operator retried after the five-minute intent expiry, `createUploadIntent` returned the original expired record. The client then received the same capability URL, but the upload route rejected it as expired. Every later exact retry returned that expired record again, permanently stranding the run.

## Verification

- `bunx vitest run functions/api/v1/trace-api.test.ts functions/api/v1/cloudflare-persistence.test.ts` — 37 passed
- `bun run typecheck` — passed
- Biome check on all three changed files — passed

The API regression creates an intent, advances six minutes, repeats the exact intent request, verifies a five-minute renewal on the same capability, and successfully uploads through it. The persistence regression covers the D1 renewal path directly.
