### PR TITLE
fix: reject impossible trace timestamps

### DIFF
--- a/backend/trace/validation.ts
+++ b/backend/trace/validation.ts
@@ -78,11 +78,20 @@ export function validEventKind(value: unknown): value is RunEventKind {
 }
 
 export function validIsoTimestamp(value: unknown): value is string {
-  return (
-    typeof value === "string" &&
-    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/u.test(value) &&
-    Number.isFinite(Date.parse(value))
-  );
+  if (
+    typeof value !== "string" ||
+    !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/u.test(value)
+  ) {
+    return false;
+  }
+  const milliseconds = Date.parse(value);
+  if (!Number.isFinite(milliseconds)) return false;
+  const canonical = value.endsWith(".000Z")
+    ? value
+    : value.endsWith("Z") && !value.includes(".")
+      ? `${value.slice(0, -1)}.000Z`
+      : value;
+  return new Date(milliseconds).toISOString() === canonical;
 }
 
 export async function readJsonObject(

--- a/functions/api/v1/trace-api.test.ts
+++ b/functions/api/v1/trace-api.test.ts
@@ -1265,6 +1265,39 @@ describe("private trace API", () => {
     });
   });
 
+  it("rejects impossible calendar dates in progress events", async () => {
+    const deps = dependencies();
+    const contributor = await token("42", "octocat", ["contributor"]);
+    const created = await createRun(
+      deps,
+      contributor,
+      "create_invalid_date_run_key_0001",
+    );
+    const { serverRunId } = (await created.json()) as { serverRunId: string };
+
+    const response = await handleTraceApi(
+      request(
+        `runs/${serverRunId}/events`,
+        "POST",
+        contributor,
+        JSON.stringify({
+          kind: "checkpoint",
+          occurredAt: "2026-02-30T11:59:00.000Z",
+          source: "agent",
+        }),
+        {
+          "content-type": "application/json",
+          "idempotency-key": "invalid_date_event_key_0001",
+        },
+      ),
+      deps,
+    );
+
+    expect(response.status).toBe(400);
+    expect(deps.persistence).toBeInstanceOf(MemoryPersistence);
+    expect((deps.persistence as MemoryPersistence).events.size).toBe(0);
+  });
+
   it("rejects digest mismatches before retaining an object", async () => {
     const store = new MemoryPersistence();
     const deps = dependencies(store);


### PR DESCRIPTION
## Problem

The shared ISO timestamp validator relies on Date.parse after checking the string shape. JavaScript normalizes impossible dates such as February 30, so the trace API accepts and persists a timestamp that never existed. The validator also protects wallet fallback observations and intake attestations.

## Fix

Require the parsed instant to serialize back to the submitted timestamp, while preserving the supported form that omits .000 milliseconds.

## Verification

- Reproduced before the fix: impossible progress-event date returned 201
- bunx vitest run functions/api/v1/trace-api.test.ts (30 passed)
- bun run typecheck
- bunx biome check backend/trace/validation.ts functions/api/v1/trace-api.test.ts