### PR TITLE
fix: reject noncanonical Solana transaction signatures

### DIFF
--- a/scripts/solana-rpc.test.ts
+++ b/scripts/solana-rpc.test.ts
@@ -54,6 +54,19 @@ describe("Solana RPC boundary", () => {
     ).rejects.toThrow("exceeded its size limit");
   });
 
+  it("rejects a base58 value that is not a 64-byte signature", async () => {
+    const fetcher = vi.fn(async () => rpcResponse({ slot: 42 }));
+
+    await expect(
+      fetchFinalizedSolanaTransaction(
+        "https://api.mainnet-beta.solana.com",
+        "2".repeat(64),
+        { fetcher },
+      ),
+    ).rejects.toThrow(/signature is invalid/u);
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
   it("aborts a stalled request at the bounded timeout", async () => {
     const fetcher = async (
       _input: RequestInfo | URL,

--- a/scripts/solana-rpc.ts
+++ b/scripts/solana-rpc.ts
@@ -3,6 +3,8 @@
  * JSON-RPC boundary with strict time, byte, encoding, and response checks.
  */
 
+import { isSolanaTransactionId } from "../src/lib/funding-address.mjs";
+
 export const DEFAULT_SOLANA_RPC_URL =
   "https://api.mainnet-beta.solana.com" as const;
 export const MAX_SOLANA_RPC_BYTES = 16 * 1024 * 1024;
@@ -29,7 +31,7 @@ function rpcUrl(value: string): string {
 }
 
 function signature(value: string): string {
-  if (!/^[1-9A-HJ-NP-Za-km-z]{64,128}$/u.test(value)) {
+  if (!isSolanaTransactionId(value)) {
     throw new TypeError("Solana transaction signature is invalid");
   }
   return value;

--- a/scripts/verify-settlement.ts
+++ b/scripts/verify-settlement.ts
@@ -8,6 +8,7 @@ import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { isSolanaTransactionId } from "../src/lib/funding-address.mjs";
 import {
   assertProjectPaymentsEnabled,
   findProject,
@@ -159,8 +160,7 @@ function parseEvidence(value: unknown, cycleId: string): SettlementEvidence {
       attempt.intentIds.length === 0 ||
       !attempt.intentIds.every((id) => typeof id === "string") ||
       new Set(attempt.intentIds).size !== attempt.intentIds.length ||
-      typeof attempt.signature !== "string" ||
-      !/^[1-9A-HJ-NP-Za-km-z]{64,128}$/u.test(attempt.signature)
+      !isSolanaTransactionId(attempt.signature)
     ) {
       throw new TypeError(`Settlement evidence attempt ${index} is invalid`);
     }
@@ -177,8 +177,7 @@ function parseEvidence(value: unknown, cycleId: string): SettlementEvidence {
   const platformFeeSignature = evidence.platformFeeSignature;
   if (
     platformFeeSignature !== null &&
-    (typeof platformFeeSignature !== "string" ||
-      !/^[1-9A-HJ-NP-Za-km-z]{64,128}$/u.test(platformFeeSignature) ||
+    (!isSolanaTransactionId(platformFeeSignature) ||
       signatures.has(platformFeeSignature))
   ) {
     throw new TypeError(

--- a/src/lib/rewards.test.ts
+++ b/src/lib/rewards.test.ts
@@ -400,6 +400,12 @@ describe("reward manifests", () => {
       "paid",
     );
 
+    const malformedSignature = structuredClone(settlement);
+    malformedSignature.attempts[0].signature = "2".repeat(64);
+    expect(() =>
+      assertRewardSettlementManifest(malformedSignature, allocation),
+    ).toThrow(/signature is invalid/u);
+
     const proposed = allocationManifest() as RewardAllocationManifest;
     proposed.status = "proposed";
     proposed.approvedAt = null;

--- a/src/lib/rewards.ts
+++ b/src/lib/rewards.ts
@@ -4,6 +4,7 @@
  * amount is tied to one immutable payout intent.
  */
 
+import { isSolanaTransactionId } from "./funding-address.mjs";
 import { assertExactModelIdentity } from "./model-identity";
 import { findProject, type ProjectId } from "./projects.mjs";
 import { isSolanaAddress, WALLET_CLAIM_REPOSITORY } from "./wallets";
@@ -248,6 +249,13 @@ function safeInteger(value: unknown, path: string): number {
 
 function sha256(value: unknown, path: string): string {
   return text(value, path, { pattern: /^[0-9a-f]{64}$/u });
+}
+
+function solanaSignature(value: unknown, path: string): string {
+  if (!isSolanaTransactionId(value)) {
+    throw new TypeError(`${path} is invalid`);
+  }
+  return value;
 }
 
 function array(value: unknown, path: string): unknown[] {
@@ -1404,11 +1412,7 @@ export function assertRewardSettlementManifest(
       const signature =
         attempt.signature === null
           ? null
-          : text(attempt.signature, `${path}.signature`, {
-              max: 128,
-              min: 64,
-              pattern: /^[1-9A-HJ-NP-Za-km-z]+$/u,
-            });
+          : solanaSignature(attempt.signature, `${path}.signature`);
       if (state === "finalized" && signature === null) {
         throw new TypeError(`${path} finalized attempt needs a signature`);
       }
@@ -1494,11 +1498,10 @@ export function assertRewardSettlementManifest(
   const feeSignature =
     platformFeeRecord.signature === null
       ? null
-      : text(platformFeeRecord.signature, "settlement platformFee.signature", {
-          max: 128,
-          min: 64,
-          pattern: /^[1-9A-HJ-NP-Za-km-z]+$/u,
-        });
+      : solanaSignature(
+          platformFeeRecord.signature,
+          "settlement platformFee.signature",
+        );
   if (BigInt(feeDueMinor) === 0n) {
     if (
       feeState !== "not-applicable" ||

--- a/src/lib/solana-settlement.test.ts
+++ b/src/lib/solana-settlement.test.ts
@@ -54,6 +54,26 @@ describe("finalized Solana settlement", () => {
     ).toEqual({ signature: SIGNATURE, slot: 123, blockTime: 1_786_000_000 });
   });
 
+  it("rejects base58 strings that do not decode to 64-byte signatures", () => {
+    const malformedSignature = "2".repeat(64);
+    const mislabeled = transaction();
+    mislabeled.transaction.signatures = [malformedSignature];
+
+    expect(() =>
+      assertFinalizedUsdcTransfer(mislabeled, malformedSignature, SOURCE, [
+        { recipientOwner: RECIPIENT, amountMinor: "1000000" },
+      ]),
+    ).toThrow(/signature/u);
+    expect(() =>
+      assertFinalizedUsdcFundingTransfer(
+        mislabeled,
+        malformedSignature,
+        RECIPIENT,
+        "1000000",
+      ),
+    ).toThrow(/signature/u);
+  });
+
   it("rejects failed, underpaid, replay-labeled, and padded transactions", () => {
     const failed = transaction();
     failed.meta.err = { InstructionError: [0, "Custom"] };

--- a/src/lib/solana-settlement.ts
+++ b/src/lib/solana-settlement.ts
@@ -4,6 +4,7 @@
  * never count as payment evidence.
  */
 
+import { isSolanaTransactionId } from "./funding-address.mjs";
 import type {
   RewardAllocationManifest,
   RewardSettlementManifest,
@@ -49,12 +50,7 @@ function safeInteger(value: unknown, field: string): number {
 }
 
 function signature(value: unknown, field: string): string {
-  if (
-    typeof value !== "string" ||
-    value.length < 64 ||
-    value.length > 128 ||
-    !/^[1-9A-HJ-NP-Za-km-z]+$/u.test(value)
-  ) {
+  if (!isSolanaTransactionId(value)) {
     throw new TypeError(`${field} is not a Solana signature`);
   }
   return value;


### PR DESCRIPTION
## Problem

Settlement evidence, reward-settlement manifests, the Solana RPC client, and the core USDC reconciler accepted any 64-128 character base58-looking string as a transaction signature. Solana signatures are exactly 64 decoded bytes; for example, 64 repeated base58 characters decode to fewer bytes but passed every loose check.

With an RPC-shaped response containing the same malformed label, the core verifier accepted it as finalized transaction evidence. This also allowed impossible identifiers into public settlement records.

## Fix

Use the existing decoded-length-aware isSolanaTransactionId validator consistently at all four boundaries:

- settlement evidence ingestion
- public settlement manifest validation
- RPC request validation
- core funding and payout reconciliation

## Reproduction

Regression fixtures use a 64-character base58 string that does not decode to 64 bytes. Before the fix the RPC was called and both core verification paths accepted it; now it is rejected before network access and by the reconciler itself.

## Verification

- bunx vitest run src/lib/solana-settlement.test.ts scripts/solana-rpc.test.ts src/lib/rewards.test.ts scripts/verify-funding-solana.test.ts scripts/money-state-commands.test.ts (30 passed)
- bun run typecheck
- Biome checks on all seven changed files

PR #355 fixes the distinct requirement that a valid signature must be first in the transaction signature array. This PR validates its decoded byte length and may need a small rebase in the shared reconciler.