### PR TITLE
Resolve reviewed receipt, funding, wallet, and scan issues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,9 +173,11 @@ shared pool unchanged; a committed review line may pay them only on top of that
 treatment, with separate public arithmetic and evidence.
 
 Proposal review lasts 14 days. Project owners may adjust awards within the cap
-with a public reason. Wallet changes append a successor and reset review;
-history is never edited. Missing wallets remain unclaimed. Related-party money
-requires separate approval.
+with a public reason; only such amount changes reset review. Wallet changes
+append a successor; a wallet observed after proposal generation applies to the
+next cycle and never touches the current proposal. History is never edited.
+Missing wallets remain unclaimed. Related-party money requires separate
+approval.
 
 Settlement tools create unsigned Solana mainnet USDC plans only. `paid`
 requires finalized evidence whose exact source and destination deltas reconcile

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,9 +173,11 @@ shared pool unchanged; a committed review line may pay them only on top of that
 treatment, with separate public arithmetic and evidence.
 
 Proposal review lasts 14 days. Project owners may adjust awards within the cap
-with a public reason. Wallet changes append a successor and reset review;
-history is never edited. Missing wallets remain unclaimed. Related-party money
-requires separate approval.
+with a public reason; only such amount changes reset review. Wallet changes
+append a successor; a wallet observed after proposal generation applies to the
+next cycle and never touches the current proposal. History is never edited.
+Missing wallets remain unclaimed. Related-party money requires separate
+approval.
 
 Settlement tools create unsigned Solana mainnet USDC plans only. `paid`
 requires finalized evidence whose exact source and destination deltas reconcile

--- a/cycles/README.md
+++ b/cycles/README.md
@@ -16,9 +16,13 @@ untouched; a directory containing only one required file is refused as partial.
 For a platform-funded monthly pool, the creator edits `proposal.json` during
 the 14-day review. The creator may set any contributor amount, including zero,
 or raise it above the deterministic suggestion while the cycle total remains
-within the published cap. Every changed amount records a public reason. Wallet
-changes update `review.lastMaterialChangeAt` and reset `review.endsAt`. The
-normal progression then adds, without replacing earlier files:
+within the published cap. Every changed amount records a public reason and
+updates `review.lastMaterialChangeAt`, which resets `review.endsAt`. Wallets
+are cut off at `generatedAt`: a wallet observed after the proposal was
+generated applies to the next cycle and never modifies the current proposal
+or its review clock. The row stays `unclaimed` and carries forward. Only a
+creator amount change moves `review.lastMaterialChangeAt`. The normal
+progression then adds, without replacing earlier files:
 
 Transfers have a 2 USDC minimum. Smaller awards remain
 `held-below-minimum`, retain their exact integer micro-USDC amount, and accrue

--- a/funding/README.md
+++ b/funding/README.md
@@ -100,7 +100,7 @@ mechanism that Slop does not control: an autonomous Squads v4 multisig vault
 holding USDC on Solana or a Sablier Lockup v4 USDC stream on Base or Ethereum.
 A Squads commitment requires an exact 2-of-2 funder and project-steward
 multisig with no configuration authority; a Sablier commitment uses a
-non-upgradeable stream. Slop holds no key, admin, or fee position in any
+non-upgradeable, non-cancelable stream. Slop holds no key, admin, or fee position in any
 instrument; it publishes the reviewed reference and read-only evidence only.
 Committed funds are constrained by that reviewed third-party instrument, not
 held by Slop.
@@ -156,7 +156,7 @@ funder's claimed wallet—and are never inferred. The verifier never signs,
 broadcasts, handles a key, or writes a record.
 
 For a Sablier Lockup v4 USDC stream on Base or Ethereum, the read-only
-verifier (`commitment-sablier-v1`) queries three fixed public RPC authorities,
+verifier (`commitment-sablier-v2`) queries three fixed public RPC authorities,
 checks each authority's chain ID, pins every stream view call to that
 authority's own finalized block, and requires two to agree exactly on the
 stream state:
@@ -174,8 +174,11 @@ on-chain end time, and the canceled and depleted flags truthfully, with the
 canonical evidence URL `https://basescan.org/address/<contract>` or
 `https://etherscan.io/address/<contract>` and each agreeing authority's
 finalized block identity. Wrong chains, wrong tokens, wrong recipients, and
-malformed return data fail closed. The verifier never signs, broadcasts,
-handles a key, or writes a record.
+malformed return data fail closed. A cancelable stream also fails closed: the
+funder could reclaim the undistributed balance at any time, so it cannot back
+a positive `committedMinor`, and no evidence is emitted for it. Only a stream
+whose `isCancelable` flag is already false can be recorded. The verifier never
+signs, broadcasts, handles a key, or writes a record.
 
 A manifest may set `fundingState: "committed"` only while an active instrument
 is declared and the verified commitment ledger (deposits minus releases and

--- a/protocol/review-budget-v1.md
+++ b/protocol/review-budget-v1.md
@@ -43,6 +43,14 @@ Only accepted `substantive-review` score events participate in the additive
 line. Self-review, bot review, post-merge review, duplicates, and excluded
 evidence remain ineligible under the scoring contract.
 
+The dedicated line is tier-only: aggregate each actor's accepted review
+`scoreThirds` and allocate by deterministic largest remainder. The finalized
+trace bonus (`evidenceBonusBasisPoints`) applies to that event's shared-pool
+weight only, not to this additional line. Two equal review tiers receive equal
+dedicated-line weight even when only one has eligible finalized trace evidence.
+Changing this invariant requires a separately reviewed prospective policy;
+existing cycle allocations are not rewritten.
+
 Slop does not hold keys, sign, or broadcast either line. A review amount may be
 called paid only after finalized public evidence reconciles its immutable
 intent, source, destination, asset, principal, and fee. Projected, under review,

--- a/scripts/record-evidence.mjs
+++ b/scripts/record-evidence.mjs
@@ -536,8 +536,9 @@ try {
       timeout: 20_000,
     });
     await page
-      .locator(".hero-action")
+      .locator(".hero-typewriter:visible, .hero-mobile-action:visible")
       .filter({ hasText: /^SHIPPING OPEN SOURCE\.$/u })
+      .first()
       .waitFor({ state: "visible", timeout: 10_000 });
     await page.locator("#projects").waitFor({ state: "visible" });
     await page

--- a/scripts/verify-commitment-sablier.test.ts
+++ b/scripts/verify-commitment-sablier.test.ts
@@ -55,6 +55,7 @@ function streamCallWords(
     withdrawnAmount: uintWord(2_000_000n),
     refundedAmount: uintWord(1_000_000n),
     endTime: uintWord(1_800_000_000),
+    isCancelable: BOOL_FALSE,
     wasCanceled: BOOL_FALSE,
     isDepleted: BOOL_FALSE,
     ...overrides,
@@ -161,6 +162,34 @@ describe("Sablier stream state assertions", () => {
     ).toThrow(/recipient is not the expected project address/u);
   });
 
+  it("refuses a cancelable stream before emitting any evidence", () => {
+    const expected = { blockNumber: 100, recipient: RECIPIENT };
+    expect(() =>
+      assertSablierStreamState(
+        streamCallWords("base", { isCancelable: BOOL_TRUE }),
+        "base",
+        STREAM_ID,
+        expected,
+      ),
+    ).toThrow(/cancelable and cannot back committed funding/u);
+    expect(() =>
+      assertSablierStreamState(
+        streamCallWords("ethereum", { isCancelable: BOOL_TRUE }),
+        "ethereum",
+        STREAM_ID,
+        expected,
+      ),
+    ).toThrow(/cancelable and cannot back committed funding/u);
+    expect(() =>
+      assertSablierStreamState(
+        streamCallWords("base", { isCancelable: uintWord(2) }),
+        "base",
+        STREAM_ID,
+        expected,
+      ),
+    ).toThrow(/not a canonical boolean word/u);
+  });
+
   it("fails closed on malformed or non-canonical return data", () => {
     const expected = { blockNumber: 100, recipient: RECIPIENT };
     expect(() =>
@@ -236,7 +265,7 @@ describe("Sablier commitment verifier", () => {
       ...VERIFIED_STREAM,
       blockNumber: 102,
       verifier: {
-        version: "commitment-sablier-v1",
+        version: "commitment-sablier-v2",
         evidenceUrl: `https://basescan.org/address/${SABLIER_LOCKUP_V4_CONTRACTS.base}`,
         reason: null,
       },
@@ -294,6 +323,23 @@ describe("Sablier commitment verifier", () => {
         withdrawnAmount: uintWord(3_000_000n),
       }),
       [BASE_HOSTS[2]]: new Error("authority offline"),
+    });
+    await expect(
+      verifyCommitmentSablier({
+        network: "base",
+        streamId: STREAM_ID,
+        recipient: RECIPIENT,
+        fetchImpl,
+      }),
+    ).rejects.toThrow(/did not reach commitment quorum/u);
+  });
+
+  it("refuses a quorum of authorities that all report a cancelable stream", async () => {
+    const cancelable = { isCancelable: BOOL_TRUE };
+    const { fetchImpl } = fetchByAuthority({
+      [BASE_HOSTS[0]]: authorityFixture("base", 101, cancelable),
+      [BASE_HOSTS[1]]: authorityFixture("base", 102, cancelable),
+      [BASE_HOSTS[2]]: authorityFixture("base", 103, cancelable),
     });
     await expect(
       verifyCommitmentSablier({

--- a/skill-tests/contribute-to-eliza.test.ts
+++ b/skill-tests/contribute-to-eliza.test.ts
@@ -34,6 +34,7 @@ import {
   createGhCommandBudget,
   createReviewEpoch,
   isBotAccount,
+  LiveInventoryChangedError,
   MAX_ACTIVITY_CONNECTION_ITEMS,
   MAX_REVIEW_EPOCH_CANDIDATES,
   MIN_REST_ACTIVITY_REQUESTS,
@@ -49,6 +50,7 @@ import {
   readProjectSelectionPolicy,
   recheckReviewEpochCandidate,
   renderMarkdown,
+  retryChangedLiveInventory,
 } from "../skills/contribute-to-eliza/scripts/live-report.mjs";
 import {
   isRepositoryRoot,
@@ -589,31 +591,40 @@ describe("live report parsing", () => {
         nodes: [{ comments: { totalCount: 1, nodes: [graphqlComment] } }],
       },
     };
-    const calls: string[][] = [];
-    const activity = readGhOpenActivity("elizaOS/eliza", (command, args) => {
-      assert.strictEqual(command, "gh");
-      calls.push(args);
-      const selector = args.at(-1);
-      return {
-        status: 0,
-        stderr: "",
-        stdout: `${JSON.stringify(
-          selector?.includes(".issues.") ? issueNode : pullNode,
-        )}\n`,
-      };
-    });
+    const calls: Array<{
+      args: string[];
+      options: import("node:child_process").SpawnSyncOptionsWithStringEncoding;
+    }> = [];
+    const activity = readGhOpenActivity(
+      "elizaOS/eliza",
+      (command, args, options) => {
+        assert.strictEqual(command, "gh");
+        calls.push({ args, options });
+        const selector = args.at(-1);
+        return {
+          status: 0,
+          stderr: "",
+          stdout: `${JSON.stringify(
+            selector?.includes(".issues.") ? issueNode : pullNode,
+          )}\n`,
+        };
+      },
+    );
 
     assert.strictEqual(calls.length, 2);
-    assert.ok(calls.every((args) => args.includes("graphql")));
-    assert.ok(calls.every((args) => args.includes("--paginate")));
+    assert.ok(calls.every(({ args }) => args.includes("graphql")));
+    assert.ok(calls.every(({ args }) => args.includes("--paginate")));
     assert.ok(
-      calls.every((args) => args[args.indexOf("--method") + 1] === "POST"),
+      calls.every(({ args }) => args[args.indexOf("--method") + 1] === "POST"),
     );
     assert.ok(
-      calls.every((args) => {
+      calls.every(({ args }) => {
         const query = args.find((argument) => argument.startsWith("query="));
         return query?.includes("query(") && !/\bmutation\b/i.test(query);
       }),
+    );
+    assert.ok(
+      calls.every(({ options }) => options.maxBuffer === 256 * 1024 * 1024),
     );
     assert.strictEqual(activity.issues.get(1)?.[0].user.id, 42);
     assert.strictEqual(activity.pulls.get(2)?.reviews[0].commit_id, HEAD_SHA);
@@ -1728,6 +1739,37 @@ describe("live report parsing", () => {
 });
 
 describe("live report behavior", () => {
+  it("retries one changed inventory snapshot without weakening other failures", () => {
+    let attempts = 0;
+    const retries: number[] = [];
+    const report = retryChangedLiveInventory(
+      () => {
+        attempts += 1;
+        if (attempts === 1) throw new LiveInventoryChangedError();
+        return { coherent: true };
+      },
+      ({ attempt }) => retries.push(attempt),
+    );
+
+    assert.deepStrictEqual(report, { coherent: true });
+    assert.strictEqual(attempts, 2);
+    assert.deepStrictEqual(retries, [1]);
+    assert.throws(
+      () =>
+        retryChangedLiveInventory(() => {
+          throw new TypeError("malformed GitHub response");
+        }),
+      /malformed GitHub response/,
+    );
+    assert.throws(
+      () =>
+        retryChangedLiveInventory(() => {
+          throw new LiveInventoryChangedError();
+        }),
+      /changed while collecting the live report after 2 attempts/,
+    );
+  });
+
   it("freezes a finite oldest-first epoch and defers arrivals and overflow", () => {
     const candidates = Array.from(
       { length: MAX_REVIEW_EPOCH_CANDIDATES + 3 },
@@ -2013,6 +2055,7 @@ describe("live report behavior", () => {
     assert.ok(
       !invocation?.args.some((argument) => /POST|PATCH|DELETE/.test(argument)),
     );
+    assert.strictEqual(invocation?.options.maxBuffer, 256 * 1024 * 1024);
   });
 
   it("keeps issues with open closing PRs out of the first-priority queue", () => {

--- a/skill-tests/contribute-to-eliza.test.ts
+++ b/skill-tests/contribute-to-eliza.test.ts
@@ -21,7 +21,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { delimiter, dirname, join, resolve } from "node:path";
 import { describe, it } from "node:test";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import {
@@ -64,6 +64,106 @@ const runReceiptPath = join(skillDir, "scripts", "run-receipt.mjs");
 const NOW = new Date("2026-01-20T12:00:00.000Z");
 const HEAD_SHA = "a".repeat(40);
 const PRIOR_SHA = "b".repeat(40);
+
+function createLiveReportGhFixture() {
+  const root = mkdtempSync(join(tmpdir(), "slop-live-report-lock-test-"));
+  const shimDirectory = join(root, "bin");
+  const logPath = join(root, "gh-commands.ndjson");
+  const readyPath = join(root, "discovery-ready");
+  const releasePath = join(root, "discovery-release");
+  const donePath = join(root, "discovery-done");
+  const scriptPath = join(shimDirectory, "gh-fixture.mjs");
+  mkdirSync(shimDirectory);
+  writeFileSync(
+    scriptPath,
+    `#!/usr/bin/env node
+import { appendFileSync, existsSync, writeFileSync } from "node:fs";
+const args = process.argv.slice(2);
+const graphqlRemaining = Number(process.env.SLOP_GH_GRAPHQL_REMAINING ?? "5000");
+appendFileSync(process.env.SLOP_GH_LOG, \`\${JSON.stringify(args)}\\n\`);
+if (args.at(-1) === "user") {
+  process.stdout.write('{"id":4242,"login":"fixture-user"}\\n');
+} else if (args.at(-1) === "rate_limit") {
+  if (process.env.SLOP_GH_HOLD === "1") {
+    writeFileSync(process.env.SLOP_GH_READY, "ready\\n");
+    const sleeper = new Int32Array(new SharedArrayBuffer(4));
+    while (!existsSync(process.env.SLOP_GH_RELEASE)) {
+      Atomics.wait(sleeper, 0, 0, 10);
+    }
+    writeFileSync(process.env.SLOP_GH_DONE, "done\\n");
+  }
+  if (process.env.SLOP_GH_FAIL_RATE === "1") {
+    process.stderr.write("fixture rate-limit failure\\n");
+    process.exit(9);
+  }
+  process.stdout.write(JSON.stringify({ resources: {
+    graphql: { limit: 5000, remaining: graphqlRemaining, reset: 1800000000 },
+    core: { limit: 5000, remaining: 5000, reset: 1800000000 },
+    search: { limit: 30, remaining: 30, reset: 1800000000 }
+  } }));
+} else if (args.some((value) => value.includes("SlopActivityRateLimit"))) {
+  process.stdout.write(\`\${JSON.stringify({ limit: 5000, remaining: graphqlRemaining, resetAt: "2027-01-15T08:00:00.000Z" })}\\n\`);
+}
+`,
+  );
+  const shimPath = join(
+    shimDirectory,
+    process.platform === "win32" ? "gh.cmd" : "gh",
+  );
+  if (process.platform === "win32") {
+    writeFileSync(shimPath, `@node "%~dp0\\gh-fixture.mjs" %*\r\n`);
+  } else {
+    symlinkSync(scriptPath, shimPath);
+    chmodSync(scriptPath, 0o755);
+  }
+  return {
+    root,
+    logPath,
+    readyPath,
+    releasePath,
+    donePath,
+    environment: {
+      ...process.env,
+      PATH: `${shimDirectory}${delimiter}${process.env.PATH ?? ""}`,
+      SLOP_GH_LOG: logPath,
+      SLOP_GH_READY: readyPath,
+      SLOP_GH_RELEASE: releasePath,
+      SLOP_GH_DONE: donePath,
+      TMPDIR: root,
+      TEMP: root,
+      TMP: root,
+    },
+  };
+}
+
+function collectChild(child: ReturnType<typeof spawn>) {
+  return new Promise<{
+    status: number | null;
+    signal: NodeJS.Signals | null;
+    stderr: string;
+    stdout: string;
+  }>((resolvePromise) => {
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr?.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("close", (status, signal) => {
+      resolvePromise({ status, signal, stderr, stdout });
+    });
+  });
+}
+
+async function waitForFixturePath(path: string, timeoutMs = 5_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (!existsSync(path)) {
+    if (Date.now() >= deadline) assert.fail(`timed out waiting for ${path}`);
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 10));
+  }
+}
 
 function account(login: string, type = "User") {
   const id = [...login.toLowerCase()].reduce(
@@ -1728,6 +1828,174 @@ describe("live report parsing", () => {
 });
 
 describe("live report behavior", () => {
+  it("keeps same-identity project reports out of simultaneous discovery", {
+    timeout: 15_000,
+  }, async () => {
+    const fixture = createLiveReportGhFixture();
+    const asiReportPath = join(
+      skillDir,
+      "..",
+      "contribute-to-asi",
+      "scripts",
+      "live-report.mjs",
+    );
+    const first = spawn(process.execPath, [liveReportPath, "--json"], {
+      env: { ...fixture.environment, SLOP_GH_HOLD: "1" },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const firstResult = collectChild(first);
+    let testError: unknown = null;
+    try {
+      await waitForFixturePath(fixture.readyPath);
+      const second = spawnSync(process.execPath, [asiReportPath, "--json"], {
+        encoding: "utf8",
+        env: fixture.environment,
+      });
+      assert.strictEqual(second.status, 2, second.stderr);
+      assert.match(second.stderr, /live report lock contention/iu);
+      const calls = readFileSync(fixture.logPath, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as string[]);
+      assert.strictEqual(
+        calls.filter((args) => args.at(-1) === "rate_limit").length,
+        1,
+        "the contending report must stop before rate-budget discovery",
+      );
+    } catch (error) {
+      testError = error;
+    } finally {
+      writeFileSync(fixture.releasePath, "release\n");
+    }
+    const completed = await firstResult;
+    rmSync(fixture.root, { force: true, recursive: true });
+    if (testError) throw testError;
+    assert.strictEqual(completed.status, 0, completed.stderr);
+  });
+
+  it("releases the identity lock after a successful report", () => {
+    const fixture = createLiveReportGhFixture();
+    const deltaStarReportPath = join(
+      skillDir,
+      "..",
+      "contribute-to-delta-star",
+      "scripts",
+      "live-report.mjs",
+    );
+    try {
+      const first = spawnSync(process.execPath, [liveReportPath, "--json"], {
+        encoding: "utf8",
+        env: fixture.environment,
+      });
+      assert.strictEqual(first.status, 0, first.stderr);
+      const second = spawnSync(
+        process.execPath,
+        [deltaStarReportPath, "--json"],
+        {
+          encoding: "utf8",
+          env: {
+            ...fixture.environment,
+            SLOP_GH_GRAPHQL_REMAINING: "999",
+          },
+        },
+      );
+      assert.strictEqual(second.status, 0, second.stderr);
+      assert.match(second.stderr, /GraphQL 999\/5000.*activity source rest/su);
+      const calls = readFileSync(fixture.logPath, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as string[]);
+      assert.strictEqual(
+        calls.filter((args) => args.at(-1) === "rate_limit").length,
+        2,
+      );
+    } finally {
+      rmSync(fixture.root, { force: true, recursive: true });
+    }
+  });
+
+  it("releases the identity lock after a handled discovery failure", () => {
+    const fixture = createLiveReportGhFixture();
+    const asiReportPath = join(
+      skillDir,
+      "..",
+      "contribute-to-asi",
+      "scripts",
+      "live-report.mjs",
+    );
+    try {
+      const failed = spawnSync(process.execPath, [liveReportPath, "--json"], {
+        encoding: "utf8",
+        env: { ...fixture.environment, SLOP_GH_FAIL_RATE: "1" },
+      });
+      assert.strictEqual(failed.status, 1);
+      assert.match(failed.stderr, /fixture rate-limit failure/u);
+      const recovered = spawnSync(process.execPath, [asiReportPath, "--json"], {
+        encoding: "utf8",
+        env: fixture.environment,
+      });
+      assert.strictEqual(recovered.status, 0, recovered.stderr);
+      const calls = readFileSync(fixture.logPath, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as string[]);
+      assert.strictEqual(
+        calls.filter((args) => args.at(-1) === "rate_limit").length,
+        2,
+      );
+    } finally {
+      rmSync(fixture.root, { force: true, recursive: true });
+    }
+  });
+
+  it("recovers the identity lock after an interrupted report", {
+    timeout: 15_000,
+  }, async () => {
+    const fixture = createLiveReportGhFixture();
+    const heirReportPath = join(
+      skillDir,
+      "..",
+      "contribute-to-heir-elements-sdk",
+      "scripts",
+      "live-report.mjs",
+    );
+    const interrupted = spawn(process.execPath, [liveReportPath, "--json"], {
+      env: { ...fixture.environment, SLOP_GH_HOLD: "1" },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const interruptedResult = collectChild(interrupted);
+    try {
+      await waitForFixturePath(fixture.readyPath);
+      assert.strictEqual(interrupted.kill("SIGKILL"), true);
+      writeFileSync(fixture.releasePath, "release\n");
+      await waitForFixturePath(fixture.donePath);
+      const killed = await interruptedResult;
+      assert.strictEqual(killed.status, null);
+      assert.strictEqual(killed.signal, "SIGKILL");
+
+      const recovered = spawnSync(
+        process.execPath,
+        [heirReportPath, "--json"],
+        { encoding: "utf8", env: fixture.environment },
+      );
+      assert.strictEqual(recovered.status, 0, recovered.stderr);
+      const calls = readFileSync(fixture.logPath, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as string[]);
+      assert.strictEqual(
+        calls.filter((args) => args.at(-1) === "rate_limit").length,
+        2,
+      );
+    } finally {
+      if (interrupted.exitCode === null) interrupted.kill("SIGKILL");
+      if (!existsSync(fixture.releasePath)) {
+        writeFileSync(fixture.releasePath, "release\n");
+      }
+      rmSync(fixture.root, { force: true, recursive: true });
+    }
+  });
+
   it("freezes a finite oldest-first epoch and defers arrivals and overflow", () => {
     const candidates = Array.from(
       { length: MAX_REVIEW_EPOCH_CANDIDATES + 3 },
@@ -3055,7 +3323,7 @@ describe("run receipt CLI", () => {
   });
 
   it("starts and finishes a measured run without passing --project to ccusage", {
-    timeout: 0,
+    timeout: 30_000,
   }, async () => {
     const fixtureRoot = realpathSync(
       mkdtempSync(join(tmpdir(), "contribute-to-eliza-start-")),

--- a/skill-tests/contribute-to-eliza.test.ts
+++ b/skill-tests/contribute-to-eliza.test.ts
@@ -70,27 +70,33 @@ const HEAD_SHA = "a".repeat(40);
 const PRIOR_SHA = "b".repeat(40);
 
 const configuredNodeExecutable = process.env.SLOP_TEST_NODE ?? "node";
-const configuredNodeRuntime = spawnSync(
-  configuredNodeExecutable,
-  [
-    "-p",
-    "JSON.stringify({ executable: process.execPath, version: process.versions.node })",
-  ],
-  { encoding: "utf8" },
-);
-assert.strictEqual(
-  configuredNodeRuntime.status,
-  0,
-  configuredNodeRuntime.stderr,
-);
-const nodeRuntime = JSON.parse(configuredNodeRuntime.stdout) as {
-  executable: string;
-  version: string;
-};
-assert.strictEqual(nodeRuntime.version, "24.15.0");
-const nodeExecutable = nodeRuntime.executable;
+const nodeExecutable = configuredNodeExecutable;
+let pinnedNodeRuntimeChecked = false;
+
+function assertPinnedNodeRuntime(): void {
+  if (pinnedNodeRuntimeChecked) return;
+  const configuredNodeRuntime = spawnSync(
+    configuredNodeExecutable,
+    [
+      "-p",
+      "JSON.stringify({ executable: process.execPath, version: process.versions.node })",
+    ],
+    { encoding: "utf8" },
+  );
+  assert.strictEqual(
+    configuredNodeRuntime.status,
+    0,
+    configuredNodeRuntime.stderr,
+  );
+  const nodeRuntime = JSON.parse(configuredNodeRuntime.stdout) as {
+    version: string;
+  };
+  assert.strictEqual(nodeRuntime.version, "24.15.0");
+  pinnedNodeRuntimeChecked = true;
+}
 
 function createLiveReportGhFixture() {
+  assertPinnedNodeRuntime();
   const root = mkdtempSync(join(tmpdir(), "slop-live-report-lock-test-"));
   const identityId = Number.parseInt(randomBytes(6).toString("hex"), 16);
   const shimDirectory = join(root, "bin");

--- a/skill-tests/contribute-to-eliza.test.ts
+++ b/skill-tests/contribute-to-eliza.test.ts
@@ -5,7 +5,7 @@
 
 import assert from "node:assert";
 import { spawn, spawnSync } from "node:child_process";
-import { createHash } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import {
   chmodSync,
   cpSync,
@@ -25,6 +25,7 @@ import { delimiter, dirname, join, resolve } from "node:path";
 import { describe, it } from "node:test";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import {
+  acquireLiveReportLock,
   auditCommentDisclosures,
   auditPrEvidence,
   CLAIM_RECENCY_DAYS,
@@ -33,6 +34,7 @@ import {
   completeReviewEpoch,
   createGhCommandBudget,
   createReviewEpoch,
+  ensureLiveReportLockRoot,
   isBotAccount,
   MAX_ACTIVITY_CONNECTION_ITEMS,
   MAX_REVIEW_EPOCH_CANDIDATES,
@@ -43,9 +45,11 @@ import {
   parseModelDisclosure,
   parsePaginatedJson,
   REQUIRED_EVIDENCE_ROWS,
+  readGhAuthenticatedIdentity,
   readGhOpenActivity,
   readGhPages,
   readLivePullHead,
+  readLiveReportProcessIdentity,
   readProjectSelectionPolicy,
   recheckReviewEpochCandidate,
   renderMarkdown,
@@ -88,11 +92,13 @@ const nodeExecutable = nodeRuntime.executable;
 
 function createLiveReportGhFixture() {
   const root = mkdtempSync(join(tmpdir(), "slop-live-report-lock-test-"));
+  const identityId = Number.parseInt(randomBytes(6).toString("hex"), 16);
   const shimDirectory = join(root, "bin");
   const logPath = join(root, "gh-commands.ndjson");
   const readyPath = join(root, "discovery-ready");
   const releasePath = join(root, "discovery-release");
   const donePath = join(root, "discovery-done");
+  const pidPath = join(root, "discovery-pid");
   const scriptPath = join(shimDirectory, "gh-fixture.mjs");
   mkdirSync(shimDirectory);
   writeFileSync(
@@ -100,12 +106,15 @@ function createLiveReportGhFixture() {
     `#!/usr/bin/env node
 import { appendFileSync, existsSync, writeFileSync } from "node:fs";
 const args = process.argv.slice(2);
-const graphqlRemaining = Number(process.env.SLOP_GH_GRAPHQL_REMAINING ?? "5000");
+const identityId = Number(process.env.SLOP_GH_ID);
+const restGraphqlRemaining = Number(process.env.SLOP_GH_REST_GRAPHQL_REMAINING ?? "5000");
+const directGraphqlRemaining = Number(process.env.SLOP_GH_DIRECT_GRAPHQL_REMAINING ?? "5000");
 appendFileSync(process.env.SLOP_GH_LOG, \`\${JSON.stringify(args)}\\n\`);
 if (args.at(-1) === "user") {
-  process.stdout.write('{"id":4242,"login":"fixture-user"}\\n');
+  process.stdout.write(\`\${JSON.stringify({ id: identityId, login: "fixture-user" })}\\n\`);
 } else if (args.at(-1) === "rate_limit") {
   if (process.env.SLOP_GH_HOLD === "1") {
+    writeFileSync(process.env.SLOP_GH_PID, \`\${process.pid}\\n\`);
     writeFileSync(process.env.SLOP_GH_READY, "ready\\n");
     const sleeper = new Int32Array(new SharedArrayBuffer(4));
     while (!existsSync(process.env.SLOP_GH_RELEASE)) {
@@ -118,12 +127,12 @@ if (args.at(-1) === "user") {
     process.exit(9);
   }
   process.stdout.write(JSON.stringify({ resources: {
-    graphql: { limit: 5000, remaining: graphqlRemaining, reset: 1800000000 },
+    graphql: { limit: 5000, remaining: restGraphqlRemaining, reset: 1800000000 },
     core: { limit: 5000, remaining: 5000, reset: 1800000000 },
     search: { limit: 30, remaining: 30, reset: 1800000000 }
   } }));
 } else if (args.some((value) => value.includes("SlopActivityRateLimit"))) {
-  process.stdout.write(\`\${JSON.stringify({ limit: 5000, remaining: graphqlRemaining, resetAt: "2027-01-15T08:00:00.000Z" })}\\n\`);
+  process.stdout.write(\`\${JSON.stringify({ limit: 5000, remaining: directGraphqlRemaining, resetAt: "2027-01-15T08:00:00.000Z" })}\\n\`);
 }
 `,
   );
@@ -150,10 +159,14 @@ if (args.at(-1) === "user") {
       SLOP_GH_READY: readyPath,
       SLOP_GH_RELEASE: releasePath,
       SLOP_GH_DONE: donePath,
+      SLOP_GH_ID: String(identityId),
+      SLOP_GH_PID: pidPath,
       TMPDIR: root,
       TEMP: root,
       TMP: root,
     },
+    identityId,
+    pidPath,
   };
 }
 
@@ -184,6 +197,25 @@ async function waitForFixturePath(path: string, timeoutMs = 5_000) {
     if (Date.now() >= deadline) assert.fail(`timed out waiting for ${path}`);
     await new Promise((resolvePromise) => setTimeout(resolvePromise, 10));
   }
+}
+
+async function waitForProcessExit(
+  pid: number,
+  expectedIdentity: string,
+  timeoutMs = 5_000,
+) {
+  const deadline = Date.now() + timeoutMs;
+  while (readLiveReportProcessIdentity(pid) === expectedIdentity) {
+    if (Date.now() >= deadline) assert.fail(`timed out waiting for PID ${pid}`);
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 10));
+  }
+}
+
+function liveReportLockPath(root: string, identityId: number) {
+  const key = createHash("sha256")
+    .update(`github.com:${identityId}`)
+    .digest("hex");
+  return join(root, `${key}.lock`);
 }
 
 function account(login: string, type = "User") {
@@ -1849,6 +1881,155 @@ describe("live report parsing", () => {
 });
 
 describe("live report behavior", () => {
+  it("pins the authenticated identity lookup to github.com", () => {
+    const calls: Array<{ command: string; args: string[] }> = [];
+    const identity = readGhAuthenticatedIdentity((command, args) => {
+      calls.push({ command, args });
+      return {
+        status: 0,
+        stderr: "",
+        stdout: '{"id":42,"login":"fixture-user"}\n',
+      };
+    });
+
+    assert.deepStrictEqual(identity, {
+      host: "github.com",
+      id: 42,
+      login: "fixture-user",
+    });
+    assert.deepStrictEqual(calls, [
+      {
+        command: "gh",
+        args: [
+          "api",
+          "--hostname",
+          "github.com",
+          "--method",
+          "GET",
+          "--jq",
+          "{id: .id, login: .login}",
+          "user",
+        ],
+      },
+    ]);
+  });
+
+  it("keeps all four live-report implementations byte-identical", () => {
+    const implementations = [
+      "contribute-to-asi",
+      "contribute-to-delta-star",
+      "contribute-to-eliza",
+      "contribute-to-heir-elements-sdk",
+    ].map((skill) =>
+      readFileSync(join(skillDir, "..", skill, "scripts", "live-report.mjs")),
+    );
+
+    for (const implementation of implementations.slice(1)) {
+      assert.deepStrictEqual(implementation, implementations[0]);
+    }
+  });
+
+  it("executes locked commands from an explicit secure root", () => {
+    const fixture = createLiveReportGhFixture();
+    const lockRoot = join(fixture.root, "locks");
+    mkdirSync(lockRoot, { mode: 0o700 });
+    const lock = acquireLiveReportLock(
+      {
+        host: "github.com",
+        id: fixture.identityId,
+        login: "fixture-user",
+      },
+      { rootPath: lockRoot },
+    );
+    try {
+      const result = lock.spawn("gh", ["api", "user"], {
+        encoding: "utf8",
+        env: fixture.environment,
+      });
+      assert.strictEqual(result.status, 0, result.stderr);
+      assert.deepStrictEqual(JSON.parse(result.stdout), {
+        id: fixture.identityId,
+        login: "fixture-user",
+      });
+    } finally {
+      lock.release();
+      rmSync(fixture.root, { force: true, recursive: true });
+    }
+  });
+
+  it("reclaims a stale reused PID but preserves malformed lock evidence", () => {
+    const root = mkdtempSync(join(tmpdir(), "slop-live-report-metadata-test-"));
+    const identity = {
+      host: "github.com",
+      id: Number.parseInt(randomBytes(6).toString("hex"), 16),
+      login: "fixture-user",
+    };
+    const lockPath = liveReportLockPath(root, identity.id);
+    const ownerPath = join(lockPath, "owner.json");
+    try {
+      mkdirSync(join(lockPath, "commands"), { recursive: true, mode: 0o700 });
+      writeFileSync(ownerPath, "{malformed\n", { mode: 0o600 });
+      const malformed = readFileSync(ownerPath);
+      assert.throws(
+        () => acquireLiveReportLock(identity, { rootPath: root }),
+        SyntaxError,
+      );
+      assert.deepStrictEqual(readFileSync(ownerPath), malformed);
+
+      rmSync(lockPath, { force: true, recursive: true });
+      mkdirSync(join(lockPath, "commands"), { recursive: true, mode: 0o700 });
+      const currentIdentity = readLiveReportProcessIdentity(process.pid);
+      assert.ok(currentIdentity);
+      const staleIdentity =
+        currentIdentity === "0".repeat(64) ? "1".repeat(64) : "0".repeat(64);
+      writeFileSync(
+        ownerPath,
+        `${JSON.stringify({
+          schemaVersion: 2,
+          pid: process.pid,
+          processIdentity: staleIdentity,
+          ownerToken: randomBytes(16).toString("hex"),
+        })}\n`,
+        { mode: 0o600 },
+      );
+
+      const recovered = acquireLiveReportLock(identity, { rootPath: root });
+      recovered.release();
+      assert.strictEqual(existsSync(lockPath), false);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects symlinked and group-readable lock roots", () => {
+    const fixtureRoot = mkdtempSync(
+      join(tmpdir(), "slop-live-report-root-test-"),
+    );
+    const target = join(fixtureRoot, "target");
+    const symlink = join(fixtureRoot, "symlink");
+    const permissive = join(fixtureRoot, "permissive");
+    try {
+      mkdirSync(target, { mode: 0o700 });
+      symlinkSync(target, symlink);
+      assert.throws(
+        () => ensureLiveReportLockRoot(symlink),
+        /must be a real directory/u,
+      );
+      assert.deepStrictEqual(readdirSync(target), []);
+
+      mkdirSync(permissive, { mode: 0o700 });
+      chmodSync(permissive, 0o755);
+      if (process.platform !== "win32") {
+        assert.throws(
+          () => ensureLiveReportLockRoot(permissive),
+          /permissions must/u,
+        );
+      }
+    } finally {
+      rmSync(fixtureRoot, { force: true, recursive: true });
+    }
+  });
+
   it("keeps same-identity project reports out of simultaneous discovery", {
     timeout: 15_000,
   }, async () => {
@@ -1860,18 +2041,33 @@ describe("live report behavior", () => {
       "scripts",
       "live-report.mjs",
     );
-    const first = spawn(nodeExecutable, [liveReportPath, "--json"], {
-      env: { ...fixture.environment, SLOP_GH_HOLD: "1" },
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+    const first = spawn(
+      nodeExecutable,
+      [liveReportPath, "--repo", "alpha/one", "--json"],
+      {
+        env: { ...fixture.environment, SLOP_GH_HOLD: "1" },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
     const firstResult = collectChild(first);
     let testError: unknown = null;
     try {
       await waitForFixturePath(fixture.readyPath);
-      const second = spawnSync(nodeExecutable, [asiReportPath, "--json"], {
-        encoding: "utf8",
-        env: fixture.environment,
-      });
+      const alternateTmp = join(fixture.root, "alternate-tmp");
+      mkdirSync(alternateTmp, { mode: 0o700 });
+      const second = spawnSync(
+        nodeExecutable,
+        [asiReportPath, "--repo", "beta/two", "--json"],
+        {
+          encoding: "utf8",
+          env: {
+            ...fixture.environment,
+            TEMP: alternateTmp,
+            TMP: alternateTmp,
+            TMPDIR: alternateTmp,
+          },
+        },
+      );
       assert.strictEqual(second.status, 2, second.stderr);
       assert.match(second.stderr, /live report lock contention/iu);
       const calls = readFileSync(fixture.logPath, "utf8")
@@ -1916,7 +2112,7 @@ describe("live report behavior", () => {
           encoding: "utf8",
           env: {
             ...fixture.environment,
-            SLOP_GH_GRAPHQL_REMAINING: "999",
+            SLOP_GH_DIRECT_GRAPHQL_REMAINING: "999",
           },
         },
       );
@@ -1928,6 +2124,12 @@ describe("live report behavior", () => {
         .map((line) => JSON.parse(line) as string[]);
       assert.strictEqual(
         calls.filter((args) => args.at(-1) === "rate_limit").length,
+        2,
+      );
+      assert.strictEqual(
+        calls.filter((args) =>
+          args.some((value) => value.includes("SlopActivityRateLimit")),
+        ).length,
         2,
       );
     } finally {
@@ -1985,13 +2187,31 @@ describe("live report behavior", () => {
       stdio: ["ignore", "pipe", "pipe"],
     });
     const interruptedResult = collectChild(interrupted);
+    let heldGhPid: number | null = null;
+    let heldGhIdentity: string | null = null;
+    let discoveryStarted = false;
     let testError: unknown = null;
     try {
       await waitForFixturePath(fixture.readyPath);
+      discoveryStarted = true;
+      heldGhPid = Number(readFileSync(fixture.pidPath, "utf8").trim());
+      assert.strictEqual(Number.isInteger(heldGhPid) && heldGhPid > 0, true);
+      heldGhIdentity = readLiveReportProcessIdentity(heldGhPid);
+      assert.ok(heldGhIdentity);
       assert.strictEqual(interrupted.kill("SIGKILL"), true);
       const killed = await interruptedResult;
       assert.strictEqual(killed.status, null);
       assert.strictEqual(killed.signal, "SIGKILL");
+      assert.strictEqual(
+        readLiveReportProcessIdentity(heldGhPid),
+        heldGhIdentity,
+      );
+      await new Promise((resolvePromise) => setTimeout(resolvePromise, 1_200));
+      assert.strictEqual(
+        readLiveReportProcessIdentity(heldGhPid),
+        heldGhIdentity,
+        "the held GitHub child must outlive the killed report owner",
+      );
 
       const contending = spawnSync(nodeExecutable, [heirReportPath, "--json"], {
         encoding: "utf8",
@@ -2015,12 +2235,15 @@ describe("live report behavior", () => {
       if (!existsSync(fixture.releasePath)) {
         writeFileSync(fixture.releasePath, "release\n");
       }
-      await waitForFixturePath(fixture.donePath);
+      if (discoveryStarted) await waitForFixturePath(fixture.donePath);
+      if (heldGhPid !== null && heldGhIdentity !== null) {
+        await waitForProcessExit(heldGhPid, heldGhIdentity);
+      }
     }
     try {
       if (testError) throw testError;
       const recoveryDeadline = Date.now() + 5_000;
-      let recovered;
+      let recovered: ReturnType<typeof spawnSync>;
       do {
         recovered = spawnSync(nodeExecutable, [heirReportPath, "--json"], {
           encoding: "utf8",

--- a/skill-tests/contribute-to-eliza.test.ts
+++ b/skill-tests/contribute-to-eliza.test.ts
@@ -3877,6 +3877,10 @@ try {
         { encoding: "utf8", env: environment },
       );
       assert.strictEqual(finished.status, 0, finished.stderr);
+      assert.match(
+        finished.stderr,
+        /wallet-claim\.mjs register --address <public-address>/u,
+      );
       const finishReport = JSON.parse(finished.stdout);
       assert.strictEqual(finishReport.receipt.usage.confidence, "exact");
       assert.strictEqual(finishReport.receipt.usage.totalTokens, 150);

--- a/skill-tests/contribute-to-eliza.test.ts
+++ b/skill-tests/contribute-to-eliza.test.ts
@@ -65,6 +65,27 @@ const NOW = new Date("2026-01-20T12:00:00.000Z");
 const HEAD_SHA = "a".repeat(40);
 const PRIOR_SHA = "b".repeat(40);
 
+const configuredNodeExecutable = process.env.SLOP_TEST_NODE ?? "node";
+const configuredNodeRuntime = spawnSync(
+  configuredNodeExecutable,
+  [
+    "-p",
+    "JSON.stringify({ executable: process.execPath, version: process.versions.node })",
+  ],
+  { encoding: "utf8" },
+);
+assert.strictEqual(
+  configuredNodeRuntime.status,
+  0,
+  configuredNodeRuntime.stderr,
+);
+const nodeRuntime = JSON.parse(configuredNodeRuntime.stdout) as {
+  executable: string;
+  version: string;
+};
+assert.strictEqual(nodeRuntime.version, "24.15.0");
+const nodeExecutable = nodeRuntime.executable;
+
 function createLiveReportGhFixture() {
   const root = mkdtempSync(join(tmpdir(), "slop-live-report-lock-test-"));
   const shimDirectory = join(root, "bin");
@@ -124,7 +145,7 @@ if (args.at(-1) === "user") {
     donePath,
     environment: {
       ...process.env,
-      PATH: `${shimDirectory}${delimiter}${process.env.PATH ?? ""}`,
+      PATH: `${shimDirectory}${delimiter}${dirname(nodeExecutable)}${delimiter}${process.env.PATH ?? ""}`,
       SLOP_GH_LOG: logPath,
       SLOP_GH_READY: readyPath,
       SLOP_GH_RELEASE: releasePath,
@@ -1839,7 +1860,7 @@ describe("live report behavior", () => {
       "scripts",
       "live-report.mjs",
     );
-    const first = spawn(process.execPath, [liveReportPath, "--json"], {
+    const first = spawn(nodeExecutable, [liveReportPath, "--json"], {
       env: { ...fixture.environment, SLOP_GH_HOLD: "1" },
       stdio: ["ignore", "pipe", "pipe"],
     });
@@ -1847,7 +1868,7 @@ describe("live report behavior", () => {
     let testError: unknown = null;
     try {
       await waitForFixturePath(fixture.readyPath);
-      const second = spawnSync(process.execPath, [asiReportPath, "--json"], {
+      const second = spawnSync(nodeExecutable, [asiReportPath, "--json"], {
         encoding: "utf8",
         env: fixture.environment,
       });
@@ -1883,13 +1904,13 @@ describe("live report behavior", () => {
       "live-report.mjs",
     );
     try {
-      const first = spawnSync(process.execPath, [liveReportPath, "--json"], {
+      const first = spawnSync(nodeExecutable, [liveReportPath, "--json"], {
         encoding: "utf8",
         env: fixture.environment,
       });
       assert.strictEqual(first.status, 0, first.stderr);
       const second = spawnSync(
-        process.execPath,
+        nodeExecutable,
         [deltaStarReportPath, "--json"],
         {
           encoding: "utf8",
@@ -1924,13 +1945,13 @@ describe("live report behavior", () => {
       "live-report.mjs",
     );
     try {
-      const failed = spawnSync(process.execPath, [liveReportPath, "--json"], {
+      const failed = spawnSync(nodeExecutable, [liveReportPath, "--json"], {
         encoding: "utf8",
         env: { ...fixture.environment, SLOP_GH_FAIL_RATE: "1" },
       });
       assert.strictEqual(failed.status, 1);
       assert.match(failed.stderr, /fixture rate-limit failure/u);
-      const recovered = spawnSync(process.execPath, [asiReportPath, "--json"], {
+      const recovered = spawnSync(nodeExecutable, [asiReportPath, "--json"], {
         encoding: "utf8",
         env: fixture.environment,
       });
@@ -1959,25 +1980,55 @@ describe("live report behavior", () => {
       "scripts",
       "live-report.mjs",
     );
-    const interrupted = spawn(process.execPath, [liveReportPath, "--json"], {
+    const interrupted = spawn(nodeExecutable, [liveReportPath, "--json"], {
       env: { ...fixture.environment, SLOP_GH_HOLD: "1" },
       stdio: ["ignore", "pipe", "pipe"],
     });
     const interruptedResult = collectChild(interrupted);
+    let testError: unknown = null;
     try {
       await waitForFixturePath(fixture.readyPath);
       assert.strictEqual(interrupted.kill("SIGKILL"), true);
-      writeFileSync(fixture.releasePath, "release\n");
-      await waitForFixturePath(fixture.donePath);
       const killed = await interruptedResult;
       assert.strictEqual(killed.status, null);
       assert.strictEqual(killed.signal, "SIGKILL");
 
-      const recovered = spawnSync(
-        process.execPath,
-        [heirReportPath, "--json"],
-        { encoding: "utf8", env: fixture.environment },
+      const contending = spawnSync(nodeExecutable, [heirReportPath, "--json"], {
+        encoding: "utf8",
+        env: fixture.environment,
+      });
+      assert.strictEqual(contending.status, 2, contending.stderr);
+      assert.match(contending.stderr, /live report lock contention/iu);
+      const calls = readFileSync(fixture.logPath, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as string[]);
+      assert.strictEqual(
+        calls.filter((args) => args.at(-1) === "rate_limit").length,
+        1,
+        "a surviving GitHub child must keep replacement discovery out",
       );
+    } catch (error) {
+      testError = error;
+    } finally {
+      if (interrupted.exitCode === null) interrupted.kill("SIGKILL");
+      if (!existsSync(fixture.releasePath)) {
+        writeFileSync(fixture.releasePath, "release\n");
+      }
+      await waitForFixturePath(fixture.donePath);
+    }
+    try {
+      if (testError) throw testError;
+      const recoveryDeadline = Date.now() + 5_000;
+      let recovered;
+      do {
+        recovered = spawnSync(nodeExecutable, [heirReportPath, "--json"], {
+          encoding: "utf8",
+          env: fixture.environment,
+        });
+        if (recovered.status !== 2) break;
+        await new Promise((resolvePromise) => setTimeout(resolvePromise, 20));
+      } while (Date.now() < recoveryDeadline);
       assert.strictEqual(recovered.status, 0, recovered.stderr);
       const calls = readFileSync(fixture.logPath, "utf8")
         .trim()
@@ -1988,10 +2039,6 @@ describe("live report behavior", () => {
         2,
       );
     } finally {
-      if (interrupted.exitCode === null) interrupted.kill("SIGKILL");
-      if (!existsSync(fixture.releasePath)) {
-        writeFileSync(fixture.releasePath, "release\n");
-      }
       rmSync(fixture.root, { force: true, recursive: true });
     }
   });

--- a/skill-tests/contribute-to-eliza.test.ts
+++ b/skill-tests/contribute-to-eliza.test.ts
@@ -36,6 +36,7 @@ import {
   isBotAccount,
   LiveInventoryChangedError,
   MAX_ACTIVITY_CONNECTION_ITEMS,
+  MAX_API_READS,
   MAX_REVIEW_EPOCH_CANDIDATES,
   MIN_REST_ACTIVITY_REQUESTS,
   MIN_SEARCH_ACTIVITY_REQUESTS,
@@ -1768,6 +1769,32 @@ describe("live report behavior", () => {
         }),
       /changed while collecting the live report after 2 attempts/,
     );
+  });
+
+  it("gives each changed-inventory attempt its own command budget", () => {
+    const attemptBudgets: number[] = [];
+    const report = retryChangedLiveInventory(
+      ({ attempt, commandBudget }) => {
+        for (let index = 0; index < MAX_API_READS; index += 1) {
+          commandBudget.run("gh", ["api", `attempt-${attempt}-${index}`], {
+            encoding: "utf8",
+          });
+        }
+        attemptBudgets.push(commandBudget.count);
+        if (attempt === 1) throw new LiveInventoryChangedError();
+        return { coherent: true };
+      },
+      () => {},
+      () =>
+        createGhCommandBudget(() => ({
+          status: 0,
+          stdout: "",
+          stderr: "",
+        })),
+    );
+
+    assert.deepStrictEqual(report, { coherent: true });
+    assert.deepStrictEqual(attemptBudgets, [MAX_API_READS, MAX_API_READS]);
   });
 
   it("freezes a finite oldest-first epoch and defers arrivals and overflow", () => {

--- a/skill-tests/project-skills.test.ts
+++ b/skill-tests/project-skills.test.ts
@@ -1037,6 +1037,100 @@ describe("project run usage", () => {
     }
   });
 
+  it("requests a fresh upload capability when retrying a failed run", async () => {
+    const root = mkdtempSync(join(tmpdir(), "slop-trace-resume-"));
+    try {
+      const path = join(root, "trace.ndjson");
+      const contents = '{"event":"complete"}\n';
+      writeFileSync(path, contents);
+      const digest = createHash("sha256").update(contents).digest("hex");
+      const state = {
+        runId: "run_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        projectId: "eliza",
+        repositoryId: "elizaOS/eliza",
+        revision: "a".repeat(40),
+        provider: "openai",
+        model: "gpt-6-astra",
+        client: "codex",
+      };
+      const keys: string[] = [];
+      let failed = false;
+      const options = {
+        disclosure: () => {},
+        assertionProvider: () => "i".repeat(32),
+        fetchImpl: async (
+          url: RequestInfo | URL,
+          request: RequestInit = {},
+        ) => {
+          const target = String(url);
+          const identity = {
+            serverRunId: "srv_resume",
+            clientRunId: state.runId,
+          };
+          if (target.endsWith("private-request-intake"))
+            return Response.json({
+              enabled: true,
+              source: "github-public-status",
+              verifiedAt: "2026-08-25T12:00:00.000Z",
+            });
+          if (target.endsWith("auth/session"))
+            return Response.json({
+              token: "s".repeat(32),
+              tokenType: "Bearer",
+              expiresAt: "2030-01-01T00:00:00.000Z",
+            });
+          if (target.endsWith("/runs"))
+            return Response.json({ ...identity, state: "awaiting_trace" });
+          if (target.endsWith("trace-intents")) {
+            keys.push(
+              new Headers(request.headers).get("Idempotency-Key") ?? "",
+            );
+            return Response.json({
+              serverRunId: identity.serverRunId,
+              uploadUrl: "https://api.slop.cash/api/v1/trace-uploads/fresh",
+              expiresAt: "2030-01-01T00:00:00.000Z",
+              sha256: digest,
+              sizeBytes: Buffer.byteLength(contents),
+              contentType: "application/x-ndjson",
+            });
+          }
+          if (request.method === "PUT") {
+            if (!failed) {
+              failed = true;
+              return Response.json(
+                { error: "internal_error" },
+                { status: 500 },
+              );
+            }
+            return Response.json({
+              ...identity,
+              state: "trace_uploaded",
+              traceSha256: digest,
+              traceObjectId: `sha256:${digest}`,
+              sizeBytes: Buffer.byteLength(contents),
+            });
+          }
+          return Response.json({
+            ...identity,
+            state: "finalized",
+            traceSha256: digest,
+            traceObjectId: `sha256:${digest}`,
+          });
+        },
+      };
+      await assert.rejects(
+        uploadPrivateTrace(state, path, "1.2.3", options),
+        /HTTP 500/u,
+      );
+      const recovered = await uploadPrivateTrace(state, path, "1.2.3", options);
+      assert.strictEqual(recovered.sha256, digest);
+      assert.strictEqual(keys.length, 2);
+      assert.notStrictEqual(keys[0], keys[1]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("finalizes an idempotently recovered run whose trace was already uploaded", async () => {
     const fixtureRoot = mkdtempSync(
       join(tmpdir(), "slop-trace-finalize-recovery-"),

--- a/skill-tests/project-skills.test.ts
+++ b/skill-tests/project-skills.test.ts
@@ -1204,6 +1204,84 @@ describe("project run usage", () => {
     assert.strictEqual(cancelled, true);
   });
 
+  it("includes the identity error code when a poll fails mid-flow", async () => {
+    const responses = [
+      new Response(
+        JSON.stringify({
+          flowId: `flow_${"f".repeat(32)}`,
+          authorizationUrl: `https://identity.slop.cash/v1/oauth/authorize?flow=${"f".repeat(32)}`,
+          pollCapability: "p".repeat(48),
+          expiresAt: "2030-01-01T00:05:00.000Z",
+          pollAfterSeconds: 2,
+        }),
+        { status: 201 },
+      ),
+      new Response(
+        JSON.stringify({
+          error: "flow_unavailable",
+          message: "Identity flow is unavailable",
+        }),
+        { status: 410 },
+      ),
+    ];
+    const originalWrite = process.stderr.write;
+    process.stderr.write = (() => true) as typeof process.stderr.write;
+    try {
+      await assert.rejects(
+        slopIdentityAssertion(
+          async () => {
+            const response = responses.shift();
+            assert.ok(response);
+            return response;
+          },
+          async () => {},
+        ),
+        /returned HTTP 410 \(flow_unavailable\)/u,
+      );
+    } finally {
+      process.stderr.write = originalWrite;
+    }
+  });
+
+  it("reports a deadline miss as expiry instead of a bare 410", async () => {
+    const responses = [
+      new Response(
+        JSON.stringify({
+          flowId: `flow_${"f".repeat(32)}`,
+          authorizationUrl: `https://identity.slop.cash/v1/oauth/authorize?flow=${"f".repeat(32)}`,
+          pollCapability: "p".repeat(48),
+          expiresAt: new Date(Date.now() + 2_500).toISOString(),
+          pollAfterSeconds: 2,
+        }),
+        { status: 201 },
+      ),
+      new Response(
+        JSON.stringify({
+          error: "flow_unavailable",
+          message: "Identity flow is unavailable",
+        }),
+        { status: 410 },
+      ),
+    ];
+    const originalWrite = process.stderr.write;
+    process.stderr.write = (() => true) as typeof process.stderr.write;
+    try {
+      await assert.rejects(
+        slopIdentityAssertion(
+          async () => {
+            const response = responses.shift();
+            assert.ok(response);
+            return response;
+          },
+          async () => {},
+        ),
+        /authorization expired before completion/u,
+      );
+    } finally {
+      process.stderr.write = originalWrite;
+    }
+  });
+
   it("serializes one terminal Slop marker without private material", () => {
     const key = generateKeyPairSync("ed25519");
     const publicDer = createPublicKey(key.privateKey).export({

--- a/skill-tests/project-skills.test.ts
+++ b/skill-tests/project-skills.test.ts
@@ -1243,44 +1243,78 @@ describe("project run usage", () => {
     }
   });
 
-  it("reports a deadline miss as expiry instead of a bare 410", async () => {
-    const responses = [
-      new Response(
-        JSON.stringify({
-          flowId: `flow_${"f".repeat(32)}`,
-          authorizationUrl: `https://identity.slop.cash/v1/oauth/authorize?flow=${"f".repeat(32)}`,
-          pollCapability: "p".repeat(48),
-          expiresAt: new Date(Date.now() + 2_500).toISOString(),
-          pollAfterSeconds: 2,
-        }),
-        { status: 201 },
-      ),
-      new Response(
-        JSON.stringify({
-          error: "flow_unavailable",
-          message: "Identity flow is unavailable",
-        }),
-        { status: 410 },
-      ),
-    ];
-    const originalWrite = process.stderr.write;
-    process.stderr.write = (() => true) as typeof process.stderr.write;
-    try {
-      await assert.rejects(
-        slopIdentityAssertion(
-          async () => {
-            const response = responses.shift();
-            assert.ok(response);
-            return response;
-          },
-          async () => {},
+  for (const { elapsed, error, expected } of [
+    {
+      elapsed: 19_000,
+      error: "flow_unavailable",
+      expected: /returned HTTP 410 \(flow_unavailable\)/u,
+    },
+    {
+      elapsed: 29_999,
+      error: "flow_unavailable",
+      expected: /returned HTTP 410 \(flow_unavailable\)/u,
+    },
+    {
+      elapsed: 30_000,
+      error: "flow_unavailable",
+      expected: /authorization expired before completion/u,
+    },
+    {
+      elapsed: 19_000,
+      error: "flow_expired",
+      expected: /authorization expired before completion/u,
+    },
+    {
+      elapsed: 30_000,
+      error: "flow_consumed",
+      expected: /returned HTTP 410 \(flow_consumed\)/u,
+    },
+  ]) {
+    it(`classifies ${error} at ${elapsed}ms against the actual 30s identity deadline`, async () => {
+      const startedAt = Date.parse("2030-01-01T00:00:00.000Z");
+      let now = startedAt;
+      const responses = [
+        new Response(
+          JSON.stringify({
+            flowId: `flow_${"f".repeat(32)}`,
+            authorizationUrl: `https://identity.slop.cash/v1/oauth/authorize?flow=${"f".repeat(32)}`,
+            pollCapability: "p".repeat(48),
+            expiresAt: new Date(startedAt + 30_000).toISOString(),
+            pollAfterSeconds: 10,
+          }),
+          { status: 201 },
         ),
-        /authorization expired before completion/u,
-      );
-    } finally {
-      process.stderr.write = originalWrite;
-    }
-  });
+        new Response(
+          JSON.stringify({
+            error,
+            message: "Identity flow is unavailable",
+          }),
+          { status: 410 },
+        ),
+      ];
+      const originalWrite = process.stderr.write;
+      process.stderr.write = (() => true) as typeof process.stderr.write;
+      try {
+        await assert.rejects(
+          slopIdentityAssertion(
+            async () => {
+              const response = responses.shift();
+              assert.ok(response);
+              if (response.status === 410) now = startedAt + elapsed;
+              return response;
+            },
+            async (milliseconds) => {
+              now += milliseconds;
+            },
+            () => now,
+          ),
+          expected,
+        );
+      } finally {
+        process.stderr.write = originalWrite;
+      }
+    });
+  }
 
   it("serializes one terminal Slop marker without private material", () => {
     const key = generateKeyPairSync("ed25519");

--- a/skill-tests/project-skills.test.ts
+++ b/skill-tests/project-skills.test.ts
@@ -1037,6 +1037,88 @@ describe("project run usage", () => {
     }
   });
 
+  it("finalizes an idempotently recovered run whose trace was already uploaded", async () => {
+    const fixtureRoot = mkdtempSync(
+      join(tmpdir(), "slop-trace-finalize-recovery-"),
+    );
+    try {
+      const trajectory = join(fixtureRoot, "trace.ndjson");
+      const contents = '{"event":"complete"}\n';
+      writeFileSync(trajectory, contents);
+      const digest = createHash("sha256").update(contents).digest("hex");
+      const serverRunId = "srv_recovered";
+      const requests: Array<{ method: string; url: string }> = [];
+      const responses = [
+        {
+          enabled: true,
+          source: "github-public-status",
+          verifiedAt: "2026-08-25T12:00:00.000Z",
+        },
+        {
+          token: "s".repeat(32),
+          tokenType: "Bearer",
+          expiresAt: "2030-01-01T00:00:00.000Z",
+        },
+        {
+          serverRunId,
+          clientRunId: "run_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+          state: "trace_uploaded",
+        },
+        {
+          serverRunId,
+          clientRunId: "run_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+          traceObjectId: `sha256:${digest}`,
+          traceSha256: digest,
+          state: "finalized",
+        },
+      ];
+      const evidence = await uploadPrivateTrace(
+        {
+          runId: "run_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+          projectId: "eliza",
+          repositoryId: "elizaOS/eliza",
+          revision: "a".repeat(40),
+          provider: "openai",
+          model: "gpt-5.6-sol",
+          client: "codex",
+        },
+        trajectory,
+        "1.2.3",
+        {
+          disclosure: () => {},
+          assertionProvider: () => "i".repeat(32),
+          fetchImpl: async (url, options = {}) => {
+            requests.push({
+              method: options.method ?? "GET",
+              url: String(url),
+            });
+            return Response.json(responses.shift(), { status: 200 });
+          },
+        },
+      );
+      assert.deepStrictEqual(evidence, {
+        authority: "https://api.slop.cash",
+        serverRunId,
+        objectId: `sha256:${digest}`,
+        sha256: digest,
+      });
+      assert.deepStrictEqual(
+        requests.map(({ method, url }) => ({
+          method,
+          path: new URL(url).pathname,
+        })),
+        [
+          { method: "GET", path: "/api/v1/private-request-intake" },
+          { method: "POST", path: "/api/v1/auth/session" },
+          { method: "POST", path: "/api/v1/runs" },
+          { method: "POST", path: `/api/v1/runs/${serverRunId}/finalize` },
+        ],
+      );
+    } finally {
+      rmSync(fixtureRoot, { force: true, recursive: true });
+    }
+  });
+
   it("reports private intake rate-limit reset before authorization", async () => {
     const fixtureRoot = mkdtempSync(join(tmpdir(), "slop-trace-intake-rate-"));
     try {

--- a/skills/contribute-to-asi/SKILL.md
+++ b/skills/contribute-to-asi/SKILL.md
@@ -535,8 +535,9 @@ node <skill-directory>/scripts/wallet-claim.mjs register --address <public-addre
    Slop bearer token only in process memory. It prints the immutable claim ID,
    record digest, and public metadata URL—never a credential.
 5. An address change appends a new claim linked to the current claim; it never
-   edits or deletes history. The change is material and restarts that
-   allocation's 14-day review.
+   edits or deletes history. A claim observed after a proposal is generated
+   applies to the next cycle; it never modifies that proposal or restarts its
+   14-day review, and the row stays unclaimed and carries forward.
 
 A claim identifies where a reviewed payout may go. It does not prove custody,
 guarantee payment, approve an allocation, connect a wallet, or move funds.

--- a/skills/contribute-to-asi/scripts/live-report.mjs
+++ b/skills/contribute-to-asi/scripts/live-report.mjs
@@ -31,9 +31,24 @@ export const REVIEW_EPOCH_SCHEMA_VERSION = 1;
 export const MAX_REVIEW_EPOCH_FILE_BYTES = 262_144;
 export const MAX_API_READS = 16;
 export const MAX_ACTIVITY_CONNECTION_ITEMS = 1_000;
+// Large repositories can legitimately exceed Node's 64 MiB spawnSync default
+// after gh concatenates bounded pages. Keep one explicit ceiling high enough
+// for the 10,000-item inventory while still failing closed on runaway output.
+export const MAX_GH_REPORT_BYTES = 256 * 1024 * 1024;
 export const MIN_GRAPHQL_ACTIVITY_POINTS = 1_000;
 export const MIN_REST_ACTIVITY_REQUESTS = 100;
 export const MIN_SEARCH_ACTIVITY_REQUESTS = 2;
+export const MAX_LIVE_INVENTORY_ATTEMPTS = 2;
+
+export class LiveInventoryChangedError extends Error {
+  constructor(
+    message = "batched activity does not exactly match the live open-item inventory",
+    options,
+  ) {
+    super(message, options);
+    this.name = "LiveInventoryChangedError";
+  }
+}
 
 const REPOSITORY_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const PLACEHOLDER_RE =
@@ -748,7 +763,7 @@ export function readGhPages(endpoint, spawn = spawnSync) {
   ];
   const result = spawn("gh", args, {
     encoding: "utf8",
-    maxBuffer: 64 * 1024 * 1024,
+    maxBuffer: MAX_GH_REPORT_BYTES,
     windowsHide: true,
   });
   if (result.error) throw result.error;
@@ -959,7 +974,7 @@ function readGhActivityPage(endpoint, pageNumber, context, spawn) {
     ["api", "--method", "GET", "--jq", ".[]", pagedEndpoint],
     {
       encoding: "utf8",
-      maxBuffer: 64 * 1024 * 1024,
+      maxBuffer: MAX_GH_REPORT_BYTES,
       windowsHide: true,
     },
   );
@@ -1051,7 +1066,7 @@ function readGhSearchPullNumbers(repo, qualifier, spawn) {
     ],
     {
       encoding: "utf8",
-      maxBuffer: 64 * 1024 * 1024,
+      maxBuffer: MAX_GH_REPORT_BYTES,
       windowsHide: true,
     },
   );
@@ -1274,7 +1289,7 @@ function readGraphqlActivityNodes(repo, query, selector, spawn, context) {
     ],
     {
       encoding: "utf8",
-      maxBuffer: 64 * 1024 * 1024,
+      maxBuffer: MAX_GH_REPORT_BYTES,
       windowsHide: true,
     },
   );
@@ -2239,9 +2254,7 @@ export function collectLiveReport(
       [...issueNumbers].some((number) => !activity.issues.has(number)) ||
       [...pullNumbers].some((number) => !activity.pulls.has(number))
     ) {
-      throw new TypeError(
-        "batched activity does not exactly match the live open-item inventory",
-      );
+      throw new LiveInventoryChangedError();
     }
   }
   onProgress({ phase: "issues", current: 0, total: issueItems.length });
@@ -2744,6 +2757,25 @@ Options:
 `;
 }
 
+/** Repeats one complete read when GitHub changes its open-item inventory mid-snapshot. */
+export function retryChangedLiveInventory(collect, onRetry = () => {}) {
+  for (let attempt = 1; attempt <= MAX_LIVE_INVENTORY_ATTEMPTS; attempt += 1) {
+    try {
+      return collect(attempt);
+    } catch (cause) {
+      if (!(cause instanceof LiveInventoryChangedError)) throw cause;
+      if (attempt === MAX_LIVE_INVENTORY_ATTEMPTS) {
+        throw new LiveInventoryChangedError(
+          `Open GitHub inventory changed while collecting the live report after ${MAX_LIVE_INVENTORY_ATTEMPTS} attempts`,
+          { cause },
+        );
+      }
+      onRetry({ attempt, cause });
+    }
+  }
+  throw new Error("unreachable live inventory retry state");
+}
+
 export function main(args = process.argv.slice(2)) {
   const selectionPolicy = readProjectSelectionPolicy();
   const options = parseCliArguments(args, selectionPolicy.repositoryId);
@@ -2779,26 +2811,40 @@ export function main(args = process.argv.slice(2)) {
   const boundedRead = (endpoint) => {
     return readGhPages(endpoint, commandBudget.run);
   };
-  const openActivity = readGhOpenActivity(options.repo, commandBudget.run, {
-    preflight: true,
-  });
-  const limits = asRecord(openActivity.rateLimits, "GitHub rate limits");
-  process.stderr.write(
-    `[Slop] GitHub budgets: GraphQL ${limits.graphqlRemaining}/${limits.graphqlLimit} (${limits.graphqlBudgetSource}); REST ${limits.restRemaining}/${limits.restLimit}; Search ${limits.searchRemaining}/${limits.searchLimit}; activity source ${openActivity.source}\n`,
-  );
-  const report = collectLiveReport(
-    options.repo,
-    boundedRead,
-    new Date(),
-    ({ phase, current, total }) => {
-      if (current === 0 || current === total || current % 10 === 0) {
-        process.stderr.write(
-          `[Slop] scanning ${phase}: ${current}/${total} (${commandBudget.count} bounded GitHub commands)\n`,
-        );
-      }
+  let rateLimits = { preflight: true };
+  const { report } = retryChangedLiveInventory(
+    () => {
+      const openActivity = readGhOpenActivity(
+        options.repo,
+        commandBudget.run,
+        rateLimits,
+      );
+      rateLimits = openActivity.rateLimits;
+      const limits = asRecord(openActivity.rateLimits, "GitHub rate limits");
+      process.stderr.write(
+        `[Slop] GitHub budgets: GraphQL ${limits.graphqlRemaining}/${limits.graphqlLimit} (${limits.graphqlBudgetSource}); REST ${limits.restRemaining}/${limits.restLimit}; Search ${limits.searchRemaining}/${limits.searchLimit}; activity source ${openActivity.source}\n`,
+      );
+      return {
+        report: collectLiveReport(
+          options.repo,
+          boundedRead,
+          new Date(),
+          ({ phase, current, total }) => {
+            if (current === 0 || current === total || current % 10 === 0) {
+              process.stderr.write(
+                `[Slop] scanning ${phase}: ${current}/${total} (${commandBudget.count} bounded GitHub commands)\n`,
+              );
+            }
+          },
+          openActivity,
+          selectionPolicy.eligibleIssueLabels,
+        ),
+      };
     },
-    openActivity,
-    selectionPolicy.eligibleIssueLabels,
+    ({ attempt }) =>
+      process.stderr.write(
+        `[Slop] open-item inventory changed during snapshot attempt ${attempt}; retrying one complete read\n`,
+      ),
   );
   process.stdout.write(
     options.epochOnly

--- a/skills/contribute-to-asi/scripts/live-report.mjs
+++ b/skills/contribute-to-asi/scripts/live-report.mjs
@@ -5,20 +5,22 @@
  * adapter; GraphQL uses explicit read-only queries over GitHub's POST endpoint.
  */
 
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { createHash, randomBytes } from "node:crypto";
 import {
   existsSync,
+  lstatSync,
   mkdirSync,
   readFileSync,
+  readdirSync,
   realpathSync,
   renameSync,
   rmSync,
   statSync,
   writeFileSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { platform, userInfo } from "node:os";
+import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 export const MODEL_DISCLOSURE_PREFIX = "AI provider/model:";
@@ -46,9 +48,14 @@ export const MIN_GRAPHQL_ACTIVITY_POINTS = 1_000;
 export const MIN_REST_ACTIVITY_REQUESTS = 100;
 export const MIN_SEARCH_ACTIVITY_REQUESTS = 2;
 
-const LIVE_REPORT_LOCK_DIRECTORY = "slop-live-report-locks-v1";
+const LIVE_REPORT_LOCK_DIRECTORY = "slop-live-report-locks-v2";
 const LIVE_REPORT_LOCK_OWNER_FILE = "owner.json";
+const LIVE_REPORT_LOCK_COMMAND_DIRECTORY = "commands";
 const LIVE_REPORT_LOCK_ACQUIRE_ATTEMPTS = 8;
+const LIVE_REPORT_ORPHAN_COMMAND_GRACE_MS = 5 * 60 * 1_000;
+const LIVE_REPORT_LOCKED_GH_ARGUMENT = "--slop-internal-locked-gh-v1";
+const LIVE_REPORT_PROCESS_IDENTITY_RE = /^[a-f0-9]{64}$/u;
+const LIVE_REPORT_TOKEN_RE = /^[a-f0-9]{32}$/u;
 
 const REPOSITORY_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const PLACEHOLDER_RE =
@@ -1332,7 +1339,16 @@ export class LiveReportLockContentionError extends Error {
 export function readGhAuthenticatedIdentity(spawn = spawnSync) {
   const result = spawn(
     "gh",
-    ["api", "--method", "GET", "--jq", "{id: .id, login: .login}", "user"],
+    [
+      "api",
+      "--hostname",
+      "github.com",
+      "--method",
+      "GET",
+      "--jq",
+      "{id: .id, login: .login}",
+      "user",
+    ],
     {
       encoding: "utf8",
       maxBuffer: 1024 * 1024,
@@ -1364,46 +1380,13 @@ export function readGhAuthenticatedIdentity(spawn = spawnSync) {
   if (id <= 0 || login.length === 0) {
     throw new TypeError("GitHub authenticated identity is invalid");
   }
-  return { id, login };
+  return { host: "github.com", id, login };
 }
 
 function fileSystemErrorCode(error) {
   return error && typeof error === "object" && "code" in error
     ? error.code
     : null;
-}
-
-function readLiveReportLockOwner(lockPath) {
-  try {
-    const owner = asRecord(
-      JSON.parse(
-        readFileSync(join(lockPath, LIVE_REPORT_LOCK_OWNER_FILE), "utf8"),
-      ),
-      "live report lock owner",
-    );
-    const schemaVersion = asNumberField(
-      owner,
-      "schemaVersion",
-      "live report lock owner",
-    );
-    const pid = asNumberField(owner, "pid", "live report lock owner");
-    const ownerToken = asStringField(
-      owner,
-      "ownerToken",
-      "live report lock owner",
-    );
-    if (
-      schemaVersion !== 1 ||
-      pid <= 0 ||
-      !/^[a-f0-9]{32}$/u.test(ownerToken)
-    ) {
-      return null;
-    }
-    return { pid, ownerToken };
-  } catch {
-    // error-policy:J3 A corrupt or incomplete lease cannot claim live ownership.
-    return null;
-  }
 }
 
 function processIsRunning(pid) {
@@ -1417,19 +1400,249 @@ function processIsRunning(pid) {
   }
 }
 
-function lockOwnerIsActive(owner) {
-  return owner !== null && processIsRunning(owner.pid);
+function hashProcessIdentity(value) {
+  return createHash("sha256").update(value).digest("hex");
 }
 
-function prepareLiveReportLockCandidate(lockPath, ownerToken) {
+export function readLiveReportProcessIdentity(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    throw new TypeError("live report process ID must be a positive integer");
+  }
+  if (!processIsRunning(pid)) return null;
+  const operatingSystem = platform();
+  if (operatingSystem === "linux") {
+    let source;
+    try {
+      source = readFileSync(`/proc/${pid}/stat`, "utf8");
+    } catch (error) {
+      if (fileSystemErrorCode(error) === "ENOENT") return null;
+      throw error;
+    }
+    const commandEnd = source.lastIndexOf(")");
+    const fields = source
+      .slice(commandEnd + 2)
+      .trim()
+      .split(/\s+/u);
+    const startTime = fields[19];
+    if (commandEnd < 1 || !/^\d+$/u.test(startTime ?? "")) {
+      throw new TypeError("Linux returned an invalid process birth identity");
+    }
+    return hashProcessIdentity(`linux:${startTime}`);
+  }
+  if (
+    operatingSystem === "darwin" ||
+    operatingSystem === "freebsd" ||
+    operatingSystem === "openbsd"
+  ) {
+    const result = spawnSync(
+      existsSync("/bin/ps") ? "/bin/ps" : "ps",
+      ["-o", "lstart=", "-p", String(pid)],
+      { encoding: "utf8", maxBuffer: 64 * 1024, windowsHide: true },
+    );
+    if (result.error) throw result.error;
+    if (result.status !== 0 || result.stdout.trim() === "") {
+      if (!processIsRunning(pid)) return null;
+      throw new Error("could not read the process birth identity from ps");
+    }
+    return hashProcessIdentity(`${operatingSystem}:${result.stdout.trim()}`);
+  }
+  if (operatingSystem === "win32") {
+    const result = spawnSync(
+      "powershell.exe",
+      [
+        "-NoLogo",
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        `(Get-Process -Id ${pid} -ErrorAction Stop).StartTime.ToUniversalTime().Ticks`,
+      ],
+      { encoding: "utf8", maxBuffer: 64 * 1024, windowsHide: true },
+    );
+    if (result.error) throw result.error;
+    if (result.status !== 0 || !/^\d+$/u.test(result.stdout.trim())) {
+      if (!processIsRunning(pid)) return null;
+      throw new Error("could not read the Windows process birth identity");
+    }
+    return hashProcessIdentity(`win32:${result.stdout.trim()}`);
+  }
+  throw new Error(
+    `live report locking does not support process identity on ${operatingSystem}`,
+  );
+}
+
+function readProcessLease(value, context) {
+  const record = asRecord(value, context);
+  const pid = asNumberField(record, "pid", context);
+  const processIdentity = asStringField(record, "processIdentity", context);
+  if (
+    !Number.isInteger(pid) ||
+    pid <= 0 ||
+    !LIVE_REPORT_PROCESS_IDENTITY_RE.test(processIdentity)
+  ) {
+    throw new TypeError(`${context} is invalid`);
+  }
+  return { pid, processIdentity };
+}
+
+function processLeaseIsActive(lease) {
+  const currentIdentity = readLiveReportProcessIdentity(lease.pid);
+  return currentIdentity !== null && currentIdentity === lease.processIdentity;
+}
+
+export function defaultLiveReportLockRoot() {
+  const uid = typeof process.getuid === "function" ? process.getuid() : null;
+  if (Number.isInteger(uid) && uid >= 0) {
+    return join("/tmp", `${LIVE_REPORT_LOCK_DIRECTORY}-${uid}`);
+  }
+  const identity = userInfo();
+  const key = createHash("sha256")
+    .update(`${identity.username}\0${identity.homedir}`)
+    .digest("hex")
+    .slice(0, 16);
+  return join(identity.homedir, `.${LIVE_REPORT_LOCK_DIRECTORY}-${key}`);
+}
+
+export function ensureLiveReportLockRoot(
+  rootPath = defaultLiveReportLockRoot(),
+) {
+  try {
+    mkdirSync(rootPath, { mode: 0o700 });
+  } catch (error) {
+    if (fileSystemErrorCode(error) !== "EEXIST") throw error;
+  }
+  const stats = lstatSync(rootPath);
+  if (stats.isSymbolicLink() || !stats.isDirectory()) {
+    throw new TypeError("live report lock root must be a real directory");
+  }
+  const uid = typeof process.getuid === "function" ? process.getuid() : null;
+  if (Number.isInteger(uid) && stats.uid !== uid) {
+    throw new TypeError(
+      "live report lock root must belong to the current user",
+    );
+  }
+  if (platform() !== "win32" && (stats.mode & 0o077) !== 0) {
+    throw new TypeError("live report lock root permissions must be 0700");
+  }
+  return rootPath;
+}
+
+function readLiveReportLockOwner(lockPath) {
+  let source;
+  try {
+    source = readFileSync(join(lockPath, LIVE_REPORT_LOCK_OWNER_FILE), "utf8");
+  } catch (error) {
+    if (fileSystemErrorCode(error) === "ENOENT") return null;
+    throw error;
+  }
+  const owner = asRecord(JSON.parse(source), "live report lock owner");
+  const schemaVersion = asNumberField(
+    owner,
+    "schemaVersion",
+    "live report lock owner",
+  );
+  const processLease = readProcessLease(owner, "live report lock owner");
+  const ownerToken = asStringField(
+    owner,
+    "ownerToken",
+    "live report lock owner",
+  );
+  if (schemaVersion !== 2 || !LIVE_REPORT_TOKEN_RE.test(ownerToken)) {
+    throw new TypeError("live report lock owner is invalid");
+  }
+  return { ...processLease, ownerToken };
+}
+
+function liveReportCommandDirectory(lockPath) {
+  return join(lockPath, LIVE_REPORT_LOCK_COMMAND_DIRECTORY);
+}
+
+function readLiveReportCommandLease(path) {
+  const record = asRecord(
+    JSON.parse(readFileSync(path, "utf8")),
+    "live report command lease",
+  );
+  const schemaVersion = asNumberField(
+    record,
+    "schemaVersion",
+    "live report command lease",
+  );
+  const ownerToken = asStringField(
+    record,
+    "ownerToken",
+    "live report command lease",
+  );
+  const startedAtMs = asNumberField(
+    record,
+    "startedAtMs",
+    "live report command lease",
+  );
+  const helper = readProcessLease(record.helper, "live report command helper");
+  const child =
+    record.child === null
+      ? null
+      : readProcessLease(record.child, "live report GitHub child");
+  if (
+    schemaVersion !== 1 ||
+    !LIVE_REPORT_TOKEN_RE.test(ownerToken) ||
+    !Number.isSafeInteger(startedAtMs) ||
+    startedAtMs <= 0
+  ) {
+    throw new TypeError("live report command lease is invalid");
+  }
+  return { child, helper, ownerToken, startedAtMs };
+}
+
+function liveReportCommandIsActive(lease, ownerToken) {
+  if (lease.ownerToken !== ownerToken) {
+    throw new TypeError("live report command lease owner does not match");
+  }
+  if (processLeaseIsActive(lease.helper)) return true;
+  if (lease.child !== null && processLeaseIsActive(lease.child)) return true;
+  return Date.now() - lease.startedAtMs < LIVE_REPORT_ORPHAN_COMMAND_GRACE_MS;
+}
+
+function liveReportHasActiveCommand(lockPath, ownerToken) {
+  const commandDirectory = liveReportCommandDirectory(lockPath);
+  let entries;
+  try {
+    entries = readdirSync(commandDirectory, { withFileTypes: true });
+  } catch (error) {
+    if (fileSystemErrorCode(error) === "ENOENT" && !existsSync(lockPath)) {
+      return false;
+    }
+    throw error;
+  }
+  for (const entry of entries) {
+    if (entry.isSymbolicLink() || (!entry.isFile() && !entry.isDirectory())) {
+      throw new TypeError("live report command directory is invalid");
+    }
+    if (!/^lease-[a-f0-9]{32}\.json$/u.test(entry.name)) continue;
+    const lease = readLiveReportCommandLease(
+      join(commandDirectory, entry.name),
+    );
+    if (liveReportCommandIsActive(lease, ownerToken)) return true;
+  }
+  return false;
+}
+
+function assertLiveReportLockDirectory(lockPath) {
+  const stats = lstatSync(lockPath);
+  if (stats.isSymbolicLink() || !stats.isDirectory()) {
+    throw new TypeError("live report lock must be a real directory");
+  }
+}
+
+function prepareLiveReportLockCandidate(lockPath, ownerToken, processIdentity) {
   const candidatePath = `${lockPath}.candidate-${process.pid}-${ownerToken}`;
   mkdirSync(candidatePath, { mode: 0o700 });
   try {
+    mkdirSync(liveReportCommandDirectory(candidatePath), { mode: 0o700 });
     writeFileSync(
       join(candidatePath, LIVE_REPORT_LOCK_OWNER_FILE),
       `${JSON.stringify({
-        schemaVersion: 1,
+        schemaVersion: 2,
         pid: process.pid,
+        processIdentity,
         ownerToken,
       })}\n`,
       { flag: "wx", mode: 0o600 },
@@ -1441,25 +1654,113 @@ function prepareLiveReportLockCandidate(lockPath, ownerToken) {
   }
 }
 
-export function acquireLiveReportLock(identity) {
+function liveReportLockKey(identity) {
+  return createHash("sha256")
+    .update(`${identity.host}:${identity.id}`)
+    .digest("hex");
+}
+
+function writeLiveReportCommandLease(path, lease, replace = false) {
+  if (!replace) {
+    writeFileSync(path, `${JSON.stringify(lease)}\n`, {
+      flag: "wx",
+      mode: 0o600,
+    });
+    return;
+  }
+  const nextPath = `${path}.next-${process.pid}-${randomBytes(16).toString("hex")}`;
+  try {
+    writeFileSync(nextPath, `${JSON.stringify(lease)}\n`, {
+      flag: "wx",
+      mode: 0o600,
+    });
+    renameSync(nextPath, path);
+  } catch (error) {
+    rmSync(nextPath, { force: true });
+    throw error;
+  }
+}
+
+function spawnLockedGh(lockPath, ownerToken, command, args, options = {}) {
+  if (
+    command !== "gh" ||
+    !Array.isArray(args) ||
+    args.some((argument) => typeof argument !== "string")
+  ) {
+    throw new TypeError("live report lock may execute only a gh argument list");
+  }
+  if (options.encoding !== undefined && options.encoding !== "utf8") {
+    throw new TypeError("live report gh commands require utf8 output");
+  }
+  const maxBuffer = options.maxBuffer ?? 1024 * 1024;
+  if (
+    !Number.isSafeInteger(maxBuffer) ||
+    maxBuffer <= 0 ||
+    maxBuffer > 256 * 1024 * 1024
+  ) {
+    throw new RangeError("live report gh command maxBuffer is invalid");
+  }
+  const commandToken = randomBytes(16).toString("hex");
+  const requestPath = join(
+    liveReportCommandDirectory(lockPath),
+    `request-${commandToken}.json`,
+  );
+  writeFileSync(
+    requestPath,
+    `${JSON.stringify({ args, maxBuffer, ownerToken, schemaVersion: 1 })}\n`,
+    { flag: "wx", mode: 0o600 },
+  );
+  try {
+    return spawnSync(
+      process.execPath,
+      [
+        fileURLToPath(import.meta.url),
+        LIVE_REPORT_LOCKED_GH_ARGUMENT,
+        lockPath,
+        ownerToken,
+        commandToken,
+      ],
+      {
+        encoding: "utf8",
+        env: { ...(options.env ?? process.env), GH_HOST: "github.com" },
+        maxBuffer: Math.min(maxBuffer + 1024 * 1024, 256 * 1024 * 1024),
+        windowsHide: true,
+      },
+    );
+  } finally {
+    rmSync(requestPath, { force: true });
+  }
+}
+
+export function acquireLiveReportLock(identity, options = {}) {
   const record = asRecord(identity, "GitHub authenticated identity");
   const id = asNumberField(record, "id", "GitHub authenticated identity");
   const login = asStringField(record, "login", "GitHub authenticated identity");
-  if (id <= 0 || login.length === 0) {
+  const host = asStringField(record, "host", "GitHub authenticated identity");
+  if (id <= 0 || login.length === 0 || host !== "github.com") {
     throw new TypeError("GitHub authenticated identity is invalid");
   }
-  const root = join(tmpdir(), LIVE_REPORT_LOCK_DIRECTORY);
-  mkdirSync(root, { mode: 0o700, recursive: true });
-  const key = createHash("sha256").update(`github.com:${id}`).digest("hex");
+  const root = ensureLiveReportLockRoot(
+    options.rootPath ?? defaultLiveReportLockRoot(),
+  );
+  const key = liveReportLockKey({ host, id });
   const lockPath = join(root, `${key}.lock`);
   const ownerToken = randomBytes(16).toString("hex");
+  const processIdentity = readLiveReportProcessIdentity(process.pid);
+  if (processIdentity === null) {
+    throw new Error("could not establish the live report process identity");
+  }
   let acquired = false;
   for (
     let attempt = 0;
     attempt < LIVE_REPORT_LOCK_ACQUIRE_ATTEMPTS;
     attempt += 1
   ) {
-    const candidatePath = prepareLiveReportLockCandidate(lockPath, ownerToken);
+    const candidatePath = prepareLiveReportLockCandidate(
+      lockPath,
+      ownerToken,
+      processIdentity,
+    );
     try {
       renameSync(candidatePath, lockPath);
       acquired = true;
@@ -1470,8 +1771,16 @@ export function acquireLiveReportLock(identity) {
         if (fileSystemErrorCode(error) === "ENOENT") continue;
         throw error;
       }
+      assertLiveReportLockDirectory(lockPath);
       const currentOwner = readLiveReportLockOwner(lockPath);
-      if (lockOwnerIsActive(currentOwner)) {
+      if (currentOwner === null) {
+        if (!existsSync(lockPath)) continue;
+        throw new Error("live report lock owner is missing");
+      }
+      if (
+        processLeaseIsActive(currentOwner) ||
+        liveReportHasActiveCommand(lockPath, currentOwner.ownerToken)
+      ) {
         throw new LiveReportLockContentionError();
       }
       const stalePath = `${lockPath}.stale-${process.pid}-${randomBytes(16).toString("hex")}`;
@@ -1489,12 +1798,16 @@ export function acquireLiveReportLock(identity) {
   }
   let released = false;
   return {
+    spawn(command, args, options) {
+      return spawnLockedGh(lockPath, ownerToken, command, args, options);
+    },
     release() {
       if (released) return;
       const owner = readLiveReportLockOwner(lockPath);
       if (
         owner === null ||
         owner.pid !== process.pid ||
+        owner.processIdentity !== processIdentity ||
         owner.ownerToken !== ownerToken
       ) {
         throw new Error("live report lock ownership changed before release");
@@ -1505,6 +1818,173 @@ export function acquireLiveReportLock(identity) {
       released = true;
     },
   };
+}
+
+function readLockedGhRequest(lockPath, ownerToken, commandToken) {
+  if (
+    !LIVE_REPORT_TOKEN_RE.test(ownerToken) ||
+    !LIVE_REPORT_TOKEN_RE.test(commandToken)
+  ) {
+    throw new TypeError("locked GitHub command tokens are invalid");
+  }
+  const root = ensureLiveReportLockRoot();
+  if (
+    dirname(lockPath) !== root ||
+    !/^[a-f0-9]{64}\.lock$/u.test(basename(lockPath))
+  ) {
+    throw new TypeError("locked GitHub command path is invalid");
+  }
+  assertLiveReportLockDirectory(lockPath);
+  const owner = readLiveReportLockOwner(lockPath);
+  if (owner === null || owner.ownerToken !== ownerToken) {
+    throw new Error("live report lock ownership changed before GitHub command");
+  }
+  const requestPath = join(
+    liveReportCommandDirectory(lockPath),
+    `request-${commandToken}.json`,
+  );
+  const request = asRecord(
+    JSON.parse(readFileSync(requestPath, "utf8")),
+    "locked GitHub command request",
+  );
+  const schemaVersion = asNumberField(
+    request,
+    "schemaVersion",
+    "locked GitHub command request",
+  );
+  const requestOwnerToken = asStringField(
+    request,
+    "ownerToken",
+    "locked GitHub command request",
+  );
+  const maxBuffer = asNumberField(
+    request,
+    "maxBuffer",
+    "locked GitHub command request",
+  );
+  if (
+    schemaVersion !== 1 ||
+    requestOwnerToken !== ownerToken ||
+    !Number.isSafeInteger(maxBuffer) ||
+    maxBuffer <= 0 ||
+    maxBuffer > 256 * 1024 * 1024 ||
+    !Array.isArray(request.args) ||
+    request.args.some((argument) => typeof argument !== "string")
+  ) {
+    throw new TypeError("locked GitHub command request is invalid");
+  }
+  return { args: request.args, maxBuffer, requestPath };
+}
+
+function collectBoundedGhChild(child, maxBuffer) {
+  return new Promise((resolvePromise) => {
+    const stdout = [];
+    const stderr = [];
+    let stdoutBytes = 0;
+    let stderrBytes = 0;
+    let overflow = null;
+    let spawnError = null;
+    const collect = (chunks, chunk, stream) => {
+      if (overflow !== null) return;
+      const value = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      if (stream === "stdout") stdoutBytes += value.length;
+      else stderrBytes += value.length;
+      if (stdoutBytes > maxBuffer || stderrBytes > maxBuffer) {
+        overflow = stream;
+        child.kill("SIGTERM");
+        return;
+      }
+      chunks.push(value);
+    };
+    child.stdout.on("data", (chunk) => collect(stdout, chunk, "stdout"));
+    child.stderr.on("data", (chunk) => collect(stderr, chunk, "stderr"));
+    child.once("error", (error) => {
+      spawnError = error;
+    });
+    child.once("close", (status, signal) => {
+      resolvePromise({
+        error: spawnError,
+        overflow,
+        signal,
+        status,
+        stderr: Buffer.concat(stderr),
+        stdout: Buffer.concat(stdout),
+      });
+    });
+  });
+}
+
+function writeProcessDescriptor(descriptor, value) {
+  if (value.length === 0) return;
+  try {
+    writeFileSync(descriptor, value);
+  } catch (error) {
+    if (fileSystemErrorCode(error) !== "EPIPE") throw error;
+  }
+}
+
+async function runLockedGhCommand(lockPath, ownerToken, commandToken) {
+  const request = readLockedGhRequest(lockPath, ownerToken, commandToken);
+  const leasePath = join(
+    liveReportCommandDirectory(lockPath),
+    `lease-${commandToken}.json`,
+  );
+  const helperIdentity = readLiveReportProcessIdentity(process.pid);
+  if (helperIdentity === null) {
+    throw new Error("could not establish the GitHub command helper identity");
+  }
+  const lease = {
+    schemaVersion: 1,
+    ownerToken,
+    startedAtMs: Date.now(),
+    helper: { pid: process.pid, processIdentity: helperIdentity },
+    child: null,
+  };
+  writeLiveReportCommandLease(leasePath, lease);
+  let result;
+  try {
+    const currentOwner = readLiveReportLockOwner(lockPath);
+    if (currentOwner === null || currentOwner.ownerToken !== ownerToken) {
+      throw new Error(
+        "live report lock ownership changed while starting GitHub command",
+      );
+    }
+    const child = spawn("gh", request.args, {
+      env: { ...process.env, GH_HOST: "github.com" },
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+    });
+    const childResult = collectBoundedGhChild(child, request.maxBuffer);
+    if (Number.isInteger(child.pid) && child.pid > 0) {
+      const childIdentity = readLiveReportProcessIdentity(child.pid);
+      if (childIdentity !== null) {
+        writeLiveReportCommandLease(
+          leasePath,
+          {
+            ...lease,
+            child: { pid: child.pid, processIdentity: childIdentity },
+          },
+          true,
+        );
+      }
+    }
+    result = await childResult;
+  } finally {
+    rmSync(leasePath, { force: true });
+    rmSync(request.requestPath, { force: true });
+  }
+  if (result.error) throw result.error;
+  if (result.overflow !== null) {
+    throw new RangeError(
+      `spawn gh ${result.overflow} exceeded the bounded output buffer`,
+    );
+  }
+  writeProcessDescriptor(1, result.stdout);
+  writeProcessDescriptor(2, result.stderr);
+  if (result.status === null) {
+    throw new Error(`gh terminated by ${result.signal ?? "an unknown signal"}`);
+  }
+  process.exitCode = result.status;
 }
 
 function rateResource(value, context) {
@@ -2964,8 +3444,8 @@ export function main(args = process.argv.slice(2)) {
     if (!result.complete) process.exitCode = 2;
     return;
   }
-  const commandBudget = createGhCommandBudget();
   if (options.recheckPr !== undefined) {
+    const commandBudget = createGhCommandBudget();
     const result = recheckLivePullHead(
       options.repo,
       {
@@ -2978,12 +3458,13 @@ export function main(args = process.argv.slice(2)) {
     if (!result.publishable) process.exitCode = 2;
     return;
   }
-  const boundedRead = (endpoint) => {
-    return readGhPages(endpoint, commandBudget.run);
-  };
   const authenticatedIdentity = readGhAuthenticatedIdentity();
   const liveReportLock = acquireLiveReportLock(authenticatedIdentity);
   try {
+    const commandBudget = createGhCommandBudget(liveReportLock.spawn);
+    const boundedRead = (endpoint) => {
+      return readGhPages(endpoint, commandBudget.run);
+    };
     const openActivity = readGhOpenActivity(options.repo, commandBudget.run, {
       preflight: true,
     });
@@ -3024,17 +3505,27 @@ const invokedDirectly =
     realpathSync(process.argv[1]);
 
 if (invokedDirectly) {
-  try {
-    main();
-  } catch (error) {
-    // error-policy:J1 The CLI boundary turns a failed read/audit into a non-zero exit.
-    const message = error instanceof Error ? error.message : String(error);
-    if (error instanceof LiveReportLockContentionError) {
-      process.stderr.write(`Slop live report deferred: ${message}\n`);
-      process.exitCode = 2;
-    } else {
-      process.stderr.write(`Slop live report failed: ${message}\n`);
+  const directArguments = process.argv.slice(2);
+  if (directArguments[0] === LIVE_REPORT_LOCKED_GH_ARGUMENT) {
+    runLockedGhCommand(...directArguments.slice(1)).catch((error) => {
+      // error-policy:J1 The internal process boundary fails the owning report.
+      const message = error instanceof Error ? error.message : String(error);
+      process.stderr.write(`Slop locked GitHub command failed: ${message}\n`);
       process.exitCode = 1;
+    });
+  } else {
+    try {
+      main(directArguments);
+    } catch (error) {
+      // error-policy:J1 The CLI boundary turns a failed read/audit into a non-zero exit.
+      const message = error instanceof Error ? error.message : String(error);
+      if (error instanceof LiveReportLockContentionError) {
+        process.stderr.write(`Slop live report deferred: ${message}\n`);
+        process.exitCode = 2;
+      } else {
+        process.stderr.write(`Slop live report failed: ${message}\n`);
+        process.exitCode = 1;
+      }
     }
   }
 }

--- a/skills/contribute-to-asi/scripts/live-report.mjs
+++ b/skills/contribute-to-asi/scripts/live-report.mjs
@@ -2758,10 +2758,15 @@ Options:
 }
 
 /** Repeats one complete read when GitHub changes its open-item inventory mid-snapshot. */
-export function retryChangedLiveInventory(collect, onRetry = () => {}) {
+export function retryChangedLiveInventory(
+  collect,
+  onRetry = () => {},
+  createCommandBudget = createGhCommandBudget,
+) {
   for (let attempt = 1; attempt <= MAX_LIVE_INVENTORY_ATTEMPTS; attempt += 1) {
+    const commandBudget = createCommandBudget();
     try {
-      return collect(attempt);
+      return collect({ attempt, commandBudget });
     } catch (cause) {
       if (!(cause instanceof LiveInventoryChangedError)) throw cause;
       if (attempt === MAX_LIVE_INVENTORY_ATTEMPTS) {
@@ -2794,8 +2799,8 @@ export function main(args = process.argv.slice(2)) {
     if (!result.complete) process.exitCode = 2;
     return;
   }
-  const commandBudget = createGhCommandBudget();
   if (options.recheckPr !== undefined) {
+    const commandBudget = createGhCommandBudget();
     const result = recheckLivePullHead(
       options.repo,
       {
@@ -2808,12 +2813,12 @@ export function main(args = process.argv.slice(2)) {
     if (!result.publishable) process.exitCode = 2;
     return;
   }
-  const boundedRead = (endpoint) => {
-    return readGhPages(endpoint, commandBudget.run);
-  };
   let rateLimits = { preflight: true };
   const { report } = retryChangedLiveInventory(
-    () => {
+    ({ commandBudget }) => {
+      const boundedRead = (endpoint) => {
+        return readGhPages(endpoint, commandBudget.run);
+      };
       const openActivity = readGhOpenActivity(
         options.repo,
         commandBudget.run,

--- a/skills/contribute-to-asi/scripts/live-report.mjs
+++ b/skills/contribute-to-asi/scripts/live-report.mjs
@@ -3,6 +3,7 @@
  * Builds a stable, read-only inventory of open elizaOS issues and pull requests
  * for contribution selection. REST pagination stays behind one GET-only
  * adapter; GraphQL uses explicit read-only queries over GitHub's POST endpoint.
+ * A user-private process lease serializes complete discovery across skill copies.
  */
 
 import { spawn, spawnSync } from "node:child_process";
@@ -11,8 +12,8 @@ import {
   existsSync,
   lstatSync,
   mkdirSync,
-  readFileSync,
   readdirSync,
+  readFileSync,
   realpathSync,
   renameSync,
   rmSync,
@@ -1389,6 +1390,23 @@ function fileSystemErrorCode(error) {
     : null;
 }
 
+function assertLiveReportPrivatePath(path, context, kind) {
+  const stats = lstatSync(path);
+  const kindMatches =
+    kind === "directory" ? stats.isDirectory() : stats.isFile();
+  if (stats.isSymbolicLink() || !kindMatches) {
+    throw new TypeError(`${context} must be a real ${kind}`);
+  }
+  const uid = typeof process.getuid === "function" ? process.getuid() : null;
+  if (Number.isInteger(uid) && stats.uid !== uid) {
+    throw new TypeError(`${context} must belong to the current user`);
+  }
+  if (platform() !== "win32" && (stats.mode & 0o077) !== 0) {
+    throw new TypeError(`${context} permissions must exclude group and others`);
+  }
+  return stats;
+}
+
 function processIsRunning(pid) {
   try {
     process.kill(pid, 0);
@@ -1510,25 +1528,18 @@ export function ensureLiveReportLockRoot(
   } catch (error) {
     if (fileSystemErrorCode(error) !== "EEXIST") throw error;
   }
-  const stats = lstatSync(rootPath);
-  if (stats.isSymbolicLink() || !stats.isDirectory()) {
-    throw new TypeError("live report lock root must be a real directory");
-  }
-  const uid = typeof process.getuid === "function" ? process.getuid() : null;
-  if (Number.isInteger(uid) && stats.uid !== uid) {
-    throw new TypeError(
-      "live report lock root must belong to the current user",
-    );
-  }
-  if (platform() !== "win32" && (stats.mode & 0o077) !== 0) {
-    throw new TypeError("live report lock root permissions must be 0700");
-  }
+  assertLiveReportPrivatePath(rootPath, "live report lock root", "directory");
   return rootPath;
 }
 
 function readLiveReportLockOwner(lockPath) {
   let source;
   try {
+    assertLiveReportPrivatePath(
+      join(lockPath, LIVE_REPORT_LOCK_OWNER_FILE),
+      "live report lock owner",
+      "file",
+    );
     source = readFileSync(join(lockPath, LIVE_REPORT_LOCK_OWNER_FILE), "utf8");
   } catch (error) {
     if (fileSystemErrorCode(error) === "ENOENT") return null;
@@ -1557,6 +1568,7 @@ function liveReportCommandDirectory(lockPath) {
 }
 
 function readLiveReportCommandLease(path) {
+  assertLiveReportPrivatePath(path, "live report command lease", "file");
   const record = asRecord(
     JSON.parse(readFileSync(path, "utf8")),
     "live report command lease",
@@ -1605,6 +1617,11 @@ function liveReportHasActiveCommand(lockPath, ownerToken) {
   const commandDirectory = liveReportCommandDirectory(lockPath);
   let entries;
   try {
+    assertLiveReportPrivatePath(
+      commandDirectory,
+      "live report command directory",
+      "directory",
+    );
     entries = readdirSync(commandDirectory, { withFileTypes: true });
   } catch (error) {
     if (fileSystemErrorCode(error) === "ENOENT" && !existsSync(lockPath)) {
@@ -1613,7 +1630,7 @@ function liveReportHasActiveCommand(lockPath, ownerToken) {
     throw error;
   }
   for (const entry of entries) {
-    if (entry.isSymbolicLink() || (!entry.isFile() && !entry.isDirectory())) {
+    if (!entry.isFile()) {
       throw new TypeError("live report command directory is invalid");
     }
     if (!/^lease-[a-f0-9]{32}\.json$/u.test(entry.name)) continue;
@@ -1626,10 +1643,7 @@ function liveReportHasActiveCommand(lockPath, ownerToken) {
 }
 
 function assertLiveReportLockDirectory(lockPath) {
-  const stats = lstatSync(lockPath);
-  if (stats.isSymbolicLink() || !stats.isDirectory()) {
-    throw new TypeError("live report lock must be a real directory");
-  }
+  assertLiveReportPrivatePath(lockPath, "live report lock", "directory");
 }
 
 function prepareLiveReportLockCandidate(lockPath, ownerToken, processIdentity) {
@@ -1701,6 +1715,11 @@ function spawnLockedGh(lockPath, ownerToken, command, args, options = {}) {
     throw new RangeError("live report gh command maxBuffer is invalid");
   }
   const commandToken = randomBytes(16).toString("hex");
+  assertLiveReportPrivatePath(
+    liveReportCommandDirectory(lockPath),
+    "live report command directory",
+    "directory",
+  );
   const requestPath = join(
     liveReportCommandDirectory(lockPath),
     `request-${commandToken}.json`,
@@ -1827,7 +1846,7 @@ function readLockedGhRequest(lockPath, ownerToken, commandToken) {
   ) {
     throw new TypeError("locked GitHub command tokens are invalid");
   }
-  const root = ensureLiveReportLockRoot();
+  const root = ensureLiveReportLockRoot(dirname(lockPath));
   if (
     dirname(lockPath) !== root ||
     !/^[a-f0-9]{64}\.lock$/u.test(basename(lockPath))
@@ -1842,6 +1861,11 @@ function readLockedGhRequest(lockPath, ownerToken, commandToken) {
   const requestPath = join(
     liveReportCommandDirectory(lockPath),
     `request-${commandToken}.json`,
+  );
+  assertLiveReportPrivatePath(
+    requestPath,
+    "locked GitHub command request",
+    "file",
   );
   const request = asRecord(
     JSON.parse(readFileSync(requestPath, "utf8")),

--- a/skills/contribute-to-asi/scripts/live-report.mjs
+++ b/skills/contribute-to-asi/scripts/live-report.mjs
@@ -6,7 +6,18 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { createHash, randomBytes } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -34,6 +45,10 @@ export const MAX_ACTIVITY_CONNECTION_ITEMS = 1_000;
 export const MIN_GRAPHQL_ACTIVITY_POINTS = 1_000;
 export const MIN_REST_ACTIVITY_REQUESTS = 100;
 export const MIN_SEARCH_ACTIVITY_REQUESTS = 2;
+
+const LIVE_REPORT_LOCK_DIRECTORY = "slop-live-report-locks-v1";
+const LIVE_REPORT_LOCK_OWNER_FILE = "owner.json";
+const LIVE_REPORT_LOCK_ACQUIRE_ATTEMPTS = 8;
 
 const REPOSITORY_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const PLACEHOLDER_RE =
@@ -1301,6 +1316,193 @@ export function createGhCommandBudget(spawn = spawnSync) {
       }
       count += 1;
       return spawn(command, args, options);
+    },
+  };
+}
+
+export class LiveReportLockContentionError extends Error {
+  constructor() {
+    super(
+      "live report lock contention: another report for this GitHub identity is already discovering activity",
+    );
+    this.name = "LiveReportLockContentionError";
+  }
+}
+
+export function readGhAuthenticatedIdentity(spawn = spawnSync) {
+  const result = spawn(
+    "gh",
+    ["api", "--method", "GET", "--jq", "{id: .id, login: .login}", "user"],
+    {
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024,
+      windowsHide: true,
+    },
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const detail =
+      result.stderr.trim().length > 0 ? `: ${result.stderr.trim()}` : "";
+    throw new Error(`gh api failed for authenticated identity${detail}`);
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(result.stdout);
+  } catch (cause) {
+    throw new SyntaxError(
+      "gh api returned malformed JSON for authenticated identity",
+      { cause },
+    );
+  }
+  const identity = asRecord(parsed, "GitHub authenticated identity");
+  const id = asNumberField(identity, "id", "GitHub authenticated identity");
+  const login = asStringField(
+    identity,
+    "login",
+    "GitHub authenticated identity",
+  );
+  if (id <= 0 || login.length === 0) {
+    throw new TypeError("GitHub authenticated identity is invalid");
+  }
+  return { id, login };
+}
+
+function fileSystemErrorCode(error) {
+  return error && typeof error === "object" && "code" in error
+    ? error.code
+    : null;
+}
+
+function readLiveReportLockOwner(lockPath) {
+  try {
+    const owner = asRecord(
+      JSON.parse(
+        readFileSync(join(lockPath, LIVE_REPORT_LOCK_OWNER_FILE), "utf8"),
+      ),
+      "live report lock owner",
+    );
+    const schemaVersion = asNumberField(
+      owner,
+      "schemaVersion",
+      "live report lock owner",
+    );
+    const pid = asNumberField(owner, "pid", "live report lock owner");
+    const ownerToken = asStringField(
+      owner,
+      "ownerToken",
+      "live report lock owner",
+    );
+    if (
+      schemaVersion !== 1 ||
+      pid <= 0 ||
+      !/^[a-f0-9]{32}$/u.test(ownerToken)
+    ) {
+      return null;
+    }
+    return { pid, ownerToken };
+  } catch {
+    // error-policy:J3 A corrupt or incomplete lease cannot claim live ownership.
+    return null;
+  }
+}
+
+function processIsRunning(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (fileSystemErrorCode(error) === "ESRCH") return false;
+    if (fileSystemErrorCode(error) === "EPERM") return true;
+    throw error;
+  }
+}
+
+function lockOwnerIsActive(owner) {
+  return owner !== null && processIsRunning(owner.pid);
+}
+
+function prepareLiveReportLockCandidate(lockPath, ownerToken) {
+  const candidatePath = `${lockPath}.candidate-${process.pid}-${ownerToken}`;
+  mkdirSync(candidatePath, { mode: 0o700 });
+  try {
+    writeFileSync(
+      join(candidatePath, LIVE_REPORT_LOCK_OWNER_FILE),
+      `${JSON.stringify({
+        schemaVersion: 1,
+        pid: process.pid,
+        ownerToken,
+      })}\n`,
+      { flag: "wx", mode: 0o600 },
+    );
+    return candidatePath;
+  } catch (error) {
+    rmSync(candidatePath, { force: true, recursive: true });
+    throw error;
+  }
+}
+
+export function acquireLiveReportLock(identity) {
+  const record = asRecord(identity, "GitHub authenticated identity");
+  const id = asNumberField(record, "id", "GitHub authenticated identity");
+  const login = asStringField(record, "login", "GitHub authenticated identity");
+  if (id <= 0 || login.length === 0) {
+    throw new TypeError("GitHub authenticated identity is invalid");
+  }
+  const root = join(tmpdir(), LIVE_REPORT_LOCK_DIRECTORY);
+  mkdirSync(root, { mode: 0o700, recursive: true });
+  const key = createHash("sha256").update(`github.com:${id}`).digest("hex");
+  const lockPath = join(root, `${key}.lock`);
+  const ownerToken = randomBytes(16).toString("hex");
+  let acquired = false;
+  for (
+    let attempt = 0;
+    attempt < LIVE_REPORT_LOCK_ACQUIRE_ATTEMPTS;
+    attempt += 1
+  ) {
+    const candidatePath = prepareLiveReportLockCandidate(lockPath, ownerToken);
+    try {
+      renameSync(candidatePath, lockPath);
+      acquired = true;
+      break;
+    } catch (error) {
+      rmSync(candidatePath, { force: true, recursive: true });
+      if (!existsSync(lockPath)) {
+        if (fileSystemErrorCode(error) === "ENOENT") continue;
+        throw error;
+      }
+      const currentOwner = readLiveReportLockOwner(lockPath);
+      if (lockOwnerIsActive(currentOwner)) {
+        throw new LiveReportLockContentionError();
+      }
+      const stalePath = `${lockPath}.stale-${process.pid}-${randomBytes(16).toString("hex")}`;
+      try {
+        renameSync(lockPath, stalePath);
+      } catch (renameError) {
+        if (fileSystemErrorCode(renameError) === "ENOENT") continue;
+        throw renameError;
+      }
+      rmSync(stalePath, { force: true, recursive: true });
+    }
+  }
+  if (!acquired) {
+    throw new Error("live report lock changed too often to acquire safely");
+  }
+  let released = false;
+  return {
+    release() {
+      if (released) return;
+      const owner = readLiveReportLockOwner(lockPath);
+      if (
+        owner === null ||
+        owner.pid !== process.pid ||
+        owner.ownerToken !== ownerToken
+      ) {
+        throw new Error("live report lock ownership changed before release");
+      }
+      const releasedPath = `${lockPath}.released-${process.pid}-${ownerToken}`;
+      renameSync(lockPath, releasedPath);
+      rmSync(releasedPath, { force: true, recursive: true });
+      released = true;
     },
   };
 }
@@ -2779,34 +2981,40 @@ export function main(args = process.argv.slice(2)) {
   const boundedRead = (endpoint) => {
     return readGhPages(endpoint, commandBudget.run);
   };
-  const openActivity = readGhOpenActivity(options.repo, commandBudget.run, {
-    preflight: true,
-  });
-  const limits = asRecord(openActivity.rateLimits, "GitHub rate limits");
-  process.stderr.write(
-    `[Slop] GitHub budgets: GraphQL ${limits.graphqlRemaining}/${limits.graphqlLimit} (${limits.graphqlBudgetSource}); REST ${limits.restRemaining}/${limits.restLimit}; Search ${limits.searchRemaining}/${limits.searchLimit}; activity source ${openActivity.source}\n`,
-  );
-  const report = collectLiveReport(
-    options.repo,
-    boundedRead,
-    new Date(),
-    ({ phase, current, total }) => {
-      if (current === 0 || current === total || current % 10 === 0) {
-        process.stderr.write(
-          `[Slop] scanning ${phase}: ${current}/${total} (${commandBudget.count} bounded GitHub commands)\n`,
-        );
-      }
-    },
-    openActivity,
-    selectionPolicy.eligibleIssueLabels,
-  );
-  process.stdout.write(
-    options.epochOnly
-      ? `${JSON.stringify(report.selection.reviewEpoch, null, 2)}\n`
-      : options.json
-        ? `${JSON.stringify(report, null, 2)}\n`
-        : renderMarkdown(report),
-  );
+  const authenticatedIdentity = readGhAuthenticatedIdentity();
+  const liveReportLock = acquireLiveReportLock(authenticatedIdentity);
+  try {
+    const openActivity = readGhOpenActivity(options.repo, commandBudget.run, {
+      preflight: true,
+    });
+    const limits = asRecord(openActivity.rateLimits, "GitHub rate limits");
+    process.stderr.write(
+      `[Slop] GitHub budgets: GraphQL ${limits.graphqlRemaining}/${limits.graphqlLimit} (${limits.graphqlBudgetSource}); REST ${limits.restRemaining}/${limits.restLimit}; Search ${limits.searchRemaining}/${limits.searchLimit}; activity source ${openActivity.source}\n`,
+    );
+    const report = collectLiveReport(
+      options.repo,
+      boundedRead,
+      new Date(),
+      ({ phase, current, total }) => {
+        if (current === 0 || current === total || current % 10 === 0) {
+          process.stderr.write(
+            `[Slop] scanning ${phase}: ${current}/${total} (${commandBudget.count} bounded GitHub commands)\n`,
+          );
+        }
+      },
+      openActivity,
+      selectionPolicy.eligibleIssueLabels,
+    );
+    process.stdout.write(
+      options.epochOnly
+        ? `${JSON.stringify(report.selection.reviewEpoch, null, 2)}\n`
+        : options.json
+          ? `${JSON.stringify(report, null, 2)}\n`
+          : renderMarkdown(report),
+    );
+  } finally {
+    liveReportLock.release();
+  }
 }
 
 const invokedDirectly =
@@ -2821,7 +3029,12 @@ if (invokedDirectly) {
   } catch (error) {
     // error-policy:J1 The CLI boundary turns a failed read/audit into a non-zero exit.
     const message = error instanceof Error ? error.message : String(error);
-    process.stderr.write(`Slop live report failed: ${message}\n`);
-    process.exitCode = 1;
+    if (error instanceof LiveReportLockContentionError) {
+      process.stderr.write(`Slop live report deferred: ${message}\n`);
+      process.exitCode = 2;
+    } else {
+      process.stderr.write(`Slop live report failed: ${message}\n`);
+      process.exitCode = 1;
+    }
   }
 }

--- a/skills/contribute-to-asi/scripts/live-report.mjs
+++ b/skills/contribute-to-asi/scripts/live-report.mjs
@@ -2811,15 +2811,11 @@ export function main(args = process.argv.slice(2)) {
   const boundedRead = (endpoint) => {
     return readGhPages(endpoint, commandBudget.run);
   };
-  let rateLimits = { preflight: true };
   const { report } = retryChangedLiveInventory(
     () => {
-      const openActivity = readGhOpenActivity(
-        options.repo,
-        commandBudget.run,
-        rateLimits,
-      );
-      rateLimits = openActivity.rateLimits;
+      const openActivity = readGhOpenActivity(options.repo, commandBudget.run, {
+        preflight: true,
+      });
       const limits = asRecord(openActivity.rateLimits, "GitHub rate limits");
       process.stderr.write(
         `[Slop] GitHub budgets: GraphQL ${limits.graphqlRemaining}/${limits.graphqlLimit} (${limits.graphqlBudgetSource}); REST ${limits.restRemaining}/${limits.restLimit}; Search ${limits.searchRemaining}/${limits.searchLimit}; activity source ${openActivity.source}\n`,

--- a/skills/contribute-to-asi/scripts/run-receipt.mjs
+++ b/skills/contribute-to-asi/scripts/run-receipt.mjs
@@ -2193,6 +2193,20 @@ function renderResult(result, json) {
   );
 }
 
+const WALLET_CLAIM_SCRIPT = join(scriptDirectory, "wallet-claim.mjs");
+
+/**
+ * One stderr line after a fresh finish for projects that pay a monthly pool.
+ * The run never reads the wallet registry, so it cannot know whether a claim
+ * exists; it only points at the register command and the cut-off rule.
+ */
+function walletNudge() {
+  if (!existsSync(WALLET_CLAIM_SCRIPT)) return;
+  process.stderr.write(
+    `No payout wallet is checked by this run. If none is registered, run: node ${WALLET_CLAIM_SCRIPT} register --address <public-address> (a wallet observed after a proposal is generated applies to the next cycle).\n`,
+  );
+}
+
 function previewRun(options) {
   const provenance = resolveSkillProvenance();
   const repositoryRoot = requireRepository(options.repoRoot);
@@ -2562,6 +2576,7 @@ function finishRun(options, testOptions) {
     },
     options.json,
   );
+  walletNudge();
 }
 
 export async function main(args = process.argv.slice(2), testOptions) {

--- a/skills/contribute-to-asi/scripts/run-receipt.mjs
+++ b/skills/contribute-to-asi/scripts/run-receipt.mjs
@@ -1299,6 +1299,7 @@ export async function slopIdentityAssertion(
   fetchImpl = globalThis.fetch,
   delayImpl = (milliseconds) =>
     new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds)),
+  nowImpl = Date.now,
 ) {
   if (typeof fetchImpl !== "function")
     fail("Slop identity transport is unavailable");
@@ -1348,10 +1349,10 @@ export async function slopIdentityAssertion(
   );
   const expiresAt = Date.parse(started.expiresAt);
   process.stderr.write(
-    `This link expires in ${Math.max(0, Math.round((expiresAt - Date.now()) / 1000))} seconds; authorize promptly.\n`,
+    `This link expires in ${Math.max(0, Math.round((expiresAt - nowImpl()) / 1000))} seconds; authorize promptly.\n`,
   );
   let retryAfterSeconds = started.pollAfterSeconds;
-  while (Date.now() < expiresAt) {
+  while (nowImpl() < expiresAt) {
     await delayImpl(retryAfterSeconds * 1000);
     let response;
     try {
@@ -1388,7 +1389,7 @@ export async function slopIdentityAssertion(
       if (
         response.status === 410 &&
         errorCode !== "flow_consumed" &&
-        Date.now() >= expiresAt - (retryAfterSeconds + 1) * 1000
+        (errorCode === "flow_expired" || nowImpl() >= expiresAt)
       ) {
         fail(
           "Slop identity authorization expired before completion; run register again and authorize within the deadline",
@@ -1436,7 +1437,7 @@ export async function slopIdentityAssertion(
       typeof result.assertion !== "string" ||
       !/^slop_assert_v1_[A-Za-z0-9_-]{20,512}$/u.test(result.assertion) ||
       canonicalIso(result.expiresAt) !== result.expiresAt ||
-      Date.parse(result.expiresAt) <= Date.now()
+      Date.parse(result.expiresAt) <= nowImpl()
     ) {
       fail("Slop identity completion response was invalid");
     }

--- a/skills/contribute-to-asi/scripts/run-receipt.mjs
+++ b/skills/contribute-to-asi/scripts/run-receipt.mjs
@@ -1347,6 +1347,9 @@ export async function slopIdentityAssertion(
     `Authorize this contribution with GitHub:\n${authorizationUrl.href}\n`,
   );
   const expiresAt = Date.parse(started.expiresAt);
+  process.stderr.write(
+    `This link expires in ${Math.max(0, Math.round((expiresAt - Date.now()) / 1000))} seconds; authorize promptly.\n`,
+  );
   let retryAfterSeconds = started.pollAfterSeconds;
   while (Date.now() < expiresAt) {
     await delayImpl(retryAfterSeconds * 1000);
@@ -1366,7 +1369,34 @@ export async function slopIdentityAssertion(
       fail("Slop identity poll request failed");
     }
     if (!response.ok) {
-      fail(`Slop identity poll returned HTTP ${response.status}`);
+      let errorCode = null;
+      try {
+        const parsed = JSON.parse(
+          await boundedResponseText(response, "Slop identity poll"),
+        );
+        if (
+          parsed &&
+          typeof parsed === "object" &&
+          typeof parsed.error === "string" &&
+          /^[a-z0-9_]{1,64}$/u.test(parsed.error)
+        ) {
+          errorCode = parsed.error;
+        }
+      } catch {
+        // Fail closed on the status alone when the body is unreadable.
+      }
+      if (
+        response.status === 410 &&
+        errorCode !== "flow_consumed" &&
+        Date.now() >= expiresAt - (retryAfterSeconds + 1) * 1000
+      ) {
+        fail(
+          "Slop identity authorization expired before completion; run register again and authorize within the deadline",
+        );
+      }
+      fail(
+        `Slop identity poll returned HTTP ${response.status}${errorCode === null ? "" : ` (${errorCode})`}`,
+      );
     }
     const source = await boundedResponseText(response, "Slop identity poll");
     let result;

--- a/skills/contribute-to-asi/scripts/run-receipt.mjs
+++ b/skills/contribute-to-asi/scripts/run-receipt.mjs
@@ -1533,88 +1533,92 @@ export async function uploadPrivateTrace(
   );
   if (
     created.clientRunId !== state.runId ||
-    created.state !== "awaiting_trace" ||
+    !["awaiting_trace", "trace_uploaded", "finalized"].includes(
+      created.state,
+    ) ||
     !/^[A-Za-z0-9][A-Za-z0-9._:-]{0,159}$/u.test(created.serverRunId ?? "")
   ) {
     fail("trace run creation returned mismatched identity");
   }
   const serverPath = encodeURIComponent(created.serverRunId);
-  const intentBody = {
-    sha256: trace.sha256,
-    sizeBytes: trace.sizeBytes,
-    contentType: trace.contentType,
-  };
-  const intent = await jsonRequest(
-    fetchImpl,
-    `${TRACE_AUTHORITY}/api/v1/runs/${serverPath}/trace-intents`,
-    {
-      method: "POST",
-      headers: {
-        ...jsonHeaders,
-        "Idempotency-Key": sha256(
-          `intent:${created.serverRunId}:${trace.sha256}`,
-        ),
+  if (created.state === "awaiting_trace") {
+    const intentBody = {
+      sha256: trace.sha256,
+      sizeBytes: trace.sizeBytes,
+      contentType: trace.contentType,
+    };
+    const intent = await jsonRequest(
+      fetchImpl,
+      `${TRACE_AUTHORITY}/api/v1/runs/${serverPath}/trace-intents`,
+      {
+        method: "POST",
+        headers: {
+          ...jsonHeaders,
+          "Idempotency-Key": sha256(
+            `intent:${created.serverRunId}:${trace.sha256}`,
+          ),
+        },
+        body: JSON.stringify(intentBody),
       },
-      body: JSON.stringify(intentBody),
-    },
-    [
-      "contentType",
-      "expiresAt",
-      "serverRunId",
-      "sha256",
-      "sizeBytes",
-      "uploadUrl",
-    ],
-    "trace upload intent",
-  );
-  let uploadUrl;
-  try {
-    uploadUrl = new URL(intent.uploadUrl);
-  } catch {
-    fail("trace upload intent returned an invalid URL");
-  }
-  if (
-    intent.serverRunId !== created.serverRunId ||
-    intent.sha256 !== trace.sha256 ||
-    intent.sizeBytes !== trace.sizeBytes ||
-    intent.contentType !== trace.contentType ||
-    uploadUrl.origin !== TRACE_AUTHORITY ||
-    uploadUrl.username ||
-    uploadUrl.password ||
-    uploadUrl.hash
-  ) {
-    fail("trace upload intent returned mismatched fields");
-  }
-  const uploaded = await jsonRequest(
-    fetchImpl,
-    uploadUrl.href,
-    {
-      method: "PUT",
-      headers: {
-        "Content-Type": trace.contentType,
-        Digest: `sha-256=${trace.sha256}`,
+      [
+        "contentType",
+        "expiresAt",
+        "serverRunId",
+        "sha256",
+        "sizeBytes",
+        "uploadUrl",
+      ],
+      "trace upload intent",
+    );
+    let uploadUrl;
+    try {
+      uploadUrl = new URL(intent.uploadUrl);
+    } catch {
+      fail("trace upload intent returned an invalid URL");
+    }
+    if (
+      intent.serverRunId !== created.serverRunId ||
+      intent.sha256 !== trace.sha256 ||
+      intent.sizeBytes !== trace.sizeBytes ||
+      intent.contentType !== trace.contentType ||
+      uploadUrl.origin !== TRACE_AUTHORITY ||
+      uploadUrl.username ||
+      uploadUrl.password ||
+      uploadUrl.hash
+    ) {
+      fail("trace upload intent returned mismatched fields");
+    }
+    const uploaded = await jsonRequest(
+      fetchImpl,
+      uploadUrl.href,
+      {
+        method: "PUT",
+        headers: {
+          "Content-Type": trace.contentType,
+          Digest: `sha-256=${trace.sha256}`,
+        },
+        body: trace.contents,
       },
-      body: trace.contents,
-    },
-    [
-      "clientRunId",
-      "serverRunId",
-      "sizeBytes",
-      "state",
-      "traceObjectId",
-      "traceSha256",
-    ],
-    "trace upload",
-  );
-  if (
-    uploaded.clientRunId !== state.runId ||
-    uploaded.serverRunId !== created.serverRunId ||
-    uploaded.sizeBytes !== trace.sizeBytes ||
-    uploaded.state !== "trace_uploaded" ||
-    uploaded.traceSha256 !== trace.sha256 ||
-    uploaded.traceObjectId !== `sha256:${trace.sha256}`
-  ) {
-    fail("trace upload returned mismatched evidence");
+      [
+        "clientRunId",
+        "serverRunId",
+        "sizeBytes",
+        "state",
+        "traceObjectId",
+        "traceSha256",
+      ],
+      "trace upload",
+    );
+    if (
+      uploaded.clientRunId !== state.runId ||
+      uploaded.serverRunId !== created.serverRunId ||
+      uploaded.sizeBytes !== trace.sizeBytes ||
+      uploaded.state !== "trace_uploaded" ||
+      uploaded.traceSha256 !== trace.sha256 ||
+      uploaded.traceObjectId !== `sha256:${trace.sha256}`
+    ) {
+      fail("trace upload returned mismatched evidence");
+    }
   }
   const finalized = await jsonRequest(
     fetchImpl,

--- a/skills/contribute-to-asi/scripts/run-receipt.mjs
+++ b/skills/contribute-to-asi/scripts/run-receipt.mjs
@@ -1585,7 +1585,7 @@ export async function uploadPrivateTrace(
         headers: {
           ...jsonHeaders,
           "Idempotency-Key": sha256(
-            `intent:${created.serverRunId}:${trace.sha256}`,
+            `intent:${created.serverRunId}:${trace.sha256}:${randomBytes(16).toString("hex")}`,
           ),
         },
         body: JSON.stringify(intentBody),

--- a/skills/contribute-to-delta-star/scripts/live-report.mjs
+++ b/skills/contribute-to-delta-star/scripts/live-report.mjs
@@ -31,9 +31,24 @@ export const REVIEW_EPOCH_SCHEMA_VERSION = 1;
 export const MAX_REVIEW_EPOCH_FILE_BYTES = 262_144;
 export const MAX_API_READS = 16;
 export const MAX_ACTIVITY_CONNECTION_ITEMS = 1_000;
+// Large repositories can legitimately exceed Node's 64 MiB spawnSync default
+// after gh concatenates bounded pages. Keep one explicit ceiling high enough
+// for the 10,000-item inventory while still failing closed on runaway output.
+export const MAX_GH_REPORT_BYTES = 256 * 1024 * 1024;
 export const MIN_GRAPHQL_ACTIVITY_POINTS = 1_000;
 export const MIN_REST_ACTIVITY_REQUESTS = 100;
 export const MIN_SEARCH_ACTIVITY_REQUESTS = 2;
+export const MAX_LIVE_INVENTORY_ATTEMPTS = 2;
+
+export class LiveInventoryChangedError extends Error {
+  constructor(
+    message = "batched activity does not exactly match the live open-item inventory",
+    options,
+  ) {
+    super(message, options);
+    this.name = "LiveInventoryChangedError";
+  }
+}
 
 const REPOSITORY_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const PLACEHOLDER_RE =
@@ -748,7 +763,7 @@ export function readGhPages(endpoint, spawn = spawnSync) {
   ];
   const result = spawn("gh", args, {
     encoding: "utf8",
-    maxBuffer: 64 * 1024 * 1024,
+    maxBuffer: MAX_GH_REPORT_BYTES,
     windowsHide: true,
   });
   if (result.error) throw result.error;
@@ -959,7 +974,7 @@ function readGhActivityPage(endpoint, pageNumber, context, spawn) {
     ["api", "--method", "GET", "--jq", ".[]", pagedEndpoint],
     {
       encoding: "utf8",
-      maxBuffer: 64 * 1024 * 1024,
+      maxBuffer: MAX_GH_REPORT_BYTES,
       windowsHide: true,
     },
   );
@@ -1051,7 +1066,7 @@ function readGhSearchPullNumbers(repo, qualifier, spawn) {
     ],
     {
       encoding: "utf8",
-      maxBuffer: 64 * 1024 * 1024,
+      maxBuffer: MAX_GH_REPORT_BYTES,
       windowsHide: true,
     },
   );
@@ -1274,7 +1289,7 @@ function readGraphqlActivityNodes(repo, query, selector, spawn, context) {
     ],
     {
       encoding: "utf8",
-      maxBuffer: 64 * 1024 * 1024,
+      maxBuffer: MAX_GH_REPORT_BYTES,
       windowsHide: true,
     },
   );
@@ -2239,9 +2254,7 @@ export function collectLiveReport(
       [...issueNumbers].some((number) => !activity.issues.has(number)) ||
       [...pullNumbers].some((number) => !activity.pulls.has(number))
     ) {
-      throw new TypeError(
-        "batched activity does not exactly match the live open-item inventory",
-      );
+      throw new LiveInventoryChangedError();
     }
   }
   onProgress({ phase: "issues", current: 0, total: issueItems.length });
@@ -2744,6 +2757,25 @@ Options:
 `;
 }
 
+/** Repeats one complete read when GitHub changes its open-item inventory mid-snapshot. */
+export function retryChangedLiveInventory(collect, onRetry = () => {}) {
+  for (let attempt = 1; attempt <= MAX_LIVE_INVENTORY_ATTEMPTS; attempt += 1) {
+    try {
+      return collect(attempt);
+    } catch (cause) {
+      if (!(cause instanceof LiveInventoryChangedError)) throw cause;
+      if (attempt === MAX_LIVE_INVENTORY_ATTEMPTS) {
+        throw new LiveInventoryChangedError(
+          `Open GitHub inventory changed while collecting the live report after ${MAX_LIVE_INVENTORY_ATTEMPTS} attempts`,
+          { cause },
+        );
+      }
+      onRetry({ attempt, cause });
+    }
+  }
+  throw new Error("unreachable live inventory retry state");
+}
+
 export function main(args = process.argv.slice(2)) {
   const selectionPolicy = readProjectSelectionPolicy();
   const options = parseCliArguments(args, selectionPolicy.repositoryId);
@@ -2779,26 +2811,40 @@ export function main(args = process.argv.slice(2)) {
   const boundedRead = (endpoint) => {
     return readGhPages(endpoint, commandBudget.run);
   };
-  const openActivity = readGhOpenActivity(options.repo, commandBudget.run, {
-    preflight: true,
-  });
-  const limits = asRecord(openActivity.rateLimits, "GitHub rate limits");
-  process.stderr.write(
-    `[Slop] GitHub budgets: GraphQL ${limits.graphqlRemaining}/${limits.graphqlLimit} (${limits.graphqlBudgetSource}); REST ${limits.restRemaining}/${limits.restLimit}; Search ${limits.searchRemaining}/${limits.searchLimit}; activity source ${openActivity.source}\n`,
-  );
-  const report = collectLiveReport(
-    options.repo,
-    boundedRead,
-    new Date(),
-    ({ phase, current, total }) => {
-      if (current === 0 || current === total || current % 10 === 0) {
-        process.stderr.write(
-          `[Slop] scanning ${phase}: ${current}/${total} (${commandBudget.count} bounded GitHub commands)\n`,
-        );
-      }
+  let rateLimits = { preflight: true };
+  const { report } = retryChangedLiveInventory(
+    () => {
+      const openActivity = readGhOpenActivity(
+        options.repo,
+        commandBudget.run,
+        rateLimits,
+      );
+      rateLimits = openActivity.rateLimits;
+      const limits = asRecord(openActivity.rateLimits, "GitHub rate limits");
+      process.stderr.write(
+        `[Slop] GitHub budgets: GraphQL ${limits.graphqlRemaining}/${limits.graphqlLimit} (${limits.graphqlBudgetSource}); REST ${limits.restRemaining}/${limits.restLimit}; Search ${limits.searchRemaining}/${limits.searchLimit}; activity source ${openActivity.source}\n`,
+      );
+      return {
+        report: collectLiveReport(
+          options.repo,
+          boundedRead,
+          new Date(),
+          ({ phase, current, total }) => {
+            if (current === 0 || current === total || current % 10 === 0) {
+              process.stderr.write(
+                `[Slop] scanning ${phase}: ${current}/${total} (${commandBudget.count} bounded GitHub commands)\n`,
+              );
+            }
+          },
+          openActivity,
+          selectionPolicy.eligibleIssueLabels,
+        ),
+      };
     },
-    openActivity,
-    selectionPolicy.eligibleIssueLabels,
+    ({ attempt }) =>
+      process.stderr.write(
+        `[Slop] open-item inventory changed during snapshot attempt ${attempt}; retrying one complete read\n`,
+      ),
   );
   process.stdout.write(
     options.epochOnly

--- a/skills/contribute-to-delta-star/scripts/live-report.mjs
+++ b/skills/contribute-to-delta-star/scripts/live-report.mjs
@@ -5,20 +5,22 @@
  * adapter; GraphQL uses explicit read-only queries over GitHub's POST endpoint.
  */
 
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { createHash, randomBytes } from "node:crypto";
 import {
   existsSync,
+  lstatSync,
   mkdirSync,
   readFileSync,
+  readdirSync,
   realpathSync,
   renameSync,
   rmSync,
   statSync,
   writeFileSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { platform, userInfo } from "node:os";
+import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 export const MODEL_DISCLOSURE_PREFIX = "AI provider/model:";
@@ -46,9 +48,14 @@ export const MIN_GRAPHQL_ACTIVITY_POINTS = 1_000;
 export const MIN_REST_ACTIVITY_REQUESTS = 100;
 export const MIN_SEARCH_ACTIVITY_REQUESTS = 2;
 
-const LIVE_REPORT_LOCK_DIRECTORY = "slop-live-report-locks-v1";
+const LIVE_REPORT_LOCK_DIRECTORY = "slop-live-report-locks-v2";
 const LIVE_REPORT_LOCK_OWNER_FILE = "owner.json";
+const LIVE_REPORT_LOCK_COMMAND_DIRECTORY = "commands";
 const LIVE_REPORT_LOCK_ACQUIRE_ATTEMPTS = 8;
+const LIVE_REPORT_ORPHAN_COMMAND_GRACE_MS = 5 * 60 * 1_000;
+const LIVE_REPORT_LOCKED_GH_ARGUMENT = "--slop-internal-locked-gh-v1";
+const LIVE_REPORT_PROCESS_IDENTITY_RE = /^[a-f0-9]{64}$/u;
+const LIVE_REPORT_TOKEN_RE = /^[a-f0-9]{32}$/u;
 
 const REPOSITORY_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const PLACEHOLDER_RE =
@@ -1332,7 +1339,16 @@ export class LiveReportLockContentionError extends Error {
 export function readGhAuthenticatedIdentity(spawn = spawnSync) {
   const result = spawn(
     "gh",
-    ["api", "--method", "GET", "--jq", "{id: .id, login: .login}", "user"],
+    [
+      "api",
+      "--hostname",
+      "github.com",
+      "--method",
+      "GET",
+      "--jq",
+      "{id: .id, login: .login}",
+      "user",
+    ],
     {
       encoding: "utf8",
       maxBuffer: 1024 * 1024,
@@ -1364,46 +1380,13 @@ export function readGhAuthenticatedIdentity(spawn = spawnSync) {
   if (id <= 0 || login.length === 0) {
     throw new TypeError("GitHub authenticated identity is invalid");
   }
-  return { id, login };
+  return { host: "github.com", id, login };
 }
 
 function fileSystemErrorCode(error) {
   return error && typeof error === "object" && "code" in error
     ? error.code
     : null;
-}
-
-function readLiveReportLockOwner(lockPath) {
-  try {
-    const owner = asRecord(
-      JSON.parse(
-        readFileSync(join(lockPath, LIVE_REPORT_LOCK_OWNER_FILE), "utf8"),
-      ),
-      "live report lock owner",
-    );
-    const schemaVersion = asNumberField(
-      owner,
-      "schemaVersion",
-      "live report lock owner",
-    );
-    const pid = asNumberField(owner, "pid", "live report lock owner");
-    const ownerToken = asStringField(
-      owner,
-      "ownerToken",
-      "live report lock owner",
-    );
-    if (
-      schemaVersion !== 1 ||
-      pid <= 0 ||
-      !/^[a-f0-9]{32}$/u.test(ownerToken)
-    ) {
-      return null;
-    }
-    return { pid, ownerToken };
-  } catch {
-    // error-policy:J3 A corrupt or incomplete lease cannot claim live ownership.
-    return null;
-  }
 }
 
 function processIsRunning(pid) {
@@ -1417,19 +1400,249 @@ function processIsRunning(pid) {
   }
 }
 
-function lockOwnerIsActive(owner) {
-  return owner !== null && processIsRunning(owner.pid);
+function hashProcessIdentity(value) {
+  return createHash("sha256").update(value).digest("hex");
 }
 
-function prepareLiveReportLockCandidate(lockPath, ownerToken) {
+export function readLiveReportProcessIdentity(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    throw new TypeError("live report process ID must be a positive integer");
+  }
+  if (!processIsRunning(pid)) return null;
+  const operatingSystem = platform();
+  if (operatingSystem === "linux") {
+    let source;
+    try {
+      source = readFileSync(`/proc/${pid}/stat`, "utf8");
+    } catch (error) {
+      if (fileSystemErrorCode(error) === "ENOENT") return null;
+      throw error;
+    }
+    const commandEnd = source.lastIndexOf(")");
+    const fields = source
+      .slice(commandEnd + 2)
+      .trim()
+      .split(/\s+/u);
+    const startTime = fields[19];
+    if (commandEnd < 1 || !/^\d+$/u.test(startTime ?? "")) {
+      throw new TypeError("Linux returned an invalid process birth identity");
+    }
+    return hashProcessIdentity(`linux:${startTime}`);
+  }
+  if (
+    operatingSystem === "darwin" ||
+    operatingSystem === "freebsd" ||
+    operatingSystem === "openbsd"
+  ) {
+    const result = spawnSync(
+      existsSync("/bin/ps") ? "/bin/ps" : "ps",
+      ["-o", "lstart=", "-p", String(pid)],
+      { encoding: "utf8", maxBuffer: 64 * 1024, windowsHide: true },
+    );
+    if (result.error) throw result.error;
+    if (result.status !== 0 || result.stdout.trim() === "") {
+      if (!processIsRunning(pid)) return null;
+      throw new Error("could not read the process birth identity from ps");
+    }
+    return hashProcessIdentity(`${operatingSystem}:${result.stdout.trim()}`);
+  }
+  if (operatingSystem === "win32") {
+    const result = spawnSync(
+      "powershell.exe",
+      [
+        "-NoLogo",
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        `(Get-Process -Id ${pid} -ErrorAction Stop).StartTime.ToUniversalTime().Ticks`,
+      ],
+      { encoding: "utf8", maxBuffer: 64 * 1024, windowsHide: true },
+    );
+    if (result.error) throw result.error;
+    if (result.status !== 0 || !/^\d+$/u.test(result.stdout.trim())) {
+      if (!processIsRunning(pid)) return null;
+      throw new Error("could not read the Windows process birth identity");
+    }
+    return hashProcessIdentity(`win32:${result.stdout.trim()}`);
+  }
+  throw new Error(
+    `live report locking does not support process identity on ${operatingSystem}`,
+  );
+}
+
+function readProcessLease(value, context) {
+  const record = asRecord(value, context);
+  const pid = asNumberField(record, "pid", context);
+  const processIdentity = asStringField(record, "processIdentity", context);
+  if (
+    !Number.isInteger(pid) ||
+    pid <= 0 ||
+    !LIVE_REPORT_PROCESS_IDENTITY_RE.test(processIdentity)
+  ) {
+    throw new TypeError(`${context} is invalid`);
+  }
+  return { pid, processIdentity };
+}
+
+function processLeaseIsActive(lease) {
+  const currentIdentity = readLiveReportProcessIdentity(lease.pid);
+  return currentIdentity !== null && currentIdentity === lease.processIdentity;
+}
+
+export function defaultLiveReportLockRoot() {
+  const uid = typeof process.getuid === "function" ? process.getuid() : null;
+  if (Number.isInteger(uid) && uid >= 0) {
+    return join("/tmp", `${LIVE_REPORT_LOCK_DIRECTORY}-${uid}`);
+  }
+  const identity = userInfo();
+  const key = createHash("sha256")
+    .update(`${identity.username}\0${identity.homedir}`)
+    .digest("hex")
+    .slice(0, 16);
+  return join(identity.homedir, `.${LIVE_REPORT_LOCK_DIRECTORY}-${key}`);
+}
+
+export function ensureLiveReportLockRoot(
+  rootPath = defaultLiveReportLockRoot(),
+) {
+  try {
+    mkdirSync(rootPath, { mode: 0o700 });
+  } catch (error) {
+    if (fileSystemErrorCode(error) !== "EEXIST") throw error;
+  }
+  const stats = lstatSync(rootPath);
+  if (stats.isSymbolicLink() || !stats.isDirectory()) {
+    throw new TypeError("live report lock root must be a real directory");
+  }
+  const uid = typeof process.getuid === "function" ? process.getuid() : null;
+  if (Number.isInteger(uid) && stats.uid !== uid) {
+    throw new TypeError(
+      "live report lock root must belong to the current user",
+    );
+  }
+  if (platform() !== "win32" && (stats.mode & 0o077) !== 0) {
+    throw new TypeError("live report lock root permissions must be 0700");
+  }
+  return rootPath;
+}
+
+function readLiveReportLockOwner(lockPath) {
+  let source;
+  try {
+    source = readFileSync(join(lockPath, LIVE_REPORT_LOCK_OWNER_FILE), "utf8");
+  } catch (error) {
+    if (fileSystemErrorCode(error) === "ENOENT") return null;
+    throw error;
+  }
+  const owner = asRecord(JSON.parse(source), "live report lock owner");
+  const schemaVersion = asNumberField(
+    owner,
+    "schemaVersion",
+    "live report lock owner",
+  );
+  const processLease = readProcessLease(owner, "live report lock owner");
+  const ownerToken = asStringField(
+    owner,
+    "ownerToken",
+    "live report lock owner",
+  );
+  if (schemaVersion !== 2 || !LIVE_REPORT_TOKEN_RE.test(ownerToken)) {
+    throw new TypeError("live report lock owner is invalid");
+  }
+  return { ...processLease, ownerToken };
+}
+
+function liveReportCommandDirectory(lockPath) {
+  return join(lockPath, LIVE_REPORT_LOCK_COMMAND_DIRECTORY);
+}
+
+function readLiveReportCommandLease(path) {
+  const record = asRecord(
+    JSON.parse(readFileSync(path, "utf8")),
+    "live report command lease",
+  );
+  const schemaVersion = asNumberField(
+    record,
+    "schemaVersion",
+    "live report command lease",
+  );
+  const ownerToken = asStringField(
+    record,
+    "ownerToken",
+    "live report command lease",
+  );
+  const startedAtMs = asNumberField(
+    record,
+    "startedAtMs",
+    "live report command lease",
+  );
+  const helper = readProcessLease(record.helper, "live report command helper");
+  const child =
+    record.child === null
+      ? null
+      : readProcessLease(record.child, "live report GitHub child");
+  if (
+    schemaVersion !== 1 ||
+    !LIVE_REPORT_TOKEN_RE.test(ownerToken) ||
+    !Number.isSafeInteger(startedAtMs) ||
+    startedAtMs <= 0
+  ) {
+    throw new TypeError("live report command lease is invalid");
+  }
+  return { child, helper, ownerToken, startedAtMs };
+}
+
+function liveReportCommandIsActive(lease, ownerToken) {
+  if (lease.ownerToken !== ownerToken) {
+    throw new TypeError("live report command lease owner does not match");
+  }
+  if (processLeaseIsActive(lease.helper)) return true;
+  if (lease.child !== null && processLeaseIsActive(lease.child)) return true;
+  return Date.now() - lease.startedAtMs < LIVE_REPORT_ORPHAN_COMMAND_GRACE_MS;
+}
+
+function liveReportHasActiveCommand(lockPath, ownerToken) {
+  const commandDirectory = liveReportCommandDirectory(lockPath);
+  let entries;
+  try {
+    entries = readdirSync(commandDirectory, { withFileTypes: true });
+  } catch (error) {
+    if (fileSystemErrorCode(error) === "ENOENT" && !existsSync(lockPath)) {
+      return false;
+    }
+    throw error;
+  }
+  for (const entry of entries) {
+    if (entry.isSymbolicLink() || (!entry.isFile() && !entry.isDirectory())) {
+      throw new TypeError("live report command directory is invalid");
+    }
+    if (!/^lease-[a-f0-9]{32}\.json$/u.test(entry.name)) continue;
+    const lease = readLiveReportCommandLease(
+      join(commandDirectory, entry.name),
+    );
+    if (liveReportCommandIsActive(lease, ownerToken)) return true;
+  }
+  return false;
+}
+
+function assertLiveReportLockDirectory(lockPath) {
+  const stats = lstatSync(lockPath);
+  if (stats.isSymbolicLink() || !stats.isDirectory()) {
+    throw new TypeError("live report lock must be a real directory");
+  }
+}
+
+function prepareLiveReportLockCandidate(lockPath, ownerToken, processIdentity) {
   const candidatePath = `${lockPath}.candidate-${process.pid}-${ownerToken}`;
   mkdirSync(candidatePath, { mode: 0o700 });
   try {
+    mkdirSync(liveReportCommandDirectory(candidatePath), { mode: 0o700 });
     writeFileSync(
       join(candidatePath, LIVE_REPORT_LOCK_OWNER_FILE),
       `${JSON.stringify({
-        schemaVersion: 1,
+        schemaVersion: 2,
         pid: process.pid,
+        processIdentity,
         ownerToken,
       })}\n`,
       { flag: "wx", mode: 0o600 },
@@ -1441,25 +1654,113 @@ function prepareLiveReportLockCandidate(lockPath, ownerToken) {
   }
 }
 
-export function acquireLiveReportLock(identity) {
+function liveReportLockKey(identity) {
+  return createHash("sha256")
+    .update(`${identity.host}:${identity.id}`)
+    .digest("hex");
+}
+
+function writeLiveReportCommandLease(path, lease, replace = false) {
+  if (!replace) {
+    writeFileSync(path, `${JSON.stringify(lease)}\n`, {
+      flag: "wx",
+      mode: 0o600,
+    });
+    return;
+  }
+  const nextPath = `${path}.next-${process.pid}-${randomBytes(16).toString("hex")}`;
+  try {
+    writeFileSync(nextPath, `${JSON.stringify(lease)}\n`, {
+      flag: "wx",
+      mode: 0o600,
+    });
+    renameSync(nextPath, path);
+  } catch (error) {
+    rmSync(nextPath, { force: true });
+    throw error;
+  }
+}
+
+function spawnLockedGh(lockPath, ownerToken, command, args, options = {}) {
+  if (
+    command !== "gh" ||
+    !Array.isArray(args) ||
+    args.some((argument) => typeof argument !== "string")
+  ) {
+    throw new TypeError("live report lock may execute only a gh argument list");
+  }
+  if (options.encoding !== undefined && options.encoding !== "utf8") {
+    throw new TypeError("live report gh commands require utf8 output");
+  }
+  const maxBuffer = options.maxBuffer ?? 1024 * 1024;
+  if (
+    !Number.isSafeInteger(maxBuffer) ||
+    maxBuffer <= 0 ||
+    maxBuffer > 256 * 1024 * 1024
+  ) {
+    throw new RangeError("live report gh command maxBuffer is invalid");
+  }
+  const commandToken = randomBytes(16).toString("hex");
+  const requestPath = join(
+    liveReportCommandDirectory(lockPath),
+    `request-${commandToken}.json`,
+  );
+  writeFileSync(
+    requestPath,
+    `${JSON.stringify({ args, maxBuffer, ownerToken, schemaVersion: 1 })}\n`,
+    { flag: "wx", mode: 0o600 },
+  );
+  try {
+    return spawnSync(
+      process.execPath,
+      [
+        fileURLToPath(import.meta.url),
+        LIVE_REPORT_LOCKED_GH_ARGUMENT,
+        lockPath,
+        ownerToken,
+        commandToken,
+      ],
+      {
+        encoding: "utf8",
+        env: { ...(options.env ?? process.env), GH_HOST: "github.com" },
+        maxBuffer: Math.min(maxBuffer + 1024 * 1024, 256 * 1024 * 1024),
+        windowsHide: true,
+      },
+    );
+  } finally {
+    rmSync(requestPath, { force: true });
+  }
+}
+
+export function acquireLiveReportLock(identity, options = {}) {
   const record = asRecord(identity, "GitHub authenticated identity");
   const id = asNumberField(record, "id", "GitHub authenticated identity");
   const login = asStringField(record, "login", "GitHub authenticated identity");
-  if (id <= 0 || login.length === 0) {
+  const host = asStringField(record, "host", "GitHub authenticated identity");
+  if (id <= 0 || login.length === 0 || host !== "github.com") {
     throw new TypeError("GitHub authenticated identity is invalid");
   }
-  const root = join(tmpdir(), LIVE_REPORT_LOCK_DIRECTORY);
-  mkdirSync(root, { mode: 0o700, recursive: true });
-  const key = createHash("sha256").update(`github.com:${id}`).digest("hex");
+  const root = ensureLiveReportLockRoot(
+    options.rootPath ?? defaultLiveReportLockRoot(),
+  );
+  const key = liveReportLockKey({ host, id });
   const lockPath = join(root, `${key}.lock`);
   const ownerToken = randomBytes(16).toString("hex");
+  const processIdentity = readLiveReportProcessIdentity(process.pid);
+  if (processIdentity === null) {
+    throw new Error("could not establish the live report process identity");
+  }
   let acquired = false;
   for (
     let attempt = 0;
     attempt < LIVE_REPORT_LOCK_ACQUIRE_ATTEMPTS;
     attempt += 1
   ) {
-    const candidatePath = prepareLiveReportLockCandidate(lockPath, ownerToken);
+    const candidatePath = prepareLiveReportLockCandidate(
+      lockPath,
+      ownerToken,
+      processIdentity,
+    );
     try {
       renameSync(candidatePath, lockPath);
       acquired = true;
@@ -1470,8 +1771,16 @@ export function acquireLiveReportLock(identity) {
         if (fileSystemErrorCode(error) === "ENOENT") continue;
         throw error;
       }
+      assertLiveReportLockDirectory(lockPath);
       const currentOwner = readLiveReportLockOwner(lockPath);
-      if (lockOwnerIsActive(currentOwner)) {
+      if (currentOwner === null) {
+        if (!existsSync(lockPath)) continue;
+        throw new Error("live report lock owner is missing");
+      }
+      if (
+        processLeaseIsActive(currentOwner) ||
+        liveReportHasActiveCommand(lockPath, currentOwner.ownerToken)
+      ) {
         throw new LiveReportLockContentionError();
       }
       const stalePath = `${lockPath}.stale-${process.pid}-${randomBytes(16).toString("hex")}`;
@@ -1489,12 +1798,16 @@ export function acquireLiveReportLock(identity) {
   }
   let released = false;
   return {
+    spawn(command, args, options) {
+      return spawnLockedGh(lockPath, ownerToken, command, args, options);
+    },
     release() {
       if (released) return;
       const owner = readLiveReportLockOwner(lockPath);
       if (
         owner === null ||
         owner.pid !== process.pid ||
+        owner.processIdentity !== processIdentity ||
         owner.ownerToken !== ownerToken
       ) {
         throw new Error("live report lock ownership changed before release");
@@ -1505,6 +1818,173 @@ export function acquireLiveReportLock(identity) {
       released = true;
     },
   };
+}
+
+function readLockedGhRequest(lockPath, ownerToken, commandToken) {
+  if (
+    !LIVE_REPORT_TOKEN_RE.test(ownerToken) ||
+    !LIVE_REPORT_TOKEN_RE.test(commandToken)
+  ) {
+    throw new TypeError("locked GitHub command tokens are invalid");
+  }
+  const root = ensureLiveReportLockRoot();
+  if (
+    dirname(lockPath) !== root ||
+    !/^[a-f0-9]{64}\.lock$/u.test(basename(lockPath))
+  ) {
+    throw new TypeError("locked GitHub command path is invalid");
+  }
+  assertLiveReportLockDirectory(lockPath);
+  const owner = readLiveReportLockOwner(lockPath);
+  if (owner === null || owner.ownerToken !== ownerToken) {
+    throw new Error("live report lock ownership changed before GitHub command");
+  }
+  const requestPath = join(
+    liveReportCommandDirectory(lockPath),
+    `request-${commandToken}.json`,
+  );
+  const request = asRecord(
+    JSON.parse(readFileSync(requestPath, "utf8")),
+    "locked GitHub command request",
+  );
+  const schemaVersion = asNumberField(
+    request,
+    "schemaVersion",
+    "locked GitHub command request",
+  );
+  const requestOwnerToken = asStringField(
+    request,
+    "ownerToken",
+    "locked GitHub command request",
+  );
+  const maxBuffer = asNumberField(
+    request,
+    "maxBuffer",
+    "locked GitHub command request",
+  );
+  if (
+    schemaVersion !== 1 ||
+    requestOwnerToken !== ownerToken ||
+    !Number.isSafeInteger(maxBuffer) ||
+    maxBuffer <= 0 ||
+    maxBuffer > 256 * 1024 * 1024 ||
+    !Array.isArray(request.args) ||
+    request.args.some((argument) => typeof argument !== "string")
+  ) {
+    throw new TypeError("locked GitHub command request is invalid");
+  }
+  return { args: request.args, maxBuffer, requestPath };
+}
+
+function collectBoundedGhChild(child, maxBuffer) {
+  return new Promise((resolvePromise) => {
+    const stdout = [];
+    const stderr = [];
+    let stdoutBytes = 0;
+    let stderrBytes = 0;
+    let overflow = null;
+    let spawnError = null;
+    const collect = (chunks, chunk, stream) => {
+      if (overflow !== null) return;
+      const value = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      if (stream === "stdout") stdoutBytes += value.length;
+      else stderrBytes += value.length;
+      if (stdoutBytes > maxBuffer || stderrBytes > maxBuffer) {
+        overflow = stream;
+        child.kill("SIGTERM");
+        return;
+      }
+      chunks.push(value);
+    };
+    child.stdout.on("data", (chunk) => collect(stdout, chunk, "stdout"));
+    child.stderr.on("data", (chunk) => collect(stderr, chunk, "stderr"));
+    child.once("error", (error) => {
+      spawnError = error;
+    });
+    child.once("close", (status, signal) => {
+      resolvePromise({
+        error: spawnError,
+        overflow,
+        signal,
+        status,
+        stderr: Buffer.concat(stderr),
+        stdout: Buffer.concat(stdout),
+      });
+    });
+  });
+}
+
+function writeProcessDescriptor(descriptor, value) {
+  if (value.length === 0) return;
+  try {
+    writeFileSync(descriptor, value);
+  } catch (error) {
+    if (fileSystemErrorCode(error) !== "EPIPE") throw error;
+  }
+}
+
+async function runLockedGhCommand(lockPath, ownerToken, commandToken) {
+  const request = readLockedGhRequest(lockPath, ownerToken, commandToken);
+  const leasePath = join(
+    liveReportCommandDirectory(lockPath),
+    `lease-${commandToken}.json`,
+  );
+  const helperIdentity = readLiveReportProcessIdentity(process.pid);
+  if (helperIdentity === null) {
+    throw new Error("could not establish the GitHub command helper identity");
+  }
+  const lease = {
+    schemaVersion: 1,
+    ownerToken,
+    startedAtMs: Date.now(),
+    helper: { pid: process.pid, processIdentity: helperIdentity },
+    child: null,
+  };
+  writeLiveReportCommandLease(leasePath, lease);
+  let result;
+  try {
+    const currentOwner = readLiveReportLockOwner(lockPath);
+    if (currentOwner === null || currentOwner.ownerToken !== ownerToken) {
+      throw new Error(
+        "live report lock ownership changed while starting GitHub command",
+      );
+    }
+    const child = spawn("gh", request.args, {
+      env: { ...process.env, GH_HOST: "github.com" },
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+    });
+    const childResult = collectBoundedGhChild(child, request.maxBuffer);
+    if (Number.isInteger(child.pid) && child.pid > 0) {
+      const childIdentity = readLiveReportProcessIdentity(child.pid);
+      if (childIdentity !== null) {
+        writeLiveReportCommandLease(
+          leasePath,
+          {
+            ...lease,
+            child: { pid: child.pid, processIdentity: childIdentity },
+          },
+          true,
+        );
+      }
+    }
+    result = await childResult;
+  } finally {
+    rmSync(leasePath, { force: true });
+    rmSync(request.requestPath, { force: true });
+  }
+  if (result.error) throw result.error;
+  if (result.overflow !== null) {
+    throw new RangeError(
+      `spawn gh ${result.overflow} exceeded the bounded output buffer`,
+    );
+  }
+  writeProcessDescriptor(1, result.stdout);
+  writeProcessDescriptor(2, result.stderr);
+  if (result.status === null) {
+    throw new Error(`gh terminated by ${result.signal ?? "an unknown signal"}`);
+  }
+  process.exitCode = result.status;
 }
 
 function rateResource(value, context) {
@@ -2964,8 +3444,8 @@ export function main(args = process.argv.slice(2)) {
     if (!result.complete) process.exitCode = 2;
     return;
   }
-  const commandBudget = createGhCommandBudget();
   if (options.recheckPr !== undefined) {
+    const commandBudget = createGhCommandBudget();
     const result = recheckLivePullHead(
       options.repo,
       {
@@ -2978,12 +3458,13 @@ export function main(args = process.argv.slice(2)) {
     if (!result.publishable) process.exitCode = 2;
     return;
   }
-  const boundedRead = (endpoint) => {
-    return readGhPages(endpoint, commandBudget.run);
-  };
   const authenticatedIdentity = readGhAuthenticatedIdentity();
   const liveReportLock = acquireLiveReportLock(authenticatedIdentity);
   try {
+    const commandBudget = createGhCommandBudget(liveReportLock.spawn);
+    const boundedRead = (endpoint) => {
+      return readGhPages(endpoint, commandBudget.run);
+    };
     const openActivity = readGhOpenActivity(options.repo, commandBudget.run, {
       preflight: true,
     });
@@ -3024,17 +3505,27 @@ const invokedDirectly =
     realpathSync(process.argv[1]);
 
 if (invokedDirectly) {
-  try {
-    main();
-  } catch (error) {
-    // error-policy:J1 The CLI boundary turns a failed read/audit into a non-zero exit.
-    const message = error instanceof Error ? error.message : String(error);
-    if (error instanceof LiveReportLockContentionError) {
-      process.stderr.write(`Slop live report deferred: ${message}\n`);
-      process.exitCode = 2;
-    } else {
-      process.stderr.write(`Slop live report failed: ${message}\n`);
+  const directArguments = process.argv.slice(2);
+  if (directArguments[0] === LIVE_REPORT_LOCKED_GH_ARGUMENT) {
+    runLockedGhCommand(...directArguments.slice(1)).catch((error) => {
+      // error-policy:J1 The internal process boundary fails the owning report.
+      const message = error instanceof Error ? error.message : String(error);
+      process.stderr.write(`Slop locked GitHub command failed: ${message}\n`);
       process.exitCode = 1;
+    });
+  } else {
+    try {
+      main(directArguments);
+    } catch (error) {
+      // error-policy:J1 The CLI boundary turns a failed read/audit into a non-zero exit.
+      const message = error instanceof Error ? error.message : String(error);
+      if (error instanceof LiveReportLockContentionError) {
+        process.stderr.write(`Slop live report deferred: ${message}\n`);
+        process.exitCode = 2;
+      } else {
+        process.stderr.write(`Slop live report failed: ${message}\n`);
+        process.exitCode = 1;
+      }
     }
   }
 }

--- a/skills/contribute-to-delta-star/scripts/live-report.mjs
+++ b/skills/contribute-to-delta-star/scripts/live-report.mjs
@@ -2758,10 +2758,15 @@ Options:
 }
 
 /** Repeats one complete read when GitHub changes its open-item inventory mid-snapshot. */
-export function retryChangedLiveInventory(collect, onRetry = () => {}) {
+export function retryChangedLiveInventory(
+  collect,
+  onRetry = () => {},
+  createCommandBudget = createGhCommandBudget,
+) {
   for (let attempt = 1; attempt <= MAX_LIVE_INVENTORY_ATTEMPTS; attempt += 1) {
+    const commandBudget = createCommandBudget();
     try {
-      return collect(attempt);
+      return collect({ attempt, commandBudget });
     } catch (cause) {
       if (!(cause instanceof LiveInventoryChangedError)) throw cause;
       if (attempt === MAX_LIVE_INVENTORY_ATTEMPTS) {
@@ -2794,8 +2799,8 @@ export function main(args = process.argv.slice(2)) {
     if (!result.complete) process.exitCode = 2;
     return;
   }
-  const commandBudget = createGhCommandBudget();
   if (options.recheckPr !== undefined) {
+    const commandBudget = createGhCommandBudget();
     const result = recheckLivePullHead(
       options.repo,
       {
@@ -2808,12 +2813,12 @@ export function main(args = process.argv.slice(2)) {
     if (!result.publishable) process.exitCode = 2;
     return;
   }
-  const boundedRead = (endpoint) => {
-    return readGhPages(endpoint, commandBudget.run);
-  };
   let rateLimits = { preflight: true };
   const { report } = retryChangedLiveInventory(
-    () => {
+    ({ commandBudget }) => {
+      const boundedRead = (endpoint) => {
+        return readGhPages(endpoint, commandBudget.run);
+      };
       const openActivity = readGhOpenActivity(
         options.repo,
         commandBudget.run,

--- a/skills/contribute-to-delta-star/scripts/live-report.mjs
+++ b/skills/contribute-to-delta-star/scripts/live-report.mjs
@@ -3,6 +3,7 @@
  * Builds a stable, read-only inventory of open elizaOS issues and pull requests
  * for contribution selection. REST pagination stays behind one GET-only
  * adapter; GraphQL uses explicit read-only queries over GitHub's POST endpoint.
+ * A user-private process lease serializes complete discovery across skill copies.
  */
 
 import { spawn, spawnSync } from "node:child_process";
@@ -11,8 +12,8 @@ import {
   existsSync,
   lstatSync,
   mkdirSync,
-  readFileSync,
   readdirSync,
+  readFileSync,
   realpathSync,
   renameSync,
   rmSync,
@@ -1389,6 +1390,23 @@ function fileSystemErrorCode(error) {
     : null;
 }
 
+function assertLiveReportPrivatePath(path, context, kind) {
+  const stats = lstatSync(path);
+  const kindMatches =
+    kind === "directory" ? stats.isDirectory() : stats.isFile();
+  if (stats.isSymbolicLink() || !kindMatches) {
+    throw new TypeError(`${context} must be a real ${kind}`);
+  }
+  const uid = typeof process.getuid === "function" ? process.getuid() : null;
+  if (Number.isInteger(uid) && stats.uid !== uid) {
+    throw new TypeError(`${context} must belong to the current user`);
+  }
+  if (platform() !== "win32" && (stats.mode & 0o077) !== 0) {
+    throw new TypeError(`${context} permissions must exclude group and others`);
+  }
+  return stats;
+}
+
 function processIsRunning(pid) {
   try {
     process.kill(pid, 0);
@@ -1510,25 +1528,18 @@ export function ensureLiveReportLockRoot(
   } catch (error) {
     if (fileSystemErrorCode(error) !== "EEXIST") throw error;
   }
-  const stats = lstatSync(rootPath);
-  if (stats.isSymbolicLink() || !stats.isDirectory()) {
-    throw new TypeError("live report lock root must be a real directory");
-  }
-  const uid = typeof process.getuid === "function" ? process.getuid() : null;
-  if (Number.isInteger(uid) && stats.uid !== uid) {
-    throw new TypeError(
-      "live report lock root must belong to the current user",
-    );
-  }
-  if (platform() !== "win32" && (stats.mode & 0o077) !== 0) {
-    throw new TypeError("live report lock root permissions must be 0700");
-  }
+  assertLiveReportPrivatePath(rootPath, "live report lock root", "directory");
   return rootPath;
 }
 
 function readLiveReportLockOwner(lockPath) {
   let source;
   try {
+    assertLiveReportPrivatePath(
+      join(lockPath, LIVE_REPORT_LOCK_OWNER_FILE),
+      "live report lock owner",
+      "file",
+    );
     source = readFileSync(join(lockPath, LIVE_REPORT_LOCK_OWNER_FILE), "utf8");
   } catch (error) {
     if (fileSystemErrorCode(error) === "ENOENT") return null;
@@ -1557,6 +1568,7 @@ function liveReportCommandDirectory(lockPath) {
 }
 
 function readLiveReportCommandLease(path) {
+  assertLiveReportPrivatePath(path, "live report command lease", "file");
   const record = asRecord(
     JSON.parse(readFileSync(path, "utf8")),
     "live report command lease",
@@ -1605,6 +1617,11 @@ function liveReportHasActiveCommand(lockPath, ownerToken) {
   const commandDirectory = liveReportCommandDirectory(lockPath);
   let entries;
   try {
+    assertLiveReportPrivatePath(
+      commandDirectory,
+      "live report command directory",
+      "directory",
+    );
     entries = readdirSync(commandDirectory, { withFileTypes: true });
   } catch (error) {
     if (fileSystemErrorCode(error) === "ENOENT" && !existsSync(lockPath)) {
@@ -1613,7 +1630,7 @@ function liveReportHasActiveCommand(lockPath, ownerToken) {
     throw error;
   }
   for (const entry of entries) {
-    if (entry.isSymbolicLink() || (!entry.isFile() && !entry.isDirectory())) {
+    if (!entry.isFile()) {
       throw new TypeError("live report command directory is invalid");
     }
     if (!/^lease-[a-f0-9]{32}\.json$/u.test(entry.name)) continue;
@@ -1626,10 +1643,7 @@ function liveReportHasActiveCommand(lockPath, ownerToken) {
 }
 
 function assertLiveReportLockDirectory(lockPath) {
-  const stats = lstatSync(lockPath);
-  if (stats.isSymbolicLink() || !stats.isDirectory()) {
-    throw new TypeError("live report lock must be a real directory");
-  }
+  assertLiveReportPrivatePath(lockPath, "live report lock", "directory");
 }
 
 function prepareLiveReportLockCandidate(lockPath, ownerToken, processIdentity) {
@@ -1701,6 +1715,11 @@ function spawnLockedGh(lockPath, ownerToken, command, args, options = {}) {
     throw new RangeError("live report gh command maxBuffer is invalid");
   }
   const commandToken = randomBytes(16).toString("hex");
+  assertLiveReportPrivatePath(
+    liveReportCommandDirectory(lockPath),
+    "live report command directory",
+    "directory",
+  );
   const requestPath = join(
     liveReportCommandDirectory(lockPath),
     `request-${commandToken}.json`,
@@ -1827,7 +1846,7 @@ function readLockedGhRequest(lockPath, ownerToken, commandToken) {
   ) {
     throw new TypeError("locked GitHub command tokens are invalid");
   }
-  const root = ensureLiveReportLockRoot();
+  const root = ensureLiveReportLockRoot(dirname(lockPath));
   if (
     dirname(lockPath) !== root ||
     !/^[a-f0-9]{64}\.lock$/u.test(basename(lockPath))
@@ -1842,6 +1861,11 @@ function readLockedGhRequest(lockPath, ownerToken, commandToken) {
   const requestPath = join(
     liveReportCommandDirectory(lockPath),
     `request-${commandToken}.json`,
+  );
+  assertLiveReportPrivatePath(
+    requestPath,
+    "locked GitHub command request",
+    "file",
   );
   const request = asRecord(
     JSON.parse(readFileSync(requestPath, "utf8")),

--- a/skills/contribute-to-delta-star/scripts/live-report.mjs
+++ b/skills/contribute-to-delta-star/scripts/live-report.mjs
@@ -6,7 +6,18 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { createHash, randomBytes } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -34,6 +45,10 @@ export const MAX_ACTIVITY_CONNECTION_ITEMS = 1_000;
 export const MIN_GRAPHQL_ACTIVITY_POINTS = 1_000;
 export const MIN_REST_ACTIVITY_REQUESTS = 100;
 export const MIN_SEARCH_ACTIVITY_REQUESTS = 2;
+
+const LIVE_REPORT_LOCK_DIRECTORY = "slop-live-report-locks-v1";
+const LIVE_REPORT_LOCK_OWNER_FILE = "owner.json";
+const LIVE_REPORT_LOCK_ACQUIRE_ATTEMPTS = 8;
 
 const REPOSITORY_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const PLACEHOLDER_RE =
@@ -1301,6 +1316,193 @@ export function createGhCommandBudget(spawn = spawnSync) {
       }
       count += 1;
       return spawn(command, args, options);
+    },
+  };
+}
+
+export class LiveReportLockContentionError extends Error {
+  constructor() {
+    super(
+      "live report lock contention: another report for this GitHub identity is already discovering activity",
+    );
+    this.name = "LiveReportLockContentionError";
+  }
+}
+
+export function readGhAuthenticatedIdentity(spawn = spawnSync) {
+  const result = spawn(
+    "gh",
+    ["api", "--method", "GET", "--jq", "{id: .id, login: .login}", "user"],
+    {
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024,
+      windowsHide: true,
+    },
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const detail =
+      result.stderr.trim().length > 0 ? `: ${result.stderr.trim()}` : "";
+    throw new Error(`gh api failed for authenticated identity${detail}`);
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(result.stdout);
+  } catch (cause) {
+    throw new SyntaxError(
+      "gh api returned malformed JSON for authenticated identity",
+      { cause },
+    );
+  }
+  const identity = asRecord(parsed, "GitHub authenticated identity");
+  const id = asNumberField(identity, "id", "GitHub authenticated identity");
+  const login = asStringField(
+    identity,
+    "login",
+    "GitHub authenticated identity",
+  );
+  if (id <= 0 || login.length === 0) {
+    throw new TypeError("GitHub authenticated identity is invalid");
+  }
+  return { id, login };
+}
+
+function fileSystemErrorCode(error) {
+  return error && typeof error === "object" && "code" in error
+    ? error.code
+    : null;
+}
+
+function readLiveReportLockOwner(lockPath) {
+  try {
+    const owner = asRecord(
+      JSON.parse(
+        readFileSync(join(lockPath, LIVE_REPORT_LOCK_OWNER_FILE), "utf8"),
+      ),
+      "live report lock owner",
+    );
+    const schemaVersion = asNumberField(
+      owner,
+      "schemaVersion",
+      "live report lock owner",
+    );
+    const pid = asNumberField(owner, "pid", "live report lock owner");
+    const ownerToken = asStringField(
+      owner,
+      "ownerToken",
+      "live report lock owner",
+    );
+    if (
+      schemaVersion !== 1 ||
+      pid <= 0 ||
+      !/^[a-f0-9]{32}$/u.test(ownerToken)
+    ) {
+      return null;
+    }
+    return { pid, ownerToken };
+  } catch {
+    // error-policy:J3 A corrupt or incomplete lease cannot claim live ownership.
+    return null;
+  }
+}
+
+function processIsRunning(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (fileSystemErrorCode(error) === "ESRCH") return false;
+    if (fileSystemErrorCode(error) === "EPERM") return true;
+    throw error;
+  }
+}
+
+function lockOwnerIsActive(owner) {
+  return owner !== null && processIsRunning(owner.pid);
+}
+
+function prepareLiveReportLockCandidate(lockPath, ownerToken) {
+  const candidatePath = `${lockPath}.candidate-${process.pid}-${ownerToken}`;
+  mkdirSync(candidatePath, { mode: 0o700 });
+  try {
+    writeFileSync(
+      join(candidatePath, LIVE_REPORT_LOCK_OWNER_FILE),
+      `${JSON.stringify({
+        schemaVersion: 1,
+        pid: process.pid,
+        ownerToken,
+      })}\n`,
+      { flag: "wx", mode: 0o600 },
+    );
+    return candidatePath;
+  } catch (error) {
+    rmSync(candidatePath, { force: true, recursive: true });
+    throw error;
+  }
+}
+
+export function acquireLiveReportLock(identity) {
+  const record = asRecord(identity, "GitHub authenticated identity");
+  const id = asNumberField(record, "id", "GitHub authenticated identity");
+  const login = asStringField(record, "login", "GitHub authenticated identity");
+  if (id <= 0 || login.length === 0) {
+    throw new TypeError("GitHub authenticated identity is invalid");
+  }
+  const root = join(tmpdir(), LIVE_REPORT_LOCK_DIRECTORY);
+  mkdirSync(root, { mode: 0o700, recursive: true });
+  const key = createHash("sha256").update(`github.com:${id}`).digest("hex");
+  const lockPath = join(root, `${key}.lock`);
+  const ownerToken = randomBytes(16).toString("hex");
+  let acquired = false;
+  for (
+    let attempt = 0;
+    attempt < LIVE_REPORT_LOCK_ACQUIRE_ATTEMPTS;
+    attempt += 1
+  ) {
+    const candidatePath = prepareLiveReportLockCandidate(lockPath, ownerToken);
+    try {
+      renameSync(candidatePath, lockPath);
+      acquired = true;
+      break;
+    } catch (error) {
+      rmSync(candidatePath, { force: true, recursive: true });
+      if (!existsSync(lockPath)) {
+        if (fileSystemErrorCode(error) === "ENOENT") continue;
+        throw error;
+      }
+      const currentOwner = readLiveReportLockOwner(lockPath);
+      if (lockOwnerIsActive(currentOwner)) {
+        throw new LiveReportLockContentionError();
+      }
+      const stalePath = `${lockPath}.stale-${process.pid}-${randomBytes(16).toString("hex")}`;
+      try {
+        renameSync(lockPath, stalePath);
+      } catch (renameError) {
+        if (fileSystemErrorCode(renameError) === "ENOENT") continue;
+        throw renameError;
+      }
+      rmSync(stalePath, { force: true, recursive: true });
+    }
+  }
+  if (!acquired) {
+    throw new Error("live report lock changed too often to acquire safely");
+  }
+  let released = false;
+  return {
+    release() {
+      if (released) return;
+      const owner = readLiveReportLockOwner(lockPath);
+      if (
+        owner === null ||
+        owner.pid !== process.pid ||
+        owner.ownerToken !== ownerToken
+      ) {
+        throw new Error("live report lock ownership changed before release");
+      }
+      const releasedPath = `${lockPath}.released-${process.pid}-${ownerToken}`;
+      renameSync(lockPath, releasedPath);
+      rmSync(releasedPath, { force: true, recursive: true });
+      released = true;
     },
   };
 }
@@ -2779,34 +2981,40 @@ export function main(args = process.argv.slice(2)) {
   const boundedRead = (endpoint) => {
     return readGhPages(endpoint, commandBudget.run);
   };
-  const openActivity = readGhOpenActivity(options.repo, commandBudget.run, {
-    preflight: true,
-  });
-  const limits = asRecord(openActivity.rateLimits, "GitHub rate limits");
-  process.stderr.write(
-    `[Slop] GitHub budgets: GraphQL ${limits.graphqlRemaining}/${limits.graphqlLimit} (${limits.graphqlBudgetSource}); REST ${limits.restRemaining}/${limits.restLimit}; Search ${limits.searchRemaining}/${limits.searchLimit}; activity source ${openActivity.source}\n`,
-  );
-  const report = collectLiveReport(
-    options.repo,
-    boundedRead,
-    new Date(),
-    ({ phase, current, total }) => {
-      if (current === 0 || current === total || current % 10 === 0) {
-        process.stderr.write(
-          `[Slop] scanning ${phase}: ${current}/${total} (${commandBudget.count} bounded GitHub commands)\n`,
-        );
-      }
-    },
-    openActivity,
-    selectionPolicy.eligibleIssueLabels,
-  );
-  process.stdout.write(
-    options.epochOnly
-      ? `${JSON.stringify(report.selection.reviewEpoch, null, 2)}\n`
-      : options.json
-        ? `${JSON.stringify(report, null, 2)}\n`
-        : renderMarkdown(report),
-  );
+  const authenticatedIdentity = readGhAuthenticatedIdentity();
+  const liveReportLock = acquireLiveReportLock(authenticatedIdentity);
+  try {
+    const openActivity = readGhOpenActivity(options.repo, commandBudget.run, {
+      preflight: true,
+    });
+    const limits = asRecord(openActivity.rateLimits, "GitHub rate limits");
+    process.stderr.write(
+      `[Slop] GitHub budgets: GraphQL ${limits.graphqlRemaining}/${limits.graphqlLimit} (${limits.graphqlBudgetSource}); REST ${limits.restRemaining}/${limits.restLimit}; Search ${limits.searchRemaining}/${limits.searchLimit}; activity source ${openActivity.source}\n`,
+    );
+    const report = collectLiveReport(
+      options.repo,
+      boundedRead,
+      new Date(),
+      ({ phase, current, total }) => {
+        if (current === 0 || current === total || current % 10 === 0) {
+          process.stderr.write(
+            `[Slop] scanning ${phase}: ${current}/${total} (${commandBudget.count} bounded GitHub commands)\n`,
+          );
+        }
+      },
+      openActivity,
+      selectionPolicy.eligibleIssueLabels,
+    );
+    process.stdout.write(
+      options.epochOnly
+        ? `${JSON.stringify(report.selection.reviewEpoch, null, 2)}\n`
+        : options.json
+          ? `${JSON.stringify(report, null, 2)}\n`
+          : renderMarkdown(report),
+    );
+  } finally {
+    liveReportLock.release();
+  }
 }
 
 const invokedDirectly =
@@ -2821,7 +3029,12 @@ if (invokedDirectly) {
   } catch (error) {
     // error-policy:J1 The CLI boundary turns a failed read/audit into a non-zero exit.
     const message = error instanceof Error ? error.message : String(error);
-    process.stderr.write(`Slop live report failed: ${message}\n`);
-    process.exitCode = 1;
+    if (error instanceof LiveReportLockContentionError) {
+      process.stderr.write(`Slop live report deferred: ${message}\n`);
+      process.exitCode = 2;
+    } else {
+      process.stderr.write(`Slop live report failed: ${message}\n`);
+      process.exitCode = 1;
+    }
   }
 }

--- a/skills/contribute-to-delta-star/scripts/live-report.mjs
+++ b/skills/contribute-to-delta-star/scripts/live-report.mjs
@@ -2811,15 +2811,11 @@ export function main(args = process.argv.slice(2)) {
   const boundedRead = (endpoint) => {
     return readGhPages(endpoint, commandBudget.run);
   };
-  let rateLimits = { preflight: true };
   const { report } = retryChangedLiveInventory(
     () => {
-      const openActivity = readGhOpenActivity(
-        options.repo,
-        commandBudget.run,
-        rateLimits,
-      );
-      rateLimits = openActivity.rateLimits;
+      const openActivity = readGhOpenActivity(options.repo, commandBudget.run, {
+        preflight: true,
+      });
       const limits = asRecord(openActivity.rateLimits, "GitHub rate limits");
       process.stderr.write(
         `[Slop] GitHub budgets: GraphQL ${limits.graphqlRemaining}/${limits.graphqlLimit} (${limits.graphqlBudgetSource}); REST ${limits.restRemaining}/${limits.restLimit}; Search ${limits.searchRemaining}/${limits.searchLimit}; activity source ${openActivity.source}\n`,

--- a/skills/contribute-to-delta-star/scripts/run-receipt.mjs
+++ b/skills/contribute-to-delta-star/scripts/run-receipt.mjs
@@ -2193,6 +2193,20 @@ function renderResult(result, json) {
   );
 }
 
+const WALLET_CLAIM_SCRIPT = join(scriptDirectory, "wallet-claim.mjs");
+
+/**
+ * One stderr line after a fresh finish for projects that pay a monthly pool.
+ * The run never reads the wallet registry, so it cannot know whether a claim
+ * exists; it only points at the register command and the cut-off rule.
+ */
+function walletNudge() {
+  if (!existsSync(WALLET_CLAIM_SCRIPT)) return;
+  process.stderr.write(
+    `No payout wallet is checked by this run. If none is registered, run: node ${WALLET_CLAIM_SCRIPT} register --address <public-address> (a wallet observed after a proposal is generated applies to the next cycle).\n`,
+  );
+}
+
 function previewRun(options) {
   const provenance = resolveSkillProvenance();
   const repositoryRoot = requireRepository(options.repoRoot);
@@ -2562,6 +2576,7 @@ function finishRun(options, testOptions) {
     },
     options.json,
   );
+  walletNudge();
 }
 
 export async function main(args = process.argv.slice(2), testOptions) {

--- a/skills/contribute-to-delta-star/scripts/run-receipt.mjs
+++ b/skills/contribute-to-delta-star/scripts/run-receipt.mjs
@@ -1299,6 +1299,7 @@ export async function slopIdentityAssertion(
   fetchImpl = globalThis.fetch,
   delayImpl = (milliseconds) =>
     new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds)),
+  nowImpl = Date.now,
 ) {
   if (typeof fetchImpl !== "function")
     fail("Slop identity transport is unavailable");
@@ -1348,10 +1349,10 @@ export async function slopIdentityAssertion(
   );
   const expiresAt = Date.parse(started.expiresAt);
   process.stderr.write(
-    `This link expires in ${Math.max(0, Math.round((expiresAt - Date.now()) / 1000))} seconds; authorize promptly.\n`,
+    `This link expires in ${Math.max(0, Math.round((expiresAt - nowImpl()) / 1000))} seconds; authorize promptly.\n`,
   );
   let retryAfterSeconds = started.pollAfterSeconds;
-  while (Date.now() < expiresAt) {
+  while (nowImpl() < expiresAt) {
     await delayImpl(retryAfterSeconds * 1000);
     let response;
     try {
@@ -1388,7 +1389,7 @@ export async function slopIdentityAssertion(
       if (
         response.status === 410 &&
         errorCode !== "flow_consumed" &&
-        Date.now() >= expiresAt - (retryAfterSeconds + 1) * 1000
+        (errorCode === "flow_expired" || nowImpl() >= expiresAt)
       ) {
         fail(
           "Slop identity authorization expired before completion; run register again and authorize within the deadline",
@@ -1436,7 +1437,7 @@ export async function slopIdentityAssertion(
       typeof result.assertion !== "string" ||
       !/^slop_assert_v1_[A-Za-z0-9_-]{20,512}$/u.test(result.assertion) ||
       canonicalIso(result.expiresAt) !== result.expiresAt ||
-      Date.parse(result.expiresAt) <= Date.now()
+      Date.parse(result.expiresAt) <= nowImpl()
     ) {
       fail("Slop identity completion response was invalid");
     }

--- a/skills/contribute-to-delta-star/scripts/run-receipt.mjs
+++ b/skills/contribute-to-delta-star/scripts/run-receipt.mjs
@@ -1347,6 +1347,9 @@ export async function slopIdentityAssertion(
     `Authorize this contribution with GitHub:\n${authorizationUrl.href}\n`,
   );
   const expiresAt = Date.parse(started.expiresAt);
+  process.stderr.write(
+    `This link expires in ${Math.max(0, Math.round((expiresAt - Date.now()) / 1000))} seconds; authorize promptly.\n`,
+  );
   let retryAfterSeconds = started.pollAfterSeconds;
   while (Date.now() < expiresAt) {
     await delayImpl(retryAfterSeconds * 1000);
@@ -1366,7 +1369,34 @@ export async function slopIdentityAssertion(
       fail("Slop identity poll request failed");
     }
     if (!response.ok) {
-      fail(`Slop identity poll returned HTTP ${response.status}`);
+      let errorCode = null;
+      try {
+        const parsed = JSON.parse(
+          await boundedResponseText(response, "Slop identity poll"),
+        );
+        if (
+          parsed &&
+          typeof parsed === "object" &&
+          typeof parsed.error === "string" &&
+          /^[a-z0-9_]{1,64}$/u.test(parsed.error)
+        ) {
+          errorCode = parsed.error;
+        }
+      } catch {
+        // Fail closed on the status alone when the body is unreadable.
+      }
+      if (
+        response.status === 410 &&
+        errorCode !== "flow_consumed" &&
+        Date.now() >= expiresAt - (retryAfterSeconds + 1) * 1000
+      ) {
+        fail(
+          "Slop identity authorization expired before completion; run register again and authorize within the deadline",
+        );
+      }
+      fail(
+        `Slop identity poll returned HTTP ${response.status}${errorCode === null ? "" : ` (${errorCode})`}`,
+      );
     }
     const source = await boundedResponseText(response, "Slop identity poll");
     let result;

--- a/skills/contribute-to-delta-star/scripts/run-receipt.mjs
+++ b/skills/contribute-to-delta-star/scripts/run-receipt.mjs
@@ -1533,88 +1533,92 @@ export async function uploadPrivateTrace(
   );
   if (
     created.clientRunId !== state.runId ||
-    created.state !== "awaiting_trace" ||
+    !["awaiting_trace", "trace_uploaded", "finalized"].includes(
+      created.state,
+    ) ||
     !/^[A-Za-z0-9][A-Za-z0-9._:-]{0,159}$/u.test(created.serverRunId ?? "")
   ) {
     fail("trace run creation returned mismatched identity");
   }
   const serverPath = encodeURIComponent(created.serverRunId);
-  const intentBody = {
-    sha256: trace.sha256,
-    sizeBytes: trace.sizeBytes,
-    contentType: trace.contentType,
-  };
-  const intent = await jsonRequest(
-    fetchImpl,
-    `${TRACE_AUTHORITY}/api/v1/runs/${serverPath}/trace-intents`,
-    {
-      method: "POST",
-      headers: {
-        ...jsonHeaders,
-        "Idempotency-Key": sha256(
-          `intent:${created.serverRunId}:${trace.sha256}`,
-        ),
+  if (created.state === "awaiting_trace") {
+    const intentBody = {
+      sha256: trace.sha256,
+      sizeBytes: trace.sizeBytes,
+      contentType: trace.contentType,
+    };
+    const intent = await jsonRequest(
+      fetchImpl,
+      `${TRACE_AUTHORITY}/api/v1/runs/${serverPath}/trace-intents`,
+      {
+        method: "POST",
+        headers: {
+          ...jsonHeaders,
+          "Idempotency-Key": sha256(
+            `intent:${created.serverRunId}:${trace.sha256}`,
+          ),
+        },
+        body: JSON.stringify(intentBody),
       },
-      body: JSON.stringify(intentBody),
-    },
-    [
-      "contentType",
-      "expiresAt",
-      "serverRunId",
-      "sha256",
-      "sizeBytes",
-      "uploadUrl",
-    ],
-    "trace upload intent",
-  );
-  let uploadUrl;
-  try {
-    uploadUrl = new URL(intent.uploadUrl);
-  } catch {
-    fail("trace upload intent returned an invalid URL");
-  }
-  if (
-    intent.serverRunId !== created.serverRunId ||
-    intent.sha256 !== trace.sha256 ||
-    intent.sizeBytes !== trace.sizeBytes ||
-    intent.contentType !== trace.contentType ||
-    uploadUrl.origin !== TRACE_AUTHORITY ||
-    uploadUrl.username ||
-    uploadUrl.password ||
-    uploadUrl.hash
-  ) {
-    fail("trace upload intent returned mismatched fields");
-  }
-  const uploaded = await jsonRequest(
-    fetchImpl,
-    uploadUrl.href,
-    {
-      method: "PUT",
-      headers: {
-        "Content-Type": trace.contentType,
-        Digest: `sha-256=${trace.sha256}`,
+      [
+        "contentType",
+        "expiresAt",
+        "serverRunId",
+        "sha256",
+        "sizeBytes",
+        "uploadUrl",
+      ],
+      "trace upload intent",
+    );
+    let uploadUrl;
+    try {
+      uploadUrl = new URL(intent.uploadUrl);
+    } catch {
+      fail("trace upload intent returned an invalid URL");
+    }
+    if (
+      intent.serverRunId !== created.serverRunId ||
+      intent.sha256 !== trace.sha256 ||
+      intent.sizeBytes !== trace.sizeBytes ||
+      intent.contentType !== trace.contentType ||
+      uploadUrl.origin !== TRACE_AUTHORITY ||
+      uploadUrl.username ||
+      uploadUrl.password ||
+      uploadUrl.hash
+    ) {
+      fail("trace upload intent returned mismatched fields");
+    }
+    const uploaded = await jsonRequest(
+      fetchImpl,
+      uploadUrl.href,
+      {
+        method: "PUT",
+        headers: {
+          "Content-Type": trace.contentType,
+          Digest: `sha-256=${trace.sha256}`,
+        },
+        body: trace.contents,
       },
-      body: trace.contents,
-    },
-    [
-      "clientRunId",
-      "serverRunId",
-      "sizeBytes",
-      "state",
-      "traceObjectId",
-      "traceSha256",
-    ],
-    "trace upload",
-  );
-  if (
-    uploaded.clientRunId !== state.runId ||
-    uploaded.serverRunId !== created.serverRunId ||
-    uploaded.sizeBytes !== trace.sizeBytes ||
-    uploaded.state !== "trace_uploaded" ||
-    uploaded.traceSha256 !== trace.sha256 ||
-    uploaded.traceObjectId !== `sha256:${trace.sha256}`
-  ) {
-    fail("trace upload returned mismatched evidence");
+      [
+        "clientRunId",
+        "serverRunId",
+        "sizeBytes",
+        "state",
+        "traceObjectId",
+        "traceSha256",
+      ],
+      "trace upload",
+    );
+    if (
+      uploaded.clientRunId !== state.runId ||
+      uploaded.serverRunId !== created.serverRunId ||
+      uploaded.sizeBytes !== trace.sizeBytes ||
+      uploaded.state !== "trace_uploaded" ||
+      uploaded.traceSha256 !== trace.sha256 ||
+      uploaded.traceObjectId !== `sha256:${trace.sha256}`
+    ) {
+      fail("trace upload returned mismatched evidence");
+    }
   }
   const finalized = await jsonRequest(
     fetchImpl,

--- a/skills/contribute-to-delta-star/scripts/run-receipt.mjs
+++ b/skills/contribute-to-delta-star/scripts/run-receipt.mjs
@@ -1585,7 +1585,7 @@ export async function uploadPrivateTrace(
         headers: {
           ...jsonHeaders,
           "Idempotency-Key": sha256(
-            `intent:${created.serverRunId}:${trace.sha256}`,
+            `intent:${created.serverRunId}:${trace.sha256}:${randomBytes(16).toString("hex")}`,
           ),
         },
         body: JSON.stringify(intentBody),

--- a/skills/contribute-to-eliza/SKILL.md
+++ b/skills/contribute-to-eliza/SKILL.md
@@ -523,8 +523,9 @@ node <skill-directory>/scripts/wallet-claim.mjs register --address <public-addre
    Slop bearer token only in process memory. It prints the immutable claim ID,
    record digest, and public metadata URL—never a credential.
 5. An address change appends a new claim linked to the current claim; it never
-   edits or deletes history. The change is material and restarts that
-   allocation's 14-day review.
+   edits or deletes history. A claim observed after a proposal is generated
+   applies to the next cycle; it never modifies that proposal or restarts its
+   14-day review, and the row stays unclaimed and carries forward.
 
 A claim identifies where a reviewed payout may go. It does not prove custody,
 guarantee payment, approve an allocation, connect a wallet, or move funds.

--- a/skills/contribute-to-eliza/scripts/live-report.mjs
+++ b/skills/contribute-to-eliza/scripts/live-report.mjs
@@ -31,9 +31,24 @@ export const REVIEW_EPOCH_SCHEMA_VERSION = 1;
 export const MAX_REVIEW_EPOCH_FILE_BYTES = 262_144;
 export const MAX_API_READS = 16;
 export const MAX_ACTIVITY_CONNECTION_ITEMS = 1_000;
+// Large repositories can legitimately exceed Node's 64 MiB spawnSync default
+// after gh concatenates bounded pages. Keep one explicit ceiling high enough
+// for the 10,000-item inventory while still failing closed on runaway output.
+export const MAX_GH_REPORT_BYTES = 256 * 1024 * 1024;
 export const MIN_GRAPHQL_ACTIVITY_POINTS = 1_000;
 export const MIN_REST_ACTIVITY_REQUESTS = 100;
 export const MIN_SEARCH_ACTIVITY_REQUESTS = 2;
+export const MAX_LIVE_INVENTORY_ATTEMPTS = 2;
+
+export class LiveInventoryChangedError extends Error {
+  constructor(
+    message = "batched activity does not exactly match the live open-item inventory",
+    options,
+  ) {
+    super(message, options);
+    this.name = "LiveInventoryChangedError";
+  }
+}
 
 const REPOSITORY_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const PLACEHOLDER_RE =
@@ -748,7 +763,7 @@ export function readGhPages(endpoint, spawn = spawnSync) {
   ];
   const result = spawn("gh", args, {
     encoding: "utf8",
-    maxBuffer: 64 * 1024 * 1024,
+    maxBuffer: MAX_GH_REPORT_BYTES,
     windowsHide: true,
   });
   if (result.error) throw result.error;
@@ -959,7 +974,7 @@ function readGhActivityPage(endpoint, pageNumber, context, spawn) {
     ["api", "--method", "GET", "--jq", ".[]", pagedEndpoint],
     {
       encoding: "utf8",
-      maxBuffer: 64 * 1024 * 1024,
+      maxBuffer: MAX_GH_REPORT_BYTES,
       windowsHide: true,
     },
   );
@@ -1051,7 +1066,7 @@ function readGhSearchPullNumbers(repo, qualifier, spawn) {
     ],
     {
       encoding: "utf8",
-      maxBuffer: 64 * 1024 * 1024,
+      maxBuffer: MAX_GH_REPORT_BYTES,
       windowsHide: true,
     },
   );
@@ -1274,7 +1289,7 @@ function readGraphqlActivityNodes(repo, query, selector, spawn, context) {
     ],
     {
       encoding: "utf8",
-      maxBuffer: 64 * 1024 * 1024,
+      maxBuffer: MAX_GH_REPORT_BYTES,
       windowsHide: true,
     },
   );
@@ -2239,9 +2254,7 @@ export function collectLiveReport(
       [...issueNumbers].some((number) => !activity.issues.has(number)) ||
       [...pullNumbers].some((number) => !activity.pulls.has(number))
     ) {
-      throw new TypeError(
-        "batched activity does not exactly match the live open-item inventory",
-      );
+      throw new LiveInventoryChangedError();
     }
   }
   onProgress({ phase: "issues", current: 0, total: issueItems.length });
@@ -2744,6 +2757,25 @@ Options:
 `;
 }
 
+/** Repeats one complete read when GitHub changes its open-item inventory mid-snapshot. */
+export function retryChangedLiveInventory(collect, onRetry = () => {}) {
+  for (let attempt = 1; attempt <= MAX_LIVE_INVENTORY_ATTEMPTS; attempt += 1) {
+    try {
+      return collect(attempt);
+    } catch (cause) {
+      if (!(cause instanceof LiveInventoryChangedError)) throw cause;
+      if (attempt === MAX_LIVE_INVENTORY_ATTEMPTS) {
+        throw new LiveInventoryChangedError(
+          `Open GitHub inventory changed while collecting the live report after ${MAX_LIVE_INVENTORY_ATTEMPTS} attempts`,
+          { cause },
+        );
+      }
+      onRetry({ attempt, cause });
+    }
+  }
+  throw new Error("unreachable live inventory retry state");
+}
+
 export function main(args = process.argv.slice(2)) {
   const selectionPolicy = readProjectSelectionPolicy();
   const options = parseCliArguments(args, selectionPolicy.repositoryId);
@@ -2779,26 +2811,40 @@ export function main(args = process.argv.slice(2)) {
   const boundedRead = (endpoint) => {
     return readGhPages(endpoint, commandBudget.run);
   };
-  const openActivity = readGhOpenActivity(options.repo, commandBudget.run, {
-    preflight: true,
-  });
-  const limits = asRecord(openActivity.rateLimits, "GitHub rate limits");
-  process.stderr.write(
-    `[Slop] GitHub budgets: GraphQL ${limits.graphqlRemaining}/${limits.graphqlLimit} (${limits.graphqlBudgetSource}); REST ${limits.restRemaining}/${limits.restLimit}; Search ${limits.searchRemaining}/${limits.searchLimit}; activity source ${openActivity.source}\n`,
-  );
-  const report = collectLiveReport(
-    options.repo,
-    boundedRead,
-    new Date(),
-    ({ phase, current, total }) => {
-      if (current === 0 || current === total || current % 10 === 0) {
-        process.stderr.write(
-          `[Slop] scanning ${phase}: ${current}/${total} (${commandBudget.count} bounded GitHub commands)\n`,
-        );
-      }
+  let rateLimits = { preflight: true };
+  const { report } = retryChangedLiveInventory(
+    () => {
+      const openActivity = readGhOpenActivity(
+        options.repo,
+        commandBudget.run,
+        rateLimits,
+      );
+      rateLimits = openActivity.rateLimits;
+      const limits = asRecord(openActivity.rateLimits, "GitHub rate limits");
+      process.stderr.write(
+        `[Slop] GitHub budgets: GraphQL ${limits.graphqlRemaining}/${limits.graphqlLimit} (${limits.graphqlBudgetSource}); REST ${limits.restRemaining}/${limits.restLimit}; Search ${limits.searchRemaining}/${limits.searchLimit}; activity source ${openActivity.source}\n`,
+      );
+      return {
+        report: collectLiveReport(
+          options.repo,
+          boundedRead,
+          new Date(),
+          ({ phase, current, total }) => {
+            if (current === 0 || current === total || current % 10 === 0) {
+              process.stderr.write(
+                `[Slop] scanning ${phase}: ${current}/${total} (${commandBudget.count} bounded GitHub commands)\n`,
+              );
+            }
+          },
+          openActivity,
+          selectionPolicy.eligibleIssueLabels,
+        ),
+      };
     },
-    openActivity,
-    selectionPolicy.eligibleIssueLabels,
+    ({ attempt }) =>
+      process.stderr.write(
+        `[Slop] open-item inventory changed during snapshot attempt ${attempt}; retrying one complete read\n`,
+      ),
   );
   process.stdout.write(
     options.epochOnly

--- a/skills/contribute-to-eliza/scripts/live-report.mjs
+++ b/skills/contribute-to-eliza/scripts/live-report.mjs
@@ -3,6 +3,7 @@
  * Builds a stable, read-only inventory of open elizaOS issues and pull requests
  * for contribution selection. REST pagination stays behind one GET-only
  * adapter; GraphQL uses explicit read-only queries over GitHub's POST endpoint.
+ * A user-private process lease serializes complete discovery across skill copies.
  */
 
 import { spawn, spawnSync } from "node:child_process";
@@ -11,8 +12,8 @@ import {
   existsSync,
   lstatSync,
   mkdirSync,
-  readFileSync,
   readdirSync,
+  readFileSync,
   realpathSync,
   renameSync,
   rmSync,
@@ -50,15 +51,11 @@ export const MIN_SEARCH_ACTIVITY_REQUESTS = 2;
 
 const LIVE_REPORT_LOCK_DIRECTORY = "slop-live-report-locks-v2";
 const LIVE_REPORT_LOCK_OWNER_FILE = "owner.json";
-const LIVE_REPORT_LOCK_HEARTBEAT_FILE = "heartbeat.json";
 const LIVE_REPORT_LOCK_COMMAND_DIRECTORY = "commands";
 const LIVE_REPORT_LOCK_ACQUIRE_ATTEMPTS = 8;
-const LIVE_REPORT_HEARTBEAT_INTERVAL_MS = 200;
-const LIVE_REPORT_HEARTBEAT_STALE_MS = 1_000;
 const LIVE_REPORT_ORPHAN_COMMAND_GRACE_MS = 5 * 60 * 1_000;
 const LIVE_REPORT_LOCKED_GH_ARGUMENT = "--slop-internal-locked-gh-v1";
-const LIVE_REPORT_LOCK_HEARTBEAT_ARGUMENT =
-  "--slop-internal-lock-heartbeat-v1";
+const LIVE_REPORT_PROCESS_IDENTITY_RE = /^[a-f0-9]{64}$/u;
 const LIVE_REPORT_TOKEN_RE = /^[a-f0-9]{32}$/u;
 
 const REPOSITORY_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
@@ -1393,10 +1390,121 @@ function fileSystemErrorCode(error) {
     : null;
 }
 
-function heartbeatTimestampIsFresh(observedAtMs) {
-  const age = Date.now() - observedAtMs;
-  return age >= -LIVE_REPORT_HEARTBEAT_STALE_MS &&
-    age <= LIVE_REPORT_HEARTBEAT_STALE_MS;
+function assertLiveReportPrivatePath(path, context, kind) {
+  const stats = lstatSync(path);
+  const kindMatches =
+    kind === "directory" ? stats.isDirectory() : stats.isFile();
+  if (stats.isSymbolicLink() || !kindMatches) {
+    throw new TypeError(`${context} must be a real ${kind}`);
+  }
+  const uid = typeof process.getuid === "function" ? process.getuid() : null;
+  if (Number.isInteger(uid) && stats.uid !== uid) {
+    throw new TypeError(`${context} must belong to the current user`);
+  }
+  if (platform() !== "win32" && (stats.mode & 0o077) !== 0) {
+    throw new TypeError(`${context} permissions must exclude group and others`);
+  }
+  return stats;
+}
+
+function processIsRunning(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (fileSystemErrorCode(error) === "ESRCH") return false;
+    if (fileSystemErrorCode(error) === "EPERM") return true;
+    throw error;
+  }
+}
+
+function hashProcessIdentity(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+export function readLiveReportProcessIdentity(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    throw new TypeError("live report process ID must be a positive integer");
+  }
+  if (!processIsRunning(pid)) return null;
+  const operatingSystem = platform();
+  if (operatingSystem === "linux") {
+    let source;
+    try {
+      source = readFileSync(`/proc/${pid}/stat`, "utf8");
+    } catch (error) {
+      if (fileSystemErrorCode(error) === "ENOENT") return null;
+      throw error;
+    }
+    const commandEnd = source.lastIndexOf(")");
+    const fields = source
+      .slice(commandEnd + 2)
+      .trim()
+      .split(/\s+/u);
+    const startTime = fields[19];
+    if (commandEnd < 1 || !/^\d+$/u.test(startTime ?? "")) {
+      throw new TypeError("Linux returned an invalid process birth identity");
+    }
+    return hashProcessIdentity(`linux:${startTime}`);
+  }
+  if (
+    operatingSystem === "darwin" ||
+    operatingSystem === "freebsd" ||
+    operatingSystem === "openbsd"
+  ) {
+    const result = spawnSync(
+      existsSync("/bin/ps") ? "/bin/ps" : "ps",
+      ["-o", "lstart=", "-p", String(pid)],
+      { encoding: "utf8", maxBuffer: 64 * 1024, windowsHide: true },
+    );
+    if (result.error) throw result.error;
+    if (result.status !== 0 || result.stdout.trim() === "") {
+      if (!processIsRunning(pid)) return null;
+      throw new Error("could not read the process birth identity from ps");
+    }
+    return hashProcessIdentity(`${operatingSystem}:${result.stdout.trim()}`);
+  }
+  if (operatingSystem === "win32") {
+    const result = spawnSync(
+      "powershell.exe",
+      [
+        "-NoLogo",
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        `(Get-Process -Id ${pid} -ErrorAction Stop).StartTime.ToUniversalTime().Ticks`,
+      ],
+      { encoding: "utf8", maxBuffer: 64 * 1024, windowsHide: true },
+    );
+    if (result.error) throw result.error;
+    if (result.status !== 0 || !/^\d+$/u.test(result.stdout.trim())) {
+      if (!processIsRunning(pid)) return null;
+      throw new Error("could not read the Windows process birth identity");
+    }
+    return hashProcessIdentity(`win32:${result.stdout.trim()}`);
+  }
+  throw new Error(
+    `live report locking does not support process identity on ${operatingSystem}`,
+  );
+}
+
+function readProcessLease(value, context) {
+  const record = asRecord(value, context);
+  const pid = asNumberField(record, "pid", context);
+  const processIdentity = asStringField(record, "processIdentity", context);
+  if (
+    !Number.isInteger(pid) ||
+    pid <= 0 ||
+    !LIVE_REPORT_PROCESS_IDENTITY_RE.test(processIdentity)
+  ) {
+    throw new TypeError(`${context} is invalid`);
+  }
+  return { pid, processIdentity };
+}
+
+function processLeaseIsActive(lease) {
+  const currentIdentity = readLiveReportProcessIdentity(lease.pid);
+  return currentIdentity !== null && currentIdentity === lease.processIdentity;
 }
 
 export function defaultLiveReportLockRoot() {
@@ -1420,25 +1528,18 @@ export function ensureLiveReportLockRoot(
   } catch (error) {
     if (fileSystemErrorCode(error) !== "EEXIST") throw error;
   }
-  const stats = lstatSync(rootPath);
-  if (stats.isSymbolicLink() || !stats.isDirectory()) {
-    throw new TypeError("live report lock root must be a real directory");
-  }
-  const uid = typeof process.getuid === "function" ? process.getuid() : null;
-  if (Number.isInteger(uid) && stats.uid !== uid) {
-    throw new TypeError(
-      "live report lock root must belong to the current user",
-    );
-  }
-  if (platform() !== "win32" && (stats.mode & 0o077) !== 0) {
-    throw new TypeError("live report lock root permissions must be 0700");
-  }
+  assertLiveReportPrivatePath(rootPath, "live report lock root", "directory");
   return rootPath;
 }
 
 function readLiveReportLockOwner(lockPath) {
   let source;
   try {
+    assertLiveReportPrivatePath(
+      join(lockPath, LIVE_REPORT_LOCK_OWNER_FILE),
+      "live report lock owner",
+      "file",
+    );
     source = readFileSync(join(lockPath, LIVE_REPORT_LOCK_OWNER_FILE), "utf8");
   } catch (error) {
     if (fileSystemErrorCode(error) === "ENOENT") return null;
@@ -1467,6 +1568,7 @@ function liveReportCommandDirectory(lockPath) {
 }
 
 function readLiveReportCommandLease(path) {
+  assertLiveReportPrivatePath(path, "live report command lease", "file");
   const record = asRecord(
     JSON.parse(readFileSync(path, "utf8")),
     "live report command lease",
@@ -1515,6 +1617,11 @@ function liveReportHasActiveCommand(lockPath, ownerToken) {
   const commandDirectory = liveReportCommandDirectory(lockPath);
   let entries;
   try {
+    assertLiveReportPrivatePath(
+      commandDirectory,
+      "live report command directory",
+      "directory",
+    );
     entries = readdirSync(commandDirectory, { withFileTypes: true });
   } catch (error) {
     if (fileSystemErrorCode(error) === "ENOENT" && !existsSync(lockPath)) {
@@ -1523,7 +1630,7 @@ function liveReportHasActiveCommand(lockPath, ownerToken) {
     throw error;
   }
   for (const entry of entries) {
-    if (entry.isSymbolicLink() || (!entry.isFile() && !entry.isDirectory())) {
+    if (!entry.isFile()) {
       throw new TypeError("live report command directory is invalid");
     }
     if (!/^lease-[a-f0-9]{32}\.json$/u.test(entry.name)) continue;
@@ -1536,10 +1643,7 @@ function liveReportHasActiveCommand(lockPath, ownerToken) {
 }
 
 function assertLiveReportLockDirectory(lockPath) {
-  const stats = lstatSync(lockPath);
-  if (stats.isSymbolicLink() || !stats.isDirectory()) {
-    throw new TypeError("live report lock must be a real directory");
-  }
+  assertLiveReportPrivatePath(lockPath, "live report lock", "directory");
 }
 
 function prepareLiveReportLockCandidate(lockPath, ownerToken, processIdentity) {
@@ -1611,6 +1715,11 @@ function spawnLockedGh(lockPath, ownerToken, command, args, options = {}) {
     throw new RangeError("live report gh command maxBuffer is invalid");
   }
   const commandToken = randomBytes(16).toString("hex");
+  assertLiveReportPrivatePath(
+    liveReportCommandDirectory(lockPath),
+    "live report command directory",
+    "directory",
+  );
   const requestPath = join(
     liveReportCommandDirectory(lockPath),
     `request-${commandToken}.json`,
@@ -1737,7 +1846,7 @@ function readLockedGhRequest(lockPath, ownerToken, commandToken) {
   ) {
     throw new TypeError("locked GitHub command tokens are invalid");
   }
-  const root = ensureLiveReportLockRoot();
+  const root = ensureLiveReportLockRoot(dirname(lockPath));
   if (
     dirname(lockPath) !== root ||
     !/^[a-f0-9]{64}\.lock$/u.test(basename(lockPath))
@@ -1752,6 +1861,11 @@ function readLockedGhRequest(lockPath, ownerToken, commandToken) {
   const requestPath = join(
     liveReportCommandDirectory(lockPath),
     `request-${commandToken}.json`,
+  );
+  assertLiveReportPrivatePath(
+    requestPath,
+    "locked GitHub command request",
+    "file",
   );
   const request = asRecord(
     JSON.parse(readFileSync(requestPath, "utf8")),

--- a/skills/contribute-to-eliza/scripts/live-report.mjs
+++ b/skills/contribute-to-eliza/scripts/live-report.mjs
@@ -2758,10 +2758,15 @@ Options:
 }
 
 /** Repeats one complete read when GitHub changes its open-item inventory mid-snapshot. */
-export function retryChangedLiveInventory(collect, onRetry = () => {}) {
+export function retryChangedLiveInventory(
+  collect,
+  onRetry = () => {},
+  createCommandBudget = createGhCommandBudget,
+) {
   for (let attempt = 1; attempt <= MAX_LIVE_INVENTORY_ATTEMPTS; attempt += 1) {
+    const commandBudget = createCommandBudget();
     try {
-      return collect(attempt);
+      return collect({ attempt, commandBudget });
     } catch (cause) {
       if (!(cause instanceof LiveInventoryChangedError)) throw cause;
       if (attempt === MAX_LIVE_INVENTORY_ATTEMPTS) {
@@ -2794,8 +2799,8 @@ export function main(args = process.argv.slice(2)) {
     if (!result.complete) process.exitCode = 2;
     return;
   }
-  const commandBudget = createGhCommandBudget();
   if (options.recheckPr !== undefined) {
+    const commandBudget = createGhCommandBudget();
     const result = recheckLivePullHead(
       options.repo,
       {
@@ -2808,12 +2813,12 @@ export function main(args = process.argv.slice(2)) {
     if (!result.publishable) process.exitCode = 2;
     return;
   }
-  const boundedRead = (endpoint) => {
-    return readGhPages(endpoint, commandBudget.run);
-  };
   let rateLimits = { preflight: true };
   const { report } = retryChangedLiveInventory(
-    () => {
+    ({ commandBudget }) => {
+      const boundedRead = (endpoint) => {
+        return readGhPages(endpoint, commandBudget.run);
+      };
       const openActivity = readGhOpenActivity(
         options.repo,
         commandBudget.run,

--- a/skills/contribute-to-eliza/scripts/live-report.mjs
+++ b/skills/contribute-to-eliza/scripts/live-report.mjs
@@ -5,20 +5,22 @@
  * adapter; GraphQL uses explicit read-only queries over GitHub's POST endpoint.
  */
 
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { createHash, randomBytes } from "node:crypto";
 import {
   existsSync,
+  lstatSync,
   mkdirSync,
   readFileSync,
+  readdirSync,
   realpathSync,
   renameSync,
   rmSync,
   statSync,
   writeFileSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { platform, userInfo } from "node:os";
+import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 export const MODEL_DISCLOSURE_PREFIX = "AI provider/model:";
@@ -46,9 +48,18 @@ export const MIN_GRAPHQL_ACTIVITY_POINTS = 1_000;
 export const MIN_REST_ACTIVITY_REQUESTS = 100;
 export const MIN_SEARCH_ACTIVITY_REQUESTS = 2;
 
-const LIVE_REPORT_LOCK_DIRECTORY = "slop-live-report-locks-v1";
+const LIVE_REPORT_LOCK_DIRECTORY = "slop-live-report-locks-v2";
 const LIVE_REPORT_LOCK_OWNER_FILE = "owner.json";
+const LIVE_REPORT_LOCK_HEARTBEAT_FILE = "heartbeat.json";
+const LIVE_REPORT_LOCK_COMMAND_DIRECTORY = "commands";
 const LIVE_REPORT_LOCK_ACQUIRE_ATTEMPTS = 8;
+const LIVE_REPORT_HEARTBEAT_INTERVAL_MS = 200;
+const LIVE_REPORT_HEARTBEAT_STALE_MS = 1_000;
+const LIVE_REPORT_ORPHAN_COMMAND_GRACE_MS = 5 * 60 * 1_000;
+const LIVE_REPORT_LOCKED_GH_ARGUMENT = "--slop-internal-locked-gh-v1";
+const LIVE_REPORT_LOCK_HEARTBEAT_ARGUMENT =
+  "--slop-internal-lock-heartbeat-v1";
+const LIVE_REPORT_TOKEN_RE = /^[a-f0-9]{32}$/u;
 
 const REPOSITORY_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const PLACEHOLDER_RE =
@@ -1332,7 +1343,16 @@ export class LiveReportLockContentionError extends Error {
 export function readGhAuthenticatedIdentity(spawn = spawnSync) {
   const result = spawn(
     "gh",
-    ["api", "--method", "GET", "--jq", "{id: .id, login: .login}", "user"],
+    [
+      "api",
+      "--hostname",
+      "github.com",
+      "--method",
+      "GET",
+      "--jq",
+      "{id: .id, login: .login}",
+      "user",
+    ],
     {
       encoding: "utf8",
       maxBuffer: 1024 * 1024,
@@ -1364,7 +1384,7 @@ export function readGhAuthenticatedIdentity(spawn = spawnSync) {
   if (id <= 0 || login.length === 0) {
     throw new TypeError("GitHub authenticated identity is invalid");
   }
-  return { id, login };
+  return { host: "github.com", id, login };
 }
 
 function fileSystemErrorCode(error) {
@@ -1373,63 +1393,166 @@ function fileSystemErrorCode(error) {
     : null;
 }
 
-function readLiveReportLockOwner(lockPath) {
-  try {
-    const owner = asRecord(
-      JSON.parse(
-        readFileSync(join(lockPath, LIVE_REPORT_LOCK_OWNER_FILE), "utf8"),
-      ),
-      "live report lock owner",
-    );
-    const schemaVersion = asNumberField(
-      owner,
-      "schemaVersion",
-      "live report lock owner",
-    );
-    const pid = asNumberField(owner, "pid", "live report lock owner");
-    const ownerToken = asStringField(
-      owner,
-      "ownerToken",
-      "live report lock owner",
-    );
-    if (
-      schemaVersion !== 1 ||
-      pid <= 0 ||
-      !/^[a-f0-9]{32}$/u.test(ownerToken)
-    ) {
-      return null;
-    }
-    return { pid, ownerToken };
-  } catch {
-    // error-policy:J3 A corrupt or incomplete lease cannot claim live ownership.
-    return null;
-  }
+function heartbeatTimestampIsFresh(observedAtMs) {
+  const age = Date.now() - observedAtMs;
+  return age >= -LIVE_REPORT_HEARTBEAT_STALE_MS &&
+    age <= LIVE_REPORT_HEARTBEAT_STALE_MS;
 }
 
-function processIsRunning(pid) {
+export function defaultLiveReportLockRoot() {
+  const uid = typeof process.getuid === "function" ? process.getuid() : null;
+  if (Number.isInteger(uid) && uid >= 0) {
+    return join("/tmp", `${LIVE_REPORT_LOCK_DIRECTORY}-${uid}`);
+  }
+  const identity = userInfo();
+  const key = createHash("sha256")
+    .update(`${identity.username}\0${identity.homedir}`)
+    .digest("hex")
+    .slice(0, 16);
+  return join(identity.homedir, `.${LIVE_REPORT_LOCK_DIRECTORY}-${key}`);
+}
+
+export function ensureLiveReportLockRoot(
+  rootPath = defaultLiveReportLockRoot(),
+) {
   try {
-    process.kill(pid, 0);
-    return true;
+    mkdirSync(rootPath, { mode: 0o700 });
   } catch (error) {
-    if (fileSystemErrorCode(error) === "ESRCH") return false;
-    if (fileSystemErrorCode(error) === "EPERM") return true;
+    if (fileSystemErrorCode(error) !== "EEXIST") throw error;
+  }
+  const stats = lstatSync(rootPath);
+  if (stats.isSymbolicLink() || !stats.isDirectory()) {
+    throw new TypeError("live report lock root must be a real directory");
+  }
+  const uid = typeof process.getuid === "function" ? process.getuid() : null;
+  if (Number.isInteger(uid) && stats.uid !== uid) {
+    throw new TypeError(
+      "live report lock root must belong to the current user",
+    );
+  }
+  if (platform() !== "win32" && (stats.mode & 0o077) !== 0) {
+    throw new TypeError("live report lock root permissions must be 0700");
+  }
+  return rootPath;
+}
+
+function readLiveReportLockOwner(lockPath) {
+  let source;
+  try {
+    source = readFileSync(join(lockPath, LIVE_REPORT_LOCK_OWNER_FILE), "utf8");
+  } catch (error) {
+    if (fileSystemErrorCode(error) === "ENOENT") return null;
     throw error;
   }
+  const owner = asRecord(JSON.parse(source), "live report lock owner");
+  const schemaVersion = asNumberField(
+    owner,
+    "schemaVersion",
+    "live report lock owner",
+  );
+  const processLease = readProcessLease(owner, "live report lock owner");
+  const ownerToken = asStringField(
+    owner,
+    "ownerToken",
+    "live report lock owner",
+  );
+  if (schemaVersion !== 2 || !LIVE_REPORT_TOKEN_RE.test(ownerToken)) {
+    throw new TypeError("live report lock owner is invalid");
+  }
+  return { ...processLease, ownerToken };
 }
 
-function lockOwnerIsActive(owner) {
-  return owner !== null && processIsRunning(owner.pid);
+function liveReportCommandDirectory(lockPath) {
+  return join(lockPath, LIVE_REPORT_LOCK_COMMAND_DIRECTORY);
 }
 
-function prepareLiveReportLockCandidate(lockPath, ownerToken) {
+function readLiveReportCommandLease(path) {
+  const record = asRecord(
+    JSON.parse(readFileSync(path, "utf8")),
+    "live report command lease",
+  );
+  const schemaVersion = asNumberField(
+    record,
+    "schemaVersion",
+    "live report command lease",
+  );
+  const ownerToken = asStringField(
+    record,
+    "ownerToken",
+    "live report command lease",
+  );
+  const startedAtMs = asNumberField(
+    record,
+    "startedAtMs",
+    "live report command lease",
+  );
+  const helper = readProcessLease(record.helper, "live report command helper");
+  const child =
+    record.child === null
+      ? null
+      : readProcessLease(record.child, "live report GitHub child");
+  if (
+    schemaVersion !== 1 ||
+    !LIVE_REPORT_TOKEN_RE.test(ownerToken) ||
+    !Number.isSafeInteger(startedAtMs) ||
+    startedAtMs <= 0
+  ) {
+    throw new TypeError("live report command lease is invalid");
+  }
+  return { child, helper, ownerToken, startedAtMs };
+}
+
+function liveReportCommandIsActive(lease, ownerToken) {
+  if (lease.ownerToken !== ownerToken) {
+    throw new TypeError("live report command lease owner does not match");
+  }
+  if (processLeaseIsActive(lease.helper)) return true;
+  if (lease.child !== null && processLeaseIsActive(lease.child)) return true;
+  return Date.now() - lease.startedAtMs < LIVE_REPORT_ORPHAN_COMMAND_GRACE_MS;
+}
+
+function liveReportHasActiveCommand(lockPath, ownerToken) {
+  const commandDirectory = liveReportCommandDirectory(lockPath);
+  let entries;
+  try {
+    entries = readdirSync(commandDirectory, { withFileTypes: true });
+  } catch (error) {
+    if (fileSystemErrorCode(error) === "ENOENT" && !existsSync(lockPath)) {
+      return false;
+    }
+    throw error;
+  }
+  for (const entry of entries) {
+    if (entry.isSymbolicLink() || (!entry.isFile() && !entry.isDirectory())) {
+      throw new TypeError("live report command directory is invalid");
+    }
+    if (!/^lease-[a-f0-9]{32}\.json$/u.test(entry.name)) continue;
+    const lease = readLiveReportCommandLease(
+      join(commandDirectory, entry.name),
+    );
+    if (liveReportCommandIsActive(lease, ownerToken)) return true;
+  }
+  return false;
+}
+
+function assertLiveReportLockDirectory(lockPath) {
+  const stats = lstatSync(lockPath);
+  if (stats.isSymbolicLink() || !stats.isDirectory()) {
+    throw new TypeError("live report lock must be a real directory");
+  }
+}
+
+function prepareLiveReportLockCandidate(lockPath, ownerToken, processIdentity) {
   const candidatePath = `${lockPath}.candidate-${process.pid}-${ownerToken}`;
   mkdirSync(candidatePath, { mode: 0o700 });
   try {
+    mkdirSync(liveReportCommandDirectory(candidatePath), { mode: 0o700 });
     writeFileSync(
       join(candidatePath, LIVE_REPORT_LOCK_OWNER_FILE),
       `${JSON.stringify({
-        schemaVersion: 1,
+        schemaVersion: 2,
         pid: process.pid,
+        processIdentity,
         ownerToken,
       })}\n`,
       { flag: "wx", mode: 0o600 },
@@ -1441,25 +1564,113 @@ function prepareLiveReportLockCandidate(lockPath, ownerToken) {
   }
 }
 
-export function acquireLiveReportLock(identity) {
+function liveReportLockKey(identity) {
+  return createHash("sha256")
+    .update(`${identity.host}:${identity.id}`)
+    .digest("hex");
+}
+
+function writeLiveReportCommandLease(path, lease, replace = false) {
+  if (!replace) {
+    writeFileSync(path, `${JSON.stringify(lease)}\n`, {
+      flag: "wx",
+      mode: 0o600,
+    });
+    return;
+  }
+  const nextPath = `${path}.next-${process.pid}-${randomBytes(16).toString("hex")}`;
+  try {
+    writeFileSync(nextPath, `${JSON.stringify(lease)}\n`, {
+      flag: "wx",
+      mode: 0o600,
+    });
+    renameSync(nextPath, path);
+  } catch (error) {
+    rmSync(nextPath, { force: true });
+    throw error;
+  }
+}
+
+function spawnLockedGh(lockPath, ownerToken, command, args, options = {}) {
+  if (
+    command !== "gh" ||
+    !Array.isArray(args) ||
+    args.some((argument) => typeof argument !== "string")
+  ) {
+    throw new TypeError("live report lock may execute only a gh argument list");
+  }
+  if (options.encoding !== undefined && options.encoding !== "utf8") {
+    throw new TypeError("live report gh commands require utf8 output");
+  }
+  const maxBuffer = options.maxBuffer ?? 1024 * 1024;
+  if (
+    !Number.isSafeInteger(maxBuffer) ||
+    maxBuffer <= 0 ||
+    maxBuffer > 256 * 1024 * 1024
+  ) {
+    throw new RangeError("live report gh command maxBuffer is invalid");
+  }
+  const commandToken = randomBytes(16).toString("hex");
+  const requestPath = join(
+    liveReportCommandDirectory(lockPath),
+    `request-${commandToken}.json`,
+  );
+  writeFileSync(
+    requestPath,
+    `${JSON.stringify({ args, maxBuffer, ownerToken, schemaVersion: 1 })}\n`,
+    { flag: "wx", mode: 0o600 },
+  );
+  try {
+    return spawnSync(
+      process.execPath,
+      [
+        fileURLToPath(import.meta.url),
+        LIVE_REPORT_LOCKED_GH_ARGUMENT,
+        lockPath,
+        ownerToken,
+        commandToken,
+      ],
+      {
+        encoding: "utf8",
+        env: { ...(options.env ?? process.env), GH_HOST: "github.com" },
+        maxBuffer: Math.min(maxBuffer + 1024 * 1024, 256 * 1024 * 1024),
+        windowsHide: true,
+      },
+    );
+  } finally {
+    rmSync(requestPath, { force: true });
+  }
+}
+
+export function acquireLiveReportLock(identity, options = {}) {
   const record = asRecord(identity, "GitHub authenticated identity");
   const id = asNumberField(record, "id", "GitHub authenticated identity");
   const login = asStringField(record, "login", "GitHub authenticated identity");
-  if (id <= 0 || login.length === 0) {
+  const host = asStringField(record, "host", "GitHub authenticated identity");
+  if (id <= 0 || login.length === 0 || host !== "github.com") {
     throw new TypeError("GitHub authenticated identity is invalid");
   }
-  const root = join(tmpdir(), LIVE_REPORT_LOCK_DIRECTORY);
-  mkdirSync(root, { mode: 0o700, recursive: true });
-  const key = createHash("sha256").update(`github.com:${id}`).digest("hex");
+  const root = ensureLiveReportLockRoot(
+    options.rootPath ?? defaultLiveReportLockRoot(),
+  );
+  const key = liveReportLockKey({ host, id });
   const lockPath = join(root, `${key}.lock`);
   const ownerToken = randomBytes(16).toString("hex");
+  const processIdentity = readLiveReportProcessIdentity(process.pid);
+  if (processIdentity === null) {
+    throw new Error("could not establish the live report process identity");
+  }
   let acquired = false;
   for (
     let attempt = 0;
     attempt < LIVE_REPORT_LOCK_ACQUIRE_ATTEMPTS;
     attempt += 1
   ) {
-    const candidatePath = prepareLiveReportLockCandidate(lockPath, ownerToken);
+    const candidatePath = prepareLiveReportLockCandidate(
+      lockPath,
+      ownerToken,
+      processIdentity,
+    );
     try {
       renameSync(candidatePath, lockPath);
       acquired = true;
@@ -1470,8 +1681,16 @@ export function acquireLiveReportLock(identity) {
         if (fileSystemErrorCode(error) === "ENOENT") continue;
         throw error;
       }
+      assertLiveReportLockDirectory(lockPath);
       const currentOwner = readLiveReportLockOwner(lockPath);
-      if (lockOwnerIsActive(currentOwner)) {
+      if (currentOwner === null) {
+        if (!existsSync(lockPath)) continue;
+        throw new Error("live report lock owner is missing");
+      }
+      if (
+        processLeaseIsActive(currentOwner) ||
+        liveReportHasActiveCommand(lockPath, currentOwner.ownerToken)
+      ) {
         throw new LiveReportLockContentionError();
       }
       const stalePath = `${lockPath}.stale-${process.pid}-${randomBytes(16).toString("hex")}`;
@@ -1489,12 +1708,16 @@ export function acquireLiveReportLock(identity) {
   }
   let released = false;
   return {
+    spawn(command, args, options) {
+      return spawnLockedGh(lockPath, ownerToken, command, args, options);
+    },
     release() {
       if (released) return;
       const owner = readLiveReportLockOwner(lockPath);
       if (
         owner === null ||
         owner.pid !== process.pid ||
+        owner.processIdentity !== processIdentity ||
         owner.ownerToken !== ownerToken
       ) {
         throw new Error("live report lock ownership changed before release");
@@ -1505,6 +1728,173 @@ export function acquireLiveReportLock(identity) {
       released = true;
     },
   };
+}
+
+function readLockedGhRequest(lockPath, ownerToken, commandToken) {
+  if (
+    !LIVE_REPORT_TOKEN_RE.test(ownerToken) ||
+    !LIVE_REPORT_TOKEN_RE.test(commandToken)
+  ) {
+    throw new TypeError("locked GitHub command tokens are invalid");
+  }
+  const root = ensureLiveReportLockRoot();
+  if (
+    dirname(lockPath) !== root ||
+    !/^[a-f0-9]{64}\.lock$/u.test(basename(lockPath))
+  ) {
+    throw new TypeError("locked GitHub command path is invalid");
+  }
+  assertLiveReportLockDirectory(lockPath);
+  const owner = readLiveReportLockOwner(lockPath);
+  if (owner === null || owner.ownerToken !== ownerToken) {
+    throw new Error("live report lock ownership changed before GitHub command");
+  }
+  const requestPath = join(
+    liveReportCommandDirectory(lockPath),
+    `request-${commandToken}.json`,
+  );
+  const request = asRecord(
+    JSON.parse(readFileSync(requestPath, "utf8")),
+    "locked GitHub command request",
+  );
+  const schemaVersion = asNumberField(
+    request,
+    "schemaVersion",
+    "locked GitHub command request",
+  );
+  const requestOwnerToken = asStringField(
+    request,
+    "ownerToken",
+    "locked GitHub command request",
+  );
+  const maxBuffer = asNumberField(
+    request,
+    "maxBuffer",
+    "locked GitHub command request",
+  );
+  if (
+    schemaVersion !== 1 ||
+    requestOwnerToken !== ownerToken ||
+    !Number.isSafeInteger(maxBuffer) ||
+    maxBuffer <= 0 ||
+    maxBuffer > 256 * 1024 * 1024 ||
+    !Array.isArray(request.args) ||
+    request.args.some((argument) => typeof argument !== "string")
+  ) {
+    throw new TypeError("locked GitHub command request is invalid");
+  }
+  return { args: request.args, maxBuffer, requestPath };
+}
+
+function collectBoundedGhChild(child, maxBuffer) {
+  return new Promise((resolvePromise) => {
+    const stdout = [];
+    const stderr = [];
+    let stdoutBytes = 0;
+    let stderrBytes = 0;
+    let overflow = null;
+    let spawnError = null;
+    const collect = (chunks, chunk, stream) => {
+      if (overflow !== null) return;
+      const value = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      if (stream === "stdout") stdoutBytes += value.length;
+      else stderrBytes += value.length;
+      if (stdoutBytes > maxBuffer || stderrBytes > maxBuffer) {
+        overflow = stream;
+        child.kill("SIGTERM");
+        return;
+      }
+      chunks.push(value);
+    };
+    child.stdout.on("data", (chunk) => collect(stdout, chunk, "stdout"));
+    child.stderr.on("data", (chunk) => collect(stderr, chunk, "stderr"));
+    child.once("error", (error) => {
+      spawnError = error;
+    });
+    child.once("close", (status, signal) => {
+      resolvePromise({
+        error: spawnError,
+        overflow,
+        signal,
+        status,
+        stderr: Buffer.concat(stderr),
+        stdout: Buffer.concat(stdout),
+      });
+    });
+  });
+}
+
+function writeProcessDescriptor(descriptor, value) {
+  if (value.length === 0) return;
+  try {
+    writeFileSync(descriptor, value);
+  } catch (error) {
+    if (fileSystemErrorCode(error) !== "EPIPE") throw error;
+  }
+}
+
+async function runLockedGhCommand(lockPath, ownerToken, commandToken) {
+  const request = readLockedGhRequest(lockPath, ownerToken, commandToken);
+  const leasePath = join(
+    liveReportCommandDirectory(lockPath),
+    `lease-${commandToken}.json`,
+  );
+  const helperIdentity = readLiveReportProcessIdentity(process.pid);
+  if (helperIdentity === null) {
+    throw new Error("could not establish the GitHub command helper identity");
+  }
+  const lease = {
+    schemaVersion: 1,
+    ownerToken,
+    startedAtMs: Date.now(),
+    helper: { pid: process.pid, processIdentity: helperIdentity },
+    child: null,
+  };
+  writeLiveReportCommandLease(leasePath, lease);
+  let result;
+  try {
+    const currentOwner = readLiveReportLockOwner(lockPath);
+    if (currentOwner === null || currentOwner.ownerToken !== ownerToken) {
+      throw new Error(
+        "live report lock ownership changed while starting GitHub command",
+      );
+    }
+    const child = spawn("gh", request.args, {
+      env: { ...process.env, GH_HOST: "github.com" },
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+    });
+    const childResult = collectBoundedGhChild(child, request.maxBuffer);
+    if (Number.isInteger(child.pid) && child.pid > 0) {
+      const childIdentity = readLiveReportProcessIdentity(child.pid);
+      if (childIdentity !== null) {
+        writeLiveReportCommandLease(
+          leasePath,
+          {
+            ...lease,
+            child: { pid: child.pid, processIdentity: childIdentity },
+          },
+          true,
+        );
+      }
+    }
+    result = await childResult;
+  } finally {
+    rmSync(leasePath, { force: true });
+    rmSync(request.requestPath, { force: true });
+  }
+  if (result.error) throw result.error;
+  if (result.overflow !== null) {
+    throw new RangeError(
+      `spawn gh ${result.overflow} exceeded the bounded output buffer`,
+    );
+  }
+  writeProcessDescriptor(1, result.stdout);
+  writeProcessDescriptor(2, result.stderr);
+  if (result.status === null) {
+    throw new Error(`gh terminated by ${result.signal ?? "an unknown signal"}`);
+  }
+  process.exitCode = result.status;
 }
 
 function rateResource(value, context) {
@@ -2964,8 +3354,8 @@ export function main(args = process.argv.slice(2)) {
     if (!result.complete) process.exitCode = 2;
     return;
   }
-  const commandBudget = createGhCommandBudget();
   if (options.recheckPr !== undefined) {
+    const commandBudget = createGhCommandBudget();
     const result = recheckLivePullHead(
       options.repo,
       {
@@ -2978,12 +3368,13 @@ export function main(args = process.argv.slice(2)) {
     if (!result.publishable) process.exitCode = 2;
     return;
   }
-  const boundedRead = (endpoint) => {
-    return readGhPages(endpoint, commandBudget.run);
-  };
   const authenticatedIdentity = readGhAuthenticatedIdentity();
   const liveReportLock = acquireLiveReportLock(authenticatedIdentity);
   try {
+    const commandBudget = createGhCommandBudget(liveReportLock.spawn);
+    const boundedRead = (endpoint) => {
+      return readGhPages(endpoint, commandBudget.run);
+    };
     const openActivity = readGhOpenActivity(options.repo, commandBudget.run, {
       preflight: true,
     });
@@ -3024,17 +3415,27 @@ const invokedDirectly =
     realpathSync(process.argv[1]);
 
 if (invokedDirectly) {
-  try {
-    main();
-  } catch (error) {
-    // error-policy:J1 The CLI boundary turns a failed read/audit into a non-zero exit.
-    const message = error instanceof Error ? error.message : String(error);
-    if (error instanceof LiveReportLockContentionError) {
-      process.stderr.write(`Slop live report deferred: ${message}\n`);
-      process.exitCode = 2;
-    } else {
-      process.stderr.write(`Slop live report failed: ${message}\n`);
+  const directArguments = process.argv.slice(2);
+  if (directArguments[0] === LIVE_REPORT_LOCKED_GH_ARGUMENT) {
+    runLockedGhCommand(...directArguments.slice(1)).catch((error) => {
+      // error-policy:J1 The internal process boundary fails the owning report.
+      const message = error instanceof Error ? error.message : String(error);
+      process.stderr.write(`Slop locked GitHub command failed: ${message}\n`);
       process.exitCode = 1;
+    });
+  } else {
+    try {
+      main(directArguments);
+    } catch (error) {
+      // error-policy:J1 The CLI boundary turns a failed read/audit into a non-zero exit.
+      const message = error instanceof Error ? error.message : String(error);
+      if (error instanceof LiveReportLockContentionError) {
+        process.stderr.write(`Slop live report deferred: ${message}\n`);
+        process.exitCode = 2;
+      } else {
+        process.stderr.write(`Slop live report failed: ${message}\n`);
+        process.exitCode = 1;
+      }
     }
   }
 }

--- a/skills/contribute-to-eliza/scripts/live-report.mjs
+++ b/skills/contribute-to-eliza/scripts/live-report.mjs
@@ -6,7 +6,18 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { createHash, randomBytes } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -34,6 +45,10 @@ export const MAX_ACTIVITY_CONNECTION_ITEMS = 1_000;
 export const MIN_GRAPHQL_ACTIVITY_POINTS = 1_000;
 export const MIN_REST_ACTIVITY_REQUESTS = 100;
 export const MIN_SEARCH_ACTIVITY_REQUESTS = 2;
+
+const LIVE_REPORT_LOCK_DIRECTORY = "slop-live-report-locks-v1";
+const LIVE_REPORT_LOCK_OWNER_FILE = "owner.json";
+const LIVE_REPORT_LOCK_ACQUIRE_ATTEMPTS = 8;
 
 const REPOSITORY_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const PLACEHOLDER_RE =
@@ -1301,6 +1316,193 @@ export function createGhCommandBudget(spawn = spawnSync) {
       }
       count += 1;
       return spawn(command, args, options);
+    },
+  };
+}
+
+export class LiveReportLockContentionError extends Error {
+  constructor() {
+    super(
+      "live report lock contention: another report for this GitHub identity is already discovering activity",
+    );
+    this.name = "LiveReportLockContentionError";
+  }
+}
+
+export function readGhAuthenticatedIdentity(spawn = spawnSync) {
+  const result = spawn(
+    "gh",
+    ["api", "--method", "GET", "--jq", "{id: .id, login: .login}", "user"],
+    {
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024,
+      windowsHide: true,
+    },
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const detail =
+      result.stderr.trim().length > 0 ? `: ${result.stderr.trim()}` : "";
+    throw new Error(`gh api failed for authenticated identity${detail}`);
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(result.stdout);
+  } catch (cause) {
+    throw new SyntaxError(
+      "gh api returned malformed JSON for authenticated identity",
+      { cause },
+    );
+  }
+  const identity = asRecord(parsed, "GitHub authenticated identity");
+  const id = asNumberField(identity, "id", "GitHub authenticated identity");
+  const login = asStringField(
+    identity,
+    "login",
+    "GitHub authenticated identity",
+  );
+  if (id <= 0 || login.length === 0) {
+    throw new TypeError("GitHub authenticated identity is invalid");
+  }
+  return { id, login };
+}
+
+function fileSystemErrorCode(error) {
+  return error && typeof error === "object" && "code" in error
+    ? error.code
+    : null;
+}
+
+function readLiveReportLockOwner(lockPath) {
+  try {
+    const owner = asRecord(
+      JSON.parse(
+        readFileSync(join(lockPath, LIVE_REPORT_LOCK_OWNER_FILE), "utf8"),
+      ),
+      "live report lock owner",
+    );
+    const schemaVersion = asNumberField(
+      owner,
+      "schemaVersion",
+      "live report lock owner",
+    );
+    const pid = asNumberField(owner, "pid", "live report lock owner");
+    const ownerToken = asStringField(
+      owner,
+      "ownerToken",
+      "live report lock owner",
+    );
+    if (
+      schemaVersion !== 1 ||
+      pid <= 0 ||
+      !/^[a-f0-9]{32}$/u.test(ownerToken)
+    ) {
+      return null;
+    }
+    return { pid, ownerToken };
+  } catch {
+    // error-policy:J3 A corrupt or incomplete lease cannot claim live ownership.
+    return null;
+  }
+}
+
+function processIsRunning(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (fileSystemErrorCode(error) === "ESRCH") return false;
+    if (fileSystemErrorCode(error) === "EPERM") return true;
+    throw error;
+  }
+}
+
+function lockOwnerIsActive(owner) {
+  return owner !== null && processIsRunning(owner.pid);
+}
+
+function prepareLiveReportLockCandidate(lockPath, ownerToken) {
+  const candidatePath = `${lockPath}.candidate-${process.pid}-${ownerToken}`;
+  mkdirSync(candidatePath, { mode: 0o700 });
+  try {
+    writeFileSync(
+      join(candidatePath, LIVE_REPORT_LOCK_OWNER_FILE),
+      `${JSON.stringify({
+        schemaVersion: 1,
+        pid: process.pid,
+        ownerToken,
+      })}\n`,
+      { flag: "wx", mode: 0o600 },
+    );
+    return candidatePath;
+  } catch (error) {
+    rmSync(candidatePath, { force: true, recursive: true });
+    throw error;
+  }
+}
+
+export function acquireLiveReportLock(identity) {
+  const record = asRecord(identity, "GitHub authenticated identity");
+  const id = asNumberField(record, "id", "GitHub authenticated identity");
+  const login = asStringField(record, "login", "GitHub authenticated identity");
+  if (id <= 0 || login.length === 0) {
+    throw new TypeError("GitHub authenticated identity is invalid");
+  }
+  const root = join(tmpdir(), LIVE_REPORT_LOCK_DIRECTORY);
+  mkdirSync(root, { mode: 0o700, recursive: true });
+  const key = createHash("sha256").update(`github.com:${id}`).digest("hex");
+  const lockPath = join(root, `${key}.lock`);
+  const ownerToken = randomBytes(16).toString("hex");
+  let acquired = false;
+  for (
+    let attempt = 0;
+    attempt < LIVE_REPORT_LOCK_ACQUIRE_ATTEMPTS;
+    attempt += 1
+  ) {
+    const candidatePath = prepareLiveReportLockCandidate(lockPath, ownerToken);
+    try {
+      renameSync(candidatePath, lockPath);
+      acquired = true;
+      break;
+    } catch (error) {
+      rmSync(candidatePath, { force: true, recursive: true });
+      if (!existsSync(lockPath)) {
+        if (fileSystemErrorCode(error) === "ENOENT") continue;
+        throw error;
+      }
+      const currentOwner = readLiveReportLockOwner(lockPath);
+      if (lockOwnerIsActive(currentOwner)) {
+        throw new LiveReportLockContentionError();
+      }
+      const stalePath = `${lockPath}.stale-${process.pid}-${randomBytes(16).toString("hex")}`;
+      try {
+        renameSync(lockPath, stalePath);
+      } catch (renameError) {
+        if (fileSystemErrorCode(renameError) === "ENOENT") continue;
+        throw renameError;
+      }
+      rmSync(stalePath, { force: true, recursive: true });
+    }
+  }
+  if (!acquired) {
+    throw new Error("live report lock changed too often to acquire safely");
+  }
+  let released = false;
+  return {
+    release() {
+      if (released) return;
+      const owner = readLiveReportLockOwner(lockPath);
+      if (
+        owner === null ||
+        owner.pid !== process.pid ||
+        owner.ownerToken !== ownerToken
+      ) {
+        throw new Error("live report lock ownership changed before release");
+      }
+      const releasedPath = `${lockPath}.released-${process.pid}-${ownerToken}`;
+      renameSync(lockPath, releasedPath);
+      rmSync(releasedPath, { force: true, recursive: true });
+      released = true;
     },
   };
 }
@@ -2779,34 +2981,40 @@ export function main(args = process.argv.slice(2)) {
   const boundedRead = (endpoint) => {
     return readGhPages(endpoint, commandBudget.run);
   };
-  const openActivity = readGhOpenActivity(options.repo, commandBudget.run, {
-    preflight: true,
-  });
-  const limits = asRecord(openActivity.rateLimits, "GitHub rate limits");
-  process.stderr.write(
-    `[Slop] GitHub budgets: GraphQL ${limits.graphqlRemaining}/${limits.graphqlLimit} (${limits.graphqlBudgetSource}); REST ${limits.restRemaining}/${limits.restLimit}; Search ${limits.searchRemaining}/${limits.searchLimit}; activity source ${openActivity.source}\n`,
-  );
-  const report = collectLiveReport(
-    options.repo,
-    boundedRead,
-    new Date(),
-    ({ phase, current, total }) => {
-      if (current === 0 || current === total || current % 10 === 0) {
-        process.stderr.write(
-          `[Slop] scanning ${phase}: ${current}/${total} (${commandBudget.count} bounded GitHub commands)\n`,
-        );
-      }
-    },
-    openActivity,
-    selectionPolicy.eligibleIssueLabels,
-  );
-  process.stdout.write(
-    options.epochOnly
-      ? `${JSON.stringify(report.selection.reviewEpoch, null, 2)}\n`
-      : options.json
-        ? `${JSON.stringify(report, null, 2)}\n`
-        : renderMarkdown(report),
-  );
+  const authenticatedIdentity = readGhAuthenticatedIdentity();
+  const liveReportLock = acquireLiveReportLock(authenticatedIdentity);
+  try {
+    const openActivity = readGhOpenActivity(options.repo, commandBudget.run, {
+      preflight: true,
+    });
+    const limits = asRecord(openActivity.rateLimits, "GitHub rate limits");
+    process.stderr.write(
+      `[Slop] GitHub budgets: GraphQL ${limits.graphqlRemaining}/${limits.graphqlLimit} (${limits.graphqlBudgetSource}); REST ${limits.restRemaining}/${limits.restLimit}; Search ${limits.searchRemaining}/${limits.searchLimit}; activity source ${openActivity.source}\n`,
+    );
+    const report = collectLiveReport(
+      options.repo,
+      boundedRead,
+      new Date(),
+      ({ phase, current, total }) => {
+        if (current === 0 || current === total || current % 10 === 0) {
+          process.stderr.write(
+            `[Slop] scanning ${phase}: ${current}/${total} (${commandBudget.count} bounded GitHub commands)\n`,
+          );
+        }
+      },
+      openActivity,
+      selectionPolicy.eligibleIssueLabels,
+    );
+    process.stdout.write(
+      options.epochOnly
+        ? `${JSON.stringify(report.selection.reviewEpoch, null, 2)}\n`
+        : options.json
+          ? `${JSON.stringify(report, null, 2)}\n`
+          : renderMarkdown(report),
+    );
+  } finally {
+    liveReportLock.release();
+  }
 }
 
 const invokedDirectly =
@@ -2821,7 +3029,12 @@ if (invokedDirectly) {
   } catch (error) {
     // error-policy:J1 The CLI boundary turns a failed read/audit into a non-zero exit.
     const message = error instanceof Error ? error.message : String(error);
-    process.stderr.write(`Slop live report failed: ${message}\n`);
-    process.exitCode = 1;
+    if (error instanceof LiveReportLockContentionError) {
+      process.stderr.write(`Slop live report deferred: ${message}\n`);
+      process.exitCode = 2;
+    } else {
+      process.stderr.write(`Slop live report failed: ${message}\n`);
+      process.exitCode = 1;
+    }
   }
 }

--- a/skills/contribute-to-eliza/scripts/live-report.mjs
+++ b/skills/contribute-to-eliza/scripts/live-report.mjs
@@ -2811,15 +2811,11 @@ export function main(args = process.argv.slice(2)) {
   const boundedRead = (endpoint) => {
     return readGhPages(endpoint, commandBudget.run);
   };
-  let rateLimits = { preflight: true };
   const { report } = retryChangedLiveInventory(
     () => {
-      const openActivity = readGhOpenActivity(
-        options.repo,
-        commandBudget.run,
-        rateLimits,
-      );
-      rateLimits = openActivity.rateLimits;
+      const openActivity = readGhOpenActivity(options.repo, commandBudget.run, {
+        preflight: true,
+      });
       const limits = asRecord(openActivity.rateLimits, "GitHub rate limits");
       process.stderr.write(
         `[Slop] GitHub budgets: GraphQL ${limits.graphqlRemaining}/${limits.graphqlLimit} (${limits.graphqlBudgetSource}); REST ${limits.restRemaining}/${limits.restLimit}; Search ${limits.searchRemaining}/${limits.searchLimit}; activity source ${openActivity.source}\n`,

--- a/skills/contribute-to-eliza/scripts/run-receipt.mjs
+++ b/skills/contribute-to-eliza/scripts/run-receipt.mjs
@@ -2193,6 +2193,20 @@ function renderResult(result, json) {
   );
 }
 
+const WALLET_CLAIM_SCRIPT = join(scriptDirectory, "wallet-claim.mjs");
+
+/**
+ * One stderr line after a fresh finish for projects that pay a monthly pool.
+ * The run never reads the wallet registry, so it cannot know whether a claim
+ * exists; it only points at the register command and the cut-off rule.
+ */
+function walletNudge() {
+  if (!existsSync(WALLET_CLAIM_SCRIPT)) return;
+  process.stderr.write(
+    `No payout wallet is checked by this run. If none is registered, run: node ${WALLET_CLAIM_SCRIPT} register --address <public-address> (a wallet observed after a proposal is generated applies to the next cycle).\n`,
+  );
+}
+
 function previewRun(options) {
   const provenance = resolveSkillProvenance();
   const repositoryRoot = requireRepository(options.repoRoot);
@@ -2562,6 +2576,7 @@ function finishRun(options, testOptions) {
     },
     options.json,
   );
+  walletNudge();
 }
 
 export async function main(args = process.argv.slice(2), testOptions) {

--- a/skills/contribute-to-eliza/scripts/run-receipt.mjs
+++ b/skills/contribute-to-eliza/scripts/run-receipt.mjs
@@ -1299,6 +1299,7 @@ export async function slopIdentityAssertion(
   fetchImpl = globalThis.fetch,
   delayImpl = (milliseconds) =>
     new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds)),
+  nowImpl = Date.now,
 ) {
   if (typeof fetchImpl !== "function")
     fail("Slop identity transport is unavailable");
@@ -1348,10 +1349,10 @@ export async function slopIdentityAssertion(
   );
   const expiresAt = Date.parse(started.expiresAt);
   process.stderr.write(
-    `This link expires in ${Math.max(0, Math.round((expiresAt - Date.now()) / 1000))} seconds; authorize promptly.\n`,
+    `This link expires in ${Math.max(0, Math.round((expiresAt - nowImpl()) / 1000))} seconds; authorize promptly.\n`,
   );
   let retryAfterSeconds = started.pollAfterSeconds;
-  while (Date.now() < expiresAt) {
+  while (nowImpl() < expiresAt) {
     await delayImpl(retryAfterSeconds * 1000);
     let response;
     try {
@@ -1388,7 +1389,7 @@ export async function slopIdentityAssertion(
       if (
         response.status === 410 &&
         errorCode !== "flow_consumed" &&
-        Date.now() >= expiresAt - (retryAfterSeconds + 1) * 1000
+        (errorCode === "flow_expired" || nowImpl() >= expiresAt)
       ) {
         fail(
           "Slop identity authorization expired before completion; run register again and authorize within the deadline",
@@ -1436,7 +1437,7 @@ export async function slopIdentityAssertion(
       typeof result.assertion !== "string" ||
       !/^slop_assert_v1_[A-Za-z0-9_-]{20,512}$/u.test(result.assertion) ||
       canonicalIso(result.expiresAt) !== result.expiresAt ||
-      Date.parse(result.expiresAt) <= Date.now()
+      Date.parse(result.expiresAt) <= nowImpl()
     ) {
       fail("Slop identity completion response was invalid");
     }

--- a/skills/contribute-to-eliza/scripts/run-receipt.mjs
+++ b/skills/contribute-to-eliza/scripts/run-receipt.mjs
@@ -1347,6 +1347,9 @@ export async function slopIdentityAssertion(
     `Authorize this contribution with GitHub:\n${authorizationUrl.href}\n`,
   );
   const expiresAt = Date.parse(started.expiresAt);
+  process.stderr.write(
+    `This link expires in ${Math.max(0, Math.round((expiresAt - Date.now()) / 1000))} seconds; authorize promptly.\n`,
+  );
   let retryAfterSeconds = started.pollAfterSeconds;
   while (Date.now() < expiresAt) {
     await delayImpl(retryAfterSeconds * 1000);
@@ -1366,7 +1369,34 @@ export async function slopIdentityAssertion(
       fail("Slop identity poll request failed");
     }
     if (!response.ok) {
-      fail(`Slop identity poll returned HTTP ${response.status}`);
+      let errorCode = null;
+      try {
+        const parsed = JSON.parse(
+          await boundedResponseText(response, "Slop identity poll"),
+        );
+        if (
+          parsed &&
+          typeof parsed === "object" &&
+          typeof parsed.error === "string" &&
+          /^[a-z0-9_]{1,64}$/u.test(parsed.error)
+        ) {
+          errorCode = parsed.error;
+        }
+      } catch {
+        // Fail closed on the status alone when the body is unreadable.
+      }
+      if (
+        response.status === 410 &&
+        errorCode !== "flow_consumed" &&
+        Date.now() >= expiresAt - (retryAfterSeconds + 1) * 1000
+      ) {
+        fail(
+          "Slop identity authorization expired before completion; run register again and authorize within the deadline",
+        );
+      }
+      fail(
+        `Slop identity poll returned HTTP ${response.status}${errorCode === null ? "" : ` (${errorCode})`}`,
+      );
     }
     const source = await boundedResponseText(response, "Slop identity poll");
     let result;

--- a/skills/contribute-to-eliza/scripts/run-receipt.mjs
+++ b/skills/contribute-to-eliza/scripts/run-receipt.mjs
@@ -1533,88 +1533,92 @@ export async function uploadPrivateTrace(
   );
   if (
     created.clientRunId !== state.runId ||
-    created.state !== "awaiting_trace" ||
+    !["awaiting_trace", "trace_uploaded", "finalized"].includes(
+      created.state,
+    ) ||
     !/^[A-Za-z0-9][A-Za-z0-9._:-]{0,159}$/u.test(created.serverRunId ?? "")
   ) {
     fail("trace run creation returned mismatched identity");
   }
   const serverPath = encodeURIComponent(created.serverRunId);
-  const intentBody = {
-    sha256: trace.sha256,
-    sizeBytes: trace.sizeBytes,
-    contentType: trace.contentType,
-  };
-  const intent = await jsonRequest(
-    fetchImpl,
-    `${TRACE_AUTHORITY}/api/v1/runs/${serverPath}/trace-intents`,
-    {
-      method: "POST",
-      headers: {
-        ...jsonHeaders,
-        "Idempotency-Key": sha256(
-          `intent:${created.serverRunId}:${trace.sha256}`,
-        ),
+  if (created.state === "awaiting_trace") {
+    const intentBody = {
+      sha256: trace.sha256,
+      sizeBytes: trace.sizeBytes,
+      contentType: trace.contentType,
+    };
+    const intent = await jsonRequest(
+      fetchImpl,
+      `${TRACE_AUTHORITY}/api/v1/runs/${serverPath}/trace-intents`,
+      {
+        method: "POST",
+        headers: {
+          ...jsonHeaders,
+          "Idempotency-Key": sha256(
+            `intent:${created.serverRunId}:${trace.sha256}`,
+          ),
+        },
+        body: JSON.stringify(intentBody),
       },
-      body: JSON.stringify(intentBody),
-    },
-    [
-      "contentType",
-      "expiresAt",
-      "serverRunId",
-      "sha256",
-      "sizeBytes",
-      "uploadUrl",
-    ],
-    "trace upload intent",
-  );
-  let uploadUrl;
-  try {
-    uploadUrl = new URL(intent.uploadUrl);
-  } catch {
-    fail("trace upload intent returned an invalid URL");
-  }
-  if (
-    intent.serverRunId !== created.serverRunId ||
-    intent.sha256 !== trace.sha256 ||
-    intent.sizeBytes !== trace.sizeBytes ||
-    intent.contentType !== trace.contentType ||
-    uploadUrl.origin !== TRACE_AUTHORITY ||
-    uploadUrl.username ||
-    uploadUrl.password ||
-    uploadUrl.hash
-  ) {
-    fail("trace upload intent returned mismatched fields");
-  }
-  const uploaded = await jsonRequest(
-    fetchImpl,
-    uploadUrl.href,
-    {
-      method: "PUT",
-      headers: {
-        "Content-Type": trace.contentType,
-        Digest: `sha-256=${trace.sha256}`,
+      [
+        "contentType",
+        "expiresAt",
+        "serverRunId",
+        "sha256",
+        "sizeBytes",
+        "uploadUrl",
+      ],
+      "trace upload intent",
+    );
+    let uploadUrl;
+    try {
+      uploadUrl = new URL(intent.uploadUrl);
+    } catch {
+      fail("trace upload intent returned an invalid URL");
+    }
+    if (
+      intent.serverRunId !== created.serverRunId ||
+      intent.sha256 !== trace.sha256 ||
+      intent.sizeBytes !== trace.sizeBytes ||
+      intent.contentType !== trace.contentType ||
+      uploadUrl.origin !== TRACE_AUTHORITY ||
+      uploadUrl.username ||
+      uploadUrl.password ||
+      uploadUrl.hash
+    ) {
+      fail("trace upload intent returned mismatched fields");
+    }
+    const uploaded = await jsonRequest(
+      fetchImpl,
+      uploadUrl.href,
+      {
+        method: "PUT",
+        headers: {
+          "Content-Type": trace.contentType,
+          Digest: `sha-256=${trace.sha256}`,
+        },
+        body: trace.contents,
       },
-      body: trace.contents,
-    },
-    [
-      "clientRunId",
-      "serverRunId",
-      "sizeBytes",
-      "state",
-      "traceObjectId",
-      "traceSha256",
-    ],
-    "trace upload",
-  );
-  if (
-    uploaded.clientRunId !== state.runId ||
-    uploaded.serverRunId !== created.serverRunId ||
-    uploaded.sizeBytes !== trace.sizeBytes ||
-    uploaded.state !== "trace_uploaded" ||
-    uploaded.traceSha256 !== trace.sha256 ||
-    uploaded.traceObjectId !== `sha256:${trace.sha256}`
-  ) {
-    fail("trace upload returned mismatched evidence");
+      [
+        "clientRunId",
+        "serverRunId",
+        "sizeBytes",
+        "state",
+        "traceObjectId",
+        "traceSha256",
+      ],
+      "trace upload",
+    );
+    if (
+      uploaded.clientRunId !== state.runId ||
+      uploaded.serverRunId !== created.serverRunId ||
+      uploaded.sizeBytes !== trace.sizeBytes ||
+      uploaded.state !== "trace_uploaded" ||
+      uploaded.traceSha256 !== trace.sha256 ||
+      uploaded.traceObjectId !== `sha256:${trace.sha256}`
+    ) {
+      fail("trace upload returned mismatched evidence");
+    }
   }
   const finalized = await jsonRequest(
     fetchImpl,

--- a/skills/contribute-to-eliza/scripts/run-receipt.mjs
+++ b/skills/contribute-to-eliza/scripts/run-receipt.mjs
@@ -1585,7 +1585,7 @@ export async function uploadPrivateTrace(
         headers: {
           ...jsonHeaders,
           "Idempotency-Key": sha256(
-            `intent:${created.serverRunId}:${trace.sha256}`,
+            `intent:${created.serverRunId}:${trace.sha256}:${randomBytes(16).toString("hex")}`,
           ),
         },
         body: JSON.stringify(intentBody),

--- a/skills/contribute-to-heir-elements-sdk/SKILL.md
+++ b/skills/contribute-to-heir-elements-sdk/SKILL.md
@@ -339,8 +339,9 @@ wait for completion. The script keeps the OAuth capability, assertion, and
 Slop bearer token only in process memory. It prints the immutable claim ID,
 record digest, and public metadata URL—never a credential.
 5. An address change appends a new claim linked to the current claim; it never
-edits or deletes history. The change is material and restarts that
-allocation's 14-day review.
+edits or deletes history. A claim observed after a proposal is generated
+applies to the next cycle; it never modifies that proposal or restarts its
+14-day review, and the row stays unclaimed and carries forward.
 
 A claim identifies where a reviewed payout may go. It does not prove custody,
 guarantee payment, approve an allocation, connect a wallet, or move funds.

--- a/skills/contribute-to-heir-elements-sdk/scripts/live-report.mjs
+++ b/skills/contribute-to-heir-elements-sdk/scripts/live-report.mjs
@@ -31,9 +31,24 @@ export const REVIEW_EPOCH_SCHEMA_VERSION = 1;
 export const MAX_REVIEW_EPOCH_FILE_BYTES = 262_144;
 export const MAX_API_READS = 16;
 export const MAX_ACTIVITY_CONNECTION_ITEMS = 1_000;
+// Large repositories can legitimately exceed Node's 64 MiB spawnSync default
+// after gh concatenates bounded pages. Keep one explicit ceiling high enough
+// for the 10,000-item inventory while still failing closed on runaway output.
+export const MAX_GH_REPORT_BYTES = 256 * 1024 * 1024;
 export const MIN_GRAPHQL_ACTIVITY_POINTS = 1_000;
 export const MIN_REST_ACTIVITY_REQUESTS = 100;
 export const MIN_SEARCH_ACTIVITY_REQUESTS = 2;
+export const MAX_LIVE_INVENTORY_ATTEMPTS = 2;
+
+export class LiveInventoryChangedError extends Error {
+  constructor(
+    message = "batched activity does not exactly match the live open-item inventory",
+    options,
+  ) {
+    super(message, options);
+    this.name = "LiveInventoryChangedError";
+  }
+}
 
 const REPOSITORY_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const PLACEHOLDER_RE =
@@ -748,7 +763,7 @@ export function readGhPages(endpoint, spawn = spawnSync) {
   ];
   const result = spawn("gh", args, {
     encoding: "utf8",
-    maxBuffer: 64 * 1024 * 1024,
+    maxBuffer: MAX_GH_REPORT_BYTES,
     windowsHide: true,
   });
   if (result.error) throw result.error;
@@ -959,7 +974,7 @@ function readGhActivityPage(endpoint, pageNumber, context, spawn) {
     ["api", "--method", "GET", "--jq", ".[]", pagedEndpoint],
     {
       encoding: "utf8",
-      maxBuffer: 64 * 1024 * 1024,
+      maxBuffer: MAX_GH_REPORT_BYTES,
       windowsHide: true,
     },
   );
@@ -1051,7 +1066,7 @@ function readGhSearchPullNumbers(repo, qualifier, spawn) {
     ],
     {
       encoding: "utf8",
-      maxBuffer: 64 * 1024 * 1024,
+      maxBuffer: MAX_GH_REPORT_BYTES,
       windowsHide: true,
     },
   );
@@ -1274,7 +1289,7 @@ function readGraphqlActivityNodes(repo, query, selector, spawn, context) {
     ],
     {
       encoding: "utf8",
-      maxBuffer: 64 * 1024 * 1024,
+      maxBuffer: MAX_GH_REPORT_BYTES,
       windowsHide: true,
     },
   );
@@ -2239,9 +2254,7 @@ export function collectLiveReport(
       [...issueNumbers].some((number) => !activity.issues.has(number)) ||
       [...pullNumbers].some((number) => !activity.pulls.has(number))
     ) {
-      throw new TypeError(
-        "batched activity does not exactly match the live open-item inventory",
-      );
+      throw new LiveInventoryChangedError();
     }
   }
   onProgress({ phase: "issues", current: 0, total: issueItems.length });
@@ -2744,6 +2757,25 @@ Options:
 `;
 }
 
+/** Repeats one complete read when GitHub changes its open-item inventory mid-snapshot. */
+export function retryChangedLiveInventory(collect, onRetry = () => {}) {
+  for (let attempt = 1; attempt <= MAX_LIVE_INVENTORY_ATTEMPTS; attempt += 1) {
+    try {
+      return collect(attempt);
+    } catch (cause) {
+      if (!(cause instanceof LiveInventoryChangedError)) throw cause;
+      if (attempt === MAX_LIVE_INVENTORY_ATTEMPTS) {
+        throw new LiveInventoryChangedError(
+          `Open GitHub inventory changed while collecting the live report after ${MAX_LIVE_INVENTORY_ATTEMPTS} attempts`,
+          { cause },
+        );
+      }
+      onRetry({ attempt, cause });
+    }
+  }
+  throw new Error("unreachable live inventory retry state");
+}
+
 export function main(args = process.argv.slice(2)) {
   const selectionPolicy = readProjectSelectionPolicy();
   const options = parseCliArguments(args, selectionPolicy.repositoryId);
@@ -2779,26 +2811,40 @@ export function main(args = process.argv.slice(2)) {
   const boundedRead = (endpoint) => {
     return readGhPages(endpoint, commandBudget.run);
   };
-  const openActivity = readGhOpenActivity(options.repo, commandBudget.run, {
-    preflight: true,
-  });
-  const limits = asRecord(openActivity.rateLimits, "GitHub rate limits");
-  process.stderr.write(
-    `[Slop] GitHub budgets: GraphQL ${limits.graphqlRemaining}/${limits.graphqlLimit} (${limits.graphqlBudgetSource}); REST ${limits.restRemaining}/${limits.restLimit}; Search ${limits.searchRemaining}/${limits.searchLimit}; activity source ${openActivity.source}\n`,
-  );
-  const report = collectLiveReport(
-    options.repo,
-    boundedRead,
-    new Date(),
-    ({ phase, current, total }) => {
-      if (current === 0 || current === total || current % 10 === 0) {
-        process.stderr.write(
-          `[Slop] scanning ${phase}: ${current}/${total} (${commandBudget.count} bounded GitHub commands)\n`,
-        );
-      }
+  let rateLimits = { preflight: true };
+  const { report } = retryChangedLiveInventory(
+    () => {
+      const openActivity = readGhOpenActivity(
+        options.repo,
+        commandBudget.run,
+        rateLimits,
+      );
+      rateLimits = openActivity.rateLimits;
+      const limits = asRecord(openActivity.rateLimits, "GitHub rate limits");
+      process.stderr.write(
+        `[Slop] GitHub budgets: GraphQL ${limits.graphqlRemaining}/${limits.graphqlLimit} (${limits.graphqlBudgetSource}); REST ${limits.restRemaining}/${limits.restLimit}; Search ${limits.searchRemaining}/${limits.searchLimit}; activity source ${openActivity.source}\n`,
+      );
+      return {
+        report: collectLiveReport(
+          options.repo,
+          boundedRead,
+          new Date(),
+          ({ phase, current, total }) => {
+            if (current === 0 || current === total || current % 10 === 0) {
+              process.stderr.write(
+                `[Slop] scanning ${phase}: ${current}/${total} (${commandBudget.count} bounded GitHub commands)\n`,
+              );
+            }
+          },
+          openActivity,
+          selectionPolicy.eligibleIssueLabels,
+        ),
+      };
     },
-    openActivity,
-    selectionPolicy.eligibleIssueLabels,
+    ({ attempt }) =>
+      process.stderr.write(
+        `[Slop] open-item inventory changed during snapshot attempt ${attempt}; retrying one complete read\n`,
+      ),
   );
   process.stdout.write(
     options.epochOnly

--- a/skills/contribute-to-heir-elements-sdk/scripts/live-report.mjs
+++ b/skills/contribute-to-heir-elements-sdk/scripts/live-report.mjs
@@ -5,20 +5,22 @@
  * adapter; GraphQL uses explicit read-only queries over GitHub's POST endpoint.
  */
 
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { createHash, randomBytes } from "node:crypto";
 import {
   existsSync,
+  lstatSync,
   mkdirSync,
   readFileSync,
+  readdirSync,
   realpathSync,
   renameSync,
   rmSync,
   statSync,
   writeFileSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { platform, userInfo } from "node:os";
+import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 export const MODEL_DISCLOSURE_PREFIX = "AI provider/model:";
@@ -46,9 +48,14 @@ export const MIN_GRAPHQL_ACTIVITY_POINTS = 1_000;
 export const MIN_REST_ACTIVITY_REQUESTS = 100;
 export const MIN_SEARCH_ACTIVITY_REQUESTS = 2;
 
-const LIVE_REPORT_LOCK_DIRECTORY = "slop-live-report-locks-v1";
+const LIVE_REPORT_LOCK_DIRECTORY = "slop-live-report-locks-v2";
 const LIVE_REPORT_LOCK_OWNER_FILE = "owner.json";
+const LIVE_REPORT_LOCK_COMMAND_DIRECTORY = "commands";
 const LIVE_REPORT_LOCK_ACQUIRE_ATTEMPTS = 8;
+const LIVE_REPORT_ORPHAN_COMMAND_GRACE_MS = 5 * 60 * 1_000;
+const LIVE_REPORT_LOCKED_GH_ARGUMENT = "--slop-internal-locked-gh-v1";
+const LIVE_REPORT_PROCESS_IDENTITY_RE = /^[a-f0-9]{64}$/u;
+const LIVE_REPORT_TOKEN_RE = /^[a-f0-9]{32}$/u;
 
 const REPOSITORY_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const PLACEHOLDER_RE =
@@ -1332,7 +1339,16 @@ export class LiveReportLockContentionError extends Error {
 export function readGhAuthenticatedIdentity(spawn = spawnSync) {
   const result = spawn(
     "gh",
-    ["api", "--method", "GET", "--jq", "{id: .id, login: .login}", "user"],
+    [
+      "api",
+      "--hostname",
+      "github.com",
+      "--method",
+      "GET",
+      "--jq",
+      "{id: .id, login: .login}",
+      "user",
+    ],
     {
       encoding: "utf8",
       maxBuffer: 1024 * 1024,
@@ -1364,46 +1380,13 @@ export function readGhAuthenticatedIdentity(spawn = spawnSync) {
   if (id <= 0 || login.length === 0) {
     throw new TypeError("GitHub authenticated identity is invalid");
   }
-  return { id, login };
+  return { host: "github.com", id, login };
 }
 
 function fileSystemErrorCode(error) {
   return error && typeof error === "object" && "code" in error
     ? error.code
     : null;
-}
-
-function readLiveReportLockOwner(lockPath) {
-  try {
-    const owner = asRecord(
-      JSON.parse(
-        readFileSync(join(lockPath, LIVE_REPORT_LOCK_OWNER_FILE), "utf8"),
-      ),
-      "live report lock owner",
-    );
-    const schemaVersion = asNumberField(
-      owner,
-      "schemaVersion",
-      "live report lock owner",
-    );
-    const pid = asNumberField(owner, "pid", "live report lock owner");
-    const ownerToken = asStringField(
-      owner,
-      "ownerToken",
-      "live report lock owner",
-    );
-    if (
-      schemaVersion !== 1 ||
-      pid <= 0 ||
-      !/^[a-f0-9]{32}$/u.test(ownerToken)
-    ) {
-      return null;
-    }
-    return { pid, ownerToken };
-  } catch {
-    // error-policy:J3 A corrupt or incomplete lease cannot claim live ownership.
-    return null;
-  }
 }
 
 function processIsRunning(pid) {
@@ -1417,19 +1400,249 @@ function processIsRunning(pid) {
   }
 }
 
-function lockOwnerIsActive(owner) {
-  return owner !== null && processIsRunning(owner.pid);
+function hashProcessIdentity(value) {
+  return createHash("sha256").update(value).digest("hex");
 }
 
-function prepareLiveReportLockCandidate(lockPath, ownerToken) {
+export function readLiveReportProcessIdentity(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    throw new TypeError("live report process ID must be a positive integer");
+  }
+  if (!processIsRunning(pid)) return null;
+  const operatingSystem = platform();
+  if (operatingSystem === "linux") {
+    let source;
+    try {
+      source = readFileSync(`/proc/${pid}/stat`, "utf8");
+    } catch (error) {
+      if (fileSystemErrorCode(error) === "ENOENT") return null;
+      throw error;
+    }
+    const commandEnd = source.lastIndexOf(")");
+    const fields = source
+      .slice(commandEnd + 2)
+      .trim()
+      .split(/\s+/u);
+    const startTime = fields[19];
+    if (commandEnd < 1 || !/^\d+$/u.test(startTime ?? "")) {
+      throw new TypeError("Linux returned an invalid process birth identity");
+    }
+    return hashProcessIdentity(`linux:${startTime}`);
+  }
+  if (
+    operatingSystem === "darwin" ||
+    operatingSystem === "freebsd" ||
+    operatingSystem === "openbsd"
+  ) {
+    const result = spawnSync(
+      existsSync("/bin/ps") ? "/bin/ps" : "ps",
+      ["-o", "lstart=", "-p", String(pid)],
+      { encoding: "utf8", maxBuffer: 64 * 1024, windowsHide: true },
+    );
+    if (result.error) throw result.error;
+    if (result.status !== 0 || result.stdout.trim() === "") {
+      if (!processIsRunning(pid)) return null;
+      throw new Error("could not read the process birth identity from ps");
+    }
+    return hashProcessIdentity(`${operatingSystem}:${result.stdout.trim()}`);
+  }
+  if (operatingSystem === "win32") {
+    const result = spawnSync(
+      "powershell.exe",
+      [
+        "-NoLogo",
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        `(Get-Process -Id ${pid} -ErrorAction Stop).StartTime.ToUniversalTime().Ticks`,
+      ],
+      { encoding: "utf8", maxBuffer: 64 * 1024, windowsHide: true },
+    );
+    if (result.error) throw result.error;
+    if (result.status !== 0 || !/^\d+$/u.test(result.stdout.trim())) {
+      if (!processIsRunning(pid)) return null;
+      throw new Error("could not read the Windows process birth identity");
+    }
+    return hashProcessIdentity(`win32:${result.stdout.trim()}`);
+  }
+  throw new Error(
+    `live report locking does not support process identity on ${operatingSystem}`,
+  );
+}
+
+function readProcessLease(value, context) {
+  const record = asRecord(value, context);
+  const pid = asNumberField(record, "pid", context);
+  const processIdentity = asStringField(record, "processIdentity", context);
+  if (
+    !Number.isInteger(pid) ||
+    pid <= 0 ||
+    !LIVE_REPORT_PROCESS_IDENTITY_RE.test(processIdentity)
+  ) {
+    throw new TypeError(`${context} is invalid`);
+  }
+  return { pid, processIdentity };
+}
+
+function processLeaseIsActive(lease) {
+  const currentIdentity = readLiveReportProcessIdentity(lease.pid);
+  return currentIdentity !== null && currentIdentity === lease.processIdentity;
+}
+
+export function defaultLiveReportLockRoot() {
+  const uid = typeof process.getuid === "function" ? process.getuid() : null;
+  if (Number.isInteger(uid) && uid >= 0) {
+    return join("/tmp", `${LIVE_REPORT_LOCK_DIRECTORY}-${uid}`);
+  }
+  const identity = userInfo();
+  const key = createHash("sha256")
+    .update(`${identity.username}\0${identity.homedir}`)
+    .digest("hex")
+    .slice(0, 16);
+  return join(identity.homedir, `.${LIVE_REPORT_LOCK_DIRECTORY}-${key}`);
+}
+
+export function ensureLiveReportLockRoot(
+  rootPath = defaultLiveReportLockRoot(),
+) {
+  try {
+    mkdirSync(rootPath, { mode: 0o700 });
+  } catch (error) {
+    if (fileSystemErrorCode(error) !== "EEXIST") throw error;
+  }
+  const stats = lstatSync(rootPath);
+  if (stats.isSymbolicLink() || !stats.isDirectory()) {
+    throw new TypeError("live report lock root must be a real directory");
+  }
+  const uid = typeof process.getuid === "function" ? process.getuid() : null;
+  if (Number.isInteger(uid) && stats.uid !== uid) {
+    throw new TypeError(
+      "live report lock root must belong to the current user",
+    );
+  }
+  if (platform() !== "win32" && (stats.mode & 0o077) !== 0) {
+    throw new TypeError("live report lock root permissions must be 0700");
+  }
+  return rootPath;
+}
+
+function readLiveReportLockOwner(lockPath) {
+  let source;
+  try {
+    source = readFileSync(join(lockPath, LIVE_REPORT_LOCK_OWNER_FILE), "utf8");
+  } catch (error) {
+    if (fileSystemErrorCode(error) === "ENOENT") return null;
+    throw error;
+  }
+  const owner = asRecord(JSON.parse(source), "live report lock owner");
+  const schemaVersion = asNumberField(
+    owner,
+    "schemaVersion",
+    "live report lock owner",
+  );
+  const processLease = readProcessLease(owner, "live report lock owner");
+  const ownerToken = asStringField(
+    owner,
+    "ownerToken",
+    "live report lock owner",
+  );
+  if (schemaVersion !== 2 || !LIVE_REPORT_TOKEN_RE.test(ownerToken)) {
+    throw new TypeError("live report lock owner is invalid");
+  }
+  return { ...processLease, ownerToken };
+}
+
+function liveReportCommandDirectory(lockPath) {
+  return join(lockPath, LIVE_REPORT_LOCK_COMMAND_DIRECTORY);
+}
+
+function readLiveReportCommandLease(path) {
+  const record = asRecord(
+    JSON.parse(readFileSync(path, "utf8")),
+    "live report command lease",
+  );
+  const schemaVersion = asNumberField(
+    record,
+    "schemaVersion",
+    "live report command lease",
+  );
+  const ownerToken = asStringField(
+    record,
+    "ownerToken",
+    "live report command lease",
+  );
+  const startedAtMs = asNumberField(
+    record,
+    "startedAtMs",
+    "live report command lease",
+  );
+  const helper = readProcessLease(record.helper, "live report command helper");
+  const child =
+    record.child === null
+      ? null
+      : readProcessLease(record.child, "live report GitHub child");
+  if (
+    schemaVersion !== 1 ||
+    !LIVE_REPORT_TOKEN_RE.test(ownerToken) ||
+    !Number.isSafeInteger(startedAtMs) ||
+    startedAtMs <= 0
+  ) {
+    throw new TypeError("live report command lease is invalid");
+  }
+  return { child, helper, ownerToken, startedAtMs };
+}
+
+function liveReportCommandIsActive(lease, ownerToken) {
+  if (lease.ownerToken !== ownerToken) {
+    throw new TypeError("live report command lease owner does not match");
+  }
+  if (processLeaseIsActive(lease.helper)) return true;
+  if (lease.child !== null && processLeaseIsActive(lease.child)) return true;
+  return Date.now() - lease.startedAtMs < LIVE_REPORT_ORPHAN_COMMAND_GRACE_MS;
+}
+
+function liveReportHasActiveCommand(lockPath, ownerToken) {
+  const commandDirectory = liveReportCommandDirectory(lockPath);
+  let entries;
+  try {
+    entries = readdirSync(commandDirectory, { withFileTypes: true });
+  } catch (error) {
+    if (fileSystemErrorCode(error) === "ENOENT" && !existsSync(lockPath)) {
+      return false;
+    }
+    throw error;
+  }
+  for (const entry of entries) {
+    if (entry.isSymbolicLink() || (!entry.isFile() && !entry.isDirectory())) {
+      throw new TypeError("live report command directory is invalid");
+    }
+    if (!/^lease-[a-f0-9]{32}\.json$/u.test(entry.name)) continue;
+    const lease = readLiveReportCommandLease(
+      join(commandDirectory, entry.name),
+    );
+    if (liveReportCommandIsActive(lease, ownerToken)) return true;
+  }
+  return false;
+}
+
+function assertLiveReportLockDirectory(lockPath) {
+  const stats = lstatSync(lockPath);
+  if (stats.isSymbolicLink() || !stats.isDirectory()) {
+    throw new TypeError("live report lock must be a real directory");
+  }
+}
+
+function prepareLiveReportLockCandidate(lockPath, ownerToken, processIdentity) {
   const candidatePath = `${lockPath}.candidate-${process.pid}-${ownerToken}`;
   mkdirSync(candidatePath, { mode: 0o700 });
   try {
+    mkdirSync(liveReportCommandDirectory(candidatePath), { mode: 0o700 });
     writeFileSync(
       join(candidatePath, LIVE_REPORT_LOCK_OWNER_FILE),
       `${JSON.stringify({
-        schemaVersion: 1,
+        schemaVersion: 2,
         pid: process.pid,
+        processIdentity,
         ownerToken,
       })}\n`,
       { flag: "wx", mode: 0o600 },
@@ -1441,25 +1654,113 @@ function prepareLiveReportLockCandidate(lockPath, ownerToken) {
   }
 }
 
-export function acquireLiveReportLock(identity) {
+function liveReportLockKey(identity) {
+  return createHash("sha256")
+    .update(`${identity.host}:${identity.id}`)
+    .digest("hex");
+}
+
+function writeLiveReportCommandLease(path, lease, replace = false) {
+  if (!replace) {
+    writeFileSync(path, `${JSON.stringify(lease)}\n`, {
+      flag: "wx",
+      mode: 0o600,
+    });
+    return;
+  }
+  const nextPath = `${path}.next-${process.pid}-${randomBytes(16).toString("hex")}`;
+  try {
+    writeFileSync(nextPath, `${JSON.stringify(lease)}\n`, {
+      flag: "wx",
+      mode: 0o600,
+    });
+    renameSync(nextPath, path);
+  } catch (error) {
+    rmSync(nextPath, { force: true });
+    throw error;
+  }
+}
+
+function spawnLockedGh(lockPath, ownerToken, command, args, options = {}) {
+  if (
+    command !== "gh" ||
+    !Array.isArray(args) ||
+    args.some((argument) => typeof argument !== "string")
+  ) {
+    throw new TypeError("live report lock may execute only a gh argument list");
+  }
+  if (options.encoding !== undefined && options.encoding !== "utf8") {
+    throw new TypeError("live report gh commands require utf8 output");
+  }
+  const maxBuffer = options.maxBuffer ?? 1024 * 1024;
+  if (
+    !Number.isSafeInteger(maxBuffer) ||
+    maxBuffer <= 0 ||
+    maxBuffer > 256 * 1024 * 1024
+  ) {
+    throw new RangeError("live report gh command maxBuffer is invalid");
+  }
+  const commandToken = randomBytes(16).toString("hex");
+  const requestPath = join(
+    liveReportCommandDirectory(lockPath),
+    `request-${commandToken}.json`,
+  );
+  writeFileSync(
+    requestPath,
+    `${JSON.stringify({ args, maxBuffer, ownerToken, schemaVersion: 1 })}\n`,
+    { flag: "wx", mode: 0o600 },
+  );
+  try {
+    return spawnSync(
+      process.execPath,
+      [
+        fileURLToPath(import.meta.url),
+        LIVE_REPORT_LOCKED_GH_ARGUMENT,
+        lockPath,
+        ownerToken,
+        commandToken,
+      ],
+      {
+        encoding: "utf8",
+        env: { ...(options.env ?? process.env), GH_HOST: "github.com" },
+        maxBuffer: Math.min(maxBuffer + 1024 * 1024, 256 * 1024 * 1024),
+        windowsHide: true,
+      },
+    );
+  } finally {
+    rmSync(requestPath, { force: true });
+  }
+}
+
+export function acquireLiveReportLock(identity, options = {}) {
   const record = asRecord(identity, "GitHub authenticated identity");
   const id = asNumberField(record, "id", "GitHub authenticated identity");
   const login = asStringField(record, "login", "GitHub authenticated identity");
-  if (id <= 0 || login.length === 0) {
+  const host = asStringField(record, "host", "GitHub authenticated identity");
+  if (id <= 0 || login.length === 0 || host !== "github.com") {
     throw new TypeError("GitHub authenticated identity is invalid");
   }
-  const root = join(tmpdir(), LIVE_REPORT_LOCK_DIRECTORY);
-  mkdirSync(root, { mode: 0o700, recursive: true });
-  const key = createHash("sha256").update(`github.com:${id}`).digest("hex");
+  const root = ensureLiveReportLockRoot(
+    options.rootPath ?? defaultLiveReportLockRoot(),
+  );
+  const key = liveReportLockKey({ host, id });
   const lockPath = join(root, `${key}.lock`);
   const ownerToken = randomBytes(16).toString("hex");
+  const processIdentity = readLiveReportProcessIdentity(process.pid);
+  if (processIdentity === null) {
+    throw new Error("could not establish the live report process identity");
+  }
   let acquired = false;
   for (
     let attempt = 0;
     attempt < LIVE_REPORT_LOCK_ACQUIRE_ATTEMPTS;
     attempt += 1
   ) {
-    const candidatePath = prepareLiveReportLockCandidate(lockPath, ownerToken);
+    const candidatePath = prepareLiveReportLockCandidate(
+      lockPath,
+      ownerToken,
+      processIdentity,
+    );
     try {
       renameSync(candidatePath, lockPath);
       acquired = true;
@@ -1470,8 +1771,16 @@ export function acquireLiveReportLock(identity) {
         if (fileSystemErrorCode(error) === "ENOENT") continue;
         throw error;
       }
+      assertLiveReportLockDirectory(lockPath);
       const currentOwner = readLiveReportLockOwner(lockPath);
-      if (lockOwnerIsActive(currentOwner)) {
+      if (currentOwner === null) {
+        if (!existsSync(lockPath)) continue;
+        throw new Error("live report lock owner is missing");
+      }
+      if (
+        processLeaseIsActive(currentOwner) ||
+        liveReportHasActiveCommand(lockPath, currentOwner.ownerToken)
+      ) {
         throw new LiveReportLockContentionError();
       }
       const stalePath = `${lockPath}.stale-${process.pid}-${randomBytes(16).toString("hex")}`;
@@ -1489,12 +1798,16 @@ export function acquireLiveReportLock(identity) {
   }
   let released = false;
   return {
+    spawn(command, args, options) {
+      return spawnLockedGh(lockPath, ownerToken, command, args, options);
+    },
     release() {
       if (released) return;
       const owner = readLiveReportLockOwner(lockPath);
       if (
         owner === null ||
         owner.pid !== process.pid ||
+        owner.processIdentity !== processIdentity ||
         owner.ownerToken !== ownerToken
       ) {
         throw new Error("live report lock ownership changed before release");
@@ -1505,6 +1818,173 @@ export function acquireLiveReportLock(identity) {
       released = true;
     },
   };
+}
+
+function readLockedGhRequest(lockPath, ownerToken, commandToken) {
+  if (
+    !LIVE_REPORT_TOKEN_RE.test(ownerToken) ||
+    !LIVE_REPORT_TOKEN_RE.test(commandToken)
+  ) {
+    throw new TypeError("locked GitHub command tokens are invalid");
+  }
+  const root = ensureLiveReportLockRoot();
+  if (
+    dirname(lockPath) !== root ||
+    !/^[a-f0-9]{64}\.lock$/u.test(basename(lockPath))
+  ) {
+    throw new TypeError("locked GitHub command path is invalid");
+  }
+  assertLiveReportLockDirectory(lockPath);
+  const owner = readLiveReportLockOwner(lockPath);
+  if (owner === null || owner.ownerToken !== ownerToken) {
+    throw new Error("live report lock ownership changed before GitHub command");
+  }
+  const requestPath = join(
+    liveReportCommandDirectory(lockPath),
+    `request-${commandToken}.json`,
+  );
+  const request = asRecord(
+    JSON.parse(readFileSync(requestPath, "utf8")),
+    "locked GitHub command request",
+  );
+  const schemaVersion = asNumberField(
+    request,
+    "schemaVersion",
+    "locked GitHub command request",
+  );
+  const requestOwnerToken = asStringField(
+    request,
+    "ownerToken",
+    "locked GitHub command request",
+  );
+  const maxBuffer = asNumberField(
+    request,
+    "maxBuffer",
+    "locked GitHub command request",
+  );
+  if (
+    schemaVersion !== 1 ||
+    requestOwnerToken !== ownerToken ||
+    !Number.isSafeInteger(maxBuffer) ||
+    maxBuffer <= 0 ||
+    maxBuffer > 256 * 1024 * 1024 ||
+    !Array.isArray(request.args) ||
+    request.args.some((argument) => typeof argument !== "string")
+  ) {
+    throw new TypeError("locked GitHub command request is invalid");
+  }
+  return { args: request.args, maxBuffer, requestPath };
+}
+
+function collectBoundedGhChild(child, maxBuffer) {
+  return new Promise((resolvePromise) => {
+    const stdout = [];
+    const stderr = [];
+    let stdoutBytes = 0;
+    let stderrBytes = 0;
+    let overflow = null;
+    let spawnError = null;
+    const collect = (chunks, chunk, stream) => {
+      if (overflow !== null) return;
+      const value = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      if (stream === "stdout") stdoutBytes += value.length;
+      else stderrBytes += value.length;
+      if (stdoutBytes > maxBuffer || stderrBytes > maxBuffer) {
+        overflow = stream;
+        child.kill("SIGTERM");
+        return;
+      }
+      chunks.push(value);
+    };
+    child.stdout.on("data", (chunk) => collect(stdout, chunk, "stdout"));
+    child.stderr.on("data", (chunk) => collect(stderr, chunk, "stderr"));
+    child.once("error", (error) => {
+      spawnError = error;
+    });
+    child.once("close", (status, signal) => {
+      resolvePromise({
+        error: spawnError,
+        overflow,
+        signal,
+        status,
+        stderr: Buffer.concat(stderr),
+        stdout: Buffer.concat(stdout),
+      });
+    });
+  });
+}
+
+function writeProcessDescriptor(descriptor, value) {
+  if (value.length === 0) return;
+  try {
+    writeFileSync(descriptor, value);
+  } catch (error) {
+    if (fileSystemErrorCode(error) !== "EPIPE") throw error;
+  }
+}
+
+async function runLockedGhCommand(lockPath, ownerToken, commandToken) {
+  const request = readLockedGhRequest(lockPath, ownerToken, commandToken);
+  const leasePath = join(
+    liveReportCommandDirectory(lockPath),
+    `lease-${commandToken}.json`,
+  );
+  const helperIdentity = readLiveReportProcessIdentity(process.pid);
+  if (helperIdentity === null) {
+    throw new Error("could not establish the GitHub command helper identity");
+  }
+  const lease = {
+    schemaVersion: 1,
+    ownerToken,
+    startedAtMs: Date.now(),
+    helper: { pid: process.pid, processIdentity: helperIdentity },
+    child: null,
+  };
+  writeLiveReportCommandLease(leasePath, lease);
+  let result;
+  try {
+    const currentOwner = readLiveReportLockOwner(lockPath);
+    if (currentOwner === null || currentOwner.ownerToken !== ownerToken) {
+      throw new Error(
+        "live report lock ownership changed while starting GitHub command",
+      );
+    }
+    const child = spawn("gh", request.args, {
+      env: { ...process.env, GH_HOST: "github.com" },
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+    });
+    const childResult = collectBoundedGhChild(child, request.maxBuffer);
+    if (Number.isInteger(child.pid) && child.pid > 0) {
+      const childIdentity = readLiveReportProcessIdentity(child.pid);
+      if (childIdentity !== null) {
+        writeLiveReportCommandLease(
+          leasePath,
+          {
+            ...lease,
+            child: { pid: child.pid, processIdentity: childIdentity },
+          },
+          true,
+        );
+      }
+    }
+    result = await childResult;
+  } finally {
+    rmSync(leasePath, { force: true });
+    rmSync(request.requestPath, { force: true });
+  }
+  if (result.error) throw result.error;
+  if (result.overflow !== null) {
+    throw new RangeError(
+      `spawn gh ${result.overflow} exceeded the bounded output buffer`,
+    );
+  }
+  writeProcessDescriptor(1, result.stdout);
+  writeProcessDescriptor(2, result.stderr);
+  if (result.status === null) {
+    throw new Error(`gh terminated by ${result.signal ?? "an unknown signal"}`);
+  }
+  process.exitCode = result.status;
 }
 
 function rateResource(value, context) {
@@ -2964,8 +3444,8 @@ export function main(args = process.argv.slice(2)) {
     if (!result.complete) process.exitCode = 2;
     return;
   }
-  const commandBudget = createGhCommandBudget();
   if (options.recheckPr !== undefined) {
+    const commandBudget = createGhCommandBudget();
     const result = recheckLivePullHead(
       options.repo,
       {
@@ -2978,12 +3458,13 @@ export function main(args = process.argv.slice(2)) {
     if (!result.publishable) process.exitCode = 2;
     return;
   }
-  const boundedRead = (endpoint) => {
-    return readGhPages(endpoint, commandBudget.run);
-  };
   const authenticatedIdentity = readGhAuthenticatedIdentity();
   const liveReportLock = acquireLiveReportLock(authenticatedIdentity);
   try {
+    const commandBudget = createGhCommandBudget(liveReportLock.spawn);
+    const boundedRead = (endpoint) => {
+      return readGhPages(endpoint, commandBudget.run);
+    };
     const openActivity = readGhOpenActivity(options.repo, commandBudget.run, {
       preflight: true,
     });
@@ -3024,17 +3505,27 @@ const invokedDirectly =
     realpathSync(process.argv[1]);
 
 if (invokedDirectly) {
-  try {
-    main();
-  } catch (error) {
-    // error-policy:J1 The CLI boundary turns a failed read/audit into a non-zero exit.
-    const message = error instanceof Error ? error.message : String(error);
-    if (error instanceof LiveReportLockContentionError) {
-      process.stderr.write(`Slop live report deferred: ${message}\n`);
-      process.exitCode = 2;
-    } else {
-      process.stderr.write(`Slop live report failed: ${message}\n`);
+  const directArguments = process.argv.slice(2);
+  if (directArguments[0] === LIVE_REPORT_LOCKED_GH_ARGUMENT) {
+    runLockedGhCommand(...directArguments.slice(1)).catch((error) => {
+      // error-policy:J1 The internal process boundary fails the owning report.
+      const message = error instanceof Error ? error.message : String(error);
+      process.stderr.write(`Slop locked GitHub command failed: ${message}\n`);
       process.exitCode = 1;
+    });
+  } else {
+    try {
+      main(directArguments);
+    } catch (error) {
+      // error-policy:J1 The CLI boundary turns a failed read/audit into a non-zero exit.
+      const message = error instanceof Error ? error.message : String(error);
+      if (error instanceof LiveReportLockContentionError) {
+        process.stderr.write(`Slop live report deferred: ${message}\n`);
+        process.exitCode = 2;
+      } else {
+        process.stderr.write(`Slop live report failed: ${message}\n`);
+        process.exitCode = 1;
+      }
     }
   }
 }

--- a/skills/contribute-to-heir-elements-sdk/scripts/live-report.mjs
+++ b/skills/contribute-to-heir-elements-sdk/scripts/live-report.mjs
@@ -2758,10 +2758,15 @@ Options:
 }
 
 /** Repeats one complete read when GitHub changes its open-item inventory mid-snapshot. */
-export function retryChangedLiveInventory(collect, onRetry = () => {}) {
+export function retryChangedLiveInventory(
+  collect,
+  onRetry = () => {},
+  createCommandBudget = createGhCommandBudget,
+) {
   for (let attempt = 1; attempt <= MAX_LIVE_INVENTORY_ATTEMPTS; attempt += 1) {
+    const commandBudget = createCommandBudget();
     try {
-      return collect(attempt);
+      return collect({ attempt, commandBudget });
     } catch (cause) {
       if (!(cause instanceof LiveInventoryChangedError)) throw cause;
       if (attempt === MAX_LIVE_INVENTORY_ATTEMPTS) {
@@ -2794,8 +2799,8 @@ export function main(args = process.argv.slice(2)) {
     if (!result.complete) process.exitCode = 2;
     return;
   }
-  const commandBudget = createGhCommandBudget();
   if (options.recheckPr !== undefined) {
+    const commandBudget = createGhCommandBudget();
     const result = recheckLivePullHead(
       options.repo,
       {
@@ -2808,12 +2813,12 @@ export function main(args = process.argv.slice(2)) {
     if (!result.publishable) process.exitCode = 2;
     return;
   }
-  const boundedRead = (endpoint) => {
-    return readGhPages(endpoint, commandBudget.run);
-  };
   let rateLimits = { preflight: true };
   const { report } = retryChangedLiveInventory(
-    () => {
+    ({ commandBudget }) => {
+      const boundedRead = (endpoint) => {
+        return readGhPages(endpoint, commandBudget.run);
+      };
       const openActivity = readGhOpenActivity(
         options.repo,
         commandBudget.run,

--- a/skills/contribute-to-heir-elements-sdk/scripts/live-report.mjs
+++ b/skills/contribute-to-heir-elements-sdk/scripts/live-report.mjs
@@ -3,6 +3,7 @@
  * Builds a stable, read-only inventory of open elizaOS issues and pull requests
  * for contribution selection. REST pagination stays behind one GET-only
  * adapter; GraphQL uses explicit read-only queries over GitHub's POST endpoint.
+ * A user-private process lease serializes complete discovery across skill copies.
  */
 
 import { spawn, spawnSync } from "node:child_process";
@@ -11,8 +12,8 @@ import {
   existsSync,
   lstatSync,
   mkdirSync,
-  readFileSync,
   readdirSync,
+  readFileSync,
   realpathSync,
   renameSync,
   rmSync,
@@ -1389,6 +1390,23 @@ function fileSystemErrorCode(error) {
     : null;
 }
 
+function assertLiveReportPrivatePath(path, context, kind) {
+  const stats = lstatSync(path);
+  const kindMatches =
+    kind === "directory" ? stats.isDirectory() : stats.isFile();
+  if (stats.isSymbolicLink() || !kindMatches) {
+    throw new TypeError(`${context} must be a real ${kind}`);
+  }
+  const uid = typeof process.getuid === "function" ? process.getuid() : null;
+  if (Number.isInteger(uid) && stats.uid !== uid) {
+    throw new TypeError(`${context} must belong to the current user`);
+  }
+  if (platform() !== "win32" && (stats.mode & 0o077) !== 0) {
+    throw new TypeError(`${context} permissions must exclude group and others`);
+  }
+  return stats;
+}
+
 function processIsRunning(pid) {
   try {
     process.kill(pid, 0);
@@ -1510,25 +1528,18 @@ export function ensureLiveReportLockRoot(
   } catch (error) {
     if (fileSystemErrorCode(error) !== "EEXIST") throw error;
   }
-  const stats = lstatSync(rootPath);
-  if (stats.isSymbolicLink() || !stats.isDirectory()) {
-    throw new TypeError("live report lock root must be a real directory");
-  }
-  const uid = typeof process.getuid === "function" ? process.getuid() : null;
-  if (Number.isInteger(uid) && stats.uid !== uid) {
-    throw new TypeError(
-      "live report lock root must belong to the current user",
-    );
-  }
-  if (platform() !== "win32" && (stats.mode & 0o077) !== 0) {
-    throw new TypeError("live report lock root permissions must be 0700");
-  }
+  assertLiveReportPrivatePath(rootPath, "live report lock root", "directory");
   return rootPath;
 }
 
 function readLiveReportLockOwner(lockPath) {
   let source;
   try {
+    assertLiveReportPrivatePath(
+      join(lockPath, LIVE_REPORT_LOCK_OWNER_FILE),
+      "live report lock owner",
+      "file",
+    );
     source = readFileSync(join(lockPath, LIVE_REPORT_LOCK_OWNER_FILE), "utf8");
   } catch (error) {
     if (fileSystemErrorCode(error) === "ENOENT") return null;
@@ -1557,6 +1568,7 @@ function liveReportCommandDirectory(lockPath) {
 }
 
 function readLiveReportCommandLease(path) {
+  assertLiveReportPrivatePath(path, "live report command lease", "file");
   const record = asRecord(
     JSON.parse(readFileSync(path, "utf8")),
     "live report command lease",
@@ -1605,6 +1617,11 @@ function liveReportHasActiveCommand(lockPath, ownerToken) {
   const commandDirectory = liveReportCommandDirectory(lockPath);
   let entries;
   try {
+    assertLiveReportPrivatePath(
+      commandDirectory,
+      "live report command directory",
+      "directory",
+    );
     entries = readdirSync(commandDirectory, { withFileTypes: true });
   } catch (error) {
     if (fileSystemErrorCode(error) === "ENOENT" && !existsSync(lockPath)) {
@@ -1613,7 +1630,7 @@ function liveReportHasActiveCommand(lockPath, ownerToken) {
     throw error;
   }
   for (const entry of entries) {
-    if (entry.isSymbolicLink() || (!entry.isFile() && !entry.isDirectory())) {
+    if (!entry.isFile()) {
       throw new TypeError("live report command directory is invalid");
     }
     if (!/^lease-[a-f0-9]{32}\.json$/u.test(entry.name)) continue;
@@ -1626,10 +1643,7 @@ function liveReportHasActiveCommand(lockPath, ownerToken) {
 }
 
 function assertLiveReportLockDirectory(lockPath) {
-  const stats = lstatSync(lockPath);
-  if (stats.isSymbolicLink() || !stats.isDirectory()) {
-    throw new TypeError("live report lock must be a real directory");
-  }
+  assertLiveReportPrivatePath(lockPath, "live report lock", "directory");
 }
 
 function prepareLiveReportLockCandidate(lockPath, ownerToken, processIdentity) {
@@ -1701,6 +1715,11 @@ function spawnLockedGh(lockPath, ownerToken, command, args, options = {}) {
     throw new RangeError("live report gh command maxBuffer is invalid");
   }
   const commandToken = randomBytes(16).toString("hex");
+  assertLiveReportPrivatePath(
+    liveReportCommandDirectory(lockPath),
+    "live report command directory",
+    "directory",
+  );
   const requestPath = join(
     liveReportCommandDirectory(lockPath),
     `request-${commandToken}.json`,
@@ -1827,7 +1846,7 @@ function readLockedGhRequest(lockPath, ownerToken, commandToken) {
   ) {
     throw new TypeError("locked GitHub command tokens are invalid");
   }
-  const root = ensureLiveReportLockRoot();
+  const root = ensureLiveReportLockRoot(dirname(lockPath));
   if (
     dirname(lockPath) !== root ||
     !/^[a-f0-9]{64}\.lock$/u.test(basename(lockPath))
@@ -1842,6 +1861,11 @@ function readLockedGhRequest(lockPath, ownerToken, commandToken) {
   const requestPath = join(
     liveReportCommandDirectory(lockPath),
     `request-${commandToken}.json`,
+  );
+  assertLiveReportPrivatePath(
+    requestPath,
+    "locked GitHub command request",
+    "file",
   );
   const request = asRecord(
     JSON.parse(readFileSync(requestPath, "utf8")),

--- a/skills/contribute-to-heir-elements-sdk/scripts/live-report.mjs
+++ b/skills/contribute-to-heir-elements-sdk/scripts/live-report.mjs
@@ -6,7 +6,18 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { createHash, randomBytes } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -34,6 +45,10 @@ export const MAX_ACTIVITY_CONNECTION_ITEMS = 1_000;
 export const MIN_GRAPHQL_ACTIVITY_POINTS = 1_000;
 export const MIN_REST_ACTIVITY_REQUESTS = 100;
 export const MIN_SEARCH_ACTIVITY_REQUESTS = 2;
+
+const LIVE_REPORT_LOCK_DIRECTORY = "slop-live-report-locks-v1";
+const LIVE_REPORT_LOCK_OWNER_FILE = "owner.json";
+const LIVE_REPORT_LOCK_ACQUIRE_ATTEMPTS = 8;
 
 const REPOSITORY_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const PLACEHOLDER_RE =
@@ -1301,6 +1316,193 @@ export function createGhCommandBudget(spawn = spawnSync) {
       }
       count += 1;
       return spawn(command, args, options);
+    },
+  };
+}
+
+export class LiveReportLockContentionError extends Error {
+  constructor() {
+    super(
+      "live report lock contention: another report for this GitHub identity is already discovering activity",
+    );
+    this.name = "LiveReportLockContentionError";
+  }
+}
+
+export function readGhAuthenticatedIdentity(spawn = spawnSync) {
+  const result = spawn(
+    "gh",
+    ["api", "--method", "GET", "--jq", "{id: .id, login: .login}", "user"],
+    {
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024,
+      windowsHide: true,
+    },
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const detail =
+      result.stderr.trim().length > 0 ? `: ${result.stderr.trim()}` : "";
+    throw new Error(`gh api failed for authenticated identity${detail}`);
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(result.stdout);
+  } catch (cause) {
+    throw new SyntaxError(
+      "gh api returned malformed JSON for authenticated identity",
+      { cause },
+    );
+  }
+  const identity = asRecord(parsed, "GitHub authenticated identity");
+  const id = asNumberField(identity, "id", "GitHub authenticated identity");
+  const login = asStringField(
+    identity,
+    "login",
+    "GitHub authenticated identity",
+  );
+  if (id <= 0 || login.length === 0) {
+    throw new TypeError("GitHub authenticated identity is invalid");
+  }
+  return { id, login };
+}
+
+function fileSystemErrorCode(error) {
+  return error && typeof error === "object" && "code" in error
+    ? error.code
+    : null;
+}
+
+function readLiveReportLockOwner(lockPath) {
+  try {
+    const owner = asRecord(
+      JSON.parse(
+        readFileSync(join(lockPath, LIVE_REPORT_LOCK_OWNER_FILE), "utf8"),
+      ),
+      "live report lock owner",
+    );
+    const schemaVersion = asNumberField(
+      owner,
+      "schemaVersion",
+      "live report lock owner",
+    );
+    const pid = asNumberField(owner, "pid", "live report lock owner");
+    const ownerToken = asStringField(
+      owner,
+      "ownerToken",
+      "live report lock owner",
+    );
+    if (
+      schemaVersion !== 1 ||
+      pid <= 0 ||
+      !/^[a-f0-9]{32}$/u.test(ownerToken)
+    ) {
+      return null;
+    }
+    return { pid, ownerToken };
+  } catch {
+    // error-policy:J3 A corrupt or incomplete lease cannot claim live ownership.
+    return null;
+  }
+}
+
+function processIsRunning(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (fileSystemErrorCode(error) === "ESRCH") return false;
+    if (fileSystemErrorCode(error) === "EPERM") return true;
+    throw error;
+  }
+}
+
+function lockOwnerIsActive(owner) {
+  return owner !== null && processIsRunning(owner.pid);
+}
+
+function prepareLiveReportLockCandidate(lockPath, ownerToken) {
+  const candidatePath = `${lockPath}.candidate-${process.pid}-${ownerToken}`;
+  mkdirSync(candidatePath, { mode: 0o700 });
+  try {
+    writeFileSync(
+      join(candidatePath, LIVE_REPORT_LOCK_OWNER_FILE),
+      `${JSON.stringify({
+        schemaVersion: 1,
+        pid: process.pid,
+        ownerToken,
+      })}\n`,
+      { flag: "wx", mode: 0o600 },
+    );
+    return candidatePath;
+  } catch (error) {
+    rmSync(candidatePath, { force: true, recursive: true });
+    throw error;
+  }
+}
+
+export function acquireLiveReportLock(identity) {
+  const record = asRecord(identity, "GitHub authenticated identity");
+  const id = asNumberField(record, "id", "GitHub authenticated identity");
+  const login = asStringField(record, "login", "GitHub authenticated identity");
+  if (id <= 0 || login.length === 0) {
+    throw new TypeError("GitHub authenticated identity is invalid");
+  }
+  const root = join(tmpdir(), LIVE_REPORT_LOCK_DIRECTORY);
+  mkdirSync(root, { mode: 0o700, recursive: true });
+  const key = createHash("sha256").update(`github.com:${id}`).digest("hex");
+  const lockPath = join(root, `${key}.lock`);
+  const ownerToken = randomBytes(16).toString("hex");
+  let acquired = false;
+  for (
+    let attempt = 0;
+    attempt < LIVE_REPORT_LOCK_ACQUIRE_ATTEMPTS;
+    attempt += 1
+  ) {
+    const candidatePath = prepareLiveReportLockCandidate(lockPath, ownerToken);
+    try {
+      renameSync(candidatePath, lockPath);
+      acquired = true;
+      break;
+    } catch (error) {
+      rmSync(candidatePath, { force: true, recursive: true });
+      if (!existsSync(lockPath)) {
+        if (fileSystemErrorCode(error) === "ENOENT") continue;
+        throw error;
+      }
+      const currentOwner = readLiveReportLockOwner(lockPath);
+      if (lockOwnerIsActive(currentOwner)) {
+        throw new LiveReportLockContentionError();
+      }
+      const stalePath = `${lockPath}.stale-${process.pid}-${randomBytes(16).toString("hex")}`;
+      try {
+        renameSync(lockPath, stalePath);
+      } catch (renameError) {
+        if (fileSystemErrorCode(renameError) === "ENOENT") continue;
+        throw renameError;
+      }
+      rmSync(stalePath, { force: true, recursive: true });
+    }
+  }
+  if (!acquired) {
+    throw new Error("live report lock changed too often to acquire safely");
+  }
+  let released = false;
+  return {
+    release() {
+      if (released) return;
+      const owner = readLiveReportLockOwner(lockPath);
+      if (
+        owner === null ||
+        owner.pid !== process.pid ||
+        owner.ownerToken !== ownerToken
+      ) {
+        throw new Error("live report lock ownership changed before release");
+      }
+      const releasedPath = `${lockPath}.released-${process.pid}-${ownerToken}`;
+      renameSync(lockPath, releasedPath);
+      rmSync(releasedPath, { force: true, recursive: true });
+      released = true;
     },
   };
 }
@@ -2779,34 +2981,40 @@ export function main(args = process.argv.slice(2)) {
   const boundedRead = (endpoint) => {
     return readGhPages(endpoint, commandBudget.run);
   };
-  const openActivity = readGhOpenActivity(options.repo, commandBudget.run, {
-    preflight: true,
-  });
-  const limits = asRecord(openActivity.rateLimits, "GitHub rate limits");
-  process.stderr.write(
-    `[Slop] GitHub budgets: GraphQL ${limits.graphqlRemaining}/${limits.graphqlLimit} (${limits.graphqlBudgetSource}); REST ${limits.restRemaining}/${limits.restLimit}; Search ${limits.searchRemaining}/${limits.searchLimit}; activity source ${openActivity.source}\n`,
-  );
-  const report = collectLiveReport(
-    options.repo,
-    boundedRead,
-    new Date(),
-    ({ phase, current, total }) => {
-      if (current === 0 || current === total || current % 10 === 0) {
-        process.stderr.write(
-          `[Slop] scanning ${phase}: ${current}/${total} (${commandBudget.count} bounded GitHub commands)\n`,
-        );
-      }
-    },
-    openActivity,
-    selectionPolicy.eligibleIssueLabels,
-  );
-  process.stdout.write(
-    options.epochOnly
-      ? `${JSON.stringify(report.selection.reviewEpoch, null, 2)}\n`
-      : options.json
-        ? `${JSON.stringify(report, null, 2)}\n`
-        : renderMarkdown(report),
-  );
+  const authenticatedIdentity = readGhAuthenticatedIdentity();
+  const liveReportLock = acquireLiveReportLock(authenticatedIdentity);
+  try {
+    const openActivity = readGhOpenActivity(options.repo, commandBudget.run, {
+      preflight: true,
+    });
+    const limits = asRecord(openActivity.rateLimits, "GitHub rate limits");
+    process.stderr.write(
+      `[Slop] GitHub budgets: GraphQL ${limits.graphqlRemaining}/${limits.graphqlLimit} (${limits.graphqlBudgetSource}); REST ${limits.restRemaining}/${limits.restLimit}; Search ${limits.searchRemaining}/${limits.searchLimit}; activity source ${openActivity.source}\n`,
+    );
+    const report = collectLiveReport(
+      options.repo,
+      boundedRead,
+      new Date(),
+      ({ phase, current, total }) => {
+        if (current === 0 || current === total || current % 10 === 0) {
+          process.stderr.write(
+            `[Slop] scanning ${phase}: ${current}/${total} (${commandBudget.count} bounded GitHub commands)\n`,
+          );
+        }
+      },
+      openActivity,
+      selectionPolicy.eligibleIssueLabels,
+    );
+    process.stdout.write(
+      options.epochOnly
+        ? `${JSON.stringify(report.selection.reviewEpoch, null, 2)}\n`
+        : options.json
+          ? `${JSON.stringify(report, null, 2)}\n`
+          : renderMarkdown(report),
+    );
+  } finally {
+    liveReportLock.release();
+  }
 }
 
 const invokedDirectly =
@@ -2821,7 +3029,12 @@ if (invokedDirectly) {
   } catch (error) {
     // error-policy:J1 The CLI boundary turns a failed read/audit into a non-zero exit.
     const message = error instanceof Error ? error.message : String(error);
-    process.stderr.write(`Slop live report failed: ${message}\n`);
-    process.exitCode = 1;
+    if (error instanceof LiveReportLockContentionError) {
+      process.stderr.write(`Slop live report deferred: ${message}\n`);
+      process.exitCode = 2;
+    } else {
+      process.stderr.write(`Slop live report failed: ${message}\n`);
+      process.exitCode = 1;
+    }
   }
 }

--- a/skills/contribute-to-heir-elements-sdk/scripts/live-report.mjs
+++ b/skills/contribute-to-heir-elements-sdk/scripts/live-report.mjs
@@ -2811,15 +2811,11 @@ export function main(args = process.argv.slice(2)) {
   const boundedRead = (endpoint) => {
     return readGhPages(endpoint, commandBudget.run);
   };
-  let rateLimits = { preflight: true };
   const { report } = retryChangedLiveInventory(
     () => {
-      const openActivity = readGhOpenActivity(
-        options.repo,
-        commandBudget.run,
-        rateLimits,
-      );
-      rateLimits = openActivity.rateLimits;
+      const openActivity = readGhOpenActivity(options.repo, commandBudget.run, {
+        preflight: true,
+      });
       const limits = asRecord(openActivity.rateLimits, "GitHub rate limits");
       process.stderr.write(
         `[Slop] GitHub budgets: GraphQL ${limits.graphqlRemaining}/${limits.graphqlLimit} (${limits.graphqlBudgetSource}); REST ${limits.restRemaining}/${limits.restLimit}; Search ${limits.searchRemaining}/${limits.searchLimit}; activity source ${openActivity.source}\n`,

--- a/skills/contribute-to-heir-elements-sdk/scripts/run-receipt.mjs
+++ b/skills/contribute-to-heir-elements-sdk/scripts/run-receipt.mjs
@@ -2193,6 +2193,20 @@ function renderResult(result, json) {
   );
 }
 
+const WALLET_CLAIM_SCRIPT = join(scriptDirectory, "wallet-claim.mjs");
+
+/**
+ * One stderr line after a fresh finish for projects that pay a monthly pool.
+ * The run never reads the wallet registry, so it cannot know whether a claim
+ * exists; it only points at the register command and the cut-off rule.
+ */
+function walletNudge() {
+  if (!existsSync(WALLET_CLAIM_SCRIPT)) return;
+  process.stderr.write(
+    `No payout wallet is checked by this run. If none is registered, run: node ${WALLET_CLAIM_SCRIPT} register --address <public-address> (a wallet observed after a proposal is generated applies to the next cycle).\n`,
+  );
+}
+
 function previewRun(options) {
   const provenance = resolveSkillProvenance();
   const repositoryRoot = requireRepository(options.repoRoot);
@@ -2562,6 +2576,7 @@ function finishRun(options, testOptions) {
     },
     options.json,
   );
+  walletNudge();
 }
 
 export async function main(args = process.argv.slice(2), testOptions) {

--- a/skills/contribute-to-heir-elements-sdk/scripts/run-receipt.mjs
+++ b/skills/contribute-to-heir-elements-sdk/scripts/run-receipt.mjs
@@ -1299,6 +1299,7 @@ export async function slopIdentityAssertion(
   fetchImpl = globalThis.fetch,
   delayImpl = (milliseconds) =>
     new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds)),
+  nowImpl = Date.now,
 ) {
   if (typeof fetchImpl !== "function")
     fail("Slop identity transport is unavailable");
@@ -1348,10 +1349,10 @@ export async function slopIdentityAssertion(
   );
   const expiresAt = Date.parse(started.expiresAt);
   process.stderr.write(
-    `This link expires in ${Math.max(0, Math.round((expiresAt - Date.now()) / 1000))} seconds; authorize promptly.\n`,
+    `This link expires in ${Math.max(0, Math.round((expiresAt - nowImpl()) / 1000))} seconds; authorize promptly.\n`,
   );
   let retryAfterSeconds = started.pollAfterSeconds;
-  while (Date.now() < expiresAt) {
+  while (nowImpl() < expiresAt) {
     await delayImpl(retryAfterSeconds * 1000);
     let response;
     try {
@@ -1388,7 +1389,7 @@ export async function slopIdentityAssertion(
       if (
         response.status === 410 &&
         errorCode !== "flow_consumed" &&
-        Date.now() >= expiresAt - (retryAfterSeconds + 1) * 1000
+        (errorCode === "flow_expired" || nowImpl() >= expiresAt)
       ) {
         fail(
           "Slop identity authorization expired before completion; run register again and authorize within the deadline",
@@ -1436,7 +1437,7 @@ export async function slopIdentityAssertion(
       typeof result.assertion !== "string" ||
       !/^slop_assert_v1_[A-Za-z0-9_-]{20,512}$/u.test(result.assertion) ||
       canonicalIso(result.expiresAt) !== result.expiresAt ||
-      Date.parse(result.expiresAt) <= Date.now()
+      Date.parse(result.expiresAt) <= nowImpl()
     ) {
       fail("Slop identity completion response was invalid");
     }

--- a/skills/contribute-to-heir-elements-sdk/scripts/run-receipt.mjs
+++ b/skills/contribute-to-heir-elements-sdk/scripts/run-receipt.mjs
@@ -1347,6 +1347,9 @@ export async function slopIdentityAssertion(
     `Authorize this contribution with GitHub:\n${authorizationUrl.href}\n`,
   );
   const expiresAt = Date.parse(started.expiresAt);
+  process.stderr.write(
+    `This link expires in ${Math.max(0, Math.round((expiresAt - Date.now()) / 1000))} seconds; authorize promptly.\n`,
+  );
   let retryAfterSeconds = started.pollAfterSeconds;
   while (Date.now() < expiresAt) {
     await delayImpl(retryAfterSeconds * 1000);
@@ -1366,7 +1369,34 @@ export async function slopIdentityAssertion(
       fail("Slop identity poll request failed");
     }
     if (!response.ok) {
-      fail(`Slop identity poll returned HTTP ${response.status}`);
+      let errorCode = null;
+      try {
+        const parsed = JSON.parse(
+          await boundedResponseText(response, "Slop identity poll"),
+        );
+        if (
+          parsed &&
+          typeof parsed === "object" &&
+          typeof parsed.error === "string" &&
+          /^[a-z0-9_]{1,64}$/u.test(parsed.error)
+        ) {
+          errorCode = parsed.error;
+        }
+      } catch {
+        // Fail closed on the status alone when the body is unreadable.
+      }
+      if (
+        response.status === 410 &&
+        errorCode !== "flow_consumed" &&
+        Date.now() >= expiresAt - (retryAfterSeconds + 1) * 1000
+      ) {
+        fail(
+          "Slop identity authorization expired before completion; run register again and authorize within the deadline",
+        );
+      }
+      fail(
+        `Slop identity poll returned HTTP ${response.status}${errorCode === null ? "" : ` (${errorCode})`}`,
+      );
     }
     const source = await boundedResponseText(response, "Slop identity poll");
     let result;

--- a/skills/contribute-to-heir-elements-sdk/scripts/run-receipt.mjs
+++ b/skills/contribute-to-heir-elements-sdk/scripts/run-receipt.mjs
@@ -1533,88 +1533,92 @@ export async function uploadPrivateTrace(
   );
   if (
     created.clientRunId !== state.runId ||
-    created.state !== "awaiting_trace" ||
+    !["awaiting_trace", "trace_uploaded", "finalized"].includes(
+      created.state,
+    ) ||
     !/^[A-Za-z0-9][A-Za-z0-9._:-]{0,159}$/u.test(created.serverRunId ?? "")
   ) {
     fail("trace run creation returned mismatched identity");
   }
   const serverPath = encodeURIComponent(created.serverRunId);
-  const intentBody = {
-    sha256: trace.sha256,
-    sizeBytes: trace.sizeBytes,
-    contentType: trace.contentType,
-  };
-  const intent = await jsonRequest(
-    fetchImpl,
-    `${TRACE_AUTHORITY}/api/v1/runs/${serverPath}/trace-intents`,
-    {
-      method: "POST",
-      headers: {
-        ...jsonHeaders,
-        "Idempotency-Key": sha256(
-          `intent:${created.serverRunId}:${trace.sha256}`,
-        ),
+  if (created.state === "awaiting_trace") {
+    const intentBody = {
+      sha256: trace.sha256,
+      sizeBytes: trace.sizeBytes,
+      contentType: trace.contentType,
+    };
+    const intent = await jsonRequest(
+      fetchImpl,
+      `${TRACE_AUTHORITY}/api/v1/runs/${serverPath}/trace-intents`,
+      {
+        method: "POST",
+        headers: {
+          ...jsonHeaders,
+          "Idempotency-Key": sha256(
+            `intent:${created.serverRunId}:${trace.sha256}`,
+          ),
+        },
+        body: JSON.stringify(intentBody),
       },
-      body: JSON.stringify(intentBody),
-    },
-    [
-      "contentType",
-      "expiresAt",
-      "serverRunId",
-      "sha256",
-      "sizeBytes",
-      "uploadUrl",
-    ],
-    "trace upload intent",
-  );
-  let uploadUrl;
-  try {
-    uploadUrl = new URL(intent.uploadUrl);
-  } catch {
-    fail("trace upload intent returned an invalid URL");
-  }
-  if (
-    intent.serverRunId !== created.serverRunId ||
-    intent.sha256 !== trace.sha256 ||
-    intent.sizeBytes !== trace.sizeBytes ||
-    intent.contentType !== trace.contentType ||
-    uploadUrl.origin !== TRACE_AUTHORITY ||
-    uploadUrl.username ||
-    uploadUrl.password ||
-    uploadUrl.hash
-  ) {
-    fail("trace upload intent returned mismatched fields");
-  }
-  const uploaded = await jsonRequest(
-    fetchImpl,
-    uploadUrl.href,
-    {
-      method: "PUT",
-      headers: {
-        "Content-Type": trace.contentType,
-        Digest: `sha-256=${trace.sha256}`,
+      [
+        "contentType",
+        "expiresAt",
+        "serverRunId",
+        "sha256",
+        "sizeBytes",
+        "uploadUrl",
+      ],
+      "trace upload intent",
+    );
+    let uploadUrl;
+    try {
+      uploadUrl = new URL(intent.uploadUrl);
+    } catch {
+      fail("trace upload intent returned an invalid URL");
+    }
+    if (
+      intent.serverRunId !== created.serverRunId ||
+      intent.sha256 !== trace.sha256 ||
+      intent.sizeBytes !== trace.sizeBytes ||
+      intent.contentType !== trace.contentType ||
+      uploadUrl.origin !== TRACE_AUTHORITY ||
+      uploadUrl.username ||
+      uploadUrl.password ||
+      uploadUrl.hash
+    ) {
+      fail("trace upload intent returned mismatched fields");
+    }
+    const uploaded = await jsonRequest(
+      fetchImpl,
+      uploadUrl.href,
+      {
+        method: "PUT",
+        headers: {
+          "Content-Type": trace.contentType,
+          Digest: `sha-256=${trace.sha256}`,
+        },
+        body: trace.contents,
       },
-      body: trace.contents,
-    },
-    [
-      "clientRunId",
-      "serverRunId",
-      "sizeBytes",
-      "state",
-      "traceObjectId",
-      "traceSha256",
-    ],
-    "trace upload",
-  );
-  if (
-    uploaded.clientRunId !== state.runId ||
-    uploaded.serverRunId !== created.serverRunId ||
-    uploaded.sizeBytes !== trace.sizeBytes ||
-    uploaded.state !== "trace_uploaded" ||
-    uploaded.traceSha256 !== trace.sha256 ||
-    uploaded.traceObjectId !== `sha256:${trace.sha256}`
-  ) {
-    fail("trace upload returned mismatched evidence");
+      [
+        "clientRunId",
+        "serverRunId",
+        "sizeBytes",
+        "state",
+        "traceObjectId",
+        "traceSha256",
+      ],
+      "trace upload",
+    );
+    if (
+      uploaded.clientRunId !== state.runId ||
+      uploaded.serverRunId !== created.serverRunId ||
+      uploaded.sizeBytes !== trace.sizeBytes ||
+      uploaded.state !== "trace_uploaded" ||
+      uploaded.traceSha256 !== trace.sha256 ||
+      uploaded.traceObjectId !== `sha256:${trace.sha256}`
+    ) {
+      fail("trace upload returned mismatched evidence");
+    }
   }
   const finalized = await jsonRequest(
     fetchImpl,

--- a/skills/contribute-to-heir-elements-sdk/scripts/run-receipt.mjs
+++ b/skills/contribute-to-heir-elements-sdk/scripts/run-receipt.mjs
@@ -1585,7 +1585,7 @@ export async function uploadPrivateTrace(
         headers: {
           ...jsonHeaders,
           "Idempotency-Key": sha256(
-            `intent:${created.serverRunId}:${trace.sha256}`,
+            `intent:${created.serverRunId}:${trace.sha256}:${randomBytes(16).toString("hex")}`,
           ),
         },
         body: JSON.stringify(intentBody),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1447,7 +1447,12 @@ function HomePage({ state, retry }: { state: DataState; retry: () => void }) {
 }
 
 function projectAgentPrompt(project: ProjectDefinition): string {
-  const repository = project.repositories[0]?.id;
+  const target = project.repositories[0];
+  // The public registry the bootstrap skill matches against publishes
+  // `aliases.at(-1) ?? id`, so a transferred repository resolves to its current
+  // path. Emitting `id` here would hand the operator the pre-transfer path,
+  // whose origin has no exact registry match and stops the skill.
+  const repository = target?.aliases?.at(-1) ?? target?.id;
   if (!repository) {
     throw new TypeError(`Project ${project.id} has no contribution repository`);
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -508,7 +508,7 @@ export function monthlyPoolLabel(
 ): string {
   return monthlyPoolUnfunded(reward)
     ? `unfunded, target ${reward.monthlyCapDisplay}`
-    : `${reward.monthlyCapDisplay} monthly pool`;
+    : `${formatMicroUsdc(reward.committedMinor)} committed · ${reward.monthlyCapDisplay} monthly target`;
 }
 
 function formatPercent(partsPerMillion: number): string {
@@ -747,7 +747,7 @@ function ProjectCard({ project }: { project: ProjectDefinition }) {
     project.reward.kind === "monthly-pool"
       ? unfunded
         ? "Unfunded"
-        : project.reward.monthlyCapDisplay
+        : formatMicroUsdc(project.reward.committedMinor)
       : (project.reward.externalOpportunity?.advertisedAmountDisplay ??
         "External");
   return (
@@ -771,7 +771,7 @@ function ProjectCard({ project }: { project: ProjectDefinition }) {
             {project.reward.kind === "monthly-pool"
               ? unfunded
                 ? `target ${project.reward.monthlyCapDisplay} / month`
-                : "/ month"
+                : `committed · target ${project.reward.monthlyCapDisplay} / month`
               : "external prize"}
           </span>
         </p>
@@ -1300,7 +1300,7 @@ function HomePage({ state, retry }: { state: DataState; retry: () => void }) {
               <strong>
                 {featuredProjects[0] &&
                 !monthlyPoolUnfunded(featuredProjects[0].reward)
-                  ? featuredProjects[0].reward.monthlyCapDisplay
+                  ? formatMicroUsdc(featuredProjects[0].reward.committedMinor)
                   : "Unfunded"}
               </strong>
               <dl>
@@ -2302,14 +2302,14 @@ function ProjectPage({
                 {project.reward.kind === "monthly-pool"
                   ? monthlyPoolUnfunded(project.reward)
                     ? "Unfunded"
-                    : project.reward.monthlyCapDisplay
+                    : formatMicroUsdc(project.reward.committedMinor)
                   : project.reward.externalOpportunity?.advertisedAmountDisplay}
               </strong>
               <p>
                 {project.reward.kind === "monthly-pool"
                   ? monthlyPoolUnfunded(project.reward)
                     ? `Target ${project.reward.monthlyCapDisplay} per month. No funding is committed, so no payment is scheduled until the project commits funds.`
-                    : "Up to this amount is allocated each month. Unused funding rolls forward without raising the cap."
+                    : `Committed funding toward a ${project.reward.monthlyCapDisplay} monthly cap. Payment requires the published cycle approval and settlement evidence.`
                   : "10% of an award actually received is allocated to Slop Cash; the remaining 90% is shared among accepted contributors. The prize sponsor controls eligibility and payment."}
               </p>
               <div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1901,7 +1901,23 @@ export function ProjectFunding({ project }: { project: ProjectDefinition }) {
       Date.parse(route.effectiveAt) <= now &&
       (route.replacedAt === null || now < Date.parse(route.replacedAt)),
   );
-  if (activeRoutes.length === 0) return null;
+  if (activeRoutes.length === 0) {
+    return (
+      <section className="section project-funding">
+        <h2>Fund this project</h2>
+        <p>Not accepting direct funding yet.</p>
+        <p>
+          Funding: {project.reward.fundingState} · Committed:{" "}
+          {formatMicroUsdc(project.reward.committedMinor)} · Payment:{" "}
+          {project.reward.paymentMode}
+        </p>
+        <p>
+          The project steward publishes a receiving address through a reviewed
+          manifest change. A published address does not prove wallet control.
+        </p>
+      </section>
+    );
+  }
   return (
     <section className="section project-funding">
       <details>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -487,6 +487,30 @@ export function reviewBudgetLabel(
     : `${reviewBudget.monthlyCapDisplay} cap · additive review line · uncommitted pledge`;
 }
 
+/**
+ * A monthly pool prints a dollar figure only once funding is committed. A
+ * pledged pool, or a committed one with nothing behind it, is unfunded: its
+ * cap is a target, never a pool.
+ */
+export function monthlyPoolUnfunded(
+  reward: Pick<ProjectDefinition["reward"], "committedMinor" | "fundingState">,
+): boolean {
+  return (
+    reward.fundingState !== "committed" || BigInt(reward.committedMinor) === 0n
+  );
+}
+
+export function monthlyPoolLabel(
+  reward: Pick<
+    ProjectDefinition["reward"],
+    "committedMinor" | "fundingState" | "monthlyCapDisplay"
+  >,
+): string {
+  return monthlyPoolUnfunded(reward)
+    ? `unfunded, target ${reward.monthlyCapDisplay}`
+    : `${reward.monthlyCapDisplay} monthly pool`;
+}
+
 function formatPercent(partsPerMillion: number): string {
   return `${(partsPerMillion / 10_000).toFixed(2)}%`;
 }
@@ -716,9 +740,14 @@ function TypewriterHeroHeading() {
 }
 
 function ProjectCard({ project }: { project: ProjectDefinition }) {
+  const unfunded =
+    project.reward.kind === "monthly-pool" &&
+    monthlyPoolUnfunded(project.reward);
   const amount =
     project.reward.kind === "monthly-pool"
-      ? project.reward.monthlyCapDisplay
+      ? unfunded
+        ? "Unfunded"
+        : project.reward.monthlyCapDisplay
       : (project.reward.externalOpportunity?.advertisedAmountDisplay ??
         "External");
   return (
@@ -740,15 +769,17 @@ function ProjectCard({ project }: { project: ProjectDefinition }) {
           <strong>{amount}</strong>
           <span>
             {project.reward.kind === "monthly-pool"
-              ? "/ month"
+              ? unfunded
+                ? `target ${project.reward.monthlyCapDisplay} / month`
+                : "/ month"
               : "external prize"}
           </span>
         </p>
         <small className="project-money-state">
           {project.reward.kind === "monthly-pool"
-            ? project.reward.fundingState === "committed"
-              ? "Committed funding · payment state published per cycle"
-              : "Projected cap · funding uncommitted"
+            ? unfunded
+              ? "Target cap · no funding committed"
+              : "Committed funding · payment state published per cycle"
             : "External sponsor controls eligibility and payment"}
         </small>
         {project.reward.reviewBudget ? (
@@ -882,7 +913,7 @@ function GlobalLeaderboard({
     : "Current month";
   const selectedRewardLabel = selectedView
     ? selectedView.reward.kind === "monthly-pool"
-      ? `${selectedView.project.reward.monthlyCapDisplay} monthly pool`
+      ? monthlyPoolLabel(selectedView.project.reward)
       : `${selectedView.reward.advertisedAmountDisplay} external opportunity`
     : "Current reward cycle";
   return (
@@ -940,7 +971,7 @@ function GlobalLeaderboard({
             {views.map((view) => {
               const rewardLabel =
                 view.reward.kind === "monthly-pool"
-                  ? `${view.project.reward.monthlyCapDisplay} monthly pool`
+                  ? monthlyPoolLabel(view.project.reward)
                   : "External prize share";
               return (
                 <button
@@ -1267,20 +1298,34 @@ function HomePage({ state, retry }: { state: DataState; retry: () => void }) {
             <article className="proof-object">
               <span className="proof-object-kicker">Pool</span>
               <strong>
-                {featuredProjects[0]?.reward.monthlyCapDisplay ?? "$0"}
+                {featuredProjects[0] &&
+                !monthlyPoolUnfunded(featuredProjects[0].reward)
+                  ? featuredProjects[0].reward.monthlyCapDisplay
+                  : "Unfunded"}
               </strong>
               <dl>
                 <div>
-                  <dt>Type</dt>
-                  <dd>Monthly contributor cap</dd>
+                  <dt>Target</dt>
+                  <dd>
+                    {featuredProjects[0]?.reward.monthlyCapDisplay ?? "$0"}{" "}
+                    monthly cap
+                  </dd>
                 </div>
                 <div>
                   <dt>Funding</dt>
-                  <dd>Uncommitted</dd>
+                  <dd>
+                    {featuredProjects[0]?.reward.fundingState === "committed"
+                      ? "Committed"
+                      : "Uncommitted"}
+                  </dd>
                 </div>
                 <div>
                   <dt>Payment</dt>
-                  <dd>Disabled</dd>
+                  <dd>
+                    {featuredProjects[0]?.reward.paymentMode === "enabled"
+                      ? "Enabled"
+                      : "Disabled"}
+                  </dd>
                 </div>
               </dl>
               <Link href="/#projects">
@@ -2255,12 +2300,16 @@ function ProjectPage({
                 }
               >
                 {project.reward.kind === "monthly-pool"
-                  ? project.reward.monthlyCapDisplay
+                  ? monthlyPoolUnfunded(project.reward)
+                    ? "Unfunded"
+                    : project.reward.monthlyCapDisplay
                   : project.reward.externalOpportunity?.advertisedAmountDisplay}
               </strong>
               <p>
                 {project.reward.kind === "monthly-pool"
-                  ? "Up to this amount is allocated each month. Unused funding rolls forward without raising the cap."
+                  ? monthlyPoolUnfunded(project.reward)
+                    ? `Target ${project.reward.monthlyCapDisplay} per month. No funding is committed, so no payment is scheduled until the project commits funds.`
+                    : "Up to this amount is allocated each month. Unused funding rolls forward without raising the cap."
                   : "10% of an award actually received is allocated to Slop Cash; the remaining 90% is shared among accepted contributors. The prize sponsor controls eligibility and payment."}
               </p>
               <div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -487,6 +487,30 @@ export function reviewBudgetLabel(
     : `${reviewBudget.monthlyCapDisplay} cap · additive review line · uncommitted pledge`;
 }
 
+/**
+ * A monthly pool prints a dollar figure only once funding is committed. A
+ * pledged pool, or a committed one with nothing behind it, is unfunded: its
+ * cap is a target, never a pool.
+ */
+export function monthlyPoolUnfunded(
+  reward: Pick<ProjectDefinition["reward"], "committedMinor" | "fundingState">,
+): boolean {
+  return (
+    reward.fundingState !== "committed" || BigInt(reward.committedMinor) === 0n
+  );
+}
+
+export function monthlyPoolLabel(
+  reward: Pick<
+    ProjectDefinition["reward"],
+    "committedMinor" | "fundingState" | "monthlyCapDisplay"
+  >,
+): string {
+  return monthlyPoolUnfunded(reward)
+    ? `unfunded, target ${reward.monthlyCapDisplay}`
+    : `${reward.monthlyCapDisplay} monthly pool`;
+}
+
 function formatPercent(partsPerMillion: number): string {
   return `${(partsPerMillion / 10_000).toFixed(2)}%`;
 }
@@ -716,9 +740,14 @@ function TypewriterHeroHeading() {
 }
 
 function ProjectCard({ project }: { project: ProjectDefinition }) {
+  const unfunded =
+    project.reward.kind === "monthly-pool" &&
+    monthlyPoolUnfunded(project.reward);
   const amount =
     project.reward.kind === "monthly-pool"
-      ? project.reward.monthlyCapDisplay
+      ? unfunded
+        ? "Unfunded"
+        : project.reward.monthlyCapDisplay
       : (project.reward.externalOpportunity?.advertisedAmountDisplay ??
         "External");
   return (
@@ -740,15 +769,17 @@ function ProjectCard({ project }: { project: ProjectDefinition }) {
           <strong>{amount}</strong>
           <span>
             {project.reward.kind === "monthly-pool"
-              ? "/ month"
+              ? unfunded
+                ? `target ${project.reward.monthlyCapDisplay} / month`
+                : "/ month"
               : "external prize"}
           </span>
         </p>
         <small className="project-money-state">
           {project.reward.kind === "monthly-pool"
-            ? project.reward.fundingState === "committed"
-              ? "Committed funding · payment state published per cycle"
-              : "Projected cap · funding uncommitted"
+            ? unfunded
+              ? "Target cap · no funding committed"
+              : "Committed funding · payment state published per cycle"
             : "External sponsor controls eligibility and payment"}
         </small>
         {project.reward.reviewBudget ? (
@@ -882,7 +913,7 @@ function GlobalLeaderboard({
     : "Current month";
   const selectedRewardLabel = selectedView
     ? selectedView.reward.kind === "monthly-pool"
-      ? `${selectedView.project.reward.monthlyCapDisplay} monthly pool`
+      ? monthlyPoolLabel(selectedView.project.reward)
       : `${selectedView.reward.advertisedAmountDisplay} external opportunity`
     : "Current reward cycle";
   return (
@@ -940,7 +971,7 @@ function GlobalLeaderboard({
             {views.map((view) => {
               const rewardLabel =
                 view.reward.kind === "monthly-pool"
-                  ? `${view.project.reward.monthlyCapDisplay} monthly pool`
+                  ? monthlyPoolLabel(view.project.reward)
                   : "External prize share";
               return (
                 <button
@@ -1267,20 +1298,34 @@ function HomePage({ state, retry }: { state: DataState; retry: () => void }) {
             <article className="proof-object">
               <span className="proof-object-kicker">Pool</span>
               <strong>
-                {featuredProjects[0]?.reward.monthlyCapDisplay ?? "$0"}
+                {featuredProjects[0] &&
+                !monthlyPoolUnfunded(featuredProjects[0].reward)
+                  ? featuredProjects[0].reward.monthlyCapDisplay
+                  : "Unfunded"}
               </strong>
               <dl>
                 <div>
-                  <dt>Type</dt>
-                  <dd>Monthly contributor cap</dd>
+                  <dt>Target</dt>
+                  <dd>
+                    {featuredProjects[0]?.reward.monthlyCapDisplay ?? "$0"}{" "}
+                    monthly cap
+                  </dd>
                 </div>
                 <div>
                   <dt>Funding</dt>
-                  <dd>Uncommitted</dd>
+                  <dd>
+                    {featuredProjects[0]?.reward.fundingState === "committed"
+                      ? "Committed"
+                      : "Uncommitted"}
+                  </dd>
                 </div>
                 <div>
                   <dt>Payment</dt>
-                  <dd>Disabled</dd>
+                  <dd>
+                    {featuredProjects[0]?.reward.paymentMode === "enabled"
+                      ? "Enabled"
+                      : "Disabled"}
+                  </dd>
                 </div>
               </dl>
               <Link href="/#projects">
@@ -2250,12 +2295,16 @@ function ProjectPage({
                 }
               >
                 {project.reward.kind === "monthly-pool"
-                  ? project.reward.monthlyCapDisplay
+                  ? monthlyPoolUnfunded(project.reward)
+                    ? "Unfunded"
+                    : project.reward.monthlyCapDisplay
                   : project.reward.externalOpportunity?.advertisedAmountDisplay}
               </strong>
               <p>
                 {project.reward.kind === "monthly-pool"
-                  ? "Up to this amount is allocated each month. Unused funding rolls forward without raising the cap."
+                  ? monthlyPoolUnfunded(project.reward)
+                    ? `Target ${project.reward.monthlyCapDisplay} per month. No funding is committed, so no payment is scheduled until the project commits funds.`
+                    : "Up to this amount is allocated each month. Unused funding rolls forward without raising the cap."
                   : "10% of an award actually received is allocated to Slop Cash; the remaining 90% is shared among accepted contributors. The prize sponsor controls eligibility and payment."}
               </p>
               <div>

--- a/src/lib/funding-commitment.test.ts
+++ b/src/lib/funding-commitment.test.ts
@@ -276,7 +276,7 @@ describe("project commitment records", () => {
       assertProjectCommitmentRecord(
         record({
           verifier: {
-            version: "commitment-sablier-v1",
+            version: "commitment-sablier-v2",
             checkedAt: "2026-08-02T01:00:00.000Z",
             evidenceUrl: `https://solscan.io/tx/${DEPOSIT_SIGNATURE}`,
             reason: null,

--- a/src/lib/funding-commitment.ts
+++ b/src/lib/funding-commitment.ts
@@ -349,7 +349,7 @@ export function assertProjectCommitmentRecord(
     const expectedVerifierVersion =
       instrument.kind === "squads-v4-vault"
         ? "commitment-squads-v2"
-        : "commitment-sablier-v1";
+        : "commitment-sablier-v2";
     if (verifier.version !== expectedVerifierVersion) {
       throw new TypeError(
         "commitment record verifier version does not match its instrument",

--- a/src/lib/reward-cycle.test.ts
+++ b/src/lib/reward-cycle.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it } from "vitest";
 import { snapshotFixture } from "../../tests/fixtures";
 import {
+  allocateReviewBudgetForEvents,
   allocateReviewBudgetMinor,
   createRewardCycleProposal,
 } from "./reward-cycle";
@@ -31,6 +32,42 @@ function wallet(): WalletProof {
 }
 
 describe("reward cycle proposals", () => {
+  it("keeps equal review tiers equal in the additive line despite trace evidence", () => {
+    const source = snapshotFixture().ledger[0];
+    const events = ([0, 1500] as const).map(
+      (evidenceBonusBasisPoints, index) => ({
+        ...source,
+        id: `review-${index}`,
+        actor: { ...source.actor, id: `actor-${index}` },
+        category: "substantive-review" as const,
+        scoreThirds: 9,
+        points: 3,
+        evidenceBonusBasisPoints,
+      }),
+    );
+    expect(
+      Object.fromEntries(allocateReviewBudgetForEvents(100n, events)),
+    ).toEqual({
+      "actor-0": 50n,
+      "actor-1": 50n,
+    });
+    expect(allocateReviewBudgetForEvents(100n, events)).toEqual(
+      allocateReviewBudgetForEvents(
+        100n,
+        events.map((event) => ({ ...event, evidenceBonusBasisPoints: 0 })),
+      ),
+    );
+    expect(
+      allocateReviewBudgetForEvents(
+        100n,
+        events.map((event) => ({
+          ...event,
+          category: "merged-pull-request" as const,
+        })),
+      ),
+    ).toEqual(new Map());
+  });
+
   it("allocates an additive review line with deterministic largest remainder", () => {
     expect(
       Object.fromEntries(

--- a/src/lib/reward-cycle.ts
+++ b/src/lib/reward-cycle.ts
@@ -4,7 +4,7 @@
  * human review and on-chain settlement remain separate, auditable transitions.
  */
 
-import type { LeaderboardSnapshot } from "./leaderboard";
+import type { LeaderboardSnapshot, ScoreEvent } from "./leaderboard";
 import { createProjectView } from "./project-view";
 import type { ProjectId } from "./projects.mjs";
 import {
@@ -84,6 +84,26 @@ export function allocateReviewBudgetMinor(
     unallocated -= 1n;
   }
   return allocations;
+}
+
+/** The additive line rewards review tiers only; trace bonuses stay in the shared pool. */
+export function allocateReviewBudgetForEvents(
+  totalMinor: bigint,
+  events: readonly ScoreEvent[],
+): Map<string, bigint> {
+  const weights = new Map<string, number>();
+  for (const event of events) {
+    if (event.category !== "substantive-review") continue;
+    weights.set(
+      event.actor.id,
+      (weights.get(event.actor.id) ?? 0) +
+        (event.scoreThirds ?? Math.round(event.points * 3)),
+    );
+  }
+  return allocateReviewBudgetMinor(
+    totalMinor,
+    [...weights].map(([actorId, scoreThirds]) => ({ actorId, scoreThirds })),
+  );
 }
 
 function cycleBounds(cycleId: string): { from: number; to: number } {
@@ -233,20 +253,9 @@ export function createRewardCycleProposal(
   const reviewEvents = view.ledger.filter(
     (event) => event.category === "substantive-review",
   );
-  const reviewScoreThirds = new Map<string, number>();
-  for (const event of reviewEvents) {
-    reviewScoreThirds.set(
-      event.actor.id,
-      (reviewScoreThirds.get(event.actor.id) ?? 0) +
-        (event.scoreThirds ?? Math.round(event.points * 3)),
-    );
-  }
-  const reviewAllocations = allocateReviewBudgetMinor(
+  const reviewAllocations = allocateReviewBudgetForEvents(
     reviewBudgetTotal,
-    [...reviewScoreThirds].map(([actorId, scoreThirds]) => ({
-      actorId,
-      scoreThirds,
-    })),
+    reviewEvents,
   );
   const reviewSuggestedTotal = [...reviewAllocations.values()].reduce(
     (total, amount) => total + amount,

--- a/src/lib/reward-finalization.test.ts
+++ b/src/lib/reward-finalization.test.ts
@@ -40,7 +40,7 @@ function reviewedProposal() {
         wallet: {
           address: "11111111111111111111111111111111",
           chain: "solana",
-          observedAt: "2026-08-03T00:00:00.000Z",
+          observedAt: "2026-08-02T00:00:00.000Z",
           sourceCommit: COMMIT,
           sourceUrl: `https://github.com/finish-line/finish-line/blob/${COMMIT}/README.md`,
         },
@@ -106,16 +106,32 @@ describe("reward allocation finalization", () => {
     ).toThrow(/unresolved/u);
   });
 
-  it("forces a new review deadline when a wallet changes", () => {
-    const staleReview = reviewedProposal();
-    staleReview.allocations[0].wallet.observedAt = "2026-08-04T00:00:00.000Z";
+  it("refuses a wallet observed after the proposal was generated", () => {
+    const lateWallet = reviewedProposal();
+    lateWallet.allocations[0].wallet.observedAt = "2026-08-02T00:00:00.001Z";
     expect(() =>
       finalizeRewardAllocation(
-        staleReview,
+        lateWallet,
         "2026-08-17T00:00:00.000Z",
         Date.parse("2026-08-17T00:01:00.000Z"),
       ),
-    ).toThrow(/newer than the declared material change/u);
+    ).toThrow(/newer than the proposal generation time/u);
+  });
+
+  it("keeps a wallet observed before generation through a later amount change", () => {
+    const earlyWallet = reviewedProposal();
+    earlyWallet.allocations[0].wallet.observedAt = "2026-08-01T00:00:00.000Z";
+    const approved = finalizeRewardAllocation(
+      earlyWallet,
+      "2026-08-17T00:00:00.000Z",
+      Date.parse("2026-08-17T00:01:00.000Z"),
+    );
+    expect(approved.review.lastMaterialChangeAt).toBe(
+      "2026-08-03T00:00:00.000Z",
+    );
+    expect(approved.allocations[0].wallet?.observedAt).toBe(
+      "2026-08-01T00:00:00.000Z",
+    );
   });
 
   it("keeps an explicit zero-award close out of the payment lifecycle", () => {

--- a/src/lib/rewards.test.ts
+++ b/src/lib/rewards.test.ts
@@ -243,6 +243,33 @@ describe("reward manifests", () => {
     );
   });
 
+  it("cuts wallets off at proposal generation, not at the last material change", () => {
+    const amended = allocationManifest() as unknown as RewardAllocationManifest;
+    amended.review = {
+      days: 14,
+      lastMaterialChangeAt: "2026-09-03T00:00:00.000Z",
+      endsAt: "2026-09-17T00:00:00.000Z",
+    };
+    amended.approvedAt = "2026-09-18T00:00:00.000Z";
+    expect(() => assertRewardAllocationManifest(amended)).not.toThrow();
+
+    const lateWallet = structuredClone(amended);
+    lateWallet.allocations[0].wallet = {
+      ...wallet,
+      observedAt: "2026-09-02T00:00:00.000Z",
+    };
+    expect(() => assertRewardAllocationManifest(lateWallet)).toThrow(
+      /newer than the proposal generation time/u,
+    );
+
+    const atGeneration = structuredClone(amended);
+    atGeneration.allocations[0].wallet = {
+      ...wallet,
+      observedAt: "2026-09-01T00:00:00.000Z",
+    };
+    expect(() => assertRewardAllocationManifest(atGeneration)).not.toThrow();
+  });
+
   it("binds a wallet claim issue to the exact contributor and body snapshot", () => {
     const manifest = allocationManifest() as unknown as {
       allocations: Array<{ wallet: unknown }>;

--- a/src/lib/rewards.ts
+++ b/src/lib/rewards.ts
@@ -875,13 +875,15 @@ export function assertRewardAllocationManifest(
     "allocation actor ids",
   );
   for (const allocation of allocations) {
+    // Wallet cut-off: a wallet observed after this proposal was generated
+    // applies to the next cycle. It never modifies the current proposal or
+    // restarts its review; the row stays unclaimed and carries instead.
     if (
       allocation.wallet &&
-      Date.parse(allocation.wallet.observedAt) >
-        Date.parse(lastMaterialChangeAt)
+      Date.parse(allocation.wallet.observedAt) > Date.parse(generatedAt)
     ) {
       throw new TypeError(
-        "wallet observation is newer than the declared material change",
+        "wallet observation is newer than the proposal generation time; it applies to the next cycle",
       );
     }
     if (

--- a/src/lib/sablier-funding.ts
+++ b/src/lib/sablier-funding.ts
@@ -11,7 +11,7 @@ import type { SABLIER_LOCKUP_V4_CONTRACTS } from "./funding-instruments.mjs";
 export { SABLIER_LOCKUP_V4_CONTRACTS } from "./funding-instruments.mjs";
 
 export const COMMITMENT_SABLIER_VERIFIER_VERSION =
-  "commitment-sablier-v1" as const;
+  "commitment-sablier-v2" as const;
 
 export type SablierNetwork = keyof typeof SABLIER_LOCKUP_V4_CONTRACTS;
 
@@ -42,6 +42,8 @@ export const SABLIER_STREAM_SELECTORS = Object.freeze({
   refundedAmount: "0xd4dbd20b",
   /** keccak256("getEndTime(uint256)")[0..4] */
   endTime: "0x9067b677",
+  /** keccak256("isCancelable(uint256)")[0..4] */
+  isCancelable: "0x4857501f",
   /** keccak256("wasCanceled(uint256)")[0..4] */
   wasCanceled: "0xf590c176",
   /** keccak256("isDepleted(uint256)")[0..4] */
@@ -131,8 +133,11 @@ function wordBoolean(value: unknown, field: string): boolean {
 /**
  * Validates one authority's finalized `eth_call` results for a Sablier
  * Lockup v4 stream: the canonical USDC token, the exact expected recipient,
- * bounded canonical integers, and a non-negative locked balance
- * (deposited minus withdrawn minus refunded).
+ * bounded canonical integers, a non-negative locked balance (deposited minus
+ * withdrawn minus refunded), and a stream the sender can no longer cancel.
+ * A cancelable stream lets the funder reclaim the undistributed balance at
+ * any time, so it can never back a positive `committedMinor`; it fails closed
+ * here before any evidence is emitted.
  */
 export function assertSablierStreamState(
   callResults: SablierStreamCallResults,
@@ -184,6 +189,11 @@ export function assertSablierStreamState(
     throw new TypeError("stream locked balance is negative");
   }
   const endTime = wordUint(callResults.endTime, MAX_UINT40, "stream end time");
+  if (wordBoolean(callResults.isCancelable, "stream cancelable flag")) {
+    throw new TypeError(
+      "stream is cancelable and cannot back committed funding",
+    );
+  }
   return {
     blockNumber: expected.blockNumber,
     depositedMinor: deposited.toString(),

--- a/tests/app.test.tsx
+++ b/tests/app.test.tsx
@@ -249,13 +249,6 @@ function septemberRollingSnapshot() {
   snapshot.source.fetchedAt = generatedAt;
   snapshot.source.rateLimit.resetAt = "2026-09-05T01:00:00.000Z";
   snapshot.source.verificationWindow = { days: 35, from, to: generatedAt };
-  for (const item of [
-    ...snapshot.workQueue.issues,
-    ...snapshot.workQueue.pullRequests,
-  ]) {
-    item.createdAt = generatedAt;
-    item.updatedAt = generatedAt;
-  }
   snapshot.ledger = snapshot.ledger.map((event) => ({
     ...event,
     occurredAt: "2026-09-04T12:00:00.000Z",

--- a/tests/app.test.tsx
+++ b/tests/app.test.tsx
@@ -93,7 +93,7 @@ describe("monthly pool display", () => {
         committedMinor: "1000000",
         fundingState: "committed",
       }),
-    ).toBe("$10,000 monthly pool");
+    ).toBe("$1 committed · $10,000 monthly target");
   });
 });
 
@@ -249,6 +249,13 @@ function septemberRollingSnapshot() {
   snapshot.source.fetchedAt = generatedAt;
   snapshot.source.rateLimit.resetAt = "2026-09-05T01:00:00.000Z";
   snapshot.source.verificationWindow = { days: 35, from, to: generatedAt };
+  for (const item of [
+    ...snapshot.workQueue.issues,
+    ...snapshot.workQueue.pullRequests,
+  ]) {
+    item.createdAt = generatedAt;
+    item.updatedAt = generatedAt;
+  }
   snapshot.ledger = snapshot.ledger.map((event) => ({
     ...event,
     occurredAt: "2026-09-04T12:00:00.000Z",

--- a/tests/app.test.tsx
+++ b/tests/app.test.tsx
@@ -217,8 +217,8 @@ function augustRollingSnapshot() {
 }
 
 function septemberRollingSnapshot() {
-  const snapshot = snapshotFixture();
   const generatedAt = "2026-09-05T00:00:00.000Z";
+  const snapshot = snapshotFixture(generatedAt);
   const from = "2026-08-01T00:00:00.000Z";
   snapshot.generatedAt = generatedAt;
   snapshot.sourceUpdatedAt = generatedAt;

--- a/tests/app.test.tsx
+++ b/tests/app.test.tsx
@@ -1550,6 +1550,33 @@ describe("direct project funding", () => {
     );
   });
 
+  it("explains why a project cannot receive direct funding without hiding its state", () => {
+    const project = PROJECTS.find((candidate) => candidate.id === "eliza");
+    if (!project) throw new TypeError("The Eliza project fixture is missing");
+    render(
+      <ProjectFunding
+        project={{ ...project, funding: { ...project.funding, addresses: [] } }}
+      />,
+    );
+    expect(
+      screen.getByRole("heading", { name: "Fund this project" }),
+    ).toBeVisible();
+    expect(screen.getByText("Not accepting direct funding yet.")).toBeVisible();
+    expect(
+      screen.getByText(
+        /Funding: pledged · Committed: \$0 · Payment: disabled/u,
+      ),
+    ).toBeVisible();
+    expect(
+      screen.getByText(
+        /steward publishes a receiving address through a reviewed/u,
+      ),
+    ).toBeVisible();
+    expect(
+      screen.queryByRole("button", { name: "Copy address" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("shows an exact address, QR, copy feedback, and explorer without wallet control", async () => {
     const project = PROJECTS.find((candidate) => candidate.id === "eliza");
     if (!project) throw new TypeError("The Eliza project fixture is missing");

--- a/tests/app.test.tsx
+++ b/tests/app.test.tsx
@@ -18,6 +18,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   App,
   DonorFundingProfile,
+  monthlyPoolLabel,
   ProjectFunding,
   ProjectManagePage,
   publicFooterDomain,
@@ -72,6 +73,27 @@ describe("review budget display", () => {
         fundingState: "pledged",
       }),
     ).toBe("$50 cap · additive review line · uncommitted pledge");
+  });
+});
+
+describe("monthly pool display", () => {
+  it("never prints a pledged or empty pool as dollars", () => {
+    const pledged = {
+      committedMinor: "0",
+      fundingState: "pledged" as const,
+      monthlyCapDisplay: "$10,000",
+    };
+    expect(monthlyPoolLabel(pledged)).toBe("unfunded, target $10,000");
+    expect(monthlyPoolLabel({ ...pledged, fundingState: "committed" })).toBe(
+      "unfunded, target $10,000",
+    );
+    expect(
+      monthlyPoolLabel({
+        ...pledged,
+        committedMinor: "1000000",
+        fundingState: "committed",
+      }),
+    ).toBe("$10,000 monthly pool");
   });
 });
 
@@ -499,7 +521,7 @@ describe("discovery", () => {
       "true",
     );
     expect(
-      screen.getByRole("tab", { name: "Eliza, $10,000 monthly pool" }),
+      screen.getByRole("tab", { name: "Eliza, unfunded, target $10,000" }),
     ).toHaveAttribute("aria-selected", "true");
     expect(screen.getByText(/July 2026 · Eliza/u)).toBeInTheDocument();
     const leaderboard = screen.getByRole("table", {
@@ -550,8 +572,11 @@ describe("discovery", () => {
       .closest("a");
     expect(elizaCard).not.toBeNull();
     if (!elizaCard) throw new Error("Eliza project card is missing");
-    expect(within(elizaCard).getByText("$10,000")).toBeInTheDocument();
-    expect(within(elizaCard).getByText("/ month")).toBeInTheDocument();
+    expect(within(elizaCard).getByText("Unfunded")).toBeInTheDocument();
+    expect(
+      within(elizaCard).getByText("target $10,000 / month"),
+    ).toBeInTheDocument();
+    expect(within(elizaCard).queryByText("$10,000")).not.toBeInTheDocument();
     expect(
       within(elizaCard).getByText(/Build and verify the elizaOS framework/u),
     ).toBeInTheDocument();
@@ -793,14 +818,17 @@ describe("project routes", () => {
       screen.queryByText("1% platform fee · Solana"),
     ).not.toBeInTheDocument();
     expect(
-      screen.getAllByText("$10,000", { exact: true }).length,
-    ).toBeGreaterThan(0);
+      screen.queryByText("$10,000 monthly pool", { exact: false }),
+    ).not.toBeInTheDocument();
     expect(
       screen
         .getByText("MONTHLY POOL")
         .closest("aside")
         ?.querySelector(".reward-amount-monthly"),
-    ).toHaveTextContent("$10,000");
+    ).toHaveTextContent("Unfunded");
+    expect(
+      screen.getByText(/Target \$10,000 per month\. No funding is committed/u),
+    ).toBeInTheDocument();
     expect(
       screen.queryByText("simulated monthly pool"),
     ).not.toBeInTheDocument();

--- a/tests/app.test.tsx
+++ b/tests/app.test.tsx
@@ -888,6 +888,23 @@ describe("project routes", () => {
       screen.getByText(/The prize sponsor controls eligibility and payment/i),
     ).toBeInTheDocument();
   });
+
+  it("prompts a transferred repository at its current path", async () => {
+    route("/projects/delta-star");
+    mockSnapshot();
+    render(<App />);
+
+    await screen.findByRole("heading", { name: "Make money solving math." });
+
+    // The bootstrap skill resolves a project by exact-matching the operator's
+    // git origin against the published registry, which uses the newest alias.
+    // Prompting the pre-transfer path leaves that match empty and stops the run.
+    const prompt = screen.getByLabelText("Agent prompt");
+    expect(prompt).toHaveTextContent(
+      "contribute to github.com/SlopDotCash/proximityprize",
+    );
+    expect(prompt).not.toHaveTextContent("elizaOS/proximityprize");
+  });
 });
 
 describe("public records", () => {

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -140,8 +140,11 @@ test("discovers both reward models and a score-ranked global ledger", async ({
     page.getByRole("heading", { exact: true, name: "Delta Star" }),
   ).toBeVisible();
   const elizaCard = page.locator('a.project-card[href="/projects/eliza"]');
-  await expect(elizaCard.getByText("$10,000", { exact: true })).toBeVisible();
-  await expect(elizaCard.getByText("/ month", { exact: true })).toBeVisible();
+  await expect(elizaCard.getByText("Unfunded", { exact: true })).toBeVisible();
+  await expect(
+    elizaCard.getByText("target $10,000 / month", { exact: true }),
+  ).toBeVisible();
+  await expect(elizaCard.getByText("$10,000", { exact: true })).toHaveCount(0);
   await expect(
     elizaCard.getByText(/Build and verify the elizaOS framework/u),
   ).toBeVisible();
@@ -188,7 +191,7 @@ test("discovers both reward models and a score-ranked global ledger", async ({
     "true",
   );
   await expect(
-    page.getByRole("tab", { name: "Eliza, $10,000 monthly pool" }),
+    page.getByRole("tab", { name: "Eliza, unfunded, target $10,000" }),
   ).toHaveAttribute("aria-selected", "true");
   await expect(
     page.getByRole("columnheader", { name: "Accepted score" }),

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -18,8 +18,9 @@ export function cycleIndexFixture(): CycleIndex {
   };
 }
 
-export function snapshotFixture(): LeaderboardSnapshot {
-  const generatedAt = new Date().toISOString();
+export function snapshotFixture(
+  generatedAt = new Date().toISOString(),
+): LeaderboardSnapshot {
   const windowTo = "2026-07-30T00:00:00.000Z";
   const leaderActor: LeaderboardSnapshot["leaders"][number]["actor"] = {
     id: "U_fixture",


### PR DESCRIPTION
## Summary

Integrates reviewed contributor PRs #327, #330, #335, #336, #337, #339, #342 and #359, preserving their commit ancestry, with integration repairs:

- Retry changing GitHub inventories with a fresh budget under one identity-scoped scan lock.
- Retain owner-specific stale-lock tombstones so delayed reapers cannot displace a successor's live lock.
- Recover uploaded/finalized receipt runs; a new authenticated retry requests a fresh upload capability instead of renewing an expired capability.
- Enforce the proposal-generation wallet cutoff.
- Reject cancelable Sablier streams as committed funding.
- Show actual committed amounts separately from funding targets, and explicitly explain absent receiving routes.
- Document and regression-test the existing tier-only additive review-budget allocation.
- Repair the September UI fixture whose work-item timestamps advanced beyond its fixed snapshot time, breaking scheduled CI.

Closes #328
Closes #329
Closes #332
Closes #353

Related: #302, #331, #333, #338. This does not implement allocator/trial-month policy, independent-vault stewardship, or new automated funding approval authority.

## Verification

In progress on this integration head. Focused UI/reward/Sablier tests: 75 passed. Skill/CLI suite: 58 passed, including deterministic delayed-reaper regression. Typecheck passed.

Full verification, four-size browser matrix, and hosted exact-head evidence will be added before merge. No production deployment or payout availability is claimed.

## Boundaries

- No shared-checkout changes, secrets, private traces, addresses, or payment credentials added.
- No signing, broadcasting, approval bypass, environment, or deployment configuration changes.
- Existing immutable cycle records are unchanged.
- Stale scan-lock tombstones contain local process metadata only and are intentionally retained for safe concurrent recovery.
