### PR TITLE
test: honor integration timeout under Bun

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "audit:dependencies": "bun audit",
     "verify": "bun run brand:check && bun run projects:check && bun run evaluations:check && bun run funding:check && bun run cycles:check && bun run protocol:check && bun run audit:dependencies && bun run typecheck && bun run format:check && bun run lint:check && bun run test && bun run build",
     "typecheck": "tsc -b",
-    "test": "vitest run && bun test ./skill-tests",
+    "test": "vitest run && bun test --timeout 30000 ./skill-tests",
     "test:e2e": "node scripts/run-e2e.mjs",
     "test:e2e:record": "node scripts/record-evidence.mjs --local",
     "test:e2e:record:production": "node scripts/record-evidence.mjs --production",


### PR DESCRIPTION
## Summary

Fixes the repeated exact-head validation blocker where Bun kills child processes in the long receipt integration test at its five-second default. The suite imports `node:test`; Bun 1.3.14 does not consistently honor that API's per-test options, so the test command now sets a bounded 30-second per-test ceiling explicitly. Timeouts remain enabled.

## Evidence

- Reproduced on three unrelated clean feature worktrees: the long receipt test failed at different child-process assertions with `status: null` and Bun reporting a killed dangling process.
- `bun test --timeout 30000 ./skill-tests`: 103 passed.
- `bun run verify`: 686 Vitest tests + 103 skill tests, all registry/protocol/audit/type/format/lint gates, and production build passed.
- Browser E2E: N/A — package test-runner command only; no product or browser code changed.

Official Bun documentation defines the default as 5 seconds and `--timeout` as the bounded global per-test override.

No production code, policy, generated artifact, dependency, or deployment setting changed.