### PR TITLE
fix(identity): verify assertion persistence

### DIFF
--- a/workers/identity/contracts.ts
+++ b/workers/identity/contracts.ts
@@ -56,7 +56,9 @@ export interface IdentityPersistence {
     pollCapabilityHash: string,
     now: string,
   ): Promise<OAuthFlow | null>;
-  createAssertion(assertion: IdentityAssertion): Promise<boolean>;
+  createAssertion(
+    assertion: IdentityAssertion,
+  ): Promise<IdentityAssertion | null>;
   markAssertionIssued(flowId: string, issuedAt: string): Promise<boolean>;
   consumeAssertion(
     tokenHash: string,

--- a/workers/identity/contracts.ts
+++ b/workers/identity/contracts.ts
@@ -56,7 +56,7 @@ export interface IdentityPersistence {
     pollCapabilityHash: string,
     now: string,
   ): Promise<OAuthFlow | null>;
-  createAssertion(assertion: IdentityAssertion): Promise<void>;
+  createAssertion(assertion: IdentityAssertion): Promise<boolean>;
   markAssertionIssued(flowId: string, issuedAt: string): Promise<boolean>;
   consumeAssertion(
     tokenHash: string,

--- a/workers/identity/handler.ts
+++ b/workers/identity/handler.ts
@@ -361,7 +361,7 @@ async function pollFlow(
     deps.assertionSecret,
   );
   const expiresAt = new Date(now.getTime() + ASSERTION_TTL_SECONDS * 1000);
-  const created = await deps.persistence.createAssertion({
+  const storedAssertion = await deps.persistence.createAssertion({
     tokenHash: await sha256Hex(assertion),
     githubActorId: flow.githubActorId,
     githubLogin: flow.githubLogin,
@@ -370,7 +370,17 @@ async function pollFlow(
     expiresAt: expiresAt.toISOString(),
     consumedAt: null,
   });
-  if (!created) {
+  const storedCreatedAt = Date.parse(storedAssertion?.createdAt ?? "");
+  const storedExpiresAt = Date.parse(storedAssertion?.expiresAt ?? "");
+  if (
+    storedAssertion === null ||
+    !Number.isFinite(storedCreatedAt) ||
+    !Number.isFinite(storedExpiresAt) ||
+    new Date(storedCreatedAt).toISOString() !== storedAssertion.createdAt ||
+    new Date(storedExpiresAt).toISOString() !== storedAssertion.expiresAt ||
+    storedCreatedAt > now.getTime() ||
+    storedExpiresAt <= now.getTime()
+  ) {
     fail(503, "assertion_unavailable", "Could not create identity assertion");
   }
   const issued = await deps.persistence.markAssertionIssued(
@@ -382,7 +392,7 @@ async function pollFlow(
     status: "complete",
     assertion,
     assertionType: "SlopIdentity",
-    expiresAt: expiresAt.toISOString(),
+    expiresAt: storedAssertion.expiresAt,
   });
 }
 

--- a/workers/identity/handler.ts
+++ b/workers/identity/handler.ts
@@ -361,7 +361,7 @@ async function pollFlow(
     deps.assertionSecret,
   );
   const expiresAt = new Date(now.getTime() + ASSERTION_TTL_SECONDS * 1000);
-  await deps.persistence.createAssertion({
+  const created = await deps.persistence.createAssertion({
     tokenHash: await sha256Hex(assertion),
     githubActorId: flow.githubActorId,
     githubLogin: flow.githubLogin,
@@ -370,6 +370,9 @@ async function pollFlow(
     expiresAt: expiresAt.toISOString(),
     consumedAt: null,
   });
+  if (!created) {
+    fail(503, "assertion_unavailable", "Could not create identity assertion");
+  }
   const issued = await deps.persistence.markAssertionIssued(
     flow.id,
     now.toISOString(),

--- a/workers/identity/identity.test.ts
+++ b/workers/identity/identity.test.ts
@@ -19,6 +19,7 @@ const ASSERTION_SECRET = "B".repeat(43);
 class MemoryIdentityPersistence implements IdentityPersistence {
   readonly flows = new Map<string, OAuthFlow>();
   readonly assertions = new Map<string, IdentityAssertion>();
+  failAssertionCreate = false;
 
   async createFlow(flow: OAuthFlow): Promise<boolean> {
     if (this.flows.has(flow.id)) return false;
@@ -92,10 +93,12 @@ class MemoryIdentityPersistence implements IdentityPersistence {
       : null;
   }
 
-  async createAssertion(assertion: IdentityAssertion): Promise<void> {
+  async createAssertion(assertion: IdentityAssertion): Promise<boolean> {
+    if (this.failAssertionCreate) return false;
     if (!this.assertions.has(assertion.tokenHash)) {
       this.assertions.set(assertion.tokenHash, { ...assertion });
     }
+    return true;
   }
 
   async markAssertionIssued(
@@ -351,6 +354,27 @@ describe("slop identity worker", () => {
       deps,
     );
     expect(consumeReplay.status).toBe(401);
+  });
+
+  it("does not issue an assertion that persistence refused to create", async () => {
+    const { deps, store } = dependencies();
+    const flow = await start(deps);
+    const { callback } = await authorizeAndCallback(deps, flow);
+    expect(callback.status).toBe(200);
+    store.failAssertionCreate = true;
+
+    const response = await handleIdentityRequest(
+      jsonRequest("identity.slop.cash", "/v1/oauth/poll", {
+        flowId: flow.flowId,
+        pollCapability: flow.pollCapability,
+        audience: IDENTITY_AUDIENCE,
+      }),
+      deps,
+    );
+
+    expect(response.status).toBe(503);
+    expect(store.flows.get(flow.flowId)?.status).toBe("callback_complete");
+    expect(store.assertions.size).toBe(0);
   });
 
   it("requires the browser-bound CSRF cookie and consumes callback state once", async () => {

--- a/workers/identity/identity.test.ts
+++ b/workers/identity/identity.test.ts
@@ -20,6 +20,7 @@ class MemoryIdentityPersistence implements IdentityPersistence {
   readonly flows = new Map<string, OAuthFlow>();
   readonly assertions = new Map<string, IdentityAssertion>();
   failAssertionCreate = false;
+  failAssertionIssueOnce = false;
 
   async createFlow(flow: OAuthFlow): Promise<boolean> {
     if (this.flows.has(flow.id)) return false;
@@ -93,18 +94,32 @@ class MemoryIdentityPersistence implements IdentityPersistence {
       : null;
   }
 
-  async createAssertion(assertion: IdentityAssertion): Promise<boolean> {
-    if (this.failAssertionCreate) return false;
+  async createAssertion(
+    assertion: IdentityAssertion,
+  ): Promise<IdentityAssertion | null> {
+    if (this.failAssertionCreate) return null;
     if (!this.assertions.has(assertion.tokenHash)) {
       this.assertions.set(assertion.tokenHash, { ...assertion });
     }
-    return true;
+    const stored = this.assertions.get(assertion.tokenHash);
+    return stored &&
+      stored.tokenHash === assertion.tokenHash &&
+      stored.githubActorId === assertion.githubActorId &&
+      stored.githubLogin === assertion.githubLogin &&
+      stored.audience === assertion.audience &&
+      stored.consumedAt === null
+      ? { ...stored }
+      : null;
   }
 
   async markAssertionIssued(
     flowId: string,
     issuedAt: string,
   ): Promise<boolean> {
+    if (this.failAssertionIssueOnce) {
+      this.failAssertionIssueOnce = false;
+      throw new Error("simulated post-insert persistence failure");
+    }
     const flow = this.flows.get(flowId);
     if (flow?.status !== "callback_complete") return false;
     this.flows.set(flowId, {
@@ -375,6 +390,38 @@ describe("slop identity worker", () => {
     expect(response.status).toBe(503);
     expect(store.flows.get(flow.flowId)?.status).toBe("callback_complete");
     expect(store.assertions.size).toBe(0);
+  });
+
+  it("recovers the original durable assertion after a post-insert failure", async () => {
+    const { deps, store } = dependencies();
+    const flow = await start(deps);
+    const { callback } = await authorizeAndCallback(deps, flow);
+    expect(callback.status).toBe(200);
+    store.failAssertionIssueOnce = true;
+
+    const poll = () =>
+      handleIdentityRequest(
+        jsonRequest("identity.slop.cash", "/v1/oauth/poll", {
+          flowId: flow.flowId,
+          pollCapability: flow.pollCapability,
+          audience: IDENTITY_AUDIENCE,
+        }),
+        deps,
+      );
+    const failed = await poll();
+    expect(failed.status).toBe(500);
+    const [durable] = [...store.assertions.values()];
+    expect(durable).toBeDefined();
+
+    deps.now = () => new Date(NOW.getTime() + 2_000);
+    const recovered = await poll();
+    expect(recovered.status).toBe(200);
+    const completion = (await recovered.json()) as {
+      expiresAt: string;
+    };
+    expect(completion.expiresAt).toBe(durable?.expiresAt);
+    expect(store.assertions.size).toBe(1);
+    expect(store.flows.get(flow.flowId)?.status).toBe("assertion_issued");
   });
 
   it("requires the browser-bound CSRF cookie and consumes callback state once", async () => {

--- a/workers/identity/persistence.test.ts
+++ b/workers/identity/persistence.test.ts
@@ -51,7 +51,7 @@ describe("D1 identity persistence", () => {
   ])("does not confirm an assertion absent from D1", async (options) => {
     await expect(
       new D1IdentityPersistence(database(options)).createAssertion(assertion),
-    ).resolves.toBe(false);
+    ).resolves.toBeNull();
   });
 
   it("confirms the exact durable assertion", async () => {
@@ -59,6 +59,19 @@ describe("D1 identity persistence", () => {
       new D1IdentityPersistence(
         database({ insertSuccess: true, stored: true }),
       ).createAssertion(assertion),
-    ).resolves.toBe(true);
+    ).resolves.toEqual(assertion);
+  });
+
+  it("returns the original assertion when a later retry finds its token", async () => {
+    const retry = {
+      ...assertion,
+      createdAt: "2026-08-15T20:00:02.000Z",
+      expiresAt: "2026-08-15T20:01:32.000Z",
+    };
+    await expect(
+      new D1IdentityPersistence(
+        database({ insertSuccess: true, stored: true }),
+      ).createAssertion(retry),
+    ).resolves.toEqual(assertion);
   });
 });

--- a/workers/identity/persistence.test.ts
+++ b/workers/identity/persistence.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import type { IdentityAssertion } from "./contracts";
+import { type D1Database, D1IdentityPersistence } from "./persistence";
+
+const assertion: IdentityAssertion = {
+  tokenHash: "a".repeat(64),
+  githubActorId: "123456",
+  githubLogin: "octocat",
+  audience: "private-trace-api",
+  createdAt: "2026-08-15T20:00:00.000Z",
+  expiresAt: "2026-08-15T20:01:30.000Z",
+  consumedAt: null,
+};
+
+function database(options: {
+  insertSuccess: boolean;
+  stored: boolean;
+}): D1Database {
+  return {
+    prepare(query) {
+      const statement = {
+        bind() {
+          return statement;
+        },
+        async first<T>() {
+          return options.stored && query.startsWith("SELECT")
+            ? ({
+                token_hash: assertion.tokenHash,
+                github_actor_id: assertion.githubActorId,
+                github_login: assertion.githubLogin,
+                audience: assertion.audience,
+                created_at: assertion.createdAt,
+                expires_at: assertion.expiresAt,
+                consumed_at: null,
+              } as T)
+            : null;
+        },
+        async run() {
+          return { success: options.insertSuccess };
+        },
+      };
+      return statement;
+    },
+  };
+}
+
+describe("D1 identity persistence", () => {
+  it.each([
+    { insertSuccess: false, stored: false },
+    { insertSuccess: true, stored: false },
+  ])("does not confirm an assertion absent from D1", async (options) => {
+    await expect(
+      new D1IdentityPersistence(database(options)).createAssertion(assertion),
+    ).resolves.toBe(false);
+  });
+
+  it("confirms the exact durable assertion", async () => {
+    await expect(
+      new D1IdentityPersistence(
+        database({ insertSuccess: true, stored: true }),
+      ).createAssertion(assertion),
+    ).resolves.toBe(true);
+  });
+});

--- a/workers/identity/persistence.ts
+++ b/workers/identity/persistence.ts
@@ -173,8 +173,8 @@ export class D1IdentityPersistence implements IdentityPersistence {
     return row === null ? null : mapFlow(row);
   }
 
-  async createAssertion(assertion: IdentityAssertion): Promise<void> {
-    await this.db
+  async createAssertion(assertion: IdentityAssertion): Promise<boolean> {
+    const result = await this.db
       .prepare(
         `INSERT INTO identity_assertions (
           token_hash, github_actor_id, github_login, audience, created_at,
@@ -190,6 +190,20 @@ export class D1IdentityPersistence implements IdentityPersistence {
         assertion.expiresAt,
       )
       .run();
+    if (!result.success) return false;
+    const row = await this.db
+      .prepare("SELECT * FROM identity_assertions WHERE token_hash = ?")
+      .bind(assertion.tokenHash)
+      .first<AssertionRow>();
+    return (
+      row !== null &&
+      row.github_actor_id === assertion.githubActorId &&
+      row.github_login === assertion.githubLogin &&
+      row.audience === assertion.audience &&
+      row.created_at === assertion.createdAt &&
+      row.expires_at === assertion.expiresAt &&
+      row.consumed_at === null
+    );
   }
 
   async markAssertionIssued(

--- a/workers/identity/persistence.ts
+++ b/workers/identity/persistence.ts
@@ -173,7 +173,9 @@ export class D1IdentityPersistence implements IdentityPersistence {
     return row === null ? null : mapFlow(row);
   }
 
-  async createAssertion(assertion: IdentityAssertion): Promise<boolean> {
+  async createAssertion(
+    assertion: IdentityAssertion,
+  ): Promise<IdentityAssertion | null> {
     const result = await this.db
       .prepare(
         `INSERT INTO identity_assertions (
@@ -190,20 +192,22 @@ export class D1IdentityPersistence implements IdentityPersistence {
         assertion.expiresAt,
       )
       .run();
-    if (!result.success) return false;
+    if (!result.success) return null;
     const row = await this.db
       .prepare("SELECT * FROM identity_assertions WHERE token_hash = ?")
       .bind(assertion.tokenHash)
       .first<AssertionRow>();
-    return (
+    if (
       row !== null &&
+      row.token_hash === assertion.tokenHash &&
       row.github_actor_id === assertion.githubActorId &&
       row.github_login === assertion.githubLogin &&
       row.audience === assertion.audience &&
-      row.created_at === assertion.createdAt &&
-      row.expires_at === assertion.expiresAt &&
       row.consumed_at === null
-    );
+    ) {
+      return mapAssertion(row);
+    }
+    return null;
   }
 
   async markAssertionIssued(


### PR DESCRIPTION
## Summary

- require the exact one-time assertion row to exist in D1 before marking its OAuth flow issued
- fail with `503 assertion_unavailable` while leaving the completed flow retryable when persistence fails
- verify both the handler behavior and D1 postcondition

## Bug

The poll handler ignored the result of assertion persistence and immediately marked the OAuth flow consumed. A non-throwing D1 failure could therefore return an assertion that had no database row; the trace API would reject it, and polling again returned `410` because the flow was already marked issued.

The persistence boundary now confirms the exact stored identity, audience, timestamps, and unconsumed state before issuance proceeds. This also safely supports retry after an insert succeeded but the caller lost its response.

## Verification

- `bunx vitest run workers/identity/persistence.test.ts workers/identity/identity.test.ts workers/identity/rate-limit.test.ts` (27 passed)
- `bun run typecheck`
- focused Biome check
- `git diff --check`
