### PR TITLE
fix(trace): reject events racing finalization

### DIFF
--- a/backend/trace/cloudflare-persistence.ts
+++ b/backend/trace/cloudflare-persistence.ts
@@ -499,12 +499,14 @@ export class CloudflareTracePersistence implements TracePersistence {
         : { status: "conflict" };
     }
     try {
-      await this.db
+      const inserted = await this.db
         .prepare(
           `INSERT INTO run_progress_events (
             id, run_id, github_user_id, kind, occurred_at, source,
             github_object_id, github_url, head_sha, created_at, idempotency_key
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          ) SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+            FROM trace_runs
+           WHERE id = ? AND github_user_id = ? AND state != 'finalized'`,
         )
         .bind(
           event.id,
@@ -518,8 +520,13 @@ export class CloudflareTracePersistence implements TracePersistence {
           event.headSha,
           event.createdAt,
           event.idempotencyKey,
+          event.runId,
+          event.githubId,
         )
         .run();
+      if ((inserted.meta?.changes ?? 0) !== 1) {
+        return { status: "conflict" };
+      }
     } catch {
       return { status: "conflict" };
     }

--- a/functions/api/v1/cloudflare-persistence.test.ts
+++ b/functions/api/v1/cloudflare-persistence.test.ts
@@ -4,7 +4,10 @@ import {
   type D1Database,
   type R2Bucket,
 } from "../../../backend/trace/cloudflare-persistence";
-import type { TraceObject } from "../../../backend/trace/contracts";
+import type {
+  RunProgressEvent,
+  TraceObject,
+} from "../../../backend/trace/contracts";
 
 const object: TraceObject = {
   sha256: "eafe895eb8119e6e5d06463590b2ef81b3651c157d5c8e18f1889186c7fd0ac0",
@@ -26,6 +29,46 @@ function body(text: string): ReadableStream<Uint8Array> {
 }
 
 describe("Cloudflare trace object persistence", () => {
+  it("rejects an event when its run finalized before the atomic insert", async () => {
+    const db: D1Database = {
+      batch: async () => [],
+      prepare(query) {
+        const statement = {
+          bind() {
+            return statement;
+          },
+          async first<_T>() {
+            if (query.includes("FROM run_progress_events")) return null;
+            throw new Error(`Unexpected query: ${query}`);
+          },
+          async run() {
+            expect(query).toMatch(/FROM trace_runs/u);
+            expect(query).toMatch(/state != 'finalized'/u);
+            return { success: true, meta: { changes: 0 } };
+          },
+        };
+        return statement;
+      },
+    };
+    const event: RunProgressEvent & { idempotencyKey: string } = {
+      id: "event-1",
+      runId: "run-1",
+      githubId: "42",
+      kind: "checkpoint",
+      occurredAt: object.createdAt,
+      source: "agent",
+      githubObjectId: null,
+      githubUrl: null,
+      headSha: null,
+      createdAt: object.createdAt,
+      idempotencyKey: "event-key-0001",
+    };
+
+    await expect(
+      new CloudflareTracePersistence(db, {} as R2Bucket).appendEvent(event),
+    ).resolves.toEqual({ status: "conflict" });
+  });
+
   it("does not disguise a missing atomic-attachment migration as replay", async () => {
     const db: D1Database = {
       batch: async () => {


### PR DESCRIPTION
## Problem

The event handler checked that a run was not finalized, then inserted the event in a separate persistence call. Finalization could commit between those operations, allowing a contributor progress event to be appended after the run became finalized despite the API contract rejecting events on finalized runs.

## Fix

Make event insertion conditional on an actor-owned run still being non-finalized in the same D1 statement. Treat a zero-row insert as a conflict, closing the time-of-check/time-of-use window and also failing closed for missing or mismatched runs.

## Reproduction

The persistence regression models a run that finalized after the handler read it. Before the fix, a non-throwing zero-row database result was reported as a created event. The regression now requires a conflict and verifies the atomic run-state predicate.

## Verification

- focused persistence and trace API tests: 36 passed
- full Vitest pass: 649 passed; 19 sandbox child-git failures plus two environment-only suite load failures (missing PyYAML and node:sqlite bundling)
- bun run typecheck
- Biome check on both changed files
- git diff --check

No open PR addresses this finalized-run event insertion race.