### PR TITLE
fix(trace): verify upload intent insertion

### DIFF
--- a/backend/trace/cloudflare-persistence.ts
+++ b/backend/trace/cloudflare-persistence.ts
@@ -552,8 +552,9 @@ export class CloudflareTracePersistence implements TracePersistence {
         ? { status: "existing", value: mapped }
         : { status: "conflict" };
     }
+    let inserted: D1Result;
     try {
-      await this.db
+      inserted = await this.db
         .prepare(
           `INSERT INTO trace_upload_intents (
             token_hash, run_id, github_user_id, trace_sha256, size_bytes,
@@ -574,6 +575,9 @@ export class CloudflareTracePersistence implements TracePersistence {
         .run();
     } catch {
       return { status: "conflict" };
+    }
+    if (!inserted.success || (inserted.meta?.changes ?? 0) !== 1) {
+      throw new Error("Trace upload intent insertion failed");
     }
     return { status: "created", value: intent };
   }

--- a/functions/api/v1/cloudflare-persistence.test.ts
+++ b/functions/api/v1/cloudflare-persistence.test.ts
@@ -26,6 +26,49 @@ function body(text: string): ReadableStream<Uint8Array> {
 }
 
 describe("Cloudflare trace object persistence", () => {
+  it.each([
+    { success: false, meta: { changes: 1 } },
+    { success: true, meta: { changes: 0 } },
+  ])(
+    "does not report an upload intent that D1 did not insert",
+    async (result) => {
+      const db: D1Database = {
+        async batch() {
+          return [];
+        },
+        prepare() {
+          const statement = {
+            bind() {
+              return statement;
+            },
+            async first<T>() {
+              return null as T | null;
+            },
+            async run() {
+              return result;
+            },
+          };
+          return statement;
+        },
+      };
+
+      await expect(
+        new CloudflareTracePersistence(db, {} as R2Bucket).createUploadIntent({
+          tokenHash: "a".repeat(64),
+          runId: "run-1",
+          githubId: "42",
+          sha256: object.sha256,
+          sizeBytes: object.sizeBytes,
+          contentType: object.contentType,
+          idempotencyKey: "intent-key-0001",
+          createdAt: object.createdAt,
+          expiresAt: "2026-08-15T12:05:00.000Z",
+          consumedAt: null,
+        }),
+      ).rejects.toThrow(/upload intent insertion failed/u);
+    },
+  );
+
   it("does not disguise a missing atomic-attachment migration as replay", async () => {
     const db: D1Database = {
       batch: async () => {


### PR DESCRIPTION
## Summary

- require D1 to report a successful one-row insert before returning a new trace upload intent
- fail instead of handing a contributor a capability with no durable backing row
- add regressions for both explicit D1 failure and zero-row success results

## Bug

`createUploadIntent` returned `{ status: "created" }` whenever `.run()` did not throw. If D1 returned `success: false` or `meta.changes: 0`, the API still exposed an upload URL whose capability could never resolve; the next upload returned used-or-expired even though the client had just received it.

## Verification

- `bunx vitest run functions/api/v1/cloudflare-persistence.test.ts functions/api/v1/trace-api.test.ts` (37 passed)
- `bun run typecheck`
- `bunx biome check backend/trace/cloudflare-persistence.ts functions/api/v1/cloudflare-persistence.test.ts`
- `git diff --check`
