### PR TITLE
fix(funding): bind index timestamp to its ledger

### DIFF
--- a/src/lib/funding.test.ts
+++ b/src/lib/funding.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it } from "vitest";
 import {
   assertProjectFundingAddresses,
+  assertProjectFundingIndex,
   assertProjectFundingLedger,
   assertProjectFundingRecord,
   currentProjectFundingRecords,
@@ -352,5 +353,35 @@ describe("project funding records", () => {
     expect(
       publicFundingRecordsForDonor(ledger, "MDQ6VXNlcjE4NjMzMjY1"),
     ).toEqual([]);
+  });
+
+  it("binds the funding index timestamp to its latest observation", () => {
+    const addresses = new Map([["eliza", routes]]);
+    const commitments = new Map<string, readonly []>([["eliza", []]]);
+    const fundingRecord = record();
+    const index = {
+      schemaVersion: "1",
+      generatedAt: fundingRecord.observedAt,
+      records: [fundingRecord],
+      commitments: [],
+    };
+
+    expect(() =>
+      assertProjectFundingIndex(index, addresses, commitments),
+    ).not.toThrow();
+    expect(() =>
+      assertProjectFundingIndex(
+        { ...index, generatedAt: "2026-08-01T00:00:00.000Z" },
+        addresses,
+        commitments,
+      ),
+    ).toThrow(/latest observation/u);
+    expect(() =>
+      assertProjectFundingIndex(
+        { ...index, generatedAt: null },
+        addresses,
+        commitments,
+      ),
+    ).toThrow(/latest observation/u);
   });
 });

--- a/src/lib/funding.ts
+++ b/src/lib/funding.ts
@@ -547,6 +547,20 @@ export function assertProjectFundingIndex(
     }
     commitmentTransactionProjects.set(key, record.projectId);
   }
+  const expectedGeneratedAt = [...records, ...commitments].reduce<
+    string | null
+  >(
+    (latest, record) =>
+      latest === null || record.observedAt > latest
+        ? record.observedAt
+        : latest,
+    null,
+  );
+  if (generatedAt !== expectedGeneratedAt) {
+    throw new TypeError(
+      "funding index generatedAt must equal its latest observation",
+    );
+  }
   return {
     schemaVersion: FUNDING_PROTOCOL_VERSION,
     generatedAt,


### PR DESCRIPTION
## Problem

The funding-index builder deterministically sets generatedAt to the latest observedAt across direct-funding and commitment records. The public validator only checked that generatedAt was a timestamp, however, and accepted a stale value or null alongside non-empty records.

That allows the published as-of time to contradict the ledger it describes and weakens freshness checks by separating aggregate metadata from its source records.

## Fix

Recompute the maximum observation timestamp from both validated ledgers and require generatedAt to equal it exactly. An empty index still requires null, matching the builder's existing behavior.

## Verification

- regression accepts the exact latest observation and rejects both a stale timestamp and null
- bunx vitest run src/lib/funding.test.ts src/lib/funding-commitment.test.ts (16 passed)
- bun run funding:check
- bun run typecheck
- bunx biome check src/lib/funding.ts src/lib/funding.test.ts
- git diff --check

PR #357 touches the same two files for the distinct cross-ledger transaction-reuse invariant. This change has no semantic overlap and may need a small rebase if that PR merges first.