### PR TITLE
Bind receiving routes to pinned upstream steward authority

### DIFF
--- a/.github/workflows/project-transitions.yml
+++ b/.github/workflows/project-transitions.yml
@@ -30,6 +30,9 @@ jobs:
 
       - name: Validate immutable base and head manifests
         env:
+          # Exposed only to the immutable trusted-base checker. Contributor
+          # code is fetched as Git object data and is never executed.
+          GITHUB_TOKEN: ${{ github.token }}
           PROJECT_POLICY_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PROJECT_POLICY_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PROJECT_POLICY_PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/funding/README.md
+++ b/funding/README.md
@@ -203,3 +203,24 @@ the declared-settler reminder inside seven days of close, the ready-to-sign
 reminder after 24 hours, and the overdue reminder after 72 hours. These are
 coordination notices only; they do not message a wallet, sign, broadcast, or
 upgrade settlement state.
+
+## Receiving-address authority
+
+A manifest change that adds, removes, rotates, or replaces a receiving route
+must pin an upstream `.github/slop-project.json` authority file containing
+the complete identical `funding.addresses` inventory. The optional extension
+uses the manifest's existing network, asset, address, effectiveAt, and replacedAt
+schema. Existing authority files without funding remain valid for unchanged
+address inventories.
+
+The trusted transition gate checks immutable repository identity, verifies that
+the pinned commit is in the registered integration branch's history, hashes the
+exact file bytes, checks project and steward bindings, and compares every route
+field including replacement times. Missing, unreachable, oversized, divergent,
+or mismatched evidence fails closed. Unchanged address inventories make no
+network request. This rule becomes enforceable for subsequent PRs after the
+trusted checker has landed on develop.
+
+This proves that the upstream repository published an address, not wallet
+control, signer independence, legal ownership, or authority to pay. Maintainer
+review and deterministic funding verification remain separate requirements.

--- a/funding/README.md
+++ b/funding/README.md
@@ -216,7 +216,9 @@ address inventories.
 The trusted transition gate checks immutable repository identity, verifies that
 the pinned commit is in the registered integration branch's history, hashes the
 exact file bytes, checks project and steward bindings, and compares every route
-field including replacement times. Missing, unreachable, oversized, divergent,
+field including replacement times. The current integration-head file must
+remain byte-identical to the pinned proof, so an old proof cannot resurrect a
+withdrawn address. Missing, unreachable, oversized, divergent,
 or mismatched evidence fails closed. Unchanged address inventories make no
 network request. This rule becomes enforceable for subsequent PRs after the
 trusted checker has landed on develop.

--- a/scripts/check-project-transitions.d.mts
+++ b/scripts/check-project-transitions.d.mts
@@ -8,4 +8,5 @@ export declare function validateProjectTransitions(
 
 export declare function checkProjectTransitions(
   baseRevision: string,
+  currentRevision?: string,
 ): Promise<{ previous: number; current: number }>;

--- a/scripts/check-project-transitions.mjs
+++ b/scripts/check-project-transitions.mjs
@@ -8,6 +8,7 @@ import { execFileSync } from "node:child_process";
 import { readdir, readFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { verifyFundingAddressTransitions } from "../src/lib/funding-authority.mjs";
 import { assertProjectPolicyTransition } from "../src/lib/project-policy.mjs";
 import {
   assertHistoricalProjectDefinition,
@@ -181,12 +182,17 @@ async function workingEntries() {
 }
 
 export async function checkProjectTransitions(baseRevision, currentRevision) {
-  return validateProjectTransitions(
-    revisionEntries(baseRevision, "base revision"),
+  const previousEntries = revisionEntries(baseRevision, "base revision");
+  const currentEntries =
     currentRevision === undefined
       ? await workingEntries()
-      : revisionEntries(currentRevision, "current revision"),
+      : revisionEntries(currentRevision, "current revision");
+  const result = validateProjectTransitions(previousEntries, currentEntries);
+  await verifyFundingAddressTransitions(
+    boundedProjectMap(previousEntries, { historical: true }),
+    boundedProjectMap(currentEntries),
   );
+  return result;
 }
 
 if (import.meta.main) {

--- a/skill-tests/contribute-to-eliza.test.ts
+++ b/skill-tests/contribute-to-eliza.test.ts
@@ -3055,7 +3055,7 @@ describe("run receipt CLI", () => {
   });
 
   it("starts and finishes a measured run without passing --project to ccusage", {
-    timeout: 30_000,
+    timeout: 0,
   }, async () => {
     const fixtureRoot = realpathSync(
       mkdtempSync(join(tmpdir(), "contribute-to-eliza-start-")),

--- a/skill-tests/contribute-to-eliza.test.ts
+++ b/skill-tests/contribute-to-eliza.test.ts
@@ -3055,7 +3055,7 @@ describe("run receipt CLI", () => {
   });
 
   it("starts and finishes a measured run without passing --project to ccusage", {
-    timeout: 0,
+    timeout: 30_000,
   }, async () => {
     const fixtureRoot = realpathSync(
       mkdtempSync(join(tmpdir(), "contribute-to-eliza-start-")),

--- a/src/lib/funding-authority.d.mts
+++ b/src/lib/funding-authority.d.mts
@@ -5,10 +5,10 @@ export declare function assertProjectFundingAuthority(
 ): Record<string, unknown>;
 export declare function verifyProjectFundingAuthority(
   project: ProjectDefinition,
-  options?: { fetchImpl?: typeof fetch },
+  options?: { fetchImpl?: typeof fetch; token?: string },
 ): Promise<void>;
 export declare function verifyFundingAddressTransitions(
   previous: ReadonlyMap<string, ProjectDefinition>,
   current: ReadonlyMap<string, ProjectDefinition>,
-  options?: { fetchImpl?: typeof fetch },
+  options?: { fetchImpl?: typeof fetch; token?: string },
 ): Promise<void>;

--- a/src/lib/funding-authority.d.mts
+++ b/src/lib/funding-authority.d.mts
@@ -1,0 +1,14 @@
+import type { ProjectDefinition } from "./projects.mjs";
+export declare function assertProjectFundingAuthority(
+  value: unknown,
+  project: ProjectDefinition,
+): Record<string, unknown>;
+export declare function verifyProjectFundingAuthority(
+  project: ProjectDefinition,
+  options?: { fetchImpl?: typeof fetch },
+): Promise<void>;
+export declare function verifyFundingAddressTransitions(
+  previous: ReadonlyMap<string, ProjectDefinition>,
+  current: ReadonlyMap<string, ProjectDefinition>,
+  options?: { fetchImpl?: typeof fetch },
+): Promise<void>;

--- a/src/lib/funding-authority.mjs
+++ b/src/lib/funding-authority.mjs
@@ -89,13 +89,14 @@ export function assertProjectFundingAuthority(value, project) {
   return authority;
 }
 
-async function githubJson(path, fetchImpl) {
+async function githubJson(path, fetchImpl, token) {
   const response = await fetchImpl(`https://api.github.com${path}`, {
     redirect: "error",
     signal: AbortSignal.timeout(20_000),
     headers: {
       Accept: "application/vnd.github+json",
       "User-Agent": "slop-funding-authority-check",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
     },
   });
   if (!response.ok || !response.body) {
@@ -127,7 +128,7 @@ async function githubJson(path, fetchImpl) {
 /** Requires the pinned file to belong to the live registered integration history. */
 export async function verifyProjectFundingAuthority(
   project,
-  { fetchImpl = fetch } = {},
+  { fetchImpl = fetch, token = process.env.GITHUB_TOKEN } = {},
 ) {
   const proof = project.authority.proof;
   if (
@@ -143,6 +144,7 @@ export async function verifyProjectFundingAuthority(
   const live = await githubJson(
     `/repositories/${project.authority.repositoryId}`,
     fetchImpl,
+    token,
   );
   const identities = [repository.id, ...(repository.aliases ?? [])];
   if (
@@ -159,6 +161,7 @@ export async function verifyProjectFundingAuthority(
   const ref = await githubJson(
     `${prefix}/git/ref/heads/${encodeURIComponent(branch)}`,
     fetchImpl,
+    token,
   );
   if (
     ref.ref !== `refs/heads/${branch}` ||
@@ -170,6 +173,7 @@ export async function verifyProjectFundingAuthority(
   const comparison = await githubJson(
     `${prefix}/compare/${proof.commitSha}...${ref.object.sha}?per_page=1`,
     fetchImpl,
+    token,
   );
   if (
     !["identical", "ahead"].includes(comparison.status) ||
@@ -183,6 +187,7 @@ export async function verifyProjectFundingAuthority(
   const file = await githubJson(
     `${prefix}/contents/.github/slop-project.json?ref=${proof.commitSha}`,
     fetchImpl,
+    token,
   );
   if (
     file.type !== "file" ||
@@ -208,6 +213,7 @@ export async function verifyProjectFundingAuthority(
     const currentFile = await githubJson(
       `${prefix}/contents/.github/slop-project.json?ref=${ref.object.sha}`,
       fetchImpl,
+      token,
     );
     if (
       currentFile.type !== "file" ||

--- a/src/lib/funding-authority.mjs
+++ b/src/lib/funding-authority.mjs
@@ -1,0 +1,237 @@
+/** A published upstream address is evidence of publication, never key control. */
+import { createHash } from "node:crypto";
+import { assertFundingAddresses } from "./funding-address.mjs";
+
+const COMMIT = /^[0-9a-f]{40}$/u;
+const MAX_RESPONSE_BYTES = 2 * 1024 * 1024;
+const MAX_AUTHORITY_BYTES = 64 * 1024;
+
+function record(value, field) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError(`${field} must be an object`);
+  }
+  return value;
+}
+
+function keys(value, expected, field) {
+  record(value, field);
+  if (
+    Object.keys(value).sort().join("\0") !== [...expected].sort().join("\0")
+  ) {
+    throw new TypeError(`${field} has unexpected or missing fields`);
+  }
+}
+
+function addressBytes(addresses) {
+  return JSON.stringify(
+    addresses.map(({ network, asset, address, effectiveAt, replacedAt }) => [
+      network,
+      asset,
+      address,
+      effectiveAt,
+      replacedAt,
+    ]),
+  );
+}
+
+/** Validates the optional extension against the same route schema as manifests. */
+export function assertProjectFundingAuthority(value, project) {
+  const authority = record(value, "upstream authority");
+  keys(
+    authority,
+    [
+      "kind",
+      "policyRevision",
+      "projectId",
+      "proposal",
+      "repository",
+      "schemaVersion",
+      "steward",
+      ...(Object.hasOwn(authority, "funding") ? ["funding"] : []),
+    ],
+    "upstream authority",
+  );
+  const repository = project.repositories[0];
+  const identities = [repository.id, ...(repository.aliases ?? [])];
+  keys(
+    authority.repository,
+    ["fullName", "id", "integrationBranch"],
+    "upstream repository",
+  );
+  keys(authority.steward, ["actorId", "login", "nodeId"], "upstream steward");
+  if (
+    authority.schemaVersion !== "1" ||
+    authority.kind !== "slop-project-authority" ||
+    authority.projectId !== project.id ||
+    authority.policyRevision !== project.authority.proof?.policyRevision ||
+    !identities.includes(authority.repository.fullName) ||
+    authority.repository.id !== project.authority.repositoryId ||
+    authority.repository.integrationBranch !== repository.integrationBranch ||
+    authority.steward.actorId !== project.steward.github.actorId ||
+    authority.steward.nodeId !== project.steward.github.nodeId ||
+    authority.steward.login !== project.steward.github.login ||
+    typeof authority.proposal !== "string" ||
+    !/^https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/issues\/[1-9]\d*$/u.test(
+      authority.proposal,
+    )
+  ) {
+    throw new TypeError(
+      "upstream authority does not bind the registered project and steward",
+    );
+  }
+  if (Object.hasOwn(authority, "funding")) {
+    keys(authority.funding, ["addresses"], "upstream funding");
+    assertFundingAddresses(
+      authority.funding.addresses,
+      "upstream funding.addresses",
+    );
+  }
+  return authority;
+}
+
+async function githubJson(path, fetchImpl) {
+  const response = await fetchImpl(`https://api.github.com${path}`, {
+    redirect: "error",
+    signal: AbortSignal.timeout(20_000),
+    headers: {
+      Accept: "application/vnd.github+json",
+      "User-Agent": "slop-funding-authority-check",
+    },
+  });
+  if (!response.ok || !response.body) {
+    await response.body?.cancel();
+    throw new Error("upstream funding authority could not be verified");
+  }
+  const reader = response.body.getReader();
+  const chunks = [];
+  let bytes = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      bytes += value.byteLength;
+      if (bytes > MAX_RESPONSE_BYTES) {
+        await reader.cancel();
+        throw new Error(
+          "upstream funding authority response exceeds the byte bound",
+        );
+      }
+      chunks.push(Buffer.from(value));
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+}
+
+/** Requires the pinned file to belong to the live registered integration history. */
+export async function verifyProjectFundingAuthority(
+  project,
+  { fetchImpl = fetch } = {},
+) {
+  const proof = project.authority.proof;
+  if (
+    project.authority.state !== "verified" ||
+    !proof ||
+    !COMMIT.test(proof.commitSha)
+  ) {
+    throw new TypeError(
+      "funding address changes require verified upstream authority",
+    );
+  }
+  const repository = project.repositories[0];
+  const live = await githubJson(
+    `/repositories/${project.authority.repositoryId}`,
+    fetchImpl,
+  );
+  const identities = [repository.id, ...(repository.aliases ?? [])];
+  if (
+    String(live.id) !== project.authority.repositoryId ||
+    live.node_id !== project.authority.repositoryNodeId ||
+    !identities.includes(live.full_name)
+  ) {
+    throw new TypeError(
+      "upstream repository identity differs from the manifest",
+    );
+  }
+  const prefix = `/repos/${live.full_name}`;
+  const branch = repository.integrationBranch;
+  const ref = await githubJson(
+    `${prefix}/git/ref/heads/${encodeURIComponent(branch)}`,
+    fetchImpl,
+  );
+  if (
+    ref.ref !== `refs/heads/${branch}` ||
+    ref.object?.type !== "commit" ||
+    !COMMIT.test(ref.object.sha)
+  ) {
+    throw new TypeError("upstream integration head is invalid");
+  }
+  const comparison = await githubJson(
+    `${prefix}/compare/${proof.commitSha}...${ref.object.sha}?per_page=1`,
+    fetchImpl,
+  );
+  if (
+    !["identical", "ahead"].includes(comparison.status) ||
+    comparison.base_commit?.sha !== proof.commitSha ||
+    comparison.merge_base_commit?.sha !== proof.commitSha
+  ) {
+    throw new TypeError(
+      "authority commit is not on the upstream integration branch",
+    );
+  }
+  const file = await githubJson(
+    `${prefix}/contents/.github/slop-project.json?ref=${proof.commitSha}`,
+    fetchImpl,
+  );
+  if (
+    file.type !== "file" ||
+    file.path !== ".github/slop-project.json" ||
+    file.encoding !== "base64" ||
+    typeof file.content !== "string" ||
+    !Number.isSafeInteger(file.size) ||
+    file.size <= 0 ||
+    file.size > MAX_AUTHORITY_BYTES
+  ) {
+    throw new TypeError("upstream authority file is invalid or oversized");
+  }
+  const source = Buffer.from(file.content, "base64");
+  if (
+    source.byteLength !== file.size ||
+    createHash("sha256").update(source).digest("hex") !== proof.fileSha256
+  ) {
+    throw new TypeError(
+      "upstream authority bytes do not match the pinned digest",
+    );
+  }
+  const authority = assertProjectFundingAuthority(
+    JSON.parse(source.toString("utf8")),
+    project,
+  );
+  if (
+    !authority.funding ||
+    addressBytes(authority.funding.addresses) !==
+      addressBytes(project.funding.addresses)
+  ) {
+    throw new TypeError(
+      "manifest addresses do not exactly match upstream funding authority",
+    );
+  }
+}
+
+/** Unchanged address inventories incur no network request; new projects are covered too. */
+export async function verifyFundingAddressTransitions(
+  previous,
+  current,
+  options,
+) {
+  for (const [id, project] of current) {
+    const prior = previous.get(id);
+    if (
+      addressBytes(prior?.funding.addresses ?? []) ===
+      addressBytes(project.funding.addresses)
+    )
+      continue;
+    await verifyProjectFundingAuthority(project, options);
+  }
+}

--- a/src/lib/funding-authority.mjs
+++ b/src/lib/funding-authority.mjs
@@ -204,6 +204,24 @@ export async function verifyProjectFundingAuthority(
       "upstream authority bytes do not match the pinned digest",
     );
   }
+  if (ref.object.sha !== proof.commitSha) {
+    const currentFile = await githubJson(
+      `${prefix}/contents/.github/slop-project.json?ref=${ref.object.sha}`,
+      fetchImpl,
+    );
+    if (
+      currentFile.type !== "file" ||
+      currentFile.path !== ".github/slop-project.json" ||
+      currentFile.encoding !== "base64" ||
+      currentFile.size !== source.byteLength ||
+      typeof currentFile.content !== "string" ||
+      !Buffer.from(currentFile.content, "base64").equals(source)
+    ) {
+      throw new TypeError(
+        "pinned authority is no longer current on the upstream integration branch",
+      );
+    }
+  }
   const authority = assertProjectFundingAuthority(
     JSON.parse(source.toString("utf8")),
     project,

--- a/src/lib/funding-authority.test.ts
+++ b/src/lib/funding-authority.test.ts
@@ -118,9 +118,14 @@ describe("receiving-address upstream authority", () => {
     await verifyFundingAddressTransitions(
       new Map(),
       new Map([[project.id, project]]),
-      { fetchImpl },
+      { fetchImpl, token: "trusted-test-token" },
     );
     expect(fetchImpl).toHaveBeenCalledTimes(5);
+    for (const [, options] of fetchImpl.mock.calls) {
+      expect(new Headers(options?.headers).get("authorization")).toBe(
+        "Bearer trusted-test-token",
+      );
+    }
   });
 
   it("verifies rotations and replacement timestamps without rewriting their values", async () => {

--- a/src/lib/funding-authority.test.ts
+++ b/src/lib/funding-authority.test.ts
@@ -71,6 +71,13 @@ function fixture(addresses = [ADDRESS]) {
         content: source.toString("base64"),
       },
   };
+  responses[
+    `/repos/elizaOS/eliza/contents/.github/slop-project.json?ref=${HEAD}`
+  ] = structuredClone(
+    responses[
+      `/repos/elizaOS/eliza/contents/.github/slop-project.json?ref=${proof.commitSha}`
+    ],
+  );
   const fetchImpl = vi.fn<typeof fetch>(async (input, options) => {
     const url = new URL(String(input));
     expect(url.origin).toBe("https://api.github.com");
@@ -113,7 +120,7 @@ describe("receiving-address upstream authority", () => {
       new Map([[project.id, project]]),
       { fetchImpl },
     );
-    expect(fetchImpl).toHaveBeenCalledTimes(4);
+    expect(fetchImpl).toHaveBeenCalledTimes(5);
   });
 
   it("verifies rotations and replacement timestamps without rewriting their values", async () => {
@@ -197,6 +204,18 @@ describe("receiving-address upstream authority", () => {
     await expect(
       verifyProjectFundingAuthority(project, { fetchImpl }),
     ).rejects.toThrow(/could not be verified/u);
+  });
+
+  it("rejects an old address authority that has been withdrawn upstream", async () => {
+    const { project, responses, fetchImpl } = fixture();
+    const currentPath = `/repos/elizaOS/eliza/contents/.github/slop-project.json?ref=${HEAD}`;
+    responses[currentPath] = {
+      ...(responses[currentPath] as Record<string, unknown>),
+      content: Buffer.from("withdrawn").toString("base64"),
+    };
+    await expect(
+      verifyProjectFundingAuthority(project, { fetchImpl }),
+    ).rejects.toThrow(/no longer current/u);
   });
 
   it("rejects an oversized authority response before accepting its contents", async () => {

--- a/src/lib/funding-authority.test.ts
+++ b/src/lib/funding-authority.test.ts
@@ -1,0 +1,211 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it, vi } from "vitest";
+import eliza from "../../projects/eliza/project.json";
+import {
+  assertProjectFundingAuthority,
+  verifyFundingAddressTransitions,
+  verifyProjectFundingAuthority,
+} from "./funding-authority.mjs";
+import { assertProjectDefinition } from "./project-schema.mjs";
+import type { ProjectDefinition } from "./projects.mjs";
+
+type Mutable<T> = { -readonly [K in keyof T]: Mutable<T[K]> };
+
+const HEAD = "b".repeat(40);
+const ADDRESS = {
+  network: "solana" as const,
+  asset: "USDC" as const,
+  address: "11111111111111111111111111111111",
+  effectiveAt: "2026-09-01T00:00:00.000Z",
+  replacedAt: null as string | null,
+};
+
+function fixture(addresses = [ADDRESS]) {
+  const project = assertProjectDefinition(
+    structuredClone(eliza),
+  ) as Mutable<ProjectDefinition>;
+  project.funding.addresses = structuredClone(addresses);
+  const proof = project.authority.proof;
+  if (!proof) throw new Error("fixture requires authority");
+  const authority = {
+    kind: "slop-project-authority",
+    schemaVersion: "1",
+    projectId: project.id,
+    policyRevision: proof.policyRevision,
+    proposal: "https://github.com/SlopDotCash/slopdotcash/issues/115",
+    repository: {
+      fullName: project.repositories[0].id,
+      id: project.authority.repositoryId,
+      integrationBranch: project.repositories[0].integrationBranch,
+    },
+    steward: {
+      actorId: project.steward.github.actorId,
+      login: project.steward.github.login,
+      nodeId: project.steward.github.nodeId,
+    },
+    funding: { addresses: structuredClone(addresses) },
+  };
+  const source = Buffer.from(JSON.stringify(authority));
+  proof.fileSha256 = createHash("sha256").update(source).digest("hex");
+  const responses: Record<string, unknown> = {
+    [`/repositories/${project.authority.repositoryId}`]: {
+      id: Number(project.authority.repositoryId),
+      node_id: project.authority.repositoryNodeId,
+      full_name: project.repositories[0].id,
+    },
+    "/repos/elizaOS/eliza/git/ref/heads/develop": {
+      ref: "refs/heads/develop",
+      object: { type: "commit", sha: HEAD },
+    },
+    [`/repos/elizaOS/eliza/compare/${proof.commitSha}...${HEAD}?per_page=1`]: {
+      status: "ahead",
+      base_commit: { sha: proof.commitSha },
+      merge_base_commit: { sha: proof.commitSha },
+    },
+    [`/repos/elizaOS/eliza/contents/.github/slop-project.json?ref=${proof.commitSha}`]:
+      {
+        type: "file",
+        path: ".github/slop-project.json",
+        encoding: "base64",
+        size: source.byteLength,
+        content: source.toString("base64"),
+      },
+  };
+  const fetchImpl = vi.fn<typeof fetch>(async (input, options) => {
+    const url = new URL(String(input));
+    expect(url.origin).toBe("https://api.github.com");
+    expect(options?.redirect).toBe("error");
+    const value = responses[url.pathname + url.search];
+    return value ? Response.json(value) : new Response(null, { status: 404 });
+  });
+  return { project, authority, responses, fetchImpl };
+}
+
+describe("receiving-address upstream authority", () => {
+  it("accepts an optional funding extension and rejects malformed or extra route fields", () => {
+    const { project, authority } = fixture();
+    expect(assertProjectFundingAuthority(authority, project)).toBe(authority);
+    const { funding: _funding, ...legacy } = authority;
+    expect(assertProjectFundingAuthority(legacy, project)).toBe(legacy);
+    for (const route of [
+      { ...ADDRESS, address: "invalid" },
+      { ...ADDRESS, owner: "invented" },
+    ]) {
+      expect(() =>
+        assertProjectFundingAuthority(
+          { ...authority, funding: { addresses: [route] } },
+          project,
+        ),
+      ).toThrow();
+    }
+    expect(() =>
+      assertProjectFundingAuthority(
+        { ...authority, steward: { ...authority.steward, actorId: "123" } },
+        project,
+      ),
+    ).toThrow(/registered project and steward/u);
+  });
+
+  it("verifies an added address using exact pinned bytes and upstream ancestry", async () => {
+    const { project, fetchImpl } = fixture();
+    await verifyFundingAddressTransitions(
+      new Map(),
+      new Map([[project.id, project]]),
+      { fetchImpl },
+    );
+    expect(fetchImpl).toHaveBeenCalledTimes(4);
+  });
+
+  it("verifies rotations and replacement timestamps without rewriting their values", async () => {
+    const { project, fetchImpl } = fixture([
+      { ...ADDRESS, replacedAt: "2026-09-02T00:00:00.000Z" },
+      {
+        ...ADDRESS,
+        address: "Vote111111111111111111111111111111111111111",
+        effectiveAt: "2026-09-02T00:00:00.000Z",
+      },
+    ]);
+    const prior = fixture().project;
+    await verifyFundingAddressTransitions(
+      new Map([[prior.id, prior]]),
+      new Map([[project.id, project]]),
+      { fetchImpl },
+    );
+    project.funding.addresses[0].replacedAt = "2026-09-03T00:00:00.000Z";
+    await expect(
+      verifyProjectFundingAuthority(project, { fetchImpl }),
+    ).rejects.toThrow(/exactly match/u);
+  });
+
+  it("makes no network request for unchanged empty or existing addresses", async () => {
+    for (const addresses of [[], [ADDRESS]]) {
+      const { project, fetchImpl } = fixture(addresses);
+      await verifyFundingAddressTransitions(
+        new Map([[project.id, project]]),
+        new Map([[project.id, project]]),
+        { fetchImpl },
+      );
+      expect(fetchImpl).not.toHaveBeenCalled();
+    }
+  });
+
+  it("rejects a missing authority, mismatched address, or byte digest", async () => {
+    const { project, fetchImpl } = fixture();
+    project.funding.addresses[0].address =
+      "Vote111111111111111111111111111111111111111";
+    await expect(
+      verifyProjectFundingAuthority(project, { fetchImpl }),
+    ).rejects.toThrow(/exactly match/u);
+    if (!project.authority.proof) throw new Error("missing fixture proof");
+    project.authority.proof.fileSha256 = "0".repeat(64);
+    await expect(
+      verifyProjectFundingAuthority(project, { fetchImpl }),
+    ).rejects.toThrow(/pinned digest/u);
+    project.authority = {
+      ...project.authority,
+      state: "unverified",
+      reason: "missing-repository-proof",
+      proof: null,
+    };
+    await expect(
+      verifyProjectFundingAuthority(project, { fetchImpl }),
+    ).rejects.toThrow(/require verified/u);
+  });
+
+  it("fails closed when the file is unreachable or the commit is off-branch", async () => {
+    const { project, responses, fetchImpl } = fixture();
+    const comparisonPath = Object.keys(responses).find((path) =>
+      path.includes("/compare/"),
+    );
+    const filePath = Object.keys(responses).find((path) =>
+      path.includes("/contents/"),
+    );
+    if (!comparisonPath || !filePath) throw new Error("missing fixture route");
+    responses[comparisonPath] = {
+      status: "diverged",
+      base_commit: { sha: project.authority.proof?.commitSha },
+    };
+    await expect(
+      verifyProjectFundingAuthority(project, { fetchImpl }),
+    ).rejects.toThrow(/not on the upstream/u);
+    responses[comparisonPath] = {
+      status: "identical",
+      base_commit: { sha: project.authority.proof?.commitSha },
+      merge_base_commit: { sha: project.authority.proof?.commitSha },
+    };
+    delete responses[filePath];
+    await expect(
+      verifyProjectFundingAuthority(project, { fetchImpl }),
+    ).rejects.toThrow(/could not be verified/u);
+  });
+
+  it("rejects an oversized authority response before accepting its contents", async () => {
+    const { project } = fixture();
+    const fetchImpl = vi.fn<typeof fetch>(
+      async () => new Response("x".repeat(2 * 1024 * 1024 + 1)),
+    );
+    await expect(
+      verifyProjectFundingAuthority(project, { fetchImpl }),
+    ).rejects.toThrow(/byte bound/u);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #367.

Adds optional `funding.addresses` to the upstream `slop-project-authority` document and enforces exact complete address history in the immutable trusted-base transition checker. The gate verifies repository and steward identities, integration-branch ancestry, pinned bytes/digest, strict route schema, and the current upstream file so withdrawn authority cannot be resurrected. Existing unchanged inventories make no network request.

GitHub reads use the workflow read-only token only inside the checked-out immutable base checker; contributor code is fetched as Git object data and never executed. This avoids the anonymous 60-request/hour ceiling without exposing credentials to PR code.

## Verification

Corrected rebased head: `ff33db48c6e67ff67955757a784293d7803e47b3`. Focused authority and transition tests: 14 passed. Canonical `bun run verify` passed, including 694 Vitest tests, 103 skill tests, typecheck, format/lint, all registry/protocol/audit checks, and the production build. Hosted checks remain required and are currently blocked by the organization Actions spending limit.

## Boundaries

This proves upstream publication only, not wallet control, signer independence, legal ownership, or payment authority. Maintainer approval remains required. No project manifest, wallet, funding instrument, production record, or deployment authority changed. The PR remains draft until exact-head local and hosted gates are terminal green.
