### PR TITLE
fix: bind Sablier commitments to the project recipient

### DIFF
--- a/src/lib/funding-commitment.test.ts
+++ b/src/lib/funding-commitment.test.ts
@@ -19,6 +19,7 @@ const FUNDER_MEMBER = "Stake11111111111111111111111111111111111111";
 const STEWARD_MEMBER = "SysvarRent111111111111111111111111111111111";
 const DEPOSIT_SIGNATURE = "3".repeat(88);
 const RELEASE_SIGNATURE = "4".repeat(88);
+const SABLIER_RECIPIENT = `0x${"a".repeat(40)}`;
 
 function squadsInstrument(overrides: Record<string, unknown> = {}) {
   return {
@@ -44,6 +45,7 @@ function sablierInstrument(overrides: Record<string, unknown> = {}) {
     network: "base",
     asset: "USDC",
     contract: SABLIER_LOCKUP_V4_CONTRACTS.base,
+    recipient: SABLIER_RECIPIENT,
     streamId: "421",
     deadline: "2026-12-01T00:00:00.000Z",
     effectiveAt: "2026-08-01T00:00:00.000Z",
@@ -124,6 +126,11 @@ describe("funding commitment instruments", () => {
     ).toThrow(/streamId is invalid/u);
     expect(() =>
       assertFundingCommitments([
+        sablierInstrument({ recipient: `0x${"0".repeat(40)}` }),
+      ]),
+    ).toThrow(/recipient is invalid/u);
+    expect(() =>
+      assertFundingCommitments([
         sablierInstrument({
           network: "ethereum",
           contract: SABLIER_LOCKUP_V4_CONTRACTS.base,
@@ -142,6 +149,12 @@ describe("funding commitment instruments", () => {
     ).toThrow(/at most 16/u);
     expect(() =>
       assertFundingCommitments([sablierInstrument(), sablierInstrument()]),
+    ).toThrow(/duplicate instrument/u);
+    expect(() =>
+      assertFundingCommitments([
+        sablierInstrument(),
+        sablierInstrument({ recipient: `0x${"b".repeat(40)}` }),
+      ]),
     ).toThrow(/duplicate instrument/u);
     expect(() =>
       assertFundingCommitments([
@@ -250,6 +263,39 @@ describe("project commitment records", () => {
     expect(() =>
       assertProjectCommitmentRecord(record({ event: "sweep" }), instruments),
     ).toThrow(/event is invalid/u);
+
+    const sablierTransaction = `0x${"a".repeat(64)}`;
+    const sablierRecord = record({
+      network: "base",
+      instrument: {
+        contract: SABLIER_LOCKUP_V4_CONTRACTS.base,
+        recipient: SABLIER_RECIPIENT,
+        streamId: "421",
+      },
+      transactionId: sablierTransaction,
+      finality: { kind: "confirmations", confirmations: 12 },
+      verifier: {
+        version: "commitment-sablier-v1",
+        checkedAt: "2026-08-02T01:00:00.000Z",
+        evidenceUrl: `https://basescan.org/tx/${sablierTransaction}`,
+        reason: null,
+      },
+    });
+    expect(
+      assertProjectCommitmentRecord(sablierRecord, instruments).instrument,
+    ).toMatchObject({ recipient: SABLIER_RECIPIENT });
+    expect(() =>
+      assertProjectCommitmentRecord(
+        {
+          ...sablierRecord,
+          instrument: {
+            ...sablierRecord.instrument,
+            recipient: `0x${"b".repeat(40)}`,
+          },
+        },
+        instruments,
+      ),
+    ).toThrow(/not active/u);
   });
 
   it("requires independent finalized evidence before verification", () => {

--- a/src/lib/funding-commitment.ts
+++ b/src/lib/funding-commitment.ts
@@ -50,7 +50,7 @@ export interface ProjectCommitmentRecord {
         vault: string;
         vaultIndex: number;
       }
-    | { contract: string; streamId: string };
+    | { contract: string; recipient: string; streamId: string };
   transactionId: string;
   amountMinor: string;
   observedAt: string;
@@ -189,7 +189,8 @@ function matchesInstrument(
   }
   return (
     identity.contract === candidate.contract &&
-    identity.streamId === candidate.streamId
+    identity.streamId === candidate.streamId &&
+    identity.recipient === candidate.recipient
   );
 }
 
@@ -266,7 +267,7 @@ export function assertProjectCommitmentRecord(
     identity,
     network === "solana"
       ? ["funderMember", "multisig", "stewardMember", "vault", "vaultIndex"]
-      : ["contract", "streamId"],
+      : ["contract", "recipient", "streamId"],
     "commitment record instrument",
   );
   if (
@@ -378,7 +379,7 @@ function instrumentIdentityKey(record: ProjectCommitmentRecord): string {
   const identity = record.instrument as Record<string, unknown>;
   return record.network === "solana"
     ? `${identity.multisig}:${identity.vaultIndex}:${identity.vault}:${identity.funderMember}:${identity.stewardMember}`
-    : `${identity.contract}:${identity.streamId}`;
+    : `${identity.contract}:${identity.streamId}:${identity.recipient}`;
 }
 
 export function assertProjectCommitmentLedger(

--- a/src/lib/funding-instruments.d.mts
+++ b/src/lib/funding-instruments.d.mts
@@ -20,6 +20,7 @@ export interface SablierLockupV4Instrument {
   readonly network: "base" | "ethereum";
   readonly asset: "USDC";
   readonly contract: string;
+  readonly recipient: string;
   readonly streamId: string;
   readonly deadline: string;
   readonly effectiveAt: string;

--- a/src/lib/funding-instruments.mjs
+++ b/src/lib/funding-instruments.mjs
@@ -138,6 +138,7 @@ function validateSablierInstrument(candidate, field) {
       "effectiveAt",
       "kind",
       "network",
+      "recipient",
       "replacedAt",
       "streamId",
     ],
@@ -154,6 +155,9 @@ function validateSablierInstrument(candidate, field) {
       `${field}.contract is not the reviewed Sablier Lockup v4 deployment`,
     );
   }
+  if (!isFundingAddress(candidate.network, candidate.recipient)) {
+    throw new TypeError(`${field}.recipient is invalid`);
+  }
   if (
     typeof candidate.streamId !== "string" ||
     candidate.streamId.length > 78 ||
@@ -167,6 +171,7 @@ function validateSablierInstrument(candidate, field) {
     network: candidate.network,
     asset: "USDC",
     contract: candidate.contract,
+    recipient: candidate.recipient,
     streamId: candidate.streamId,
     ...window,
   };

--- a/src/lib/project-schema.test.ts
+++ b/src/lib/project-schema.test.ts
@@ -420,6 +420,7 @@ describe("project proposal schema", () => {
         network: "base",
         asset: "USDC",
         contract: `0x${"9".repeat(40)}`,
+        recipient: `0x${"a".repeat(40)}`,
         streamId: "7",
         deadline: "2026-12-01T00:00:00.000Z",
         effectiveAt: "2026-08-01T00:00:00.000Z",


### PR DESCRIPTION
## Problem

A reviewed Sablier commitment instrument contains the Lockup contract and stream ID but no recipient. The live verifier checks a recipient supplied on the command line, while the durable commitment record matches only contract and stream ID. Nothing therefore proves that a recorded stream pays the project whose committed pool it backs.

A project could reference a real USDC stream payable to another address and count its locked balance toward committedMinor.

## Fix

- require a canonical recipient in every Sablier instrument
- include that recipient in durable commitment-record identity and correction identity
- require records to match the exact manifest-bound recipient
- continue treating contract plus stream ID as the unique on-chain instrument, so declaring the same stream with two recipients is rejected rather than creating two identities

No current project manifest or funding record declares a Sablier commitment, so this tightens the pre-activation schema without migrating published evidence.

## Verification

- regression accepts the exact manifest recipient and rejects another valid EVM address
- duplicate stream declarations with different recipients fail closed
- bunx vitest run src/lib/funding-commitment.test.ts src/lib/project-schema.test.ts (26 passed)
- bun run projects:check
- bun run funding:check
- bun run typecheck
- biome checks pass

PR #354 fixes a distinct RPC quorum-state issue and does not add this durable manifest binding.