### PR TITLE
fix(tests): keep snapshot fixture timestamps consistent

### DIFF
--- a/tests/app.test.tsx
+++ b/tests/app.test.tsx
@@ -217,8 +217,8 @@ function augustRollingSnapshot() {
 }
 
 function septemberRollingSnapshot() {
-  const snapshot = snapshotFixture();
   const generatedAt = "2026-09-05T00:00:00.000Z";
+  const snapshot = snapshotFixture(generatedAt);
   const from = "2026-08-01T00:00:00.000Z";
   snapshot.generatedAt = generatedAt;
   snapshot.sourceUpdatedAt = generatedAt;

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -18,8 +18,9 @@ export function cycleIndexFixture(): CycleIndex {
   };
 }
 
-export function snapshotFixture(): LeaderboardSnapshot {
-  const generatedAt = new Date().toISOString();
+export function snapshotFixture(
+  generatedAt = new Date().toISOString(),
+): LeaderboardSnapshot {
   const windowTo = "2026-07-30T00:00:00.000Z";
   const leaderActor: LeaderboardSnapshot["leaders"][number]["actor"] = {
     id: "U_fixture",


### PR DESCRIPTION
The September app fixture replaces its snapshot timestamp but leaves work queue items dated at wall clock time. After September 5 at midnight, validation rejects those items as future data and six UI tests fail. Allow snapshotFixture to receive the timestamp at construction and use it in the September fixture. The production timestamp validator remains unchanged.