### PR TITLE
fix(settlement): bind timestamp to chain evidence

### DIFF
--- a/src/lib/solana-settlement.test.ts
+++ b/src/lib/solana-settlement.test.ts
@@ -5,6 +5,7 @@ import { SOLANA_MAINNET_USDC_MINT } from "./settlement-plan";
 import {
   assertFinalizedUsdcFundingTransfer,
   assertFinalizedUsdcTransfer,
+  assertSettlementChronology,
 } from "./solana-settlement";
 
 const SOURCE = "Vote111111111111111111111111111111111111111";
@@ -46,6 +47,14 @@ function transaction() {
 }
 
 describe("finalized Solana settlement", () => {
+  it("rejects a settlement timestamp before its finalized transaction", () => {
+    expect(() =>
+      assertSettlementChronology("2026-08-01T00:00:00.000Z", [
+        { signature: SIGNATURE, slot: 123, blockTime: 1_786_000_000 },
+      ]),
+    ).toThrow(/predates its finalized transaction/u);
+  });
+
   it("accepts only the exact raw USDC debit and credit", () => {
     expect(
       assertFinalizedUsdcTransfer(transaction(), SIGNATURE, SOURCE, [

--- a/src/lib/solana-settlement.ts
+++ b/src/lib/solana-settlement.ts
@@ -34,6 +34,24 @@ export interface VerifiedSolanaTransaction {
 
 export const SOLANA_FUNDING_VERIFIER_VERSION = "funding-solana-v1" as const;
 
+/** Refuses an immutable settlement time earlier than its chain evidence. */
+export function assertSettlementChronology(
+  settledAt: string,
+  transactions: readonly VerifiedSolanaTransaction[],
+): void {
+  const settledAtMs = Date.parse(settledAt);
+  if (!Number.isFinite(settledAtMs)) {
+    throw new TypeError("Settlement time is invalid");
+  }
+  if (
+    transactions.some(
+      (transaction) => transaction.blockTime * 1_000 > settledAtMs,
+    )
+  ) {
+    throw new TypeError("Settlement time predates its finalized transaction");
+  }
+}
+
 function record(value: unknown, field: string): Record<string, unknown> {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     throw new TypeError(`${field} must be an object`);
@@ -361,5 +379,6 @@ export async function verifyRewardSettlementOnchain(input: {
       ),
     );
   }
+  assertSettlementChronology(settlement.settledAt, verified);
   return verified;
 }


### PR DESCRIPTION
## Summary

- bind an immutable settlement timestamp to the finalized Solana block times that prove payment
- reject a settlement record whose `settledAt` predates any contributor or platform-fee transaction
- add a focused adversarial chronology regression

## Bug

The verifier reconciled exact finalized USDC deltas but never compared their block times with `settledAt`. An operator-supplied timestamp could therefore claim that a paid settlement existed before its on-chain payment evidence.

The verifier now checks every accepted transaction before returning or allowing the settlement file to be written.

## Verification

- `bunx vitest run src/lib/solana-settlement.test.ts src/lib/rewards.test.ts src/lib/settlement-plan.test.ts` (20 passed)
- `bun run typecheck`
- `bunx biome check src/lib/solana-settlement.ts src/lib/solana-settlement.test.ts`
- `git diff --check`
