### PR TITLE
fix(identity): return assertion from consume update

### DIFF
--- a/workers/identity/persistence.test.ts
+++ b/workers/identity/persistence.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { type D1Database, D1IdentityPersistence } from "./persistence";
+
+describe("D1 identity persistence", () => {
+  it("returns a consumed assertion from the same statement that consumes it", async () => {
+    const queries: string[] = [];
+    const db: D1Database = {
+      prepare(query) {
+        queries.push(query);
+        const statement = {
+          bind() {
+            return statement;
+          },
+          async first<T>() {
+            if (!query.includes("UPDATE identity_assertions")) {
+              throw new Error(
+                "identity lookup ran after assertion consumption",
+              );
+            }
+            return {
+              token_hash: "a".repeat(64),
+              github_actor_id: "123456",
+              github_login: "octocat",
+              audience: "private-trace-api",
+              created_at: "2026-08-15T20:00:00.000Z",
+              expires_at: "2026-08-15T20:01:30.000Z",
+              consumed_at: "2026-08-15T20:00:30.000Z",
+            } as T;
+          },
+          async run() {
+            throw new Error("assertion consumption did not return its row");
+          },
+        };
+        return statement;
+      },
+    };
+
+    await expect(
+      new D1IdentityPersistence(db).consumeAssertion(
+        "a".repeat(64),
+        "private-trace-api",
+        "2026-08-15T20:00:30.000Z",
+      ),
+    ).resolves.toMatchObject({
+      githubActorId: "123456",
+      githubLogin: "octocat",
+      consumedAt: "2026-08-15T20:00:30.000Z",
+    });
+    expect(queries).toHaveLength(1);
+  });
+});

--- a/workers/identity/persistence.ts
+++ b/workers/identity/persistence.ts
@@ -212,17 +212,13 @@ export class D1IdentityPersistence implements IdentityPersistence {
     audience: string,
     now: string,
   ): Promise<IdentityAssertion | null> {
-    const result = await this.db
+    const row = await this.db
       .prepare(
         `UPDATE identity_assertions SET consumed_at = ?
-         WHERE token_hash = ? AND audience = ? AND consumed_at IS NULL AND expires_at > ?`,
+         WHERE token_hash = ? AND audience = ? AND consumed_at IS NULL AND expires_at > ?
+         RETURNING *`,
       )
       .bind(now, tokenHash, audience, now)
-      .run();
-    if ((result.meta?.changes ?? 0) !== 1) return null;
-    const row = await this.db
-      .prepare("SELECT * FROM identity_assertions WHERE token_hash = ?")
-      .bind(tokenHash)
       .first<AssertionRow>();
     return row === null ? null : mapAssertion(row);
   }


### PR DESCRIPTION
## Summary

- consume a one-time identity assertion and return its identity from one conditional D1 statement
- remove the post-consumption lookup that could fail after permanently burning the assertion
- add a persistence regression that requires consumption and retrieval to share one statement

## Bug

`consumeAssertion` previously committed an `UPDATE` and then selected the consumed row in a separate query. If that second query failed or returned no row, the identity service returned an error after the one-time assertion had already been consumed. Retrying could only return `401`, preventing an otherwise valid sign-in from reaching the trace API.

The conditional `UPDATE ... RETURNING *` now makes mutation and retrieval one database operation.

## Verification

- `bunx vitest run workers/identity/persistence.test.ts workers/identity/identity.test.ts workers/identity/rate-limit.test.ts` (24 passed)
- `bun run typecheck`
- `bunx biome check workers/identity/persistence.ts workers/identity/persistence.test.ts`
- `git diff --check`
