### PR TITLE
fix(cycles): reject files ahead of lifecycle state

### DIFF
--- a/src/lib/cycle-index.test.ts
+++ b/src/lib/cycle-index.test.ts
@@ -170,6 +170,57 @@ describe("public cycle index", () => {
     );
   });
 
+  it("rejects lifecycle files that are ahead of the declared state", () => {
+    const allocationDuringReview = entry();
+    allocationDuringReview.files.allocation = {
+      sha256: DIGEST,
+      url: "/data/cycles/eliza/2026-07/allocation.json",
+    };
+    expect(() => assertCycleIndex(index([allocationDuringReview]))).toThrow(
+      "state does not match",
+    );
+
+    const planDuringReview = entry();
+    planDuringReview.files.executionPlan = {
+      sha256: DIGEST,
+      url: "/data/cycles/eliza/2026-07/execution-plan.json",
+    };
+    expect(() => assertCycleIndex(index([planDuringReview]))).toThrow(
+      "state does not match",
+    );
+
+    const planBeforeSettlement = entry({
+      state: "payment-ready",
+      approvedAt: "2026-08-16T00:00:00.000Z",
+      reward: {
+        ...entry().reward,
+        approvedMinor: "10000000000",
+        feeMinor: "100000000",
+      },
+      contributors: [
+        {
+          ...entry().contributors[0],
+          state: "approved",
+          approvedMinor: "10000000000",
+        },
+      ],
+      files: {
+        ...entry().files,
+        allocation: {
+          sha256: DIGEST,
+          url: "/data/cycles/eliza/2026-07/allocation.json",
+        },
+        executionPlan: {
+          sha256: DIGEST,
+          url: "/data/cycles/eliza/2026-07/execution-plan.json",
+        },
+      },
+    });
+    expect(() => assertCycleIndex(index([planBeforeSettlement]))).toThrow(
+      "state does not match",
+    );
+  });
+
   it("binds each lifecycle label to exact money and timestamp state", () => {
     const premature = entry({
       state: "payment-ready",

--- a/src/lib/cycle-index.ts
+++ b/src/lib/cycle-index.ts
@@ -789,12 +789,19 @@ function cycleEntry(value: unknown, index: number): CycleIndexEntry {
     state === "review" &&
     (approvedAt !== null ||
       settledAt !== null ||
+      normalizedFiles.allocation !== null ||
+      normalizedFiles.executionPlan !== null ||
+      normalizedFiles.settlement !== null ||
       normalizedReward.approvedMinor !== "0" ||
       normalizedReward.paidMinor !== "0" ||
       contributors.some(
         (contributor) =>
           contributor.state !== "proposed" && contributor.state !== "unclaimed",
       ));
+  const paymentReadyStateInvalid =
+    state === "payment-ready" &&
+    (normalizedFiles.executionPlan !== null ||
+      normalizedFiles.settlement !== null);
   const approvalStateInvalid =
     ["payment-ready", "settlement-planned", "paid"].includes(state) &&
     (approvedAt === null ||
@@ -833,6 +840,7 @@ function cycleEntry(value: unknown, index: number): CycleIndexEntry {
       !normalizedFiles.executionPlan) ||
     (state === "paid" && !normalizedFiles.settlement) ||
     reviewStateInvalid ||
+    paymentReadyStateInvalid ||
     approvalStateInvalid ||
     settlementStateInvalid ||
     paidStateInvalid ||


### PR DESCRIPTION
## Problem

The browser-facing cycle-index validator required later states to have their prerequisite files, but did not enforce the reverse direction. A review entry could reference an allocation or execution plan, and a payment-ready entry could already reference an execution plan, while still passing validation.

Those combinations cannot be emitted by the canonical cycle builder and expose contradictory public money state: the lifecycle label says no approval or settlement plan exists while its immutable-file links say otherwise.

## Fix

Make the file/state mapping bidirectional:

- review permits no allocation, execution plan, or settlement
- payment-ready requires its allocation but permits no execution plan or settlement
- existing settlement-planned behavior remains unchanged so failed or partial settlement records remain representable

## Verification

- regressions cover allocation during review, plan during review, and plan during payment-ready
- bunx vitest run src/lib/cycle-index.test.ts (11 passed)
- bun run typecheck
- bun run cycles:check (validated the published reward cycle)
- bunx biome check src/lib/cycle-index.ts src/lib/cycle-index.test.ts
- git diff --check

No open PR overlaps this cycle-index file/state validation gap.