### PR TITLE
fix: bind Solana evidence to the transaction ID

### DIFF
--- a/src/lib/solana-settlement.test.ts
+++ b/src/lib/solana-settlement.test.ts
@@ -86,6 +86,25 @@ describe("finalized Solana settlement", () => {
     ).toThrow(/source USDC debit|undeclared/u);
   });
 
+  it("requires the receipt signature to be the transaction identifier", () => {
+    const cosigned = transaction();
+    cosigned.transaction.signatures = ["4".repeat(88), SIGNATURE];
+
+    expect(() =>
+      assertFinalizedUsdcTransfer(cosigned, SIGNATURE, SOURCE, [
+        { recipientOwner: RECIPIENT, amountMinor: "1000000" },
+      ]),
+    ).toThrow(/signature/u);
+    expect(() =>
+      assertFinalizedUsdcFundingTransfer(
+        cosigned,
+        SIGNATURE,
+        RECIPIENT,
+        "1000000",
+      ),
+    ).toThrow(/signature/u);
+  });
+
   it("verifies an exact direct-funding credit without trusting the sender", () => {
     expect(
       assertFinalizedUsdcFundingTransfer(

--- a/src/lib/solana-settlement.ts
+++ b/src/lib/solana-settlement.ts
@@ -147,7 +147,7 @@ export function assertFinalizedUsdcTransfer(
   );
   if (
     !Array.isArray(envelope.signatures) ||
-    !envelope.signatures.some((value) => value === expectedSignature)
+    envelope.signatures[0] !== expectedSignature
   ) {
     throw new TypeError(
       "Solana transaction signature does not match the receipt",
@@ -229,7 +229,7 @@ export function assertFinalizedUsdcFundingTransfer(
   );
   if (
     !Array.isArray(envelope.signatures) ||
-    !envelope.signatures.some((value) => value === expectedSignature)
+    envelope.signatures[0] !== expectedSignature
   ) {
     throw new TypeError(
       "Solana transaction signature does not match the funding record",


### PR DESCRIPTION
## Problem

Solana identifies a transaction by the first signature in its signature array. Both USDC settlement and direct-funding verification instead accepted the expected receipt signature at any position. A secondary cosigner signature could therefore be treated as the transaction ID when reconciling an RPC-shaped response.

Solana's canonical JSON structure documents that the first signature is the transaction ID: https://solana.com/docs/rpc/json-structures

## Fix

Require the expected receipt signature to equal signatures[0] in both verification paths.

## Reproduction

A transaction fixture with an unrelated primary signature and the claimed receipt signature in position two previously passed both settlement and funding verification. The regression now proves both paths reject it.

## Verification

- bunx vitest run src/lib/solana-settlement.test.ts scripts/verify-settlement.test.ts scripts/verify-funding-solana.test.ts scripts/verify-commitment-squads.test.ts (15 passed across the matched suites)
- bun run typecheck
- bunx biome check src/lib/solana-settlement.ts src/lib/solana-settlement.test.ts