### PR TITLE
fix(ui): repair clipboard failures and project allocation drafts

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "audit:dependencies": "bun audit",
     "verify": "bun run brand:check && bun run projects:check && bun run evaluations:check && bun run funding:check && bun run cycles:check && bun run protocol:check && bun run audit:dependencies && bun run typecheck && bun run format:check && bun run lint:check && bun run test && bun run build",
     "typecheck": "tsc -b",
-    "test": "vitest run && bun test ./skill-tests",
+    "test": "vitest run && bun test --timeout 60000 ./skill-tests",
     "test:e2e": "node scripts/run-e2e.mjs",
     "test:e2e:record": "node scripts/record-evidence.mjs --local",
     "test:e2e:record:production": "node scripts/record-evidence.mjs --production",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -150,6 +150,12 @@ function immutableProposalTermsUrl(
   );
 }
 
+// An async boundary turns an absent clipboard API or synchronous browser error
+// into the same rejected promise as a denied clipboard permission.
+async function copyText(value: string): Promise<void> {
+  await navigator.clipboard.writeText(value);
+}
+
 function boundedText(value: string, minimum: number, maximum: number): boolean {
   const length = value.trim().length;
   return length >= minimum && length <= maximum;
@@ -1469,7 +1475,7 @@ function AgentPromptBox({ prompt }: { prompt: string }) {
   }, [copy]);
   const copyPrompt = async () => {
     try {
-      await navigator.clipboard.writeText(prompt);
+      await copyText(prompt);
       setCopy("copied");
     } catch {
       // error-policy:J4 Clipboard denial remains visibly distinct and selectable text stays available.
@@ -1528,7 +1534,7 @@ function InstallPanel({ project }: { project: ProjectDefinition }) {
   const manualCommand = projectInstallCommand(project);
   const copyManualCommand = async () => {
     try {
-      await navigator.clipboard.writeText(manualCommand);
+      await copyText(manualCommand);
       setCopy("manual-copied");
     } catch {
       // error-policy:J4 Clipboard denial remains visibly distinct and selectable text stays available.
@@ -1885,7 +1891,7 @@ export function ProjectFunding({ project }: { project: ProjectDefinition }) {
                   <button
                     className="text-button"
                     onClick={() => {
-                      void navigator.clipboard.writeText(route.address).then(
+                      void copyText(route.address).then(
                         () => setCopy({ key, status: "copied" }),
                         () => setCopy({ key, status: "error" }),
                       );
@@ -3098,8 +3104,11 @@ export function ProjectManagePage({
       row.approvedMinor === row.suggestedMinor ||
       row.reason.trim().length > 0,
   );
+  const allocationCapMinor =
+    currentRecord?.reward.capMinor ?? project.reward.monthlyCapMinor;
   const validAllocation =
     parsedTotal !== null &&
+    BigInt(parsedTotal) <= BigInt(allocationCapMinor) &&
     parsedRows.every((row) => row.approvedMinor !== null) &&
     allocated === BigInt(parsedTotal) &&
     changedRowsHaveReasons;
@@ -3131,7 +3140,7 @@ export function ProjectManagePage({
   const projectBrief = `Update ${project.id} through a reviewed Slop PR.\n\nHeadline: ${headline}\nGoal: ${goal}\nAcceptance criteria: ${criteria}\n\nKeep the project manifest, contributor skill, reviewer skill, goals, and criteria synchronized. Any model may contribute, but every run must publish its exact provider, model, and client. Every run must upload a permanent trace whose contents are restricted to Slop operators.`;
   const copy = async (kind: "allocation" | "project", value: string) => {
     try {
-      await navigator.clipboard.writeText(value);
+      await copyText(value);
       setCopyStatus({ kind, status: "copied" });
     } catch {
       setCopyStatus({ kind, status: "error" });
@@ -3215,7 +3224,7 @@ export function ProjectManagePage({
                 Edit {rows.length} contributor allocation
                 {rows.length === 1 ? "" : "s"}
               </summary>
-              {rows.length > 20 ? (
+              {rows.length > 10 ? (
                 <label className="allocation-search">
                   Find contributor
                   <input
@@ -3300,8 +3309,9 @@ export function ProjectManagePage({
             </div>
             {!validAllocation && rows.length > 0 ? (
               <p className="form-error" role="alert">
-                Allocations must equal the total. Add a reason for every changed
-                amount.
+                Allocations must equal the total and stay within the{" "}
+                {formatMicroUsdc(allocationCapMinor)} monthly cap. Add a reason
+                for every changed amount.
               </p>
             ) : null}
             <button
@@ -4064,7 +4074,7 @@ ${manifestText}`;
             className="text-button"
             disabled={!valid}
             onClick={() =>
-              void navigator.clipboard.writeText(agentBrief).then(
+              void copyText(agentBrief).then(
                 () => setCopyStatus({ kind: "brief", status: "copied" }),
                 () => setCopyStatus({ kind: "brief", status: "error" }),
               )
@@ -4083,7 +4093,7 @@ ${manifestText}`;
             <span>projects/{slug}/project.json</span>
             <button
               onClick={() =>
-                void navigator.clipboard.writeText(manifestText).then(
+                void copyText(manifestText).then(
                   () => setCopyStatus({ kind: "json", status: "copied" }),
                   () => setCopyStatus({ kind: "json", status: "error" }),
                 )
@@ -4404,7 +4414,7 @@ export function App() {
     const project = findProject(route.projectId ?? "");
     content = project ? (
       state.status === "ready" ? (
-        <ProjectManagePage project={project} state={state} />
+        <ProjectManagePage key={project.id} project={project} state={state} />
       ) : (
         <main className="shell route-main">
           <DataNotice retry={retry} state={state} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3104,8 +3104,15 @@ export function ProjectManagePage({
       row.approvedMinor === row.suggestedMinor ||
       row.reason.trim().length > 0,
   );
-  const allocationCapMinor =
-    currentRecord?.reward.capMinor ?? project.reward.monthlyCapMinor;
+  const reviewBudget = project.reward.reviewBudget;
+  const reviewCapMinor =
+    currentRecord?.reward.lines && reviewBudget
+      ? BigInt(reviewBudget.monthlyCapMinor)
+      : 0n;
+  const allocationCapMinor = (
+    BigInt(currentRecord?.reward.capMinor ?? project.reward.monthlyCapMinor) +
+    reviewCapMinor
+  ).toString();
   const validAllocation =
     parsedTotal !== null &&
     BigInt(parsedTotal) <= BigInt(allocationCapMinor) &&

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3106,8 +3106,13 @@ export function ProjectManagePage({
   );
   const reviewBudget = project.reward.reviewBudget;
   const reviewCapMinor =
-    currentRecord?.reward.lines && reviewBudget
-      ? BigInt(reviewBudget.monthlyCapMinor)
+    currentRecord?.reward.lines &&
+    reviewBudget?.fundingState === "committed" &&
+    reviewBudget.paymentMode === "enabled"
+      ? BigInt(reviewBudget.committedMinor) <
+        BigInt(reviewBudget.monthlyCapMinor)
+        ? BigInt(reviewBudget.committedMinor)
+        : BigInt(reviewBudget.monthlyCapMinor)
       : 0n;
   const allocationCapMinor = (
     BigInt(currentRecord?.reward.capMinor ?? project.reward.monthlyCapMinor) +
@@ -4064,8 +4069,7 @@ ${manifestText}`;
               when payouts settle
             </p>
             <p>
-              Draft only · Signed in as: not yet · Project steward:{" "}
-              {stewardName || "not yet verified"}
+              Draft only · Project steward: {stewardName || "not yet verified"}
             </p>
             <p>
               Payment does not transfer IP. Material changes require a new

--- a/src/styles.css
+++ b/src/styles.css
@@ -2705,6 +2705,49 @@ small {
 }
 
 @media (max-width: 900px) {
+  .header-inner {
+    min-height: 62px;
+  }
+
+  .menu-button {
+    width: 44px;
+    height: 44px;
+    display: inline-grid;
+    place-items: center;
+  }
+
+  .nav-links {
+    display: none;
+  }
+
+  .nav-links-open {
+    position: absolute;
+    top: 62px;
+    right: 14px;
+    left: 14px;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0;
+    padding: 10px;
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    background: var(--white);
+    box-shadow: 0 18px 40px rgba(23, 21, 16, 0.14);
+  }
+
+  .nav-links-open a {
+    padding: 13px;
+  }
+
+  .nav-links-open .nav-cta {
+    border-radius: 8px;
+  }
+
+  .footer-grid {
+    grid-template-columns: 1fr;
+  }
+
   .section-heading,
   .home-leaderboard-heading,
   .project-hero-grid,
@@ -2789,45 +2832,6 @@ small {
 @media (max-width: 680px) {
   .shell {
     width: min(100% - 28px, 1180px);
-  }
-
-  .header-inner {
-    min-height: 62px;
-  }
-
-  .menu-button {
-    width: 44px;
-    height: 44px;
-    display: inline-grid;
-    place-items: center;
-  }
-
-  .nav-links {
-    display: none;
-  }
-
-  .nav-links-open {
-    position: absolute;
-    top: 62px;
-    right: 14px;
-    left: 14px;
-    display: flex;
-    flex-direction: column;
-    align-items: stretch;
-    gap: 0;
-    padding: 10px;
-    border: 1px solid var(--line);
-    border-radius: 12px;
-    background: var(--white);
-    box-shadow: 0 18px 40px rgba(23, 21, 16, 0.14);
-  }
-
-  .nav-links-open a {
-    padding: 13px;
-  }
-
-  .nav-links-open .nav-cta {
-    border-radius: 8px;
   }
 
   .hero {
@@ -3067,10 +3071,6 @@ small {
     font-weight: 800;
     letter-spacing: 0.08em;
     text-transform: uppercase;
-  }
-
-  .footer-grid {
-    grid-template-columns: 1fr;
   }
 
   .footer-links {

--- a/tests/app.test.tsx
+++ b/tests/app.test.tsx
@@ -1918,64 +1918,93 @@ describe("public project draft workspace", () => {
     ).toBeVisible();
   });
 
-  it("includes an archived additive review line in the draft ceiling", () => {
-    const project = PROJECTS.find((candidate) => candidate.id === "eliza");
-    if (!project) throw new TypeError("The Eliza project fixture is missing");
-    const snapshot = septemberRollingSnapshot();
-    const cycleIndex = archivedPaidCycleIndex();
-    const cycle = cycleIndex.cycles[0];
-    cycle.cycleId = "2026-09";
-    cycle.reward.lines = {
-      sharedPool: {
-        suggestedMinor: "1000000",
-        approvedMinor: "1000000",
-        paidMinor: "1000000",
-      },
-      reviewBudget: { suggestedMinor: "0", approvedMinor: "0", paidMinor: "0" },
-    };
-    render(
-      <ProjectManagePage
-        project={{
-          ...project,
-          reward: {
-            ...project.reward,
-            paymentMode: "enabled",
-            reviewBudget: {
-              effectiveAt: "2026-09-01T00:00:00.000Z",
-              monthlyCapMinor: "50000000",
-              monthlyCapDisplay: "$50",
-              committedMinor: "50000000",
+  it.each([
+    {
+      committedMinor: "25000000",
+      fundingState: "committed",
+      paymentMode: "enabled",
+      ceiling: "10025",
+      over: "10025.000001",
+    },
+    {
+      committedMinor: "100000000",
+      fundingState: "committed",
+      paymentMode: "enabled",
+      ceiling: "10050",
+      over: "10050.000001",
+    },
+    {
+      committedMinor: "0",
+      fundingState: "pledged",
+      paymentMode: "disabled",
+      ceiling: "10000",
+      over: "10000.000001",
+    },
+  ] as const)(
+    "bounds archived review drafts by funded principal ($committedMinor)",
+    ({ committedMinor, fundingState, paymentMode, ceiling, over }) => {
+      const project = PROJECTS.find((candidate) => candidate.id === "eliza");
+      if (!project) throw new TypeError("The Eliza project fixture is missing");
+      const snapshot = septemberRollingSnapshot();
+      const cycleIndex = archivedPaidCycleIndex();
+      const cycle = cycleIndex.cycles[0];
+      cycle.cycleId = "2026-09";
+      cycle.reward.lines = {
+        sharedPool: {
+          suggestedMinor: "1000000",
+          approvedMinor: "1000000",
+          paidMinor: "1000000",
+        },
+        reviewBudget: {
+          suggestedMinor: "0",
+          approvedMinor: "0",
+          paidMinor: "0",
+        },
+      };
+      render(
+        <ProjectManagePage
+          project={{
+            ...project,
+            reward: {
+              ...project.reward,
               paymentMode: "enabled",
-              fundingState: "committed",
-              unusedFunds: "rollover-without-cap-increase",
+              reviewBudget: {
+                effectiveAt: "2026-09-01T00:00:00.000Z",
+                monthlyCapMinor: "50000000",
+                monthlyCapDisplay: "$50",
+                committedMinor,
+                paymentMode,
+                fundingState,
+                unusedFunds: "rollover-without-cap-increase",
+              },
             },
-          },
-        }}
-        state={{
-          status: "ready",
-          snapshot,
-          cycleIndex,
-          views: [createProjectView(snapshot, "eliza")],
-        }}
-      />,
-    );
-    fireEvent.click(screen.getByText("Edit 1 contributor allocation"));
-    fireEvent.change(screen.getByLabelText("archive-only reason"), {
-      target: { value: "Reviewed shared pool and review allocation" },
-    });
-    const amount = screen.getByLabelText("archive-only amount in USDC");
-    const total = screen.getByLabelText("Draft total, USDC");
-    fireEvent.change(amount, { target: { value: "10050" } });
-    fireEvent.change(total, { target: { value: "10050" } });
-    expect(
-      screen.getByRole("button", { name: "Copy unsigned allocation" }),
-    ).toBeEnabled();
-    fireEvent.change(amount, { target: { value: "10050.000001" } });
-    fireEvent.change(total, { target: { value: "10050.000001" } });
-    expect(
-      screen.getByRole("button", { name: "Copy unsigned allocation" }),
-    ).toBeDisabled();
-  });
+          }}
+          state={{
+            status: "ready",
+            snapshot,
+            cycleIndex,
+            views: [createProjectView(snapshot, "eliza")],
+          }}
+        />,
+      );
+      fireEvent.click(screen.getByText("Edit 1 contributor allocation"));
+      fireEvent.change(screen.getByLabelText("archive-only reason"), {
+        target: { value: "Reviewed shared pool and review allocation" },
+      });
+      const amount = screen.getByLabelText("archive-only amount in USDC");
+      const total = screen.getByLabelText("Draft total, USDC");
+      fireEvent.change(amount, { target: { value: ceiling } });
+      fireEvent.change(total, { target: { value: ceiling } });
+      expect(
+        screen.getByRole("button", { name: "Copy unsigned allocation" }),
+      ).toBeEnabled();
+      fireEvent.change(amount, { target: { value: over } });
+      fireEvent.change(total, { target: { value: over } });
+      expect(
+        screen.getByRole("button", { name: "Copy unsigned allocation" }),
+      ).toBeDisabled();
+    },
+  );
 
   it("shows project payment history without exposing trace contents", async () => {
     route("/projects/eliza");

--- a/tests/app.test.tsx
+++ b/tests/app.test.tsx
@@ -1918,6 +1918,65 @@ describe("public project draft workspace", () => {
     ).toBeVisible();
   });
 
+  it("includes an archived additive review line in the draft ceiling", () => {
+    const project = PROJECTS.find((candidate) => candidate.id === "eliza");
+    if (!project) throw new TypeError("The Eliza project fixture is missing");
+    const snapshot = septemberRollingSnapshot();
+    const cycleIndex = archivedPaidCycleIndex();
+    const cycle = cycleIndex.cycles[0];
+    cycle.cycleId = "2026-09";
+    cycle.reward.lines = {
+      sharedPool: {
+        suggestedMinor: "1000000",
+        approvedMinor: "1000000",
+        paidMinor: "1000000",
+      },
+      reviewBudget: { suggestedMinor: "0", approvedMinor: "0", paidMinor: "0" },
+    };
+    render(
+      <ProjectManagePage
+        project={{
+          ...project,
+          reward: {
+            ...project.reward,
+            paymentMode: "enabled",
+            reviewBudget: {
+              effectiveAt: "2026-09-01T00:00:00.000Z",
+              monthlyCapMinor: "50000000",
+              monthlyCapDisplay: "$50",
+              committedMinor: "50000000",
+              paymentMode: "enabled",
+              fundingState: "committed",
+              unusedFunds: "rollover-without-cap-increase",
+            },
+          },
+        }}
+        state={{
+          status: "ready",
+          snapshot,
+          cycleIndex,
+          views: [createProjectView(snapshot, "eliza")],
+        }}
+      />,
+    );
+    fireEvent.click(screen.getByText("Edit 1 contributor allocation"));
+    fireEvent.change(screen.getByLabelText("archive-only reason"), {
+      target: { value: "Reviewed shared pool and review allocation" },
+    });
+    const amount = screen.getByLabelText("archive-only amount in USDC");
+    const total = screen.getByLabelText("Draft total, USDC");
+    fireEvent.change(amount, { target: { value: "10050" } });
+    fireEvent.change(total, { target: { value: "10050" } });
+    expect(
+      screen.getByRole("button", { name: "Copy unsigned allocation" }),
+    ).toBeEnabled();
+    fireEvent.change(amount, { target: { value: "10050.000001" } });
+    fireEvent.change(total, { target: { value: "10050.000001" } });
+    expect(
+      screen.getByRole("button", { name: "Copy unsigned allocation" }),
+    ).toBeDisabled();
+  });
+
   it("shows project payment history without exposing trace contents", async () => {
     route("/projects/eliza");
     const index = archivedPaidCycleIndex();

--- a/tests/app.test.tsx
+++ b/tests/app.test.tsx
@@ -1411,6 +1411,19 @@ describe("project proposals", () => {
     expect(agentBrief?.indexOf("Operating rules:")).toBeLessThan(
       agentBrief?.indexOf("Untrusted proposal input") ?? -1,
     );
+    Object.defineProperty(navigator, "clipboard", { value: undefined });
+    fireEvent.click(screen.getByRole("button", { name: "Brief copied" }));
+    expect(
+      await screen.findByRole("button", {
+        name: "Copy unavailable; select the brief",
+      }),
+    ).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: /copy json/i }));
+    expect(
+      await screen.findByRole("button", {
+        name: "Copy unavailable; select JSON",
+      }),
+    ).toBeVisible();
   });
 
   it("does not hand off an over-limit or imprecise money pool", () => {
@@ -1719,6 +1732,62 @@ describe("direct project funding", () => {
 });
 
 describe("public project draft workspace", () => {
+  it("resets the project brief when history navigates to another project", async () => {
+    route("/projects/eliza/manage");
+    mockSnapshot();
+    render(<App />);
+    const headline = await screen.findByLabelText("Headline");
+    fireEvent.change(headline, { target: { value: "Eliza-only draft" } });
+    await act(async () => {
+      window.history.pushState({}, "", "/projects/asi/manage");
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    });
+    const project = PROJECTS.find((candidate) => candidate.id === "asi");
+    expect(screen.getByLabelText("Headline")).toHaveValue(project?.headline);
+    fireEvent.click(screen.getByRole("button", { name: "Copy GitHub brief" }));
+    await waitFor(() =>
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        expect.stringContaining(`Headline: ${project?.headline}`),
+      ),
+    );
+  });
+
+  it("lets the owner find and edit the eleventh allocation", () => {
+    const project = PROJECTS.find((candidate) => candidate.id === "eliza");
+    if (!project) throw new TypeError("The Eliza project fixture is missing");
+    const snapshot = septemberRollingSnapshot();
+    const view = createProjectView(snapshot, project.id);
+    view.leaders = Array.from({ length: 11 }, (_, index) => ({
+      ...view.leaders[0],
+      actor: {
+        ...view.leaders[0].actor,
+        id: `U_${index}`,
+        login: `contributor-${index}`,
+      },
+    }));
+    render(
+      <ProjectManagePage
+        project={{
+          ...project,
+          reward: { ...project.reward, paymentMode: "enabled" },
+        }}
+        state={{
+          status: "ready",
+          snapshot,
+          views: [view],
+          cycleIndex: cycleIndexFixture(),
+        }}
+      />,
+    );
+    fireEvent.click(screen.getByText("Edit 11 contributor allocations"));
+    fireEvent.change(screen.getByLabelText("Find contributor"), {
+      target: { value: "contributor-10" },
+    });
+    const amount = screen.getByLabelText("contributor-10 amount in USDC");
+    fireEvent.change(amount, { target: { value: "2" } });
+    expect(amount).toHaveValue(2);
+  });
+
   it("makes the public boundary explicit and hides disabled payout controls", async () => {
     route("/projects/eliza/manage");
     const index = archivedPaidCycleIndex();
@@ -1830,6 +1899,16 @@ describe("public project draft workspace", () => {
       expect.stringContaining('"feeMinor": "123456"'),
     );
 
+    fireEvent.change(amount, { target: { value: "10000.000001" } });
+    fireEvent.change(total, { target: { value: "10000.000001" } });
+    expect(
+      screen.getByRole("button", { name: "Allocation copied" }),
+    ).toBeDisabled();
+    fireEvent.change(amount, { target: { value: "10000" } });
+    fireEvent.change(total, { target: { value: "10000" } });
+    expect(
+      screen.getByRole("button", { name: "Allocation copied" }),
+    ).toBeEnabled();
     vi.mocked(navigator.clipboard.writeText).mockRejectedValueOnce(
       new DOMException("denied", "NotAllowedError"),
     );

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -554,6 +554,14 @@ test("makes the public project draft boundary unmistakable", async ({
   await expect(page.getByLabel("Draft total, USDC")).toHaveCount(0);
   await expect(page.locator(".allocation-rows")).toHaveCount(0);
   await expect(page.getByText(/mainnet USDC transfers/u)).toHaveCount(0);
+  await page.getByLabel("Headline").fill("Eliza-only draft");
+  await page.evaluate(() => {
+    window.history.pushState({}, "", "/projects/asi/manage");
+    window.dispatchEvent(new PopStateEvent("popstate"));
+  });
+  const nextProject = PROJECTS.find((project) => project.id === "asi");
+  if (!nextProject) throw new Error("ASI project is missing");
+  await expect(page.getByLabel("Headline")).toHaveValue(nextProject.headline);
 });
 
 test("creates a valid GitHub-native project handoff", async ({
@@ -617,6 +625,21 @@ test("creates a valid GitHub-native project handoff", async ({
   expect(agentBrief).toContain(
     '"acceptanceCriteria": "Accepted pull requests with verified tests."',
   );
+  await page.evaluate(() => {
+    Object.defineProperty(navigator, "clipboard", { value: undefined });
+  });
+  await page.getByRole("button", { name: "Brief copied" }).click();
+  await expect(
+    page.getByRole("button", {
+      name: "Copy unavailable; select the brief",
+    }),
+  ).toBeVisible();
+  await page.getByRole("button", { name: "Copy JSON" }).click();
+  await expect(
+    page.getByRole("button", {
+      name: "Copy unavailable; select JSON",
+    }),
+  ).toBeVisible();
 });
 
 test("serves byte-consistent install and read-only artifacts for every project", async ({

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -281,7 +281,7 @@ test("starts Eliza with one prompt and no separate payout form", async ({
   await context.grantPermissions(["clipboard-read", "clipboard-write"]);
   await page.goto("/projects/eliza", { waitUntil: "networkidle" });
   const homeLink = page.getByRole("link", { name: "Home", exact: true });
-  if ((page.viewportSize()?.width ?? 0) <= 680) {
+  if (await page.getByRole("button", { name: "Open navigation" }).isVisible()) {
     await page.getByRole("button", { name: "Open navigation" }).click();
     await expect(homeLink).toBeVisible();
     await expect(homeLink).toHaveAttribute("href", "/");


### PR DESCRIPTION
Repair public drafting failures and misleading UI states:

- Normalize absent or denied clipboard APIs into visible copy failure feedback.
- Reset project drafts when history navigation switches projects.
- Expose allocation search whenever the ten-row display truncates the list.
- Reject draft totals above the applicable shared and funded review limits using integer micro-USDC.
- Switch navigation and footer layouts before tablet widths crowd their contents.
- Remove the fake sign-in state from the public proposal form.
- Give the CLI integration suite an explicit 60-second budget; Bun's default five-second budget killed its subprocesses.

Current head: a3a7d22bc96681f6d138e6d34f4060eb91f9d8cb. The focused component suite passes 57 tests, including partially funded and uncommitted review budgets. Full verification and the 37-test desktop/mobile/Pages browser matrix passed on the preceding rebased revision. Fresh GitHub ingestion completed with 117 leaders and 10,375 accepted events. Exact current-head hosted checks are pending.

This remains a draft until the coordinated carry/index repair lands: the allocation editor must consume validated carriedMinor before final verification. Production deployment evidence is N/A because this PR has not merged or deployed. Local screenshots, keyboard checks, accessibility results, zoom-equivalent reflow checks, and logs are retained outside Git in /tmp/slop-review-evidence.
