### PR TITLE
fix: prevent orphan traces at upload expiry

### DIFF
--- a/backend/trace/handler.ts
+++ b/backend/trace/handler.ts
@@ -621,9 +621,10 @@ async function uploadTraceCapability(
     fail(404, "not_found", "Upload capability not found");
   }
   const tokenHash = await sha256Hex(new TextEncoder().encode(capability));
+  const authorizedAt = deps.now().toISOString();
   const intent = await deps.persistence.getUploadIntent(
     tokenHash,
-    deps.now().toISOString(),
+    authorizedAt,
   );
   if (intent === null) {
     fail(
@@ -679,12 +680,11 @@ async function uploadTraceCapability(
       createdAt: deps.now().toISOString(),
     } as const);
   await deps.persistence.putTraceBytes(object, bytes);
-  const intentConsumedAt = deps.now().toISOString();
   const result = await deps.persistence.attachTrace({
     runId: intent.runId,
     githubId: intent.githubId,
     idempotencyKey: tokenHash,
-    intentConsumedAt,
+    intentConsumedAt: authorizedAt,
     object,
   });
   if (result.status === "conflict") {

--- a/functions/api/v1/trace-api.test.ts
+++ b/functions/api/v1/trace-api.test.ts
@@ -1351,6 +1351,61 @@ describe("private trace API", () => {
     expect((await handleTraceApi(uploadRequest(), deps)).status).toBe(201);
   });
 
+  it("completes an upload authorized immediately before capability expiry", async () => {
+    const store = new MemoryPersistence();
+    const deps = dependencies(store);
+    const contributor = await token("42", "octocat", ["contributor"]);
+    const created = await createRun(
+      deps,
+      contributor,
+      "create_expiring_upload_run_0001",
+    );
+    const { serverRunId } = (await created.json()) as { serverRunId: string };
+    const bytes = new TextEncoder().encode("authorized before expiry");
+    const digest = await sha256Hex(bytes);
+    const intentResponse = await handleTraceApi(
+      request(
+        `runs/${serverRunId}/trace-intents`,
+        "POST",
+        contributor,
+        JSON.stringify({
+          sha256: digest,
+          sizeBytes: bytes.byteLength,
+          contentType: "text/plain",
+        }),
+        {
+          "content-type": "application/json",
+          "idempotency-key": "expiring_upload_key_0001",
+        },
+      ),
+      deps,
+    );
+    const { uploadUrl } = (await intentResponse.json()) as {
+      uploadUrl: string;
+    };
+    const intent = [...store.intents.values()][0];
+    intent.expiresAt = new Date(NOW.getTime() + 1).toISOString();
+    const times = [
+      NOW,
+      new Date(NOW.getTime() + 2),
+      new Date(NOW.getTime() + 3),
+    ];
+    deps.now = () => new Date(times.shift() ?? times.at(-1) ?? NOW);
+
+    const response = await handleTraceApi(
+      new Request(uploadUrl, {
+        method: "PUT",
+        body: bytes.slice().buffer,
+        headers: { "content-type": "text/plain", digest: `sha-256=${digest}` },
+      }),
+      deps,
+    );
+
+    expect(response.status).toBe(201);
+    expect(store.bytes.has(digest)).toBe(true);
+    expect(store.uploads.size).toBe(1);
+  });
+
   it("atomically permits only one concurrent upload capability consumer", async () => {
     const store = new MemoryPersistence();
     const deps = dependencies(store);


### PR DESCRIPTION
## Problem

The upload handler checked capability expiry before reading the body, but generated a new timestamp only after writing the immutable R2 object and used that later time in the atomic D1 attachment. A request authorized just before expiry could therefore:

1. pass the capability check;
2. write permanent trace bytes to R2;
3. cross the expiry boundary;
4. fail D1 attachment with 409.

That leaves an untracked immutable object even though the upload was rejected.

## Fix

Capture one authorization timestamp when the capability is resolved and use that same timestamp for atomic intent consumption. Capability validity can no longer change midway through one bounded request. Validation failures and storage failures still leave the capability retryable, and concurrent consumption remains guarded by D1.

## Reproduction

The regression sets expiry one millisecond after authorization and advances the clock while the upload is processed. Before the fix the API returned 409 after retaining bytes; it now completes the already-authorized upload and records its attachment.

## Verification

- bunx vitest run functions/api/v1/trace-api.test.ts (30 passed)
- bun run typecheck
- bunx biome check backend/trace/handler.ts functions/api/v1/trace-api.test.ts

PR #340 changes client retry behavior for transient 5xx responses. It does not address this server-side expiry race.