### PR TITLE
fix: require quorum on full Sablier stream state

### DIFF
--- a/scripts/verify-commitment-sablier.test.ts
+++ b/scripts/verify-commitment-sablier.test.ts
@@ -305,6 +305,26 @@ describe("Sablier commitment verifier", () => {
     ).rejects.toThrow(/did not reach commitment quorum/u);
   });
 
+  it("refuses equal net balances backed by different stream states", async () => {
+    const { fetchImpl } = fetchByAuthority({
+      [BASE_HOSTS[0]]: authorityFixture("base", 101),
+      [BASE_HOSTS[1]]: authorityFixture("base", 102, {
+        depositedAmount: uintWord(10_000_000n),
+        withdrawnAmount: uintWord(3_000_000n),
+      }),
+      [BASE_HOSTS[2]]: new Error("authority offline"),
+    });
+
+    await expect(
+      verifyCommitmentSablier({
+        network: "base",
+        streamId: STREAM_ID,
+        recipient: RECIPIENT,
+        fetchImpl,
+      }),
+    ).rejects.toThrow(/did not reach commitment quorum/u);
+  });
+
   it("refuses authorities serving the wrong chain or malformed data", async () => {
     const wrongChain = authorityFixture("base", 101);
     wrongChain.chainId = "0x1";

--- a/scripts/verify-commitment-sablier.ts
+++ b/scripts/verify-commitment-sablier.ts
@@ -282,10 +282,20 @@ async function verifyStreamState(
       return { authority: rpc.toString(), block, verified };
     }),
   );
-  const agreeing = quorumGroups<VerifiedSablierStream>(
-    settled,
-    (verified) =>
-      `${verified.streamId}:${verified.lockedMinor}:${verified.recipient}:USDC:${contract}`,
+  const agreeing = quorumGroups<VerifiedSablierStream>(settled, (verified) =>
+    JSON.stringify([
+      verified.streamId,
+      verified.recipient,
+      verified.sender,
+      verified.depositedMinor,
+      verified.withdrawnMinor,
+      verified.refundedMinor,
+      verified.lockedMinor,
+      verified.endTime,
+      verified.wasCanceled,
+      verified.isDepleted,
+      contract,
+    ]),
   );
   const checkedAt = new Date().toISOString();
   const canonical = agreeing[0].verified;


### PR DESCRIPTION
## Problem

The Sablier verifier groups RPC responses using only stream ID, recipient, contract, and net locked balance. Two authorities can disagree on sender, deposited, withdrawn, refunded, end time, cancellation, or depletion while producing the same net balance, yet the verifier reports a quorum and emits one authority's state as verified.

## Fix

Bind quorum agreement to every material stream-state field returned by the verifier. Different histories or control/status fields now form different groups and fail closed without two matching authorities.

## Reproduction

One authority reports 9 USDC deposited and 2 withdrawn; another reports 10 deposited and 3 withdrawn. Both have the same 6 USDC locked after a 1 USDC refund. Before this fix the verifier incorrectly resolved with verified-on-chain state; the regression now requires rejection.

## Verification

- bunx vitest run scripts/verify-commitment-sablier.test.ts src/lib/funding-commitment.test.ts (18 passed)
- bun run typecheck
- bunx biome check scripts/verify-commitment-sablier.ts scripts/verify-commitment-sablier.test.ts

PR #336 also touches the Sablier verifier for a distinct cancelability defect. This change does not duplicate that fix and may need a straightforward rebase after it merges.