### PR TITLE
fix(trace): reject future progress events

### DIFF
--- a/backend/trace/handler.ts
+++ b/backend/trace/handler.ts
@@ -46,6 +46,7 @@ export type TraceApiDependencies = {
 type ApiError = Error & { status?: number; code?: string };
 
 export const TRACE_API_CONTRACT_VERSION = "private-trace-v1-opaque-hmac-v1";
+const MAX_EVENT_CLOCK_SKEW_MS = 5 * 60 * 1000;
 
 function fail(status: number, code: string, message: string): never {
   const error: ApiError = new Error(message);
@@ -745,6 +746,10 @@ async function appendEvent(
   const kind = body.kind;
   if (!validEventKind(kind)) fail(400, "invalid_request", "Invalid event kind");
   const occurredAt = requiredString(body, "occurredAt", validIsoTimestamp);
+  const createdAt = deps.now();
+  if (Date.parse(occurredAt) > createdAt.getTime() + MAX_EVENT_CLOCK_SKEW_MS) {
+    fail(400, "invalid_request", "Event time is too far in the future");
+  }
   const source = body.source;
   // GitHub-authoritative events are written only by the webhook processor,
   // never by this contributor endpoint.
@@ -770,7 +775,7 @@ async function appendEvent(
     }),
     headSha: optionalString(body, "headSha", validGitSha),
     idempotencyKey: idempotencyKey(request),
-    createdAt: deps.now().toISOString(),
+    createdAt: createdAt.toISOString(),
   });
   if (result.status === "conflict") {
     fail(409, "idempotency_conflict", "Idempotency key was reused");

--- a/functions/api/v1/trace-api.test.ts
+++ b/functions/api/v1/trace-api.test.ts
@@ -1265,6 +1265,39 @@ describe("private trace API", () => {
     });
   });
 
+  it("rejects a progress event beyond the server clock tolerance", async () => {
+    const store = new MemoryPersistence();
+    const deps = dependencies(store);
+    const contributor = await token("42", "octocat", ["contributor"]);
+    const created = await createRun(
+      deps,
+      contributor,
+      "create_future_event_run_key_0001",
+    );
+    const { serverRunId } = (await created.json()) as { serverRunId: string };
+    const response = await handleTraceApi(
+      request(
+        `runs/${serverRunId}/events`,
+        "POST",
+        contributor,
+        JSON.stringify({
+          kind: "run_completed",
+          occurredAt: new Date(NOW.getTime() + 5 * 60_000 + 1).toISOString(),
+          source: "agent",
+        }),
+        {
+          "content-type": "application/json",
+          "idempotency-key": "future_progress_event_key_0001",
+        },
+      ),
+      deps,
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({ error: "invalid_request" });
+    expect(store.events.size).toBe(0);
+  });
+
   it("rejects digest mismatches before retaining an object", async () => {
     const store = new MemoryPersistence();
     const deps = dependencies(store);


### PR DESCRIPTION
## Summary

- reject contributor progress events more than five minutes ahead of server time
- capture one server timestamp for both validation and event creation
- add a regression proving a future `run_completed` event never reaches persistence

## Bug

The trace API validated only the syntax of agent-supplied `occurredAt`. A contributor could attach events arbitrarily far in the future, including `merged` or `run_completed`, creating lifecycle metadata that contradicts the run and cannot yet have occurred.

The five-minute tolerance preserves bounded client clock skew while rejecting fabricated future chronology.

## Verification

- `bunx vitest run functions/api/v1/trace-api.test.ts` (30 passed)
- `bun run typecheck`
- `bunx biome check backend/trace/handler.ts functions/api/v1/trace-api.test.ts`
- `git diff --check`
