### PR TITLE
fix(wallet): reject future claim observations

### DIFF
--- a/backend/trace/handler.ts
+++ b/backend/trace/handler.ts
@@ -354,6 +354,10 @@ async function createFallbackWalletClaim(
     fail(400, "invalid_request", "Invalid Solana address");
   }
   const observedAt = requiredString(body, "observedAt", validIsoTimestamp);
+  const createdAt = deps.now();
+  if (Date.parse(observedAt) > createdAt.getTime()) {
+    fail(400, "invalid_request", "Wallet observation cannot be in the future");
+  }
   const sourceBodySha256 = requiredString(
     body,
     "sourceBodySha256",
@@ -414,7 +418,7 @@ async function createFallbackWalletClaim(
     observedAt,
     recordSha256: await sha256Hex(new TextEncoder().encode(canonicalRecord)),
     supersedesClaimId,
-    createdAt: deps.now().toISOString(),
+    createdAt: createdAt.toISOString(),
   };
   const result = await deps.persistence.createWalletClaim(claim);
   if (result.status === "conflict")
@@ -428,7 +432,7 @@ async function createFallbackWalletClaim(
         : "wallet_claim.operator_recovery_created",
     target: `wallet-claim:${result.value.id}`,
     requestId: deps.randomId(),
-    createdAt: deps.now().toISOString(),
+    createdAt: createdAt.toISOString(),
     details: {
       githubActorId: result.value.githubId,
       recordDigest: result.value.recordSha256,

--- a/functions/api/v1/trace-api.test.ts
+++ b/functions/api/v1/trace-api.test.ts
@@ -1489,6 +1489,34 @@ describe("private trace API", () => {
     });
   });
 
+  it("rejects an operator wallet observation from the future", async () => {
+    const store = new MemoryPersistence();
+    const deps = dependencies(store);
+    const operator = await token("99", "slop-operator", ["operator"]);
+    const response = await handleTraceApi(
+      request(
+        "operator/wallet-claims",
+        "POST",
+        operator,
+        JSON.stringify({
+          githubActorId: "42",
+          githubLogin: "octocat",
+          address: "11111111111111111111111111111111",
+          observedAt: new Date(NOW.getTime() + 1).toISOString(),
+          sourceBodySha256: "b".repeat(64),
+        }),
+        { "content-type": "application/json" },
+      ),
+      deps,
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      error: "invalid_request",
+    });
+    expect(store.claims.size).toBe(0);
+  });
+
   it("lets a GitHub-authenticated contributor create and supersede one wallet lineage", async () => {
     const deps = dependencies();
     const contributor = await token("42", "octocat", ["contributor"]);


### PR DESCRIPTION
## Summary

- reject operator wallet-claim imports whose observation time is later than the server's creation time
- use one captured server timestamp for the claim and its audit record
- add a regression proving future provenance cannot create public claim state

## Bug

The operator recovery endpoint validated only the syntax of `observedAt`. It accepted a future timestamp, hashed it into the immutable claim, and published it as wallet provenance even though that observation had not happened yet. Future-dated records can also distort proposal cutoffs that rely on observation time.

## Verification

- `bunx vitest run functions/api/v1/trace-api.test.ts` (30 passed)
- `bun run typecheck`
- `bunx biome check backend/trace/handler.ts functions/api/v1/trace-api.test.ts`
- `git diff --check`
