### PR TITLE
fix(identity): verify OAuth flow insertion

### DIFF
--- a/workers/identity/persistence.test.ts
+++ b/workers/identity/persistence.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import type { OAuthFlow } from "./contracts";
+import { type D1Database, D1IdentityPersistence } from "./persistence";
+
+const flow: OAuthFlow = {
+  id: "flow_abcdefghijklmnopqrst",
+  stateHash: "a".repeat(64),
+  pollCapabilityHash: "b".repeat(64),
+  encryptedPkceVerifier: "ciphertext",
+  pkceIv: "initialization-vector",
+  audience: "private-trace-api",
+  status: "pending",
+  githubActorId: null,
+  githubLogin: null,
+  createdAt: "2026-08-15T20:00:00.000Z",
+  expiresAt: "2026-08-15T20:05:00.000Z",
+  callbackCompletedAt: null,
+  assertionIssuedAt: null,
+};
+
+function database(result: {
+  success: boolean;
+  meta?: { changes?: number };
+}): D1Database {
+  return {
+    prepare() {
+      const statement = {
+        bind() {
+          return statement;
+        },
+        async first<T>() {
+          return null as T | null;
+        },
+        async run() {
+          return result;
+        },
+      };
+      return statement;
+    },
+  };
+}
+
+describe("D1 identity persistence", () => {
+  it.each([
+    { success: false, meta: { changes: 1 } },
+    { success: true, meta: { changes: 0 } },
+  ])("does not report an OAuth flow that D1 did not insert", async (result) => {
+    await expect(
+      new D1IdentityPersistence(database(result)).createFlow(flow),
+    ).resolves.toBe(false);
+  });
+});

--- a/workers/identity/persistence.ts
+++ b/workers/identity/persistence.ts
@@ -76,7 +76,7 @@ export class D1IdentityPersistence implements IdentityPersistence {
 
   async createFlow(flow: OAuthFlow): Promise<boolean> {
     try {
-      await this.db
+      const result = await this.db
         .prepare(
           `INSERT INTO identity_oauth_flows (
             id, state_hash, poll_capability_hash, encrypted_pkce_verifier,
@@ -96,7 +96,7 @@ export class D1IdentityPersistence implements IdentityPersistence {
           flow.expiresAt,
         )
         .run();
-      return true;
+      return result.success && (result.meta?.changes ?? 0) === 1;
     } catch {
       return false;
     }


### PR DESCRIPTION
## Summary

- require D1 to report both success and exactly one inserted row before exposing a new OAuth flow
- return the existing `flow_unavailable` response when D1 reports a non-throwing failure or zero-row write
- add persistence regressions for both failed postconditions

## Bug

`createFlow` returned `true` for every D1 call that did not throw. A D1 result with `success: false` or `meta.changes: 0` therefore caused the public endpoint to return an authorization URL and polling capability for a flow that was never persisted. The client could only poll a dead flow afterward.

## Verification

- `bunx vitest run workers/identity/persistence.test.ts workers/identity/identity.test.ts workers/identity/rate-limit.test.ts` (25 passed)
- `bun run typecheck`
- `bunx biome check workers/identity/persistence.ts workers/identity/persistence.test.ts`
- `git diff --check`
