### PR TITLE
fix(wallet): refresh claims after GitHub login rename

### DIFF
--- a/backend/trace/handler.ts
+++ b/backend/trace/handler.ts
@@ -265,7 +265,10 @@ async function createContributorWalletClaim(
       "Wallet claim changed; reload the current claim before submitting",
     );
   }
-  if (current?.walletAddress === walletAddress) {
+  if (
+    current?.walletAddress === walletAddress &&
+    current.githubLogin.toLowerCase() === actor.githubLogin.toLowerCase()
+  ) {
     return json(200, publicWalletClaim(current));
   }
 

--- a/functions/api/v1/trace-api.test.ts
+++ b/functions/api/v1/trace-api.test.ts
@@ -1584,6 +1584,44 @@ describe("private trace API", () => {
     expect(await stale.json()).toMatchObject({ error: "stale_wallet_claim" });
   });
 
+  it("refreshes an unchanged wallet claim after a GitHub login rename", async () => {
+    const deps = dependencies();
+    const originalActor = await token("42", "old-login", ["contributor"]);
+    const original = await handleTraceApi(
+      request(
+        "wallet-claims",
+        "POST",
+        originalActor,
+        JSON.stringify({ address: "11111111111111111111111111111111" }),
+        { "content-type": "application/json" },
+      ),
+      deps,
+    );
+    const originalClaim = (await original.json()) as { claimId: string };
+    const renamedActor = await token("42", "new-login", ["contributor"]);
+
+    const refreshed = await handleTraceApi(
+      request(
+        "wallet-claims",
+        "POST",
+        renamedActor,
+        JSON.stringify({
+          address: "11111111111111111111111111111111",
+          supersedesClaimId: originalClaim.claimId,
+        }),
+        { "content-type": "application/json" },
+      ),
+      deps,
+    );
+
+    expect(refreshed.status).toBe(201);
+    expect(await refreshed.json()).toMatchObject({
+      githubActorId: "42",
+      githubLogin: "new-login",
+      supersedesClaimId: originalClaim.claimId,
+    });
+  });
+
   it("does not let an unauthenticated caller create a wallet claim", async () => {
     const response = await handleTraceApi(
       new Request("https://api.slop.cash/api/v1/wallet-claims", {


### PR DESCRIPTION
## Problem

Wallet claims are correctly owned by the stable numeric GitHub actor ID, but an unchanged-address registration returned the current claim solely by comparing wallet addresses. After a GitHub username rename, that returned the immutable claim containing the old login.

Reward preparation independently compares the registry login with GitHub's current login and rejects the stale claim. The contributor therefore could not refresh valid payout provenance while keeping the same wallet address.

## Fix

Treat an unchanged wallet registration as idempotent only when both the address and login (case-insensitively) still match. When the stable actor ID is unchanged but the login changed, append a same-address successor containing the current authenticated login.

Case-only username spelling remains idempotent, and the existing predecessor/concurrency checks continue to protect the single claim lineage.

## Verification

- regression proves the same numeric actor can refresh the same address after a login rename
- bunx vitest run functions/api/v1/trace-api.test.ts scripts/github-wallets.test.ts (37 passed)
- bun run typecheck
- bunx biome check backend/trace/handler.ts functions/api/v1/trace-api.test.ts
- git diff --check

No open wallet PR addresses login-renamed claim refresh; #343 covers claim/audit atomicity, #349 future observations, and #335 proposal cutoffs.