### PR TITLE
fix(trace): recover uploaded runs before finalize

### DIFF
--- a/skill-tests/project-skills.test.ts
+++ b/skill-tests/project-skills.test.ts
@@ -1037,6 +1037,88 @@ describe("project run usage", () => {
     }
   });
 
+  it("finalizes an idempotently recovered run whose trace was already uploaded", async () => {
+    const fixtureRoot = mkdtempSync(
+      join(tmpdir(), "slop-trace-finalize-recovery-"),
+    );
+    try {
+      const trajectory = join(fixtureRoot, "trace.ndjson");
+      const contents = '{"event":"complete"}\n';
+      writeFileSync(trajectory, contents);
+      const digest = createHash("sha256").update(contents).digest("hex");
+      const serverRunId = "srv_recovered";
+      const requests: Array<{ method: string; url: string }> = [];
+      const responses = [
+        {
+          enabled: true,
+          source: "github-public-status",
+          verifiedAt: "2026-08-25T12:00:00.000Z",
+        },
+        {
+          token: "s".repeat(32),
+          tokenType: "Bearer",
+          expiresAt: "2030-01-01T00:00:00.000Z",
+        },
+        {
+          serverRunId,
+          clientRunId: "run_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+          state: "trace_uploaded",
+        },
+        {
+          serverRunId,
+          clientRunId: "run_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+          traceObjectId: `sha256:${digest}`,
+          traceSha256: digest,
+          state: "finalized",
+        },
+      ];
+      const evidence = await uploadPrivateTrace(
+        {
+          runId: "run_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+          projectId: "eliza",
+          repositoryId: "elizaOS/eliza",
+          revision: "a".repeat(40),
+          provider: "openai",
+          model: "gpt-5.6-sol",
+          client: "codex",
+        },
+        trajectory,
+        "1.2.3",
+        {
+          disclosure: () => {},
+          assertionProvider: () => "i".repeat(32),
+          fetchImpl: async (url, options = {}) => {
+            requests.push({
+              method: options.method ?? "GET",
+              url: String(url),
+            });
+            return Response.json(responses.shift(), { status: 200 });
+          },
+        },
+      );
+      assert.deepStrictEqual(evidence, {
+        authority: "https://api.slop.cash",
+        serverRunId,
+        objectId: `sha256:${digest}`,
+        sha256: digest,
+      });
+      assert.deepStrictEqual(
+        requests.map(({ method, url }) => ({
+          method,
+          path: new URL(url).pathname,
+        })),
+        [
+          { method: "GET", path: "/api/v1/private-request-intake" },
+          { method: "POST", path: "/api/v1/auth/session" },
+          { method: "POST", path: "/api/v1/runs" },
+          { method: "POST", path: `/api/v1/runs/${serverRunId}/finalize` },
+        ],
+      );
+    } finally {
+      rmSync(fixtureRoot, { force: true, recursive: true });
+    }
+  });
+
   it("reports private intake rate-limit reset before authorization", async () => {
     const fixtureRoot = mkdtempSync(join(tmpdir(), "slop-trace-intake-rate-"));
     try {

--- a/skills/contribute-to-asi/scripts/run-receipt.mjs
+++ b/skills/contribute-to-asi/scripts/run-receipt.mjs
@@ -1533,88 +1533,92 @@ export async function uploadPrivateTrace(
   );
   if (
     created.clientRunId !== state.runId ||
-    created.state !== "awaiting_trace" ||
+    !["awaiting_trace", "trace_uploaded", "finalized"].includes(
+      created.state,
+    ) ||
     !/^[A-Za-z0-9][A-Za-z0-9._:-]{0,159}$/u.test(created.serverRunId ?? "")
   ) {
     fail("trace run creation returned mismatched identity");
   }
   const serverPath = encodeURIComponent(created.serverRunId);
-  const intentBody = {
-    sha256: trace.sha256,
-    sizeBytes: trace.sizeBytes,
-    contentType: trace.contentType,
-  };
-  const intent = await jsonRequest(
-    fetchImpl,
-    `${TRACE_AUTHORITY}/api/v1/runs/${serverPath}/trace-intents`,
-    {
-      method: "POST",
-      headers: {
-        ...jsonHeaders,
-        "Idempotency-Key": sha256(
-          `intent:${created.serverRunId}:${trace.sha256}`,
-        ),
+  if (created.state === "awaiting_trace") {
+    const intentBody = {
+      sha256: trace.sha256,
+      sizeBytes: trace.sizeBytes,
+      contentType: trace.contentType,
+    };
+    const intent = await jsonRequest(
+      fetchImpl,
+      `${TRACE_AUTHORITY}/api/v1/runs/${serverPath}/trace-intents`,
+      {
+        method: "POST",
+        headers: {
+          ...jsonHeaders,
+          "Idempotency-Key": sha256(
+            `intent:${created.serverRunId}:${trace.sha256}`,
+          ),
+        },
+        body: JSON.stringify(intentBody),
       },
-      body: JSON.stringify(intentBody),
-    },
-    [
-      "contentType",
-      "expiresAt",
-      "serverRunId",
-      "sha256",
-      "sizeBytes",
-      "uploadUrl",
-    ],
-    "trace upload intent",
-  );
-  let uploadUrl;
-  try {
-    uploadUrl = new URL(intent.uploadUrl);
-  } catch {
-    fail("trace upload intent returned an invalid URL");
-  }
-  if (
-    intent.serverRunId !== created.serverRunId ||
-    intent.sha256 !== trace.sha256 ||
-    intent.sizeBytes !== trace.sizeBytes ||
-    intent.contentType !== trace.contentType ||
-    uploadUrl.origin !== TRACE_AUTHORITY ||
-    uploadUrl.username ||
-    uploadUrl.password ||
-    uploadUrl.hash
-  ) {
-    fail("trace upload intent returned mismatched fields");
-  }
-  const uploaded = await jsonRequest(
-    fetchImpl,
-    uploadUrl.href,
-    {
-      method: "PUT",
-      headers: {
-        "Content-Type": trace.contentType,
-        Digest: `sha-256=${trace.sha256}`,
+      [
+        "contentType",
+        "expiresAt",
+        "serverRunId",
+        "sha256",
+        "sizeBytes",
+        "uploadUrl",
+      ],
+      "trace upload intent",
+    );
+    let uploadUrl;
+    try {
+      uploadUrl = new URL(intent.uploadUrl);
+    } catch {
+      fail("trace upload intent returned an invalid URL");
+    }
+    if (
+      intent.serverRunId !== created.serverRunId ||
+      intent.sha256 !== trace.sha256 ||
+      intent.sizeBytes !== trace.sizeBytes ||
+      intent.contentType !== trace.contentType ||
+      uploadUrl.origin !== TRACE_AUTHORITY ||
+      uploadUrl.username ||
+      uploadUrl.password ||
+      uploadUrl.hash
+    ) {
+      fail("trace upload intent returned mismatched fields");
+    }
+    const uploaded = await jsonRequest(
+      fetchImpl,
+      uploadUrl.href,
+      {
+        method: "PUT",
+        headers: {
+          "Content-Type": trace.contentType,
+          Digest: `sha-256=${trace.sha256}`,
+        },
+        body: trace.contents,
       },
-      body: trace.contents,
-    },
-    [
-      "clientRunId",
-      "serverRunId",
-      "sizeBytes",
-      "state",
-      "traceObjectId",
-      "traceSha256",
-    ],
-    "trace upload",
-  );
-  if (
-    uploaded.clientRunId !== state.runId ||
-    uploaded.serverRunId !== created.serverRunId ||
-    uploaded.sizeBytes !== trace.sizeBytes ||
-    uploaded.state !== "trace_uploaded" ||
-    uploaded.traceSha256 !== trace.sha256 ||
-    uploaded.traceObjectId !== `sha256:${trace.sha256}`
-  ) {
-    fail("trace upload returned mismatched evidence");
+      [
+        "clientRunId",
+        "serverRunId",
+        "sizeBytes",
+        "state",
+        "traceObjectId",
+        "traceSha256",
+      ],
+      "trace upload",
+    );
+    if (
+      uploaded.clientRunId !== state.runId ||
+      uploaded.serverRunId !== created.serverRunId ||
+      uploaded.sizeBytes !== trace.sizeBytes ||
+      uploaded.state !== "trace_uploaded" ||
+      uploaded.traceSha256 !== trace.sha256 ||
+      uploaded.traceObjectId !== `sha256:${trace.sha256}`
+    ) {
+      fail("trace upload returned mismatched evidence");
+    }
   }
   const finalized = await jsonRequest(
     fetchImpl,

--- a/skills/contribute-to-delta-star/scripts/run-receipt.mjs
+++ b/skills/contribute-to-delta-star/scripts/run-receipt.mjs
@@ -1533,88 +1533,92 @@ export async function uploadPrivateTrace(
   );
   if (
     created.clientRunId !== state.runId ||
-    created.state !== "awaiting_trace" ||
+    !["awaiting_trace", "trace_uploaded", "finalized"].includes(
+      created.state,
+    ) ||
     !/^[A-Za-z0-9][A-Za-z0-9._:-]{0,159}$/u.test(created.serverRunId ?? "")
   ) {
     fail("trace run creation returned mismatched identity");
   }
   const serverPath = encodeURIComponent(created.serverRunId);
-  const intentBody = {
-    sha256: trace.sha256,
-    sizeBytes: trace.sizeBytes,
-    contentType: trace.contentType,
-  };
-  const intent = await jsonRequest(
-    fetchImpl,
-    `${TRACE_AUTHORITY}/api/v1/runs/${serverPath}/trace-intents`,
-    {
-      method: "POST",
-      headers: {
-        ...jsonHeaders,
-        "Idempotency-Key": sha256(
-          `intent:${created.serverRunId}:${trace.sha256}`,
-        ),
+  if (created.state === "awaiting_trace") {
+    const intentBody = {
+      sha256: trace.sha256,
+      sizeBytes: trace.sizeBytes,
+      contentType: trace.contentType,
+    };
+    const intent = await jsonRequest(
+      fetchImpl,
+      `${TRACE_AUTHORITY}/api/v1/runs/${serverPath}/trace-intents`,
+      {
+        method: "POST",
+        headers: {
+          ...jsonHeaders,
+          "Idempotency-Key": sha256(
+            `intent:${created.serverRunId}:${trace.sha256}`,
+          ),
+        },
+        body: JSON.stringify(intentBody),
       },
-      body: JSON.stringify(intentBody),
-    },
-    [
-      "contentType",
-      "expiresAt",
-      "serverRunId",
-      "sha256",
-      "sizeBytes",
-      "uploadUrl",
-    ],
-    "trace upload intent",
-  );
-  let uploadUrl;
-  try {
-    uploadUrl = new URL(intent.uploadUrl);
-  } catch {
-    fail("trace upload intent returned an invalid URL");
-  }
-  if (
-    intent.serverRunId !== created.serverRunId ||
-    intent.sha256 !== trace.sha256 ||
-    intent.sizeBytes !== trace.sizeBytes ||
-    intent.contentType !== trace.contentType ||
-    uploadUrl.origin !== TRACE_AUTHORITY ||
-    uploadUrl.username ||
-    uploadUrl.password ||
-    uploadUrl.hash
-  ) {
-    fail("trace upload intent returned mismatched fields");
-  }
-  const uploaded = await jsonRequest(
-    fetchImpl,
-    uploadUrl.href,
-    {
-      method: "PUT",
-      headers: {
-        "Content-Type": trace.contentType,
-        Digest: `sha-256=${trace.sha256}`,
+      [
+        "contentType",
+        "expiresAt",
+        "serverRunId",
+        "sha256",
+        "sizeBytes",
+        "uploadUrl",
+      ],
+      "trace upload intent",
+    );
+    let uploadUrl;
+    try {
+      uploadUrl = new URL(intent.uploadUrl);
+    } catch {
+      fail("trace upload intent returned an invalid URL");
+    }
+    if (
+      intent.serverRunId !== created.serverRunId ||
+      intent.sha256 !== trace.sha256 ||
+      intent.sizeBytes !== trace.sizeBytes ||
+      intent.contentType !== trace.contentType ||
+      uploadUrl.origin !== TRACE_AUTHORITY ||
+      uploadUrl.username ||
+      uploadUrl.password ||
+      uploadUrl.hash
+    ) {
+      fail("trace upload intent returned mismatched fields");
+    }
+    const uploaded = await jsonRequest(
+      fetchImpl,
+      uploadUrl.href,
+      {
+        method: "PUT",
+        headers: {
+          "Content-Type": trace.contentType,
+          Digest: `sha-256=${trace.sha256}`,
+        },
+        body: trace.contents,
       },
-      body: trace.contents,
-    },
-    [
-      "clientRunId",
-      "serverRunId",
-      "sizeBytes",
-      "state",
-      "traceObjectId",
-      "traceSha256",
-    ],
-    "trace upload",
-  );
-  if (
-    uploaded.clientRunId !== state.runId ||
-    uploaded.serverRunId !== created.serverRunId ||
-    uploaded.sizeBytes !== trace.sizeBytes ||
-    uploaded.state !== "trace_uploaded" ||
-    uploaded.traceSha256 !== trace.sha256 ||
-    uploaded.traceObjectId !== `sha256:${trace.sha256}`
-  ) {
-    fail("trace upload returned mismatched evidence");
+      [
+        "clientRunId",
+        "serverRunId",
+        "sizeBytes",
+        "state",
+        "traceObjectId",
+        "traceSha256",
+      ],
+      "trace upload",
+    );
+    if (
+      uploaded.clientRunId !== state.runId ||
+      uploaded.serverRunId !== created.serverRunId ||
+      uploaded.sizeBytes !== trace.sizeBytes ||
+      uploaded.state !== "trace_uploaded" ||
+      uploaded.traceSha256 !== trace.sha256 ||
+      uploaded.traceObjectId !== `sha256:${trace.sha256}`
+    ) {
+      fail("trace upload returned mismatched evidence");
+    }
   }
   const finalized = await jsonRequest(
     fetchImpl,

--- a/skills/contribute-to-eliza/scripts/run-receipt.mjs
+++ b/skills/contribute-to-eliza/scripts/run-receipt.mjs
@@ -1533,88 +1533,92 @@ export async function uploadPrivateTrace(
   );
   if (
     created.clientRunId !== state.runId ||
-    created.state !== "awaiting_trace" ||
+    !["awaiting_trace", "trace_uploaded", "finalized"].includes(
+      created.state,
+    ) ||
     !/^[A-Za-z0-9][A-Za-z0-9._:-]{0,159}$/u.test(created.serverRunId ?? "")
   ) {
     fail("trace run creation returned mismatched identity");
   }
   const serverPath = encodeURIComponent(created.serverRunId);
-  const intentBody = {
-    sha256: trace.sha256,
-    sizeBytes: trace.sizeBytes,
-    contentType: trace.contentType,
-  };
-  const intent = await jsonRequest(
-    fetchImpl,
-    `${TRACE_AUTHORITY}/api/v1/runs/${serverPath}/trace-intents`,
-    {
-      method: "POST",
-      headers: {
-        ...jsonHeaders,
-        "Idempotency-Key": sha256(
-          `intent:${created.serverRunId}:${trace.sha256}`,
-        ),
+  if (created.state === "awaiting_trace") {
+    const intentBody = {
+      sha256: trace.sha256,
+      sizeBytes: trace.sizeBytes,
+      contentType: trace.contentType,
+    };
+    const intent = await jsonRequest(
+      fetchImpl,
+      `${TRACE_AUTHORITY}/api/v1/runs/${serverPath}/trace-intents`,
+      {
+        method: "POST",
+        headers: {
+          ...jsonHeaders,
+          "Idempotency-Key": sha256(
+            `intent:${created.serverRunId}:${trace.sha256}`,
+          ),
+        },
+        body: JSON.stringify(intentBody),
       },
-      body: JSON.stringify(intentBody),
-    },
-    [
-      "contentType",
-      "expiresAt",
-      "serverRunId",
-      "sha256",
-      "sizeBytes",
-      "uploadUrl",
-    ],
-    "trace upload intent",
-  );
-  let uploadUrl;
-  try {
-    uploadUrl = new URL(intent.uploadUrl);
-  } catch {
-    fail("trace upload intent returned an invalid URL");
-  }
-  if (
-    intent.serverRunId !== created.serverRunId ||
-    intent.sha256 !== trace.sha256 ||
-    intent.sizeBytes !== trace.sizeBytes ||
-    intent.contentType !== trace.contentType ||
-    uploadUrl.origin !== TRACE_AUTHORITY ||
-    uploadUrl.username ||
-    uploadUrl.password ||
-    uploadUrl.hash
-  ) {
-    fail("trace upload intent returned mismatched fields");
-  }
-  const uploaded = await jsonRequest(
-    fetchImpl,
-    uploadUrl.href,
-    {
-      method: "PUT",
-      headers: {
-        "Content-Type": trace.contentType,
-        Digest: `sha-256=${trace.sha256}`,
+      [
+        "contentType",
+        "expiresAt",
+        "serverRunId",
+        "sha256",
+        "sizeBytes",
+        "uploadUrl",
+      ],
+      "trace upload intent",
+    );
+    let uploadUrl;
+    try {
+      uploadUrl = new URL(intent.uploadUrl);
+    } catch {
+      fail("trace upload intent returned an invalid URL");
+    }
+    if (
+      intent.serverRunId !== created.serverRunId ||
+      intent.sha256 !== trace.sha256 ||
+      intent.sizeBytes !== trace.sizeBytes ||
+      intent.contentType !== trace.contentType ||
+      uploadUrl.origin !== TRACE_AUTHORITY ||
+      uploadUrl.username ||
+      uploadUrl.password ||
+      uploadUrl.hash
+    ) {
+      fail("trace upload intent returned mismatched fields");
+    }
+    const uploaded = await jsonRequest(
+      fetchImpl,
+      uploadUrl.href,
+      {
+        method: "PUT",
+        headers: {
+          "Content-Type": trace.contentType,
+          Digest: `sha-256=${trace.sha256}`,
+        },
+        body: trace.contents,
       },
-      body: trace.contents,
-    },
-    [
-      "clientRunId",
-      "serverRunId",
-      "sizeBytes",
-      "state",
-      "traceObjectId",
-      "traceSha256",
-    ],
-    "trace upload",
-  );
-  if (
-    uploaded.clientRunId !== state.runId ||
-    uploaded.serverRunId !== created.serverRunId ||
-    uploaded.sizeBytes !== trace.sizeBytes ||
-    uploaded.state !== "trace_uploaded" ||
-    uploaded.traceSha256 !== trace.sha256 ||
-    uploaded.traceObjectId !== `sha256:${trace.sha256}`
-  ) {
-    fail("trace upload returned mismatched evidence");
+      [
+        "clientRunId",
+        "serverRunId",
+        "sizeBytes",
+        "state",
+        "traceObjectId",
+        "traceSha256",
+      ],
+      "trace upload",
+    );
+    if (
+      uploaded.clientRunId !== state.runId ||
+      uploaded.serverRunId !== created.serverRunId ||
+      uploaded.sizeBytes !== trace.sizeBytes ||
+      uploaded.state !== "trace_uploaded" ||
+      uploaded.traceSha256 !== trace.sha256 ||
+      uploaded.traceObjectId !== `sha256:${trace.sha256}`
+    ) {
+      fail("trace upload returned mismatched evidence");
+    }
   }
   const finalized = await jsonRequest(
     fetchImpl,

--- a/skills/contribute-to-heir-elements-sdk/scripts/run-receipt.mjs
+++ b/skills/contribute-to-heir-elements-sdk/scripts/run-receipt.mjs
@@ -1533,88 +1533,92 @@ export async function uploadPrivateTrace(
   );
   if (
     created.clientRunId !== state.runId ||
-    created.state !== "awaiting_trace" ||
+    !["awaiting_trace", "trace_uploaded", "finalized"].includes(
+      created.state,
+    ) ||
     !/^[A-Za-z0-9][A-Za-z0-9._:-]{0,159}$/u.test(created.serverRunId ?? "")
   ) {
     fail("trace run creation returned mismatched identity");
   }
   const serverPath = encodeURIComponent(created.serverRunId);
-  const intentBody = {
-    sha256: trace.sha256,
-    sizeBytes: trace.sizeBytes,
-    contentType: trace.contentType,
-  };
-  const intent = await jsonRequest(
-    fetchImpl,
-    `${TRACE_AUTHORITY}/api/v1/runs/${serverPath}/trace-intents`,
-    {
-      method: "POST",
-      headers: {
-        ...jsonHeaders,
-        "Idempotency-Key": sha256(
-          `intent:${created.serverRunId}:${trace.sha256}`,
-        ),
+  if (created.state === "awaiting_trace") {
+    const intentBody = {
+      sha256: trace.sha256,
+      sizeBytes: trace.sizeBytes,
+      contentType: trace.contentType,
+    };
+    const intent = await jsonRequest(
+      fetchImpl,
+      `${TRACE_AUTHORITY}/api/v1/runs/${serverPath}/trace-intents`,
+      {
+        method: "POST",
+        headers: {
+          ...jsonHeaders,
+          "Idempotency-Key": sha256(
+            `intent:${created.serverRunId}:${trace.sha256}`,
+          ),
+        },
+        body: JSON.stringify(intentBody),
       },
-      body: JSON.stringify(intentBody),
-    },
-    [
-      "contentType",
-      "expiresAt",
-      "serverRunId",
-      "sha256",
-      "sizeBytes",
-      "uploadUrl",
-    ],
-    "trace upload intent",
-  );
-  let uploadUrl;
-  try {
-    uploadUrl = new URL(intent.uploadUrl);
-  } catch {
-    fail("trace upload intent returned an invalid URL");
-  }
-  if (
-    intent.serverRunId !== created.serverRunId ||
-    intent.sha256 !== trace.sha256 ||
-    intent.sizeBytes !== trace.sizeBytes ||
-    intent.contentType !== trace.contentType ||
-    uploadUrl.origin !== TRACE_AUTHORITY ||
-    uploadUrl.username ||
-    uploadUrl.password ||
-    uploadUrl.hash
-  ) {
-    fail("trace upload intent returned mismatched fields");
-  }
-  const uploaded = await jsonRequest(
-    fetchImpl,
-    uploadUrl.href,
-    {
-      method: "PUT",
-      headers: {
-        "Content-Type": trace.contentType,
-        Digest: `sha-256=${trace.sha256}`,
+      [
+        "contentType",
+        "expiresAt",
+        "serverRunId",
+        "sha256",
+        "sizeBytes",
+        "uploadUrl",
+      ],
+      "trace upload intent",
+    );
+    let uploadUrl;
+    try {
+      uploadUrl = new URL(intent.uploadUrl);
+    } catch {
+      fail("trace upload intent returned an invalid URL");
+    }
+    if (
+      intent.serverRunId !== created.serverRunId ||
+      intent.sha256 !== trace.sha256 ||
+      intent.sizeBytes !== trace.sizeBytes ||
+      intent.contentType !== trace.contentType ||
+      uploadUrl.origin !== TRACE_AUTHORITY ||
+      uploadUrl.username ||
+      uploadUrl.password ||
+      uploadUrl.hash
+    ) {
+      fail("trace upload intent returned mismatched fields");
+    }
+    const uploaded = await jsonRequest(
+      fetchImpl,
+      uploadUrl.href,
+      {
+        method: "PUT",
+        headers: {
+          "Content-Type": trace.contentType,
+          Digest: `sha-256=${trace.sha256}`,
+        },
+        body: trace.contents,
       },
-      body: trace.contents,
-    },
-    [
-      "clientRunId",
-      "serverRunId",
-      "sizeBytes",
-      "state",
-      "traceObjectId",
-      "traceSha256",
-    ],
-    "trace upload",
-  );
-  if (
-    uploaded.clientRunId !== state.runId ||
-    uploaded.serverRunId !== created.serverRunId ||
-    uploaded.sizeBytes !== trace.sizeBytes ||
-    uploaded.state !== "trace_uploaded" ||
-    uploaded.traceSha256 !== trace.sha256 ||
-    uploaded.traceObjectId !== `sha256:${trace.sha256}`
-  ) {
-    fail("trace upload returned mismatched evidence");
+      [
+        "clientRunId",
+        "serverRunId",
+        "sizeBytes",
+        "state",
+        "traceObjectId",
+        "traceSha256",
+      ],
+      "trace upload",
+    );
+    if (
+      uploaded.clientRunId !== state.runId ||
+      uploaded.serverRunId !== created.serverRunId ||
+      uploaded.sizeBytes !== trace.sizeBytes ||
+      uploaded.state !== "trace_uploaded" ||
+      uploaded.traceSha256 !== trace.sha256 ||
+      uploaded.traceObjectId !== `sha256:${trace.sha256}`
+    ) {
+      fail("trace upload returned mismatched evidence");
+    }
   }
   const finalized = await jsonRequest(
     fetchImpl,


### PR DESCRIPTION
## Summary

- recover idempotently when a trace is already uploaded but the prior client process did not finish
- skip creating another upload intent for `trace_uploaded` or `finalized` runs
- call the idempotent finalize endpoint and verify its returned digest against the inspected local trace
- apply the byte-identical receipt change to all four packaged project skills

## Reproduction

If the upload committed and the process stopped before finalization, rerunning `trace` recreated the run idempotently with `state: trace_uploaded`. The client required exactly `awaiting_trace`, rejected the valid server state, and could never recover the finalized evidence needed for submission.

## Verification

- `bun test skill-tests/project-skills.test.ts` — 26 passed
- `bun run typecheck` — passed
- Biome check on all changed files — passed

The new regression starts from a recovered `trace_uploaded` response, verifies that no second intent or upload occurs, finalizes the existing run, and accepts evidence only when the server returns the exact locally inspected trace digest.

## Coordination

This is a separate recovery case from #340, although both necessarily touch the byte-identical packaged receipt scripts. It can be rebased after #340 if that PR lands first.
