### PR TITLE
fix(trace): commit read grants with audits

### DIFF
--- a/backend/trace/cloudflare-persistence.ts
+++ b/backend/trace/cloudflare-persistence.ts
@@ -634,8 +634,11 @@ export class CloudflareTracePersistence implements TracePersistence {
     }
   }
 
-  async createReadGrant(input: CreateGrantInput): Promise<void> {
-    await this.db
+  async createReadGrant(
+    input: CreateGrantInput,
+    audit: AuditInput,
+  ): Promise<void> {
+    const grantInsert = this.db
       .prepare(
         `INSERT INTO trace_read_grants (
           token_hash, trace_sha256, operator_github_id, reason, request_id,
@@ -650,8 +653,30 @@ export class CloudflareTracePersistence implements TracePersistence {
         input.requestId,
         input.createdAt,
         input.expiresAt,
+      );
+    const auditInsert = this.db
+      .prepare(
+        `INSERT INTO private_audit_events (
+          id, actor_github_id, action, target, request_id, created_at, details_json
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
       )
-      .run();
+      .bind(
+        audit.id,
+        audit.actorGithubId,
+        audit.action,
+        audit.target,
+        audit.requestId,
+        audit.createdAt,
+        JSON.stringify(audit.details),
+      );
+    const results = await this.db.batch([grantInsert, auditInsert]);
+    if (
+      results.length !== 2 ||
+      results.some((result) => !result.success) ||
+      results.some((result) => (result.meta?.changes ?? 0) !== 1)
+    ) {
+      throw new Error("Atomic trace read grant creation failed");
+    }
   }
 
   async consumeReadGrant(
@@ -659,16 +684,50 @@ export class CloudflareTracePersistence implements TracePersistence {
     traceSha256: string,
     operatorGithubId: string,
     now: string,
+    audit: AuditInput,
   ): Promise<boolean> {
-    const result = await this.db
+    const auditInsert = this.db
+      .prepare(
+        `INSERT INTO private_audit_events (
+          id, actor_github_id, action, target, request_id, created_at, details_json
+        ) SELECT ?, ?, ?, ?, ?, ?, ?
+          WHERE EXISTS (
+            SELECT 1 FROM trace_read_grants
+            WHERE token_hash = ? AND trace_sha256 = ? AND operator_github_id = ?
+              AND consumed_at IS NULL AND expires_at > ?
+          )`,
+      )
+      .bind(
+        audit.id,
+        audit.actorGithubId,
+        audit.action,
+        audit.target,
+        audit.requestId,
+        audit.createdAt,
+        JSON.stringify(audit.details),
+        tokenHash,
+        traceSha256,
+        operatorGithubId,
+        now,
+      );
+    const grantConsume = this.db
       .prepare(
         `UPDATE trace_read_grants SET consumed_at = ?
          WHERE token_hash = ? AND trace_sha256 = ? AND operator_github_id = ?
            AND consumed_at IS NULL AND expires_at > ?`,
       )
-      .bind(now, tokenHash, traceSha256, operatorGithubId, now)
-      .run();
-    return (result.meta?.changes ?? 0) === 1;
+      .bind(now, tokenHash, traceSha256, operatorGithubId, now);
+    const results = await this.db.batch([auditInsert, grantConsume]);
+    if (results.length !== 2 || results.some((result) => !result.success)) {
+      throw new Error("Atomic trace read grant consumption failed");
+    }
+    const auditChanges = results[0].meta?.changes ?? 0;
+    const grantChanges = results[1].meta?.changes ?? 0;
+    if (auditChanges === 0 && grantChanges === 0) return false;
+    if (auditChanges !== 1 || grantChanges !== 1) {
+      throw new Error("Trace read grant and audit state diverged");
+    }
+    return true;
   }
 
   async readTraceBytes(object: TraceObject): Promise<Uint8Array | null> {

--- a/backend/trace/contracts.ts
+++ b/backend/trace/contracts.ts
@@ -165,12 +165,13 @@ export interface TracePersistence {
     now: string,
   ): Promise<TraceUploadIntent | null>;
   putTraceBytes(object: TraceObject, bytes: Uint8Array): Promise<void>;
-  createReadGrant(input: CreateGrantInput): Promise<void>;
+  createReadGrant(input: CreateGrantInput, audit: AuditInput): Promise<void>;
   consumeReadGrant(
     tokenHash: string,
     traceSha256: string,
     operatorGithubId: string,
     now: string,
+    audit: AuditInput,
   ): Promise<boolean>;
   readTraceBytes(
     object: TraceObject,

--- a/backend/trace/handler.ts
+++ b/backend/trace/handler.ts
@@ -772,24 +772,26 @@ async function createReadGrant(
   const expiresAt = new Date(
     createdAt.getTime() + OPERATOR_GRANT_TTL_SECONDS * 1000,
   );
-  await deps.persistence.createReadGrant({
-    tokenHash,
-    traceSha256: sha256,
-    operatorGithubId: actor.githubId,
-    reason,
-    requestId,
-    createdAt: createdAt.toISOString(),
-    expiresAt: expiresAt.toISOString(),
-  });
-  await deps.persistence.writeAudit({
-    id: deps.randomId(),
-    actorGithubId: actor.githubId,
-    action: "trace.read_grant.created",
-    target: `sha256:${sha256}`,
-    requestId,
-    createdAt: createdAt.toISOString(),
-    details: { reason, expiresAt: expiresAt.toISOString() },
-  });
+  await deps.persistence.createReadGrant(
+    {
+      tokenHash,
+      traceSha256: sha256,
+      operatorGithubId: actor.githubId,
+      reason,
+      requestId,
+      createdAt: createdAt.toISOString(),
+      expiresAt: expiresAt.toISOString(),
+    },
+    {
+      id: deps.randomId(),
+      actorGithubId: actor.githubId,
+      action: "trace.read_grant.created",
+      target: `sha256:${sha256}`,
+      requestId,
+      createdAt: createdAt.toISOString(),
+      details: { reason, expiresAt: expiresAt.toISOString() },
+    },
+  );
   return json(201, {
     grant,
     expiresAt: expiresAt.toISOString(),
@@ -810,29 +812,30 @@ async function readTrace(
     fail(403, "read_grant_required", "A one-time trace read grant is required");
   }
   const tokenHash = await sha256Hex(new TextEncoder().encode(grant));
-  const consumed = await deps.persistence.consumeReadGrant(
-    tokenHash,
-    sha256,
-    actor.githubId,
-    deps.now().toISOString(),
-  );
-  if (!consumed)
-    fail(403, "invalid_read_grant", "Trace read grant is invalid or expired");
   const object = await deps.persistence.getTraceObject(sha256);
   if (object === null) fail(404, "not_found", "Trace not found");
   const bytes = await deps.persistence.readTraceBytes(object);
   if (bytes === null)
     fail(503, "object_unavailable", "Trace object is unavailable");
   const requestId = deps.randomId();
-  await deps.persistence.writeAudit({
-    id: deps.randomId(),
-    actorGithubId: actor.githubId,
-    action: "trace.read_grant.consumed",
-    target: `sha256:${sha256}`,
-    requestId,
-    createdAt: deps.now().toISOString(),
-    details: { sizeBytes: object.sizeBytes },
-  });
+  const consumedAt = deps.now().toISOString();
+  const consumed = await deps.persistence.consumeReadGrant(
+    tokenHash,
+    sha256,
+    actor.githubId,
+    consumedAt,
+    {
+      id: deps.randomId(),
+      actorGithubId: actor.githubId,
+      action: "trace.read_grant.consumed",
+      target: `sha256:${sha256}`,
+      requestId,
+      createdAt: consumedAt,
+      details: { sizeBytes: object.sizeBytes },
+    },
+  );
+  if (!consumed)
+    fail(403, "invalid_read_grant", "Trace read grant is invalid or expired");
   const responseBody =
     bytes instanceof Uint8Array ? bytes.slice().buffer : bytes;
   return new Response(responseBody, {

--- a/functions/api/v1/cloudflare-persistence.test.ts
+++ b/functions/api/v1/cloudflare-persistence.test.ts
@@ -4,7 +4,11 @@ import {
   type D1Database,
   type R2Bucket,
 } from "../../../backend/trace/cloudflare-persistence";
-import type { TraceObject } from "../../../backend/trace/contracts";
+import type {
+  AuditInput,
+  CreateGrantInput,
+  TraceObject,
+} from "../../../backend/trace/contracts";
 
 const object: TraceObject = {
   sha256: "eafe895eb8119e6e5d06463590b2ef81b3651c157d5c8e18f1889186c7fd0ac0",
@@ -26,6 +30,104 @@ function body(text: string): ReadableStream<Uint8Array> {
 }
 
 describe("Cloudflare trace object persistence", () => {
+  it("creates read grants and their audit records in one D1 batch", async () => {
+    const queries: string[] = [];
+    const batches: string[][] = [];
+    const db: D1Database = {
+      async batch(statements) {
+        batches.push(queries.slice(-statements.length));
+        return statements.map(() => ({ success: true, meta: { changes: 1 } }));
+      },
+      prepare(query) {
+        queries.push(query);
+        const statement = {
+          bind() {
+            return statement;
+          },
+          async first<T>() {
+            return null as T | null;
+          },
+          async run() {
+            return { success: true };
+          },
+        };
+        return statement;
+      },
+    };
+    const grant: CreateGrantInput = {
+      tokenHash: "a".repeat(64),
+      traceSha256: object.sha256,
+      operatorGithubId: "99",
+      reason: "investigate payout dispute",
+      requestId: "request-1",
+      createdAt: object.createdAt,
+      expiresAt: "2026-08-15T12:05:00.000Z",
+    };
+    const audit: AuditInput = {
+      id: "audit-1",
+      actorGithubId: "99",
+      action: "trace.read_grant.created",
+      target: `sha256:${object.sha256}`,
+      requestId: grant.requestId,
+      createdAt: grant.createdAt,
+      details: { reason: grant.reason, expiresAt: grant.expiresAt },
+    };
+
+    await new CloudflareTracePersistence(db, {} as R2Bucket).createReadGrant(
+      grant,
+      audit,
+    );
+
+    expect(batches).toHaveLength(1);
+    expect(batches[0]).toHaveLength(2);
+    expect(batches[0][0]).toContain("INSERT INTO trace_read_grants");
+    expect(batches[0][1]).toContain("INSERT INTO private_audit_events");
+  });
+
+  it("fails closed when read-grant consumption and audit results diverge", async () => {
+    const db: D1Database = {
+      async batch() {
+        return [
+          { success: true, meta: { changes: 1 } },
+          { success: true, meta: { changes: 0 } },
+        ];
+      },
+      prepare() {
+        const statement = {
+          bind() {
+            return statement;
+          },
+          async first<T>() {
+            return null as T | null;
+          },
+          async run() {
+            return { success: true };
+          },
+        };
+        return statement;
+      },
+    };
+    const audit: AuditInput = {
+      id: "audit-2",
+      actorGithubId: "99",
+      action: "trace.read_grant.consumed",
+      target: `sha256:${object.sha256}`,
+      requestId: "request-2",
+      createdAt: object.createdAt,
+      details: { sizeBytes: object.sizeBytes },
+    };
+
+    await expect(
+      new CloudflareTracePersistence(db, {} as R2Bucket).consumeReadGrant(
+        "a".repeat(64),
+        object.sha256,
+        "99",
+        object.createdAt,
+        audit,
+      ),
+    ).rejects.toThrow("Trace read grant and audit state diverged");
+  });
+
   it("does not disguise a missing atomic-attachment migration as replay", async () => {
     const db: D1Database = {
       batch: async () => {

--- a/functions/api/v1/trace-api.test.ts
+++ b/functions/api/v1/trace-api.test.ts
@@ -44,6 +44,7 @@ class MemoryPersistence implements TracePersistence {
   readonly audits: AuditInput[] = [];
   readonly claims = new Map<string, WalletClaim>();
   failNextPut = false;
+  failNextAudit = false;
 
   async createRun(input: CreateRunInput): Promise<PersistenceResult<TraceRun>> {
     const key = `${input.githubId}:${input.idempotencyKey}`;
@@ -236,8 +237,16 @@ class MemoryPersistence implements TracePersistence {
     this.bytes.set(object.sha256, bytes.slice());
   }
 
-  async createReadGrant(input: CreateGrantInput): Promise<void> {
+  async createReadGrant(
+    input: CreateGrantInput,
+    audit: AuditInput,
+  ): Promise<void> {
+    if (this.failNextAudit) {
+      this.failNextAudit = false;
+      throw new Error("injected audit failure");
+    }
     this.grants.set(input.tokenHash, { ...input, consumed: false });
+    this.audits.push(audit);
   }
 
   async consumeReadGrant(
@@ -245,6 +254,7 @@ class MemoryPersistence implements TracePersistence {
     traceSha256: string,
     operatorGithubId: string,
     now: string,
+    audit: AuditInput,
   ): Promise<boolean> {
     const grant = this.grants.get(tokenHash);
     if (
@@ -256,7 +266,12 @@ class MemoryPersistence implements TracePersistence {
     ) {
       return false;
     }
+    if (this.failNextAudit) {
+      this.failNextAudit = false;
+      throw new Error("injected audit failure");
+    }
     grant.consumed = true;
+    this.audits.push(audit);
     return true;
   }
 
@@ -265,6 +280,10 @@ class MemoryPersistence implements TracePersistence {
   }
 
   async writeAudit(input: AuditInput): Promise<void> {
+    if (this.failNextAudit) {
+      this.failNextAudit = false;
+      throw new Error("injected audit failure");
+    }
     this.audits.push(input);
   }
 
@@ -1387,6 +1406,66 @@ describe("private trace API", () => {
       "trace.read_grant.created",
       "trace.read_grant.consumed",
     ]);
+  });
+
+  it("does not activate or consume a read grant without its audit event", async () => {
+    const store = new MemoryPersistence();
+    const deps = dependencies(store);
+    const contributor = await token("42", "octocat", ["contributor"]);
+    const operator = await token("99", "slop-operator", ["operator"]);
+    const created = await createRun(deps, contributor);
+    const { serverRunId } = (await created.json()) as { serverRunId: string };
+    const bytes = new TextEncoder().encode("audited private trace");
+    const digest = await sha256Hex(bytes);
+    await uploadTrace(
+      deps,
+      contributor,
+      serverRunId,
+      bytes,
+      "upload_trace_key_audit_failure",
+    );
+
+    store.failNextAudit = true;
+    const failedGrant = await handleTraceApi(
+      request(
+        `operator/traces/${digest}/grant`,
+        "POST",
+        operator,
+        JSON.stringify({ reason: "verify atomic grant audit behavior" }),
+        { "content-type": "application/json" },
+      ),
+      deps,
+    );
+    expect(failedGrant.status).toBe(500);
+    expect(store.grants.size).toBe(0);
+
+    const grantResponse = await handleTraceApi(
+      request(
+        `operator/traces/${digest}/grant`,
+        "POST",
+        operator,
+        JSON.stringify({ reason: "verify atomic read audit behavior" }),
+        { "content-type": "application/json" },
+      ),
+      deps,
+    );
+    const { grant } = (await grantResponse.json()) as { grant: string };
+    store.failNextAudit = true;
+    const failedRead = await handleTraceApi(
+      request(`operator/traces/${digest}`, "GET", operator, undefined, {
+        "x-trace-read-grant": grant,
+      }),
+      deps,
+    );
+    expect(failedRead.status).toBe(500);
+    const retriedRead = await handleTraceApi(
+      request(`operator/traces/${digest}`, "GET", operator, undefined, {
+        "x-trace-read-grant": grant,
+      }),
+      deps,
+    );
+    expect(retriedRead.status).toBe(200);
+    expect(await retriedRead.text()).toBe("audited private trace");
   });
 
   it("publishes only immutable wallet claim metadata", async () => {


### PR DESCRIPTION
## Summary

- commit operator trace-read grant creation with its required audit record in one D1 batch
- commit one-time grant consumption with its audit record in one D1 batch
- defer consumption until the immutable trace object has been read successfully, so an R2 failure does not destroy the capability

## Bug

Grant state and private audit state were previously written separately. If the audit insert failed, grant creation returned 500 while leaving an active unaudited grant. During reads, the one-time grant was consumed before the audit insert, so an audit failure returned 500 and made the same grant unusable on retry.

## Verification

- `bunx vitest run functions/api/v1/trace-api.test.ts functions/api/v1/cloudflare-persistence.test.ts` (37 passed)
- `bun run typecheck`
- `bunx biome check backend/trace/contracts.ts backend/trace/cloudflare-persistence.ts backend/trace/handler.ts functions/api/v1/trace-api.test.ts functions/api/v1/cloudflare-persistence.test.ts`
- `git diff --check`
