### PR TITLE
fix(policy): bind terms to their activation date

### DIFF
--- a/src/lib/project-policy.test.ts
+++ b/src/lib/project-policy.test.ts
@@ -50,6 +50,7 @@ describe("project policy transitions", () => {
     authority: unknown;
     terms: {
       revision: string;
+      effectiveAt: string;
       repositoryLicense: { fileSha256: string | null };
       inbound: { fileSha256: string | null };
       receiptPolicy: {
@@ -66,6 +67,7 @@ describe("project policy transitions", () => {
     ) as unknown as MutableActivePolicyFixture;
     const licenseSha256 = fixture.terms.repositoryLicense.fileSha256;
     if (!licenseSha256) throw new Error("missing fixture license digest");
+    fixture.terms.effectiveAt = "2026-08-19T00:00:00.000Z";
     fixture.authority = {
       state: "verified",
       reason: null,
@@ -326,6 +328,7 @@ describe("project policy transitions", () => {
     const previous = activePolicyFixture();
     const next = structuredClone(previous);
     next.terms.revision = `${previous.terms.revision}-appended`;
+    next.terms.effectiveAt = "2026-08-21T00:00:00.000Z";
     const licenseSha256 = next.terms.repositoryLicense.fileSha256;
     if (!licenseSha256) throw new Error("missing fixture license digest");
     const lastActivation = "2026-08-20T00:00:00.000Z";

--- a/src/lib/project-schema.mjs
+++ b/src/lib/project-schema.mjs
@@ -638,12 +638,13 @@ function validateTerms(
     }
     if (
       current.policyRevision !== terms.revision ||
+      current.activatedAt !== terms.effectiveAt ||
       current.licenseSha256 !== license.fileSha256 ||
       current.inboundTermsSha256 !== inbound.fileSha256 ||
       current.prizeRulesSha256 !== (terms.externalPrize?.rulesSha256 ?? null)
     ) {
       throw new TypeError(
-        `${field}.receiptPolicy latest binding must match current terms`,
+        `${field}.receiptPolicy latest binding must match current terms and effective date`,
       );
     }
   }

--- a/src/lib/project-schema.test.ts
+++ b/src/lib/project-schema.test.ts
@@ -29,6 +29,7 @@ interface MutableActivationFixture {
   status: string;
   authority: unknown;
   terms: {
+    effectiveAt: string;
     revision: string;
     receiptPolicy: unknown;
     inbound: unknown;
@@ -48,6 +49,7 @@ function activatedWithoutOwnershipClaim(model: string): unknown {
   const proofCommit = "a".repeat(40);
   const inboundCommit = "c".repeat(40);
   fixture.status = "active";
+  fixture.terms.effectiveAt = verifiedAt;
   fixture.authority = {
     state: "verified",
     reason: null,
@@ -453,6 +455,12 @@ describe("project proposal schema", () => {
     mutableLicense.terms.repositoryLicense.url =
       "https://github.com/elizaOS/eliza/blob/develop/LICENSE";
     expect(() => assertProjectDefinition(mutableLicense)).toThrow(/immutable/u);
+
+    const retroactiveEffectiveDate = structuredClone(eliza);
+    retroactiveEffectiveDate.terms.effectiveAt = "2026-08-01T00:00:00.000Z";
+    expect(() => assertProjectDefinition(retroactiveEffectiveDate)).toThrow(
+      /effective date/u,
+    );
 
     const mismatchedInbound = structuredClone(eliza) as unknown as {
       terms: {


### PR DESCRIPTION
## Problem

Active project terms declare that they are non-retroactive and maintain an ordered immutable receipt-policy binding history. The schema binds the latest entry to the current revision and source hashes, but not to terms.effectiveAt.

A well-shaped manifest could therefore retain the exact same current binding while moving the declared effective date into the past or future. That makes the public terms chronology disagree with the activation record that is supposed to anchor it.

## Fix

Require active terms.effectiveAt to equal the latest receipt-policy binding's activatedAt. Pending policies remain unchanged because they do not yet have an activation binding.

All current project manifests already satisfy this invariant.

## Verification

- regression rejects a retroactively shifted effective date with otherwise unchanged binding evidence
- synthetic activation fixture now declares the same effective and activation instant
- bunx vitest run src/lib/project-schema.test.ts scripts/check-project-transitions.test.ts (24 passed)
- bun run projects:check
- bun run typecheck
- bunx biome check src/lib/project-schema.mjs src/lib/project-schema.test.ts
- git diff --check

No open PR overlaps project terms effective-date binding.