### PR TITLE
fix(wallet): commit claims with audit records

### DIFF
--- a/backend/trace/cloudflare-persistence.ts
+++ b/backend/trace/cloudflare-persistence.ts
@@ -735,6 +735,7 @@ export class CloudflareTracePersistence implements TracePersistence {
 
   async createWalletClaim(
     claim: WalletClaim,
+    audit: AuditInput,
   ): Promise<PersistenceResult<WalletClaim>> {
     const byDigest = await this.db
       .prepare("SELECT * FROM wallet_claims WHERE record_sha256 = ?")
@@ -748,32 +749,72 @@ export class CloudflareTracePersistence implements TracePersistence {
         return { status: "conflict" };
       }
     }
-    try {
-      await this.db
-        .prepare(
-          `INSERT INTO wallet_claims (
+    const claimInsert = this.db
+      .prepare(
+        `INSERT INTO wallet_claims (
             id, github_user_id, github_login, wallet_address, source,
             issue_repository, issue_number, source_body_sha256, observed_at,
             record_sha256, supersedes_claim_id, created_at
           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(
+        claim.id,
+        claim.githubId,
+        claim.githubLogin,
+        claim.walletAddress,
+        claim.source,
+        claim.issueRepository,
+        claim.issueNumber,
+        claim.sourceBodySha256,
+        claim.observedAt,
+        claim.recordSha256,
+        claim.supersedesClaimId,
+        claim.createdAt,
+      );
+    const auditInsert = this.db
+      .prepare(
+        `INSERT INTO private_audit_events (
+          id, actor_github_id, action, target, request_id, created_at, details_json
+        ) SELECT ?, ?, ?, ?, ?, ?, ?
+          WHERE EXISTS (SELECT 1 FROM wallet_claims WHERE id = ?)`,
+      )
+      .bind(
+        audit.id,
+        audit.actorGithubId,
+        audit.action,
+        audit.target,
+        audit.requestId,
+        audit.createdAt,
+        JSON.stringify(audit.details),
+        claim.id,
+      );
+    try {
+      const results = await this.db.batch([claimInsert, auditInsert]);
+      if (
+        results.length !== 2 ||
+        results.some((result) => !result.success) ||
+        results.some((result) => (result.meta?.changes ?? 0) !== 1)
+      ) {
+        throw new Error("Atomic wallet claim and audit did not both commit");
+      }
+    } catch (error) {
+      const raced = await this.db
+        .prepare("SELECT * FROM wallet_claims WHERE record_sha256 = ?")
+        .bind(claim.recordSha256)
+        .first<WalletClaimRow>();
+      if (raced !== null)
+        return { status: "existing", value: mapWalletClaim(raced) };
+      const competing = await this.db
+        .prepare(
+          claim.supersedesClaimId === null
+            ? `SELECT id FROM wallet_claims
+               WHERE github_user_id = ? AND supersedes_claim_id IS NULL`
+            : "SELECT id FROM wallet_claims WHERE supersedes_claim_id = ?",
         )
-        .bind(
-          claim.id,
-          claim.githubId,
-          claim.githubLogin,
-          claim.walletAddress,
-          claim.source,
-          claim.issueRepository,
-          claim.issueNumber,
-          claim.sourceBodySha256,
-          claim.observedAt,
-          claim.recordSha256,
-          claim.supersedesClaimId,
-          claim.createdAt,
-        )
-        .run();
-    } catch {
-      return { status: "conflict" };
+        .bind(claim.supersedesClaimId ?? claim.githubId)
+        .first<{ id: string }>();
+      if (competing !== null) return { status: "conflict" };
+      throw error;
     }
     return { status: "created", value: claim };
   }

--- a/backend/trace/contracts.ts
+++ b/backend/trace/contracts.ts
@@ -176,8 +176,10 @@ export interface TracePersistence {
     object: TraceObject,
   ): Promise<ReadableStream<Uint8Array> | Uint8Array | null>;
   writeAudit(input: AuditInput): Promise<void>;
+  /** Atomically commits a wallet claim and its required audit event. */
   createWalletClaim(
     claim: WalletClaim,
+    audit: AuditInput,
   ): Promise<PersistenceResult<WalletClaim>>;
   getWalletClaim(claimId: string): Promise<WalletClaim | null>;
   getCurrentWalletClaim(githubId: string): Promise<WalletClaim | null>;

--- a/backend/trace/handler.ts
+++ b/backend/trace/handler.ts
@@ -2,6 +2,7 @@ import { isSolanaAddress } from "../../src/lib/wallets";
 import { signApiToken, verifyApiToken } from "./auth";
 import {
   type ApiRole,
+  type AuditInput,
   type AuthenticatedActor,
   MAX_TRACE_BYTES,
   OPERATOR_GRANT_TTL_SECONDS,
@@ -269,7 +270,19 @@ async function createContributorWalletClaim(
     supersedesClaimId: requestedPredecessor,
     createdAt: observedAt,
   };
-  const result = await deps.persistence.createWalletClaim(claim);
+  const audit: AuditInput = {
+    id: deps.randomId(),
+    actorGithubId: actor.githubId,
+    action: "wallet_claim.created",
+    target: `wallet-claim:${claim.id}`,
+    requestId: deps.randomId(),
+    createdAt: observedAt,
+    details: {
+      recordDigest: claim.recordSha256,
+      supersedesClaimId: claim.supersedesClaimId,
+    },
+  };
+  const result = await deps.persistence.createWalletClaim(claim, audit);
   if (result.status === "conflict") {
     fail(
       409,
@@ -277,18 +290,6 @@ async function createContributorWalletClaim(
       "Wallet claim changed; reload the current claim before submitting",
     );
   }
-  await deps.persistence.writeAudit({
-    id: deps.randomId(),
-    actorGithubId: actor.githubId,
-    action: "wallet_claim.created",
-    target: `wallet-claim:${result.value.id}`,
-    requestId: deps.randomId(),
-    createdAt: observedAt,
-    details: {
-      recordDigest: result.value.recordSha256,
-      supersedesClaimId: result.value.supersedesClaimId,
-    },
-  });
   return json(
     result.status === "created" ? 201 : 200,
     publicWalletClaim(result.value),
@@ -380,24 +381,24 @@ async function createFallbackWalletClaim(
     supersedesClaimId,
     createdAt: deps.now().toISOString(),
   };
-  const result = await deps.persistence.createWalletClaim(claim);
-  if (result.status === "conflict")
-    fail(409, "claim_conflict", "Wallet claim conflicts");
-  await deps.persistence.writeAudit({
+  const audit: AuditInput = {
     id: deps.randomId(),
     actorGithubId: actor.githubId,
     action:
       source === "github_issue"
         ? "wallet_claim.historical_issue_migrated"
         : "wallet_claim.operator_recovery_created",
-    target: `wallet-claim:${result.value.id}`,
+    target: `wallet-claim:${claim.id}`,
     requestId: deps.randomId(),
     createdAt: deps.now().toISOString(),
     details: {
-      githubActorId: result.value.githubId,
-      recordDigest: result.value.recordSha256,
+      githubActorId: claim.githubId,
+      recordDigest: claim.recordSha256,
     },
-  });
+  };
+  const result = await deps.persistence.createWalletClaim(claim, audit);
+  if (result.status === "conflict")
+    fail(409, "claim_conflict", "Wallet claim conflicts");
   return json(
     result.status === "created" ? 201 : 200,
     publicWalletClaim(result.value),

--- a/functions/api/v1/cloudflare-persistence.test.ts
+++ b/functions/api/v1/cloudflare-persistence.test.ts
@@ -4,7 +4,11 @@ import {
   type D1Database,
   type R2Bucket,
 } from "../../../backend/trace/cloudflare-persistence";
-import type { TraceObject } from "../../../backend/trace/contracts";
+import type {
+  AuditInput,
+  TraceObject,
+  WalletClaim,
+} from "../../../backend/trace/contracts";
 
 const object: TraceObject = {
   sha256: "eafe895eb8119e6e5d06463590b2ef81b3651c157d5c8e18f1889186c7fd0ac0",
@@ -26,6 +30,69 @@ function body(text: string): ReadableStream<Uint8Array> {
 }
 
 describe("Cloudflare trace object persistence", () => {
+  it("submits wallet claim and audit writes in one atomic D1 batch", async () => {
+    const queries: string[] = [];
+    const db: D1Database = {
+      async batch(statements) {
+        expect(statements).toHaveLength(2);
+        return statements.map(() => ({ success: true, meta: { changes: 1 } }));
+      },
+      prepare(query) {
+        queries.push(query);
+        const statement = {
+          bind() {
+            return statement;
+          },
+          async first<T>() {
+            return null as T;
+          },
+          async run() {
+            throw new Error("wallet writes must use the atomic batch");
+          },
+        };
+        return statement;
+      },
+    };
+    const claim: WalletClaim = {
+      id: "claim-1",
+      githubId: "42",
+      githubLogin: "octocat",
+      walletAddress: "11111111111111111111111111111111",
+      source: "d1_registry",
+      issueRepository: null,
+      issueNumber: null,
+      sourceBodySha256: "b".repeat(64),
+      observedAt: object.createdAt,
+      recordSha256: "c".repeat(64),
+      supersedesClaimId: null,
+      createdAt: object.createdAt,
+    };
+    const audit: AuditInput = {
+      id: "audit-1",
+      actorGithubId: "42",
+      action: "wallet_claim.created",
+      target: "wallet-claim:claim-1",
+      requestId: "request-1",
+      createdAt: object.createdAt,
+      details: { recordDigest: claim.recordSha256 },
+    };
+
+    await expect(
+      new CloudflareTracePersistence(db, {} as R2Bucket).createWalletClaim(
+        claim,
+        audit,
+      ),
+    ).resolves.toEqual({ status: "created", value: claim });
+    expect(
+      queries.some((query) => query.includes("INSERT INTO wallet_claims")),
+    ).toBe(true);
+    expect(
+      queries.some((query) =>
+        query.includes("INSERT INTO private_audit_events"),
+      ),
+    ).toBe(true);
+  });
+
   it("does not disguise a missing atomic-attachment migration as replay", async () => {
     const db: D1Database = {
       batch: async () => {

--- a/functions/api/v1/trace-api.test.ts
+++ b/functions/api/v1/trace-api.test.ts
@@ -44,6 +44,7 @@ class MemoryPersistence implements TracePersistence {
   readonly audits: AuditInput[] = [];
   readonly claims = new Map<string, WalletClaim>();
   failNextPut = false;
+  failNextAudit = false;
 
   async createRun(input: CreateRunInput): Promise<PersistenceResult<TraceRun>> {
     const key = `${input.githubId}:${input.idempotencyKey}`;
@@ -265,11 +266,16 @@ class MemoryPersistence implements TracePersistence {
   }
 
   async writeAudit(input: AuditInput): Promise<void> {
+    if (this.failNextAudit) {
+      this.failNextAudit = false;
+      throw new Error("injected audit failure");
+    }
     this.audits.push(input);
   }
 
   async createWalletClaim(
     claim: WalletClaim,
+    audit: AuditInput,
   ): Promise<PersistenceResult<WalletClaim>> {
     const existing = [...this.claims.values()].find(
       (item) => item.recordSha256 === claim.recordSha256,
@@ -288,7 +294,12 @@ class MemoryPersistence implements TracePersistence {
     ) {
       return { status: "conflict" };
     }
+    if (this.failNextAudit) {
+      this.failNextAudit = false;
+      throw new Error("injected audit failure");
+    }
     this.claims.set(claim.id, claim);
+    this.audits.push(audit);
     return { status: "created", value: claim };
   }
 
@@ -1535,6 +1546,26 @@ describe("private trace API", () => {
       dependencies(),
     );
     expect(response.status).toBe(401);
+  });
+
+  it("does not activate a wallet claim when its required audit write fails", async () => {
+    const store = new MemoryPersistence();
+    const deps = dependencies(store);
+    const contributor = await token("42", "octocat", ["contributor"]);
+    store.failNextAudit = true;
+    const failed = await handleTraceApi(
+      request(
+        "wallet-claims",
+        "POST",
+        contributor,
+        JSON.stringify({ address: "11111111111111111111111111111111" }),
+        { "content-type": "application/json" },
+      ),
+      deps,
+    );
+    expect(failed.status).toBe(500);
+    expect(await store.getCurrentWalletClaim("42")).toBeNull();
+    expect(store.audits).toEqual([]);
   });
 
   it("reports unknown paths as not found instead of demanding authentication", async () => {


### PR DESCRIPTION
## Summary

- atomically commit each wallet claim with its required private audit event
- preserve exact replay and competing-lineage conflict behavior
- cover both contributor claims and operator recovery/migration claims

## Reproduction

Wallet claims were inserted before `writeAudit`. If that second write failed, the API returned HTTP 500 while the new wallet remained active. Retrying the same address then returned the existing claim early and never repaired the missing audit record. This left payment authority without the audit record promised by the registry contract.

## Fix

`TracePersistence.createWalletClaim` now accepts the associated audit event. Cloudflare persistence submits both inserts in one D1 batch and requires both writes to succeed. Exact concurrent replays return the winning record, competing roots/successors remain conflicts, and infrastructure failures propagate without activating a claim.

## Verification

- `bunx vitest run functions/api/v1/trace-api.test.ts functions/api/v1/cloudflare-persistence.test.ts` — 36 passed
- `bun run typecheck` — passed
- Biome check on all changed files — passed

The failure-sensitive API regression injects an audit failure and asserts both that the request fails and that no current wallet claim exists afterward. A Cloudflare persistence regression verifies claim and audit statements are submitted in one batch.
