### PR TITLE
docs(rewards): define tier-only additive review budget

### DIFF
--- a/protocol/review-budget-v1.md
+++ b/protocol/review-budget-v1.md
@@ -43,6 +43,12 @@ Only accepted `substantive-review` score events participate in the additive
 line. Self-review, bot review, post-merge review, duplicates, and excluded
 evidence remain ineligible under the scoring contract.
 
+The additive line is intentionally tier-only. Its weights use each accepted
+review event's base `scoreThirds` and ignore `evidenceBonusBasisPoints`.
+Finalized private-trace evidence may still increase that review's weight in the
+shared contributor pool under Score v2; it never changes the separate review
+line. This avoids paying the same trace bonus from both funding lines.
+
 Slop does not hold keys, sign, or broadcast either line. A review amount may be
 called paid only after finalized public evidence reconciles its immutable
 intent, source, destination, asset, principal, and fee. Projected, under review,

--- a/src/lib/reward-cycle.test.ts
+++ b/src/lib/reward-cycle.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it } from "vitest";
 import { snapshotFixture } from "../../tests/fixtures";
 import {
+  additiveReviewBudgetWeights,
   allocateReviewBudgetMinor,
   createRewardCycleProposal,
 } from "./reward-cycle";
@@ -59,6 +60,35 @@ describe("reward cycle proposals", () => {
         { actorId: "duplicate", scoreThirds: 2 },
       ]),
     ).toThrow(/unique non-negative/u);
+  });
+
+  it("keeps the additive review line tier-only when trace weight differs", () => {
+    const base = snapshotFixture().ledger[0];
+    const events = [
+      {
+        ...base,
+        id: "review-with-trace",
+        actor: { ...base.actor, id: "actor-a", login: "actor-a" },
+        category: "substantive-review" as const,
+        points: 1,
+        scoreThirds: 3,
+        evidenceBonusBasisPoints: 1_500 as const,
+      },
+      {
+        ...base,
+        id: "review-without-trace",
+        actor: { ...base.actor, id: "actor-b", login: "actor-b" },
+        category: "substantive-review" as const,
+        points: 1,
+        scoreThirds: 3,
+      },
+    ];
+
+    expect(
+      Object.fromEntries(
+        allocateReviewBudgetMinor(10n, additiveReviewBudgetWeights(events)),
+      ),
+    ).toEqual({ "actor-a": 5n, "actor-b": 5n });
   });
 
   it("proposes the exact Eliza pool without approving a payment", () => {

--- a/src/lib/reward-cycle.ts
+++ b/src/lib/reward-cycle.ts
@@ -86,6 +86,28 @@ export function allocateReviewBudgetMinor(
   return allocations;
 }
 
+/**
+ * The additive review line is tier-only: finalized-trace weight remains part
+ * of the shared-pool score and does not change this second allocation.
+ */
+export function additiveReviewBudgetWeights(
+  events: readonly LeaderboardSnapshot["ledger"][number][],
+): Array<{ actorId: string; scoreThirds: number }> {
+  const weights = new Map<string, number>();
+  for (const event of events) {
+    if (event.category !== "substantive-review") continue;
+    weights.set(
+      event.actor.id,
+      (weights.get(event.actor.id) ?? 0) +
+        (event.scoreThirds ?? Math.round(event.points * 3)),
+    );
+  }
+  return [...weights].map(([actorId, scoreThirds]) => ({
+    actorId,
+    scoreThirds,
+  }));
+}
+
 function cycleBounds(cycleId: string): { from: number; to: number } {
   if (!/^\d{4}-(?:0[1-9]|1[0-2])$/u.test(cycleId)) {
     throw new TypeError(`Invalid reward cycle id: ${cycleId}`);
@@ -233,20 +255,9 @@ export function createRewardCycleProposal(
   const reviewEvents = view.ledger.filter(
     (event) => event.category === "substantive-review",
   );
-  const reviewScoreThirds = new Map<string, number>();
-  for (const event of reviewEvents) {
-    reviewScoreThirds.set(
-      event.actor.id,
-      (reviewScoreThirds.get(event.actor.id) ?? 0) +
-        (event.scoreThirds ?? Math.round(event.points * 3)),
-    );
-  }
   const reviewAllocations = allocateReviewBudgetMinor(
     reviewBudgetTotal,
-    [...reviewScoreThirds].map(([actorId, scoreThirds]) => ({
-      actorId,
-      scoreThirds,
-    })),
+    additiveReviewBudgetWeights(reviewEvents),
   );
   const reviewSuggestedTotal = [...reviewAllocations.values()].reduce(
     (total, amount) => total + amount,


### PR DESCRIPTION
Closes #328.

The dedicated review-budget line now has an explicit, tested invariant: it uses accepted review base `scoreThirds` only. A finalized-trace `evidenceBonusBasisPoints` adjustment remains part of the shared-pool Score v2 weight and is not paid a second time from the additive line.

Implementation:
- document the tier-only policy in `protocol/review-budget-v1.md`;
- centralize review-weight aggregation in `additiveReviewBudgetWeights`;
- add the requested two-review fixture, with equal base tier and only one 15% trace bonus, proving an equal 5/5 additive allocation.

Exact head: `5ddbd829a71bd84d5d2b37f69bad72ccc36b2db2`

Local validation:
- `bun run typecheck`
- `bunx vitest run src/lib/reward-cycle.test.ts` (10/10)
- Biome on touched TypeScript
- `git diff --check`

Hosted exact-head checks remain required before merge.
