### PR TITLE
Fund reward cycles from verified committed principal

### DIFF
--- a/cycles/README.md
+++ b/cycles/README.md
@@ -13,6 +13,39 @@ no work qualified, so a zero-award month is auditable and unused funding can
 roll forward without raising the next cap. Existing complete cycles are left
 untouched; a directory containing only one required file is refused as partial.
 
+New monthly proposals freeze `fundingBasis` (funding state, committed amount,
+and monthly cap). Their new shared-pool allocation is the smaller of committed
+funding and the cap when funding is committed, and zero otherwise. Accepted
+events, scores, evidence, and previously reviewed carry remain recorded even
+when this month's allocation is zero. A zero-funded proposal with no carry
+does not prevent the next snapshot or close and contributes no monetary carry.
+
+The existing July 2026 cap-based proposal is the grandfathered unfunded trial.
+Its original snapshot, score table, suggestions, and review dates remain intact;
+the old suggestions do not become carry without a reviewed allocation. Cycle
+validation retains the historical cap basis through July. From August onward,
+new cycle artifacts must include their frozen funding basis. The cycle index
+identifies the historical trial as unfunded without rewriting its artifacts.
+
+The trusted project-transition gate executes from the immutable base commit.
+For each newly added monthly proposal it requires the frozen funding basis to
+equal that base commit's reviewed project manifest. Changes to that project's
+funding state, committed amount, or cap must land separately before a proposal;
+the proposal cannot authorize its own funding. Historical funding bases remain
+unchanged when later manifests evolve. This migration activates that gate for
+subsequent proposal PRs and adds no proposal itself.
+
+After two consecutive closed unfunded months, the site suppresses project pool
+promotion and the skill install CTA until positive committed funding resumes.
+This affects discovery only: the project page, score history, snapshot writing,
+cycle closing, and existing reviewed balances remain available. Missing cycle
+history cannot authorize promotion.
+
+Later funding supports a new reviewed allocation; retained scores create no
+automatic claim on it. Re-proposing an old cycle would need a separate reviewed
+append-only revision mechanism and a fresh 14-day review. The current CLI does
+not overwrite a closed proposal, and this migration does not add that mechanism.
+
 For a platform-funded monthly pool, the creator edits `proposal.json` during
 the 14-day review. The creator may set any contributor amount, including zero,
 or raise it above the deterministic suggestion while the cycle total remains
@@ -36,7 +69,8 @@ cycle. `held-below-minimum` and `unclaimed` balances carry even when the actor
 did no new work; approved payout intents stay in their original cycle, while
 excluded and manually held rows never become new payment proposals
 automatically. An unfinished review or unresolved proposed row fails the next
-cycle closed instead of guessing what is owed.
+cycle closed instead of guessing a reviewed balance; an unfunded record with
+no carried amount is exempt because it contains no monetary allocation.
 
 - `allocation.json` — reviewed and approved payout intents;
 - `execution-plan.json` — an unsigned, exact Solana USDC transfer plan;

--- a/cycles/README.md
+++ b/cycles/README.md
@@ -22,8 +22,10 @@ does not prevent the next snapshot or close and contributes no monetary carry.
 
 The existing July 2026 cap-based proposal is the grandfathered unfunded trial.
 Its original snapshot, score table, suggestions, and review dates remain intact;
-the old suggestions do not become carry without a reviewed allocation. Cycle
-validation retains the historical cap basis through July. From August onward,
+the old suggestions never become carry, even when a reviewed allocation exists.
+Cycle validation uses the cap recorded in the historical artifact through July,
+not the current project cap; the trusted transition gate forbids changing that
+recorded cap. From August onward,
 new cycle artifacts must include their frozen funding basis. The cycle index
 identifies the historical trial as unfunded without rewriting its artifacts.
 

--- a/cycles/README.md
+++ b/cycles/README.md
@@ -72,6 +72,11 @@ automatically. An unfinished review or unresolved proposed row fails the next
 cycle closed instead of guessing a reviewed balance; an unfunded record with
 no carried amount is exempt because it contains no monetary allocation.
 
+The public cycle index carries `carriedMinor` separately from the new cycle's
+cap. Shared-pool approvals may total at most cap plus carry. An additive review
+line publishes its own `reviewBudgetCapMinor`, the smaller of its committed
+amount and cap; shared-pool carry never increases that separate limit.
+
 - `allocation.json` — reviewed and approved payout intents;
 - `execution-plan.json` — an unsigned, exact Solana USDC transfer plan;
 - `transactions.json` — submitted public transaction signatures;

--- a/cycles/README.md
+++ b/cycles/README.md
@@ -13,8 +13,14 @@ no work qualified, so a zero-award month is auditable and unused funding can
 roll forward without raising the next cap. Existing complete cycles are left
 untouched; a directory containing only one required file is refused as partial.
 
-New monthly proposals freeze `fundingBasis` (funding state, committed amount,
-and monthly cap). Their new shared-pool allocation is the smaller of committed
+New monthly proposals freeze `fundingBasis` (cycle ID, stable instrument ID,
+funding state, applicable committed amount, and monthly cap). Positive new
+principal requires exactly one unreplaced reviewed instrument whose
+`monthlyCommitment.cycleId` equals the proposal cycle. An instrument for an
+earlier or later month contributes zero, not retroactive or advance funding.
+The stable ID binds Squads kind/network/multisig/vault index/vault, or Sablier
+kind/network/contract/stream ID; an unfunded cycle records a null instrument ID.
+Their new shared-pool allocation is the smaller of committed
 funding and the cap when funding is committed, and zero otherwise. Accepted
 events, scores, evidence, and previously reviewed carry remain recorded even
 when this month's allocation is zero. A zero-funded proposal with no carry
@@ -32,7 +38,7 @@ identifies the historical trial as unfunded without rewriting its artifacts.
 The trusted project-transition gate executes from the immutable base commit.
 For each newly added monthly proposal it requires the frozen funding basis to
 equal that base commit's reviewed project manifest. Changes to that project's
-funding state, committed amount, or cap must land separately before a proposal;
+reward policy or instrument inventory must land separately before a proposal;
 the proposal cannot authorize its own funding. Historical funding bases remain
 unchanged when later manifests evolve. This migration activates that gate for
 subsequent proposal PRs and adds no proposal itself.
@@ -73,6 +79,9 @@ excluded and manually held rows never become new payment proposals
 automatically. An unfinished review or unresolved proposed row fails the next
 cycle closed instead of guessing a reviewed balance; an unfunded record with
 no carried amount is exempt because it contains no monetary allocation.
+For line-aware rows, only `lines.sharedPool.suggestedMinor` carries; additive
+review awards never become shared-pool principal. Rows without lines retain
+the historical `accruedMinor ?? suggestedMinor` interpretation.
 
 The public cycle index carries `carriedMinor` separately from the new cycle's
 cap. Shared-pool approvals may total at most cap plus carry. An additive review

--- a/cycles/README.md
+++ b/cycles/README.md
@@ -44,7 +44,10 @@ unchanged when later manifests evolve. This migration activates that gate for
 subsequent proposal PRs and adds no proposal itself.
 
 After two consecutive closed unfunded months, the site suppresses project pool
-promotion and the skill install CTA until positive committed funding resumes.
+promotion and the skill install CTA until positive committed funding for the
+explicit display cycle resumes. A commitment for another month cannot reopen
+promotion; each caller uses its snapshot-derived project view cycle, not the
+wall clock or a raw policy balance.
 This affects discovery only: the project page, score history, snapshot writing,
 cycle closing, and existing reviewed balances remain available. Missing cycle
 history cannot authorize promotion.

--- a/scripts/check-project-transitions.d.mts
+++ b/scripts/check-project-transitions.d.mts
@@ -1,5 +1,12 @@
 export type ProjectManifestEntry = readonly [path: string, bytes: string];
 
+export declare function validateProposalFundingTransitions(
+  previousProjects: readonly ProjectManifestEntry[],
+  currentProjects: readonly ProjectManifestEntry[],
+  previousProposals: readonly ProjectManifestEntry[],
+  currentProposals: readonly ProjectManifestEntry[],
+): void;
+
 export declare function validateProjectTransitions(
   previousEntries: readonly ProjectManifestEntry[],
   currentEntries: readonly ProjectManifestEntry[],

--- a/scripts/check-project-transitions.mjs
+++ b/scripts/check-project-transitions.mjs
@@ -90,6 +90,8 @@ export function validateProposalFundingTransitions(
     if (proposal.kind !== "reward-allocation") continue;
     if (priorFiles.has(path)) {
       const prior = JSON.parse(priorFiles.get(path));
+      if (prior.capMinor !== proposal.capMinor)
+        throw new TypeError("historical proposal cap cannot change");
       if (
         JSON.stringify(prior.fundingBasis) !==
         JSON.stringify(proposal.fundingBasis)

--- a/scripts/check-project-transitions.mjs
+++ b/scripts/check-project-transitions.mjs
@@ -8,6 +8,7 @@ import { execFileSync } from "node:child_process";
 import { readdir, readFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { deriveAllocationFundingBasis } from "../src/lib/allocation-funding-basis.mjs";
 import { verifyFundingAddressTransitions } from "../src/lib/funding-authority.mjs";
 import { assertProjectPolicyTransition } from "../src/lib/project-policy.mjs";
 import {
@@ -27,20 +28,14 @@ const MAX_PROPOSAL_INVENTORY_BYTES = 256 * 1024 * 1024;
 const PROPOSAL_PATH =
   /^cycles\/([a-z0-9-]+)\/(\d{4}-(?:0[1-9]|1[0-2]))\/proposal\.json$/u;
 
-function fundingBasis(reward) {
-  return {
-    fundingState: reward.fundingState,
-    committedMinor: reward.committedMinor,
-    monthlyCapMinor: reward.monthlyCapMinor,
-  };
-}
-
 function sameFundingBasis(left, right) {
   return (
     left &&
     right &&
-    Object.keys(left).length === 3 &&
-    Object.keys(right).length === 3 &&
+    Object.keys(left).length === 5 &&
+    Object.keys(right).length === 5 &&
+    left.cycleId === right.cycleId &&
+    left.instrumentId === right.instrumentId &&
     left.fundingState === right.fundingState &&
     left.committedMinor === right.committedMinor &&
     left.monthlyCapMinor === right.monthlyCapMinor
@@ -112,12 +107,19 @@ export function validateProposalFundingTransitions(
         "new proposal needs an existing reviewed monthly-pool project",
       );
     if (
-      !sameFundingBasis(fundingBasis(prior.reward), fundingBasis(next.reward))
+      JSON.stringify(prior.reward) !== JSON.stringify(next.reward) ||
+      JSON.stringify(prior.funding.commitments) !==
+        JSON.stringify(next.funding.commitments)
     )
       throw new TypeError(
         "funding policy and a new proposal must land in separate reviewed changes",
       );
-    if (!sameFundingBasis(proposal.fundingBasis, fundingBasis(prior.reward)))
+    if (
+      !sameFundingBasis(
+        proposal.fundingBasis,
+        deriveAllocationFundingBasis(prior, match[2]),
+      )
+    )
       throw new TypeError(
         "new proposal funding basis differs from the immutable base project policy",
       );

--- a/scripts/check-project-transitions.mjs
+++ b/scripts/check-project-transitions.mjs
@@ -1,5 +1,5 @@
 /**
- * Validates every project manifest transition against an immutable Git base.
+ * Validates project policy and new proposal funding against an immutable Git base.
  * Schema validation alone cannot protect append-only policy history because a
  * well-shaped manifest may still rewrite or delete an earlier binding.
  */
@@ -22,6 +22,105 @@ const PROJECT_PATH =
   /^projects\/([a-z0-9](?:[a-z0-9-]{0,46}[a-z0-9])?)\/project\.json$/u;
 const MAX_PROJECTS = 100;
 const MAX_MANIFEST_BYTES = 1024 * 1024;
+const MAX_PROPOSAL_FILES = 24_000;
+const MAX_PROPOSAL_INVENTORY_BYTES = 256 * 1024 * 1024;
+const PROPOSAL_PATH =
+  /^cycles\/([a-z0-9-]+)\/(\d{4}-(?:0[1-9]|1[0-2]))\/proposal\.json$/u;
+
+function fundingBasis(reward) {
+  return {
+    fundingState: reward.fundingState,
+    committedMinor: reward.committedMinor,
+    monthlyCapMinor: reward.monthlyCapMinor,
+  };
+}
+
+function sameFundingBasis(left, right) {
+  return (
+    left &&
+    right &&
+    Object.keys(left).length === 3 &&
+    Object.keys(right).length === 3 &&
+    left.fundingState === right.fundingState &&
+    left.committedMinor === right.committedMinor &&
+    left.monthlyCapMinor === right.monthlyCapMinor
+  );
+}
+
+/** Runs from the immutable base commit; proposal fields never authorize funds. */
+export function validateProposalFundingTransitions(
+  previousProjects,
+  currentProjects,
+  previousProposals,
+  currentProposals,
+) {
+  const previous = boundedProjectMap(previousProjects, { historical: true });
+  const current = boundedProjectMap(currentProjects);
+  const priorFiles = new Map(previousProposals);
+  const nextPaths = new Set(currentProposals.map(([path]) => path));
+  for (const path of priorFiles.keys()) {
+    if (!nextPaths.has(path))
+      throw new TypeError("historical cycle proposals cannot be deleted");
+  }
+  if (
+    currentProposals.length > MAX_PROPOSAL_FILES ||
+    priorFiles.size > MAX_PROPOSAL_FILES
+  )
+    throw new TypeError("cycle proposal inventory exceeds its bound");
+  let proposalBytes = 0;
+  for (const [, bytes] of [...previousProposals, ...currentProposals]) {
+    const size = Buffer.byteLength(bytes);
+    proposalBytes += size;
+    if (
+      size > MAX_MANIFEST_BYTES ||
+      proposalBytes > MAX_PROPOSAL_INVENTORY_BYTES
+    )
+      throw new TypeError("cycle proposal inventory exceeds its byte bound");
+  }
+  for (const [path, bytes] of currentProposals) {
+    const match = path.match(PROPOSAL_PATH);
+    if (!match || Buffer.byteLength(bytes) > MAX_MANIFEST_BYTES)
+      throw new TypeError("invalid cycle proposal path or size");
+    const proposal = JSON.parse(bytes);
+    if (
+      previous.get(match[1])?.reward.kind === "monthly-pool" &&
+      proposal.kind !== "reward-allocation"
+    )
+      throw new TypeError("monthly proposal must retain its allocation kind");
+    if (proposal.kind !== "reward-allocation") continue;
+    if (priorFiles.has(path)) {
+      const prior = JSON.parse(priorFiles.get(path));
+      if (
+        JSON.stringify(prior.fundingBasis) !==
+        JSON.stringify(proposal.fundingBasis)
+      )
+        throw new TypeError("historical proposal funding basis cannot change");
+      continue;
+    }
+    const prior = previous.get(match[1]);
+    const next = current.get(match[1]);
+    if (
+      !prior ||
+      !next ||
+      prior.reward.kind !== "monthly-pool" ||
+      proposal.projectId !== match[1] ||
+      proposal.cycleId !== match[2]
+    )
+      throw new TypeError(
+        "new proposal needs an existing reviewed monthly-pool project",
+      );
+    if (
+      !sameFundingBasis(fundingBasis(prior.reward), fundingBasis(next.reward))
+    )
+      throw new TypeError(
+        "funding policy and a new proposal must land in separate reviewed changes",
+      );
+    if (!sameFundingBasis(proposal.fundingBasis, fundingBasis(prior.reward)))
+      throw new TypeError(
+        "new proposal funding basis differs from the immutable base project policy",
+      );
+  }
+}
 
 function parseManifest(bytes, path, { historical = false } = {}) {
   if (Buffer.byteLength(bytes) > MAX_MANIFEST_BYTES) {
@@ -182,15 +281,59 @@ async function workingEntries() {
 }
 
 export async function checkProjectTransitions(baseRevision, currentRevision) {
-  const previousEntries = revisionEntries(baseRevision, "base revision");
-  const currentEntries =
+  const previous = revisionEntries(baseRevision, "base revision");
+  const current =
     currentRevision === undefined
       ? await workingEntries()
       : revisionEntries(currentRevision, "current revision");
-  const result = validateProjectTransitions(previousEntries, currentEntries);
+  const result = validateProjectTransitions(previous, current);
   await verifyFundingAddressTransitions(
-    boundedProjectMap(previousEntries, { historical: true }),
-    boundedProjectMap(currentEntries),
+    boundedProjectMap(previous, { historical: true }),
+    boundedProjectMap(current),
+  );
+  const proposalPaths = (revision) =>
+    git(
+      revision
+        ? ["ls-tree", "-r", "--name-only", revision, "--", "cycles"]
+        : [
+            "ls-files",
+            "--cached",
+            "--others",
+            "--exclude-standard",
+            "--",
+            "cycles",
+          ],
+    )
+      .split("\n")
+      .filter((path) => PROPOSAL_PATH.test(path));
+  let aggregateBytes = 0;
+  const readProposals = async (revision) => {
+    const paths = proposalPaths(revision);
+    if (paths.length > MAX_PROPOSAL_FILES)
+      throw new TypeError("cycle proposal inventory exceeds its bound");
+    const entries = [];
+    for (const path of paths) {
+      const bytes = revision
+        ? git(["show", `${revision}:${path}`])
+        : await readFile(resolve(ROOT, path), "utf8");
+      const size = Buffer.byteLength(bytes);
+      aggregateBytes += size;
+      if (
+        size > MAX_MANIFEST_BYTES ||
+        aggregateBytes > MAX_PROPOSAL_INVENTORY_BYTES
+      )
+        throw new TypeError("cycle proposal inventory exceeds its byte bound");
+      entries.push([path, bytes]);
+    }
+    return entries;
+  };
+  const priorProposals = await readProposals(baseRevision);
+  const nextProposals = await readProposals(currentRevision);
+  validateProposalFundingTransitions(
+    previous,
+    current,
+    priorProposals,
+    nextProposals,
   );
   return result;
 }

--- a/scripts/check-project-transitions.test.ts
+++ b/scripts/check-project-transitions.test.ts
@@ -13,6 +13,43 @@ function entry(value: { id: string }): [string, string] {
 }
 
 describe("project transition gate", () => {
+  it("freezes legacy proposal caps independently of later project caps", () => {
+    const path = "cycles/eliza/2026-07/proposal.json";
+    const proposal = {
+      kind: "reward-allocation",
+      projectId: "eliza",
+      cycleId: "2026-07",
+      capMinor: eliza.reward.monthlyCapMinor,
+    };
+    const original: [string, string][] = [[path, JSON.stringify(proposal)]];
+    const changed = structuredClone(eliza);
+    changed.reward.monthlyCapMinor = "20000000000";
+    changed.reward.monthlyCapDisplay = "$20,000";
+    expect(() =>
+      validateProposalFundingTransitions(
+        [entry(eliza)],
+        [entry(changed)],
+        original,
+        original,
+      ),
+    ).not.toThrow();
+    expect(() =>
+      validateProposalFundingTransitions(
+        [entry(eliza)],
+        [entry(changed)],
+        original,
+        [
+          [
+            path,
+            JSON.stringify({
+              ...proposal,
+              capMinor: changed.reward.monthlyCapMinor,
+            }),
+          ],
+        ],
+      ),
+    ).toThrow(/historical proposal cap cannot change/u);
+  });
   it("retains a multi-year proposal archive while bounding each artifact", () => {
     const historical: [string, string][] = Array.from(
       { length: 300 },

--- a/scripts/check-project-transitions.test.ts
+++ b/scripts/check-project-transitions.test.ts
@@ -3,13 +3,113 @@ import asi from "../projects/asi/project.json";
 import deltaStar from "../projects/delta-star/project.json";
 import eliza from "../projects/eliza/project.json";
 import heirElementsSdk from "../projects/heir-elements-sdk/project.json";
-import { validateProjectTransitions } from "./check-project-transitions.mjs";
+import {
+  validateProjectTransitions,
+  validateProposalFundingTransitions,
+} from "./check-project-transitions.mjs";
 
 function entry(value: { id: string }): [string, string] {
   return [`projects/${value.id}/project.json`, JSON.stringify(value)];
 }
 
 describe("project transition gate", () => {
+  it("retains a multi-year proposal archive while bounding each artifact", () => {
+    const historical: [string, string][] = Array.from(
+      { length: 300 },
+      (_, index) => [
+        `cycles/eliza/${2000 + Math.floor(index / 12)}-${String((index % 12) + 1).padStart(2, "0")}/proposal.json`,
+        JSON.stringify({ kind: "reward-allocation" }),
+      ],
+    );
+    expect(() =>
+      validateProposalFundingTransitions(
+        [entry(eliza)],
+        [entry(eliza)],
+        historical,
+        historical,
+      ),
+    ).not.toThrow();
+    expect(() =>
+      validateProposalFundingTransitions(
+        [entry(eliza)],
+        [entry(eliza)],
+        [],
+        [["cycles/eliza/2026-08/proposal.json", " ".repeat(1024 * 1024 + 1)]],
+      ),
+    ).toThrow(/byte bound/u);
+  });
+  it("binds new proposals to immutable-base funding and rejects self-declared commitment", () => {
+    const path = "cycles/eliza/2026-08/proposal.json";
+    const basis = {
+      fundingState: eliza.reward.fundingState,
+      committedMinor: eliza.reward.committedMinor,
+      monthlyCapMinor: eliza.reward.monthlyCapMinor,
+    };
+    const proposal = {
+      kind: "reward-allocation",
+      projectId: "eliza",
+      cycleId: "2026-08",
+      fundingBasis: basis,
+    };
+    const validate = (value: unknown, next = eliza) =>
+      validateProposalFundingTransitions(
+        [entry(eliza)],
+        [entry(next)],
+        [],
+        [[path, JSON.stringify(value)]],
+      );
+    expect(() => validate(proposal)).not.toThrow();
+    expect(() =>
+      validate({
+        ...proposal,
+        fundingBasis: {
+          ...basis,
+          fundingState: "committed",
+          committedMinor: "10000000000",
+        },
+      }),
+    ).toThrow(/immutable base project policy/u);
+    expect(() =>
+      validate({
+        ...proposal,
+        fundingBasis: { ...basis, monthlyCapMinor: "20000000000" },
+      }),
+    ).toThrow(/immutable base project policy/u);
+    expect(() => validate({ ...proposal, fundingBasis: undefined })).toThrow(
+      /immutable base project policy/u,
+    );
+    const changed = structuredClone(eliza);
+    changed.reward.monthlyCapMinor = "20000000000";
+    changed.reward.monthlyCapDisplay = "$20,000";
+    expect(() => validate(proposal, changed)).toThrow(
+      /separate reviewed changes/u,
+    );
+    const historic: [string, string][] = [[path, JSON.stringify(proposal)]];
+    expect(() =>
+      validateProposalFundingTransitions(
+        [entry(eliza)],
+        [entry(changed)],
+        historic,
+        historic,
+      ),
+    ).not.toThrow();
+    expect(() =>
+      validateProposalFundingTransitions(
+        [entry(eliza)],
+        [entry(eliza)],
+        historic,
+        [
+          [
+            path,
+            JSON.stringify({
+              ...proposal,
+              fundingBasis: { ...basis, committedMinor: "1" },
+            }),
+          ],
+        ],
+      ),
+    ).toThrow(/historical proposal funding basis cannot change/u);
+  });
   it("accepts unchanged policy and rejects silent terms history edits", () => {
     expect(validateProjectTransitions([entry(eliza)], [entry(eliza)])).toEqual({
       previous: 1,

--- a/scripts/check-project-transitions.test.ts
+++ b/scripts/check-project-transitions.test.ts
@@ -78,6 +78,8 @@ describe("project transition gate", () => {
   it("binds new proposals to immutable-base funding and rejects self-declared commitment", () => {
     const path = "cycles/eliza/2026-08/proposal.json";
     const basis = {
+      cycleId: "2026-08",
+      instrumentId: null,
       fundingState: eliza.reward.fundingState,
       committedMinor: eliza.reward.committedMinor,
       monthlyCapMinor: eliza.reward.monthlyCapMinor,

--- a/scripts/prepare-reward-cycle.test.ts
+++ b/scripts/prepare-reward-cycle.test.ts
@@ -48,6 +48,13 @@ describe("prepare reward cycle accrual", () => {
     expect(proposal.kind).toBe("reward-allocation");
     if (proposal.kind !== "reward-allocation") return;
     expect(proposal.carriedMinor).toBe("1500000");
+    expect(proposal.capMinor).toBe("0");
+    expect(proposal.totals.suggestedMinor).toBe("1500000");
+    expect(write).toHaveBeenCalledWith(
+      arguments_.snapshotArchivePath,
+      Buffer.from(JSON.stringify(snapshot)),
+    );
+    expect(write).toHaveBeenCalledWith(arguments_.outputPath, proposal);
     expect(proposal.allocations).toContainEqual(
       expect.objectContaining({
         actor: { id: "U_quiet", login: "quiet-contributor" },

--- a/scripts/prior-cycle-accrual.test.ts
+++ b/scripts/prior-cycle-accrual.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -16,6 +16,11 @@ function julyProposal() {
     cycleId: "2026-07",
     generatedAt: "2026-08-02T00:00:00.000Z",
     projectId: "eliza",
+    fundingBasis: {
+      fundingState: "committed",
+      committedMinor: "10000000000",
+      monthlyCapMinor: "10000000000",
+    },
     snapshot,
     sourceSnapshotSha256: "a".repeat(64),
   });
@@ -24,6 +29,83 @@ function julyProposal() {
 }
 
 describe("prior cycle accrual", () => {
+  it("never carries the immutable historical trial suggestion", async () => {
+    const cyclesRoot = join(process.cwd(), "cycles");
+    const proposalPath = join(cyclesRoot, "eliza", "2026-07", "proposal.json");
+    const before = await readFile(proposalPath);
+    const result = await loadPriorCycleAccrual({
+      asOf: "2026-09-05T00:00:00.000Z",
+      cycleId: "2026-08",
+      cyclesRoot,
+      projectId: "eliza",
+    });
+    expect([...result.accruedMinor]).toEqual([]);
+    expect(await readFile(proposalPath)).toEqual(before);
+  });
+  it("closes an unfunded score record, then funds a new cycle without creating retroactive carry", async () => {
+    const root = await mkdtemp(join(tmpdir(), "slop-unfunded-transition-"));
+    const directory = join(root, "eliza", "2026-07");
+    await mkdir(directory, { recursive: true });
+    const july = julyProposal();
+    const snapshot = snapshotFixture();
+    snapshot.window.from = "2026-06-28T00:00:00.000Z";
+    snapshot.window.to = "2026-08-02T00:00:00.000Z";
+    snapshot.source.verificationWindow = { ...snapshot.window };
+    const zero = createRewardCycleProposal({
+      cycleId: "2026-07",
+      generatedAt: july.generatedAt,
+      projectId: "eliza",
+      snapshot,
+      sourceSnapshotSha256: july.sourceSnapshotSha256,
+    });
+    if (zero.kind !== "reward-allocation") throw new Error("wrong fixture");
+    expect(zero.totals.suggestedMinor).toBe("0");
+    expect(zero.allocations[0].score).toBe(july.allocations[0].score);
+    expect(zero.allocations[0].evidenceEventIds).toEqual(
+      july.allocations[0].evidenceEventIds,
+    );
+    const original = JSON.stringify(zero);
+    await writeFile(join(directory, "proposal.json"), original);
+    const carry = await loadPriorCycleAccrual({
+      asOf: "2026-08-03T00:00:00.000Z",
+      cycleId: "2026-08",
+      cyclesRoot: root,
+      projectId: "eliza",
+    });
+    expect([...carry.accruedMinor]).toEqual([]);
+    snapshot.window = {
+      days: 35,
+      from: "2026-07-28T00:00:00.000Z",
+      to: "2026-09-01T00:00:00.000Z",
+    };
+    snapshot.source.verificationWindow = { ...snapshot.window };
+    snapshot.ledger = snapshot.ledger.map((event) => ({
+      ...event,
+      occurredAt: event.occurredAt.replace("2026-07", "2026-08"),
+    }));
+    const august = createRewardCycleProposal({
+      cycleId: "2026-08",
+      generatedAt: "2026-09-02T00:00:00.000Z",
+      projectId: "eliza",
+      snapshot,
+      sourceSnapshotSha256: "b".repeat(64),
+      fundingBasis: {
+        fundingState: "committed",
+        committedMinor: "5000000",
+        monthlyCapMinor: "10000000000",
+      },
+      priorAccruedMinor: carry.accruedMinor,
+    });
+    expect(august).toMatchObject({
+      carriedMinor: "0",
+      capMinor: "5000000",
+      totals: { suggestedMinor: "5000000" },
+    });
+    expect(await readFile(join(directory, "proposal.json"), "utf8")).toBe(
+      original,
+    );
+  });
+
   it("handles calendar-year boundaries", () => {
     expect(previousCycleId("2026-01")).toBe("2025-12");
   });

--- a/scripts/prior-cycle-accrual.test.ts
+++ b/scripts/prior-cycle-accrual.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { createRewardCycleProposal } from "../src/lib/reward-cycle";
+import { finalizeRewardAllocation } from "../src/lib/reward-finalization";
 import { snapshotFixture } from "../tests/fixtures";
 import { loadPriorCycleAccrual, previousCycleId } from "./prior-cycle-accrual";
 
@@ -29,6 +30,32 @@ function julyProposal() {
 }
 
 describe("prior cycle accrual", () => {
+  it("never carries historical trial suggestions from a reviewed allocation", async () => {
+    const root = await mkdtemp(join(tmpdir(), "slop-reviewed-trial-"));
+    const directory = join(root, "eliza", "2026-07");
+    await mkdir(directory, { recursive: true });
+    const proposal = julyProposal();
+    delete proposal.fundingBasis;
+    const allocation = finalizeRewardAllocation(
+      proposal,
+      "2026-08-17T00:00:00.000Z",
+      Date.parse("2026-08-17T00:00:00.000Z"),
+    );
+    expect(allocation.allocations[0].state).toBe("unclaimed");
+    expect(allocation.allocations[0].suggestedMinor).toBe("10000000000");
+    await writeFile(join(directory, "proposal.json"), JSON.stringify(proposal));
+    await writeFile(
+      join(directory, "allocation.json"),
+      JSON.stringify(allocation),
+    );
+    const result = await loadPriorCycleAccrual({
+      asOf: "2026-09-05T00:00:00.000Z",
+      cycleId: "2026-08",
+      cyclesRoot: root,
+      projectId: "eliza",
+    });
+    expect([...result.accruedMinor]).toEqual([]);
+  });
   it("never carries the immutable historical trial suggestion", async () => {
     const cyclesRoot = join(process.cwd(), "cycles");
     const proposalPath = join(cyclesRoot, "eliza", "2026-07", "proposal.json");

--- a/scripts/prior-cycle-accrual.test.ts
+++ b/scripts/prior-cycle-accrual.test.ts
@@ -18,6 +18,8 @@ function julyProposal() {
     generatedAt: "2026-08-02T00:00:00.000Z",
     projectId: "eliza",
     fundingBasis: {
+      cycleId: "2026-07",
+      instrumentId: `sablier-lockup-v4:base:0x${"1".repeat(40)}:1`,
       fundingState: "committed",
       committedMinor: "10000000000",
       monthlyCapMinor: "10000000000",
@@ -117,6 +119,8 @@ describe("prior cycle accrual", () => {
       snapshot,
       sourceSnapshotSha256: "b".repeat(64),
       fundingBasis: {
+        cycleId: "2026-08",
+        instrumentId: `sablier-lockup-v4:base:0x${"1".repeat(40)}:1`,
         fundingState: "committed",
         committedMinor: "5000000",
         monthlyCapMinor: "10000000000",

--- a/scripts/prior-cycle-accrual.ts
+++ b/scripts/prior-cycle-accrual.ts
@@ -2,6 +2,10 @@
 
 import { lstat, readFile } from "node:fs/promises";
 import { join } from "node:path";
+import {
+  allocationFundingMinor,
+  LAST_LEGACY_CAP_CYCLE,
+} from "../src/lib/allocation-funding";
 import type { ProjectId } from "../src/lib/projects.mjs";
 import {
   assertRewardAllocationManifest,
@@ -129,6 +133,16 @@ export async function loadPriorCycleAccrual(input: {
     );
   }
   if (!allocation) {
+    // An unfunded score record has no reviewed monetary balance to carry.
+    // This also excludes the grandfathered cap-only trial suggestion.
+    if (
+      (proposal.fundingBasis &&
+        allocationFundingMinor(proposal.fundingBasis) === 0n &&
+        BigInt(proposal.carriedMinor ?? "0") === 0n) ||
+      (!proposal.fundingBasis && proposal.cycleId <= LAST_LEGACY_CAP_CYCLE)
+    ) {
+      return { actorLogins: new Map(), accruedMinor: new Map() };
+    }
     if (Date.parse(input.asOf) < Date.parse(proposal.review.endsAt)) {
       throw new PriorCycleNotReadyError({
         cycleId: priorId,

--- a/scripts/prior-cycle-accrual.ts
+++ b/scripts/prior-cycle-accrual.ts
@@ -132,14 +132,17 @@ export async function loadPriorCycleAccrual(input: {
       `Prior cycle ${input.projectId}/${priorId} contains future review state`,
     );
   }
+  // The historical trial never creates a monetary balance, including when
+  // a later reviewed allocation retains its original unclaimed suggestions.
+  if (!proposal.fundingBasis && proposal.cycleId <= LAST_LEGACY_CAP_CYCLE) {
+    return { actorLogins: new Map(), accruedMinor: new Map() };
+  }
   if (!allocation) {
     // An unfunded score record has no reviewed monetary balance to carry.
-    // This also excludes the grandfathered cap-only trial suggestion.
     if (
-      (proposal.fundingBasis &&
-        allocationFundingMinor(proposal.fundingBasis) === 0n &&
-        BigInt(proposal.carriedMinor ?? "0") === 0n) ||
-      (!proposal.fundingBasis && proposal.cycleId <= LAST_LEGACY_CAP_CYCLE)
+      proposal.fundingBasis &&
+      allocationFundingMinor(proposal.fundingBasis) === 0n &&
+      BigInt(proposal.carriedMinor ?? "0") === 0n
     ) {
       return { actorLogins: new Map(), accruedMinor: new Map() };
     }

--- a/scripts/prior-cycle-accrual.ts
+++ b/scripts/prior-cycle-accrual.ts
@@ -170,7 +170,10 @@ export async function loadPriorCycleAccrual(input: {
     if (row.state !== "held-below-minimum" && row.state !== "unclaimed") {
       continue;
     }
-    const amount = row.accruedMinor ?? row.suggestedMinor;
+    const amount =
+      row.lines?.sharedPool.suggestedMinor ??
+      row.accruedMinor ??
+      row.suggestedMinor;
     if (BigInt(amount) === 0n) continue;
     accruedMinor.set(row.actor.id, amount);
     actorLogins.set(row.actor.id, row.actor.login);

--- a/scripts/sync-cycle-index.ts
+++ b/scripts/sync-cycle-index.ts
@@ -16,6 +16,7 @@ import {
 } from "node:fs/promises";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { LAST_LEGACY_CAP_CYCLE } from "../src/lib/allocation-funding";
 import {
   assertCycleIndex,
   CYCLE_INDEX_SCHEMA_VERSION,
@@ -143,6 +144,11 @@ async function verifyProposalAgainstSnapshot(
   snapshot: LeaderboardSnapshot,
   snapshotDigest: string,
 ): Promise<void> {
+  if (!proposal.fundingBasis && proposal.cycleId > LAST_LEGACY_CAP_CYCLE) {
+    throw new TypeError(
+      "New cycle proposals must freeze their committed funding basis",
+    );
+  }
   const priorAccrual = await loadPriorCycleAccrual({
     asOf: proposal.generatedAt,
     cycleId: proposal.cycleId,
@@ -150,6 +156,11 @@ async function verifyProposalAgainstSnapshot(
     projectId: proposal.projectId as ProjectId,
   });
   const baseline = createRewardCycleProposal({
+    fundingBasis: proposal.fundingBasis ?? {
+      fundingState: "committed",
+      committedMinor: proposal.capMinor,
+      monthlyCapMinor: proposal.capMinor,
+    },
     cycleId: proposal.cycleId,
     generatedAt: proposal.generatedAt,
     projectId: proposal.projectId,
@@ -451,6 +462,12 @@ async function buildCycle(
       settledAt: settlement?.settledAt ?? null,
       reward: {
         currency: "USDC",
+        carriedMinor: proposal.carriedMinor ?? "0",
+        fundingBasis: proposal.fundingBasis ?? {
+          fundingState: "pledged",
+          committedMinor: "0",
+          monthlyCapMinor: proposal.capMinor,
+        },
         capMinor: proposal.capMinor,
         suggestedMinor: proposal.totals.suggestedMinor,
         approvedMinor: allocation?.totals.approvedMinor ?? "0",

--- a/scripts/sync-cycle-index.ts
+++ b/scripts/sync-cycle-index.ts
@@ -463,11 +463,9 @@ async function buildCycle(
       reward: {
         currency: "USDC",
         carriedMinor: proposal.carriedMinor ?? "0",
-        fundingBasis: proposal.fundingBasis ?? {
-          fundingState: "pledged",
-          committedMinor: "0",
-          monthlyCapMinor: proposal.capMinor,
-        },
+        ...(proposal.fundingBasis
+          ? { fundingBasis: proposal.fundingBasis }
+          : {}),
         capMinor: proposal.capMinor,
         suggestedMinor: proposal.totals.suggestedMinor,
         approvedMinor: allocation?.totals.approvedMinor ?? "0",
@@ -476,6 +474,12 @@ async function buildCycle(
         sharePartsPerMillion: null,
         ...(proposal.rewardLines
           ? {
+              reviewBudgetCapMinor: (BigInt(
+                proposal.rewardLines.reviewBudget.capMinor,
+              ) < BigInt(proposal.rewardLines.reviewBudget.committedMinor)
+                ? BigInt(proposal.rewardLines.reviewBudget.capMinor)
+                : BigInt(proposal.rewardLines.reviewBudget.committedMinor)
+              ).toString(),
               lines: {
                 sharedPool: {
                   suggestedMinor:

--- a/scripts/sync-cycle-index.ts
+++ b/scripts/sync-cycle-index.ts
@@ -156,11 +156,9 @@ async function verifyProposalAgainstSnapshot(
     projectId: proposal.projectId as ProjectId,
   });
   const baseline = createRewardCycleProposal({
-    fundingBasis: proposal.fundingBasis ?? {
-      fundingState: "committed",
-      committedMinor: proposal.capMinor,
-      monthlyCapMinor: proposal.capMinor,
-    },
+    ...(proposal.fundingBasis
+      ? { fundingBasis: proposal.fundingBasis }
+      : { legacyCapMinor: proposal.capMinor }),
     cycleId: proposal.cycleId,
     generatedAt: proposal.generatedAt,
     projectId: proposal.projectId,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1173,6 +1173,7 @@ function HomePage({ state, retry }: { state: DataState; retry: () => void }) {
     projectPromotionEligible(
       project,
       state.status === "ready" ? state.cycleIndex.cycles : null,
+      views.find((view) => view.project.id === project.id)?.cycle.id ?? null,
     ),
   );
   const featuredProjects = promotedProjects.filter(
@@ -1584,11 +1585,13 @@ function projectInstallCommand(project: ProjectDefinition): string {
 export function ProjectParticipation({
   project,
   cycles,
+  displayCycleId,
 }: {
   project: ProjectDefinition;
   cycles: readonly PromotionCycle[] | null;
+  displayCycleId: string | null;
 }) {
-  if (projectPromotionEligible(project, cycles))
+  if (projectPromotionEligible(project, cycles, displayCycleId))
     return <InstallPanel project={project} />;
   return (
     <section className="section" id="start">
@@ -2303,6 +2306,7 @@ function ProjectPage({
   const promotionEligible = projectPromotionEligible(
     project,
     state.status === "ready" ? state.cycleIndex.cycles : null,
+    view?.cycle.id ?? null,
   );
   const headlineAction = project.headline.startsWith(headlinePrefix)
     ? project.headline.slice(headlinePrefix.length)
@@ -2407,6 +2411,7 @@ function ProjectPage({
       <div className="shell">
         <ProjectParticipation
           project={project}
+          displayCycleId={view?.cycle.id ?? null}
           cycles={state.status === "ready" ? state.cycleIndex.cycles : null}
         />
         <ProjectFunding project={project} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,11 @@ import {
   useState,
 } from "react";
 import {
+  allocationFundingMinor,
+  type PromotionCycle,
+  projectPromotionEligible,
+} from "./lib/allocation-funding";
+import {
   assertCycleIndex,
   type CycleIndex,
   type CycleIndexEntry,
@@ -781,6 +786,10 @@ function ProjectCard({ project }: { project: ProjectDefinition }) {
               : "Committed balance · accessibility unknown · payments disabled"
             : "External sponsor controls eligibility and payment"}
         </small>
+        {project.reward.kind === "monthly-pool" &&
+        allocationFundingMinor(project.reward) === 0n ? (
+          <small>Unfunded trial · score recording remains open</small>
+        ) : null}
         {project.reward.reviewBudget ? (
           <small className="project-review-budget">
             + {reviewBudgetLabel(project.reward.reviewBudget)}
@@ -1160,10 +1169,16 @@ function GlobalLeaderboard({
 
 function HomePage({ state, retry }: { state: DataState; retry: () => void }) {
   const views = state.status === "ready" ? state.views : [];
-  const featuredProjects = PROJECTS.filter(
+  const promotedProjects = PROJECTS.filter((project) =>
+    projectPromotionEligible(
+      project,
+      state.status === "ready" ? state.cycleIndex.cycles : null,
+    ),
+  );
+  const featuredProjects = promotedProjects.filter(
     (project) => project.listingTier === "featured",
   );
-  const communityProjects = PROJECTS.filter(
+  const communityProjects = promotedProjects.filter(
     (project) => project.listingTier === "community",
   );
   const latestReceipt =
@@ -1566,6 +1581,27 @@ function projectInstallCommand(project: ProjectDefinition): string {
   });
 }
 
+export function ProjectParticipation({
+  project,
+  cycles,
+}: {
+  project: ProjectDefinition;
+  cycles: readonly PromotionCycle[] | null;
+}) {
+  if (projectPromotionEligible(project, cycles))
+    return <InstallPanel project={project} />;
+  return (
+    <section className="section" id="start">
+      <h2>Contribution record remains open</h2>
+      <p>
+        {cycles
+          ? "Skill promotion is paused after two unfunded cycles. Accepted work and scores continue to be recorded; committed funding is required to resume promotion."
+          : "Funding history must load before skill promotion is available."}
+      </p>
+    </section>
+  );
+}
+
 function InstallPanel({ project }: { project: ProjectDefinition }) {
   const [copy, setCopy] = useState<"manual-copied" | "error" | "idle">("idle");
   const origin = window.location.origin.replace(/\/$/u, "");
@@ -1592,6 +1628,13 @@ function InstallPanel({ project }: { project: ProjectDefinition }) {
         </div>
       </div>
       <AgentPromptBox prompt={projectAgentPrompt(project)} />
+      {project.reward.kind === "monthly-pool" &&
+      allocationFundingMinor(project.reward) === 0n ? (
+        <p>
+          Unfunded trial: this skill records accepted work and scores with a $0
+          funding-backed projection.
+        </p>
+      ) : null}
       <p className="install-note">
         Any model can join. The skill publishes the exact provider, model, and
         client. Every agent run uploads a permanent private trace; only Slop
@@ -1900,17 +1943,29 @@ export function ProjectFunding({ project }: { project: ProjectDefinition }) {
       Date.parse(route.effectiveAt) <= now &&
       (route.replacedAt === null || now < Date.parse(route.replacedAt)),
   );
-  if (activeRoutes.length === 0) return null;
   return (
     <section className="section project-funding">
-      <details>
+      <details open={activeRoutes.length === 0}>
         <summary>Fund this project</summary>
-        <p>{project.funding.disclosure}</p>
         <p>
-          Check the network, asset, and full address in your wallet before
-          sending. Transfers are irreversible. GitHub identity does not prove
-          wallet ownership.
+          Funding: {project.reward.fundingState} · Committed:{" "}
+          {formatMicroUsdc(project.reward.committedMinor)} · Payments:{" "}
+          {project.reward.paymentMode}
         </p>
+        {activeRoutes.length === 0 ? (
+          <p>
+            Not accepting direct funding yet. The steward publishes an address
+            through a reviewed manifest change.
+          </p>
+        ) : null}
+        <p>{project.funding.disclosure}</p>
+        {activeRoutes.length > 0 ? (
+          <p>
+            Check the network, asset, and full address in your wallet before
+            sending. Transfers are irreversible. GitHub identity does not prove
+            wallet ownership.
+          </p>
+        ) : null}
         <div className="funding-routes">
           {activeRoutes.map((route) => {
             const key = `${route.network}:${route.asset}:${route.address}:${route.effectiveAt}`;
@@ -2245,6 +2300,10 @@ function ProjectPage({
       ? state.views.find((candidate) => candidate.project.id === project.id)
       : undefined;
   const headlinePrefix = "Make money ";
+  const promotionEligible = projectPromotionEligible(
+    project,
+    state.status === "ready" ? state.cycleIndex.cycles : null,
+  );
   const headlineAction = project.headline.startsWith(headlinePrefix)
     ? project.headline.slice(headlinePrefix.length)
     : null;
@@ -2290,54 +2349,66 @@ function ProjectPage({
                 </p>
               ) : null}
             </div>
-            <aside className="reward-card">
-              <span>
-                {project.reward.kind === "monthly-pool"
-                  ? "MONTHLY POOL"
-                  : "EXTERNAL OPPORTUNITY"}
-              </span>
-              <strong
-                className={
-                  project.reward.kind === "monthly-pool"
-                    ? "reward-amount-monthly"
-                    : undefined
-                }
-              >
-                {project.reward.kind === "monthly-pool"
-                  ? monthlyPoolUnfunded(project.reward)
-                    ? "Unfunded"
-                    : "Accessibility unknown"
-                  : project.reward.externalOpportunity?.advertisedAmountDisplay}
-              </strong>
-              <p>
-                {project.reward.kind === "monthly-pool"
-                  ? monthlyPoolUnfunded(project.reward)
-                    ? `Target ${project.reward.monthlyCapDisplay} per month. No funding is committed, so no payment is scheduled until the project commits funds.`
-                    : `${formatMicroUsdc(project.reward.committedMinor)} committed against a ${project.reward.monthlyCapDisplay} monthly target. Accessibility is unknown; no payment is enabled.`
-                  : "10% of an award actually received is allocated to Slop Cash; the remaining 90% is shared among accepted contributors. The prize sponsor controls eligibility and payment."}
-              </p>
-              <div>
-                {project.reward.reviewBudget ? (
-                  <small>
-                    + {reviewBudgetLabel(project.reward.reviewBudget)}
-                  </small>
-                ) : null}
-                {project.reward.kind === "external-prize-share" ? (
-                  <small>No platform pool · no dollar projection</small>
-                ) : null}
-                <div className="reward-actions">
-                  <ExternalLinkAnchor href={project.links.repository}>
-                    View in GitHub
-                    <ExternalLink aria-hidden="true" size={14} />
-                  </ExternalLinkAnchor>
+            {promotionEligible ? (
+              <aside className="reward-card">
+                <span>
+                  {project.reward.kind === "monthly-pool"
+                    ? "MONTHLY POOL"
+                    : "EXTERNAL OPPORTUNITY"}
+                </span>
+                <strong
+                  className={
+                    project.reward.kind === "monthly-pool"
+                      ? "reward-amount-monthly"
+                      : undefined
+                  }
+                >
+                  {project.reward.kind === "monthly-pool"
+                    ? monthlyPoolUnfunded(project.reward)
+                      ? "Unfunded"
+                      : "Accessibility unknown"
+                    : project.reward.externalOpportunity
+                        ?.advertisedAmountDisplay}
+                </strong>
+                <p>
+                  {project.reward.kind === "monthly-pool"
+                    ? monthlyPoolUnfunded(project.reward)
+                      ? `Target ${project.reward.monthlyCapDisplay} per month. No funding is committed, so no payment is scheduled until the project commits funds.`
+                      : `${formatMicroUsdc(project.reward.committedMinor)} committed against a ${project.reward.monthlyCapDisplay} monthly target. Accessibility is unknown; no payment is enabled.`
+                    : "10% of an award actually received is allocated to Slop Cash; the remaining 90% is shared among accepted contributors. The prize sponsor controls eligibility and payment."}
+                </p>
+                <div>
+                  {project.reward.reviewBudget ? (
+                    <small>
+                      + {reviewBudgetLabel(project.reward.reviewBudget)}
+                    </small>
+                  ) : null}
+                  {project.reward.kind === "external-prize-share" ? (
+                    <small>No platform pool · no dollar projection</small>
+                  ) : null}
+                  <div className="reward-actions">
+                    <ExternalLinkAnchor href={project.links.repository}>
+                      View in GitHub
+                      <ExternalLink aria-hidden="true" size={14} />
+                    </ExternalLinkAnchor>
+                  </div>
                 </div>
-              </div>
-            </aside>
+              </aside>
+            ) : (
+              <aside className="reward-card">
+                <span>FUNDING PROMOTION PAUSED</span>
+                <strong>$0</strong>
+                <p>Accepted work and cycle history remain available.</p>
+              </aside>
+            )}
           </div>
         </div>
       </section>
       <div className="shell">
-        <InstallPanel project={project} />
+        <ProjectParticipation
+          project={project}
+          cycles={state.status === "ready" ? state.cycleIndex.cycles : null}
+        />
         <ProjectFunding project={project} />
         <ProjectPaymentHistory project={project} state={state} />
         {view && state.status === "ready" ? (

--- a/src/lib/allocation-funding-basis.d.mts
+++ b/src/lib/allocation-funding-basis.d.mts
@@ -1,0 +1,15 @@
+import type { ProjectDefinition } from "./projects.mjs";
+export interface AllocationFundingBasis {
+  cycleId: string;
+  instrumentId: string | null;
+  fundingState: "committed" | "pledged";
+  committedMinor: string;
+  monthlyCapMinor: string;
+}
+export function assertAllocationFundingBasis(
+  value: unknown,
+): AllocationFundingBasis;
+export function deriveAllocationFundingBasis(
+  project: ProjectDefinition,
+  cycleId: string,
+): AllocationFundingBasis;

--- a/src/lib/allocation-funding-basis.mjs
+++ b/src/lib/allocation-funding-basis.mjs
@@ -1,0 +1,66 @@
+/** Stable public identity, never a mutable list index or observed balance. */
+function instrumentIdentity(instrument) {
+  return instrument.kind === "squads-v4-vault"
+    ? `squads-v4-vault:solana:${instrument.multisig}:${instrument.vaultIndex}:${instrument.vault}`
+    : `sablier-lockup-v4:${instrument.network}:${instrument.contract}:${instrument.streamId}`;
+}
+
+export function assertAllocationFundingBasis(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value))
+    throw new TypeError("invalid allocation funding basis");
+  const money = /^(0|[1-9][0-9]{0,19})$/u;
+  if (
+    Object.keys(value).sort().join(",") !==
+      "committedMinor,cycleId,fundingState,instrumentId,monthlyCapMinor" ||
+    typeof value.cycleId !== "string" ||
+    !/^\d{4}-(?:0[1-9]|1[0-2])$/u.test(value.cycleId) ||
+    !["pledged", "committed"].includes(value.fundingState) ||
+    typeof value.committedMinor !== "string" ||
+    !money.test(value.committedMinor) ||
+    typeof value.monthlyCapMinor !== "string" ||
+    !money.test(value.monthlyCapMinor) ||
+    (value.instrumentId !== null &&
+      (typeof value.instrumentId !== "string" ||
+        value.instrumentId.length > 200 ||
+        !/^(?:squads-v4-vault:solana:[1-9A-HJ-NP-Za-km-z]{32,44}:(?:0|[1-9][0-9]*):[1-9A-HJ-NP-Za-km-z]{32,44}|sablier-lockup-v4:(?:base|ethereum):0x[0-9a-fA-F]{40}:(?:0|[1-9][0-9]*))$/u.test(
+          value.instrumentId,
+        ))) ||
+    (BigInt(value.committedMinor) > 0n
+      ? value.fundingState !== "committed" || value.instrumentId === null
+      : value.instrumentId !== null)
+  )
+    throw new TypeError("invalid allocation funding basis");
+  return { ...value };
+}
+
+/** Input project has already passed the reviewed project schema. Wrong months
+ * have no applicable principal; a later commitment never funds an earlier cycle. */
+export function deriveAllocationFundingBasis(project, cycleId) {
+  const applicable = (project.funding.commitments ?? []).filter(
+    (instrument) =>
+      instrument.replacedAt === null &&
+      instrument.monthlyCommitment?.cycleId === cycleId,
+  );
+  if (applicable.length > 1)
+    throw new TypeError("ambiguous monthly funding instrument");
+  const instrument = applicable[0];
+  const committedMinor =
+    project.reward.fundingState === "committed" && instrument
+      ? project.reward.committedMinor
+      : "0";
+  if (
+    instrument &&
+    BigInt(committedMinor) > BigInt(instrument.monthlyCommitment.amountMinor)
+  )
+    throw new TypeError(
+      "monthly instrument does not cover committed principal",
+    );
+  return assertAllocationFundingBasis({
+    cycleId,
+    instrumentId:
+      BigInt(committedMinor) > 0n ? instrumentIdentity(instrument) : null,
+    fundingState: project.reward.fundingState,
+    committedMinor,
+    monthlyCapMinor: project.reward.monthlyCapMinor,
+  });
+}

--- a/src/lib/allocation-funding.test.ts
+++ b/src/lib/allocation-funding.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { snapshotFixture } from "../../tests/fixtures";
+import {
+  allocationFundingMinor,
+  type PromotionCycle,
+  projectPromotionEligible,
+} from "./allocation-funding";
+import { createProjectView } from "./project-view";
+import { findProject } from "./projects.mjs";
+
+const project = findProject("eliza");
+if (!project) throw new Error("Missing Eliza fixture");
+const unfunded = {
+  fundingState: "pledged" as const,
+  committedMinor: "0",
+  monthlyCapMinor: "10000000000",
+};
+const cycle = (cycleId: string, committedMinor = "0"): PromotionCycle => ({
+  projectId: project.id,
+  kind: "monthly-pool",
+  cycleId,
+  reward: {
+    fundingBasis: {
+      ...unfunded,
+      committedMinor,
+      fundingState: committedMinor === "0" ? "pledged" : "committed",
+    },
+  },
+});
+
+describe("funding-backed allocation and promotion", () => {
+  it("rejects malformed money before conversion", () => {
+    expect(() =>
+      allocationFundingMinor({
+        ...unfunded,
+        fundingState: "committed",
+        committedMinor: "-1",
+      }),
+    ).toThrow(/invalid allocation funding basis/u);
+    expect(() =>
+      allocationFundingMinor({ ...unfunded, monthlyCapMinor: "1.5" }),
+    ).toThrow(/invalid allocation funding basis/u);
+  });
+  it.each([
+    ["pledged", "10000000", 0n],
+    ["committed", "0", 0n],
+    ["committed", "5000000", 5000000n],
+    ["committed", "20000000000", 10000000000n],
+  ])(
+    "uses %s funding of %s without changing score",
+    (fundingState, committedMinor, expected) => {
+      const basis = {
+        ...unfunded,
+        fundingState: fundingState as "pledged" | "committed",
+        committedMinor: String(committedMinor),
+      };
+      expect(allocationFundingMinor(basis)).toBe(expected);
+      const snapshot = snapshotFixture();
+      const before = createProjectView(snapshot, "eliza", "2026-07");
+      const after = createProjectView(snapshot, "eliza", "2026-07", basis);
+      expect(after.ledger).toEqual(before.ledger);
+      expect(
+        after.leaders.map(({ score, evidenceEventIds }) => ({
+          score,
+          evidenceEventIds,
+        })),
+      ).toEqual(
+        before.leaders.map(({ score, evidenceEventIds }) => ({
+          score,
+          evidenceEventIds,
+        })),
+      );
+      expect(
+        after.leaders.reduce(
+          (sum, leader) => sum + BigInt(leader.projectedMinor ?? "0"),
+          0n,
+        ),
+      ).toBe(expected);
+    },
+  );
+
+  it("allows a trial, pauses only after two adjacent unfunded cycles, and resumes when funded", () => {
+    expect(projectPromotionEligible(project, null)).toBe(false);
+    expect(projectPromotionEligible(project, [])).toBe(true);
+    expect(projectPromotionEligible(project, [cycle("2026-07")])).toBe(true);
+    expect(
+      projectPromotionEligible(project, [cycle("2026-07"), cycle("2026-08")]),
+    ).toBe(false);
+    expect(
+      projectPromotionEligible(project, [cycle("2026-07"), cycle("2026-09")]),
+    ).toBe(true);
+    expect(
+      projectPromotionEligible(project, [
+        cycle("2026-07"),
+        cycle("2026-08", "10"),
+        cycle("2026-09"),
+      ]),
+    ).toBe(true);
+    expect(
+      projectPromotionEligible(
+        {
+          ...project,
+          reward: {
+            ...project.reward,
+            fundingState: "committed",
+            committedMinor: "1",
+          },
+        },
+        [cycle("2026-07"), cycle("2026-08")],
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/lib/allocation-funding.test.ts
+++ b/src/lib/allocation-funding.test.ts
@@ -85,21 +85,32 @@ describe("funding-backed allocation and promotion", () => {
   );
 
   it("allows a trial, pauses only after two adjacent unfunded cycles, and resumes when funded", () => {
-    expect(projectPromotionEligible(project, null)).toBe(false);
-    expect(projectPromotionEligible(project, [])).toBe(true);
-    expect(projectPromotionEligible(project, [cycle("2026-07")])).toBe(true);
+    expect(projectPromotionEligible(project, null, "2026-10")).toBe(false);
+    expect(projectPromotionEligible(project, [], null)).toBe(false);
+    expect(projectPromotionEligible(project, [], "2026-10")).toBe(true);
     expect(
-      projectPromotionEligible(project, [cycle("2026-07"), cycle("2026-08")]),
-    ).toBe(false);
-    expect(
-      projectPromotionEligible(project, [cycle("2026-07"), cycle("2026-09")]),
+      projectPromotionEligible(project, [cycle("2026-07")], "2026-10"),
     ).toBe(true);
     expect(
-      projectPromotionEligible(project, [
-        cycle("2026-07"),
-        cycle("2026-08", "10"),
-        cycle("2026-09"),
-      ]),
+      projectPromotionEligible(
+        project,
+        [cycle("2026-07"), cycle("2026-08")],
+        "2026-10",
+      ),
+    ).toBe(false);
+    expect(
+      projectPromotionEligible(
+        project,
+        [cycle("2026-07"), cycle("2026-09")],
+        "2026-10",
+      ),
+    ).toBe(true);
+    expect(
+      projectPromotionEligible(
+        project,
+        [cycle("2026-07"), cycle("2026-08", "10"), cycle("2026-09")],
+        "2026-10",
+      ),
     ).toBe(true);
     expect(
       projectPromotionEligible(
@@ -112,7 +123,8 @@ describe("funding-backed allocation and promotion", () => {
           },
         },
         [cycle("2026-07"), cycle("2026-08")],
+        "2026-09",
       ),
-    ).toBe(true);
+    ).toBe(false);
   });
 });

--- a/src/lib/allocation-funding.test.ts
+++ b/src/lib/allocation-funding.test.ts
@@ -22,6 +22,11 @@ const cycle = (cycleId: string, committedMinor = "0"): PromotionCycle => ({
   reward: {
     fundingBasis: {
       ...unfunded,
+      cycleId,
+      instrumentId:
+        committedMinor === "0"
+          ? null
+          : `sablier-lockup-v4:base:0x${"1".repeat(40)}:1`,
       committedMinor,
       fundingState: committedMinor === "0" ? "pledged" : "committed",
     },

--- a/src/lib/allocation-funding.ts
+++ b/src/lib/allocation-funding.ts
@@ -1,0 +1,90 @@
+/** Frozen monetary basis for new proposals; accepted score is independent. */
+import type { CycleIndexEntry } from "./cycle-index";
+import type { ProjectDefinition } from "./projects.mjs";
+
+export interface AllocationFundingBasis {
+  fundingState: "committed" | "pledged";
+  committedMinor: string;
+  monthlyCapMinor: string;
+}
+
+// July is the final historical cap-based cycle. Its artifacts are never rewritten.
+export const LAST_LEGACY_CAP_CYCLE = "2026-07";
+
+export function allocationFundingMinor(basis: {
+  fundingState: string;
+  committedMinor: string;
+  monthlyCapMinor: string;
+}): bigint {
+  const validated = assertAllocationFundingBasis({
+    fundingState: basis.fundingState,
+    committedMinor: basis.committedMinor,
+    monthlyCapMinor: basis.monthlyCapMinor,
+  });
+  if (validated.fundingState !== "committed") return 0n;
+  const committed = BigInt(validated.committedMinor);
+  const cap = BigInt(validated.monthlyCapMinor);
+  return committed < cap ? committed : cap;
+}
+
+export function assertAllocationFundingBasis(
+  value: unknown,
+): AllocationFundingBasis {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError("allocation funding basis must be an object");
+  }
+  const basis = value as Record<string, unknown>;
+  if (
+    Object.keys(basis).sort().join(",") !==
+      "committedMinor,fundingState,monthlyCapMinor" ||
+    (basis.fundingState !== "pledged" && basis.fundingState !== "committed") ||
+    typeof basis.committedMinor !== "string" ||
+    !/^(0|[1-9][0-9]{0,19})$/u.test(basis.committedMinor) ||
+    typeof basis.monthlyCapMinor !== "string" ||
+    !/^(0|[1-9][0-9]{0,19})$/u.test(basis.monthlyCapMinor)
+  ) {
+    throw new TypeError("invalid allocation funding basis");
+  }
+  return {
+    fundingState: basis.fundingState,
+    committedMinor: basis.committedMinor,
+    monthlyCapMinor: basis.monthlyCapMinor,
+  };
+}
+
+export type PromotionCycle = Pick<
+  CycleIndexEntry,
+  "cycleId" | "projectId" | "kind"
+> & { reward: Pick<CycleIndexEntry["reward"], "fundingBasis"> };
+
+/** Missing history cannot authorize promotion; funded projects may resume it. */
+export function projectPromotionEligible(
+  project: ProjectDefinition,
+  cycles: readonly PromotionCycle[] | null,
+): boolean {
+  if (project.reward.kind !== "monthly-pool") return true;
+  if (cycles === null) return false;
+  if (allocationFundingMinor(project.reward) > 0n) return true;
+  const history = cycles
+    .filter(
+      (cycle) =>
+        cycle.projectId === project.id && cycle.kind === "monthly-pool",
+    )
+    .sort((left, right) => right.cycleId.localeCompare(left.cycleId));
+  let consecutive = 0;
+  let previousMonth: number | null = null;
+  for (const cycle of history) {
+    const [year, month] = cycle.cycleId.split("-").map(Number);
+    const monthOrdinal = year * 12 + month;
+    if (previousMonth !== null && monthOrdinal !== previousMonth - 1) break;
+    previousMonth = monthOrdinal;
+    if (
+      cycle.reward.fundingBasis &&
+      allocationFundingMinor(cycle.reward.fundingBasis) > 0n
+    )
+      break;
+    consecutive += 1;
+    if (consecutive >= 2) return false;
+  }
+  return true;
+}

--- a/src/lib/allocation-funding.ts
+++ b/src/lib/allocation-funding.ts
@@ -1,4 +1,6 @@
 /** Frozen monetary basis for new proposals; accepted score is independent. */
+
+import { deriveAllocationFundingBasis } from "./allocation-funding-basis.mjs";
 import type { CycleIndexEntry } from "./cycle-index";
 import type { ProjectDefinition } from "./projects.mjs";
 
@@ -63,14 +65,22 @@ export type PromotionCycle = Pick<
 export function projectPromotionEligible(
   project: ProjectDefinition,
   cycles: readonly PromotionCycle[] | null,
+  displayCycleId: string | null,
 ): boolean {
   if (project.reward.kind !== "monthly-pool") return true;
-  if (cycles === null) return false;
-  if (allocationFundingMinor(project.reward) > 0n) return true;
+  if (cycles === null || displayCycleId === null) return false;
+  if (
+    allocationFundingMinor(
+      deriveAllocationFundingBasis(project, displayCycleId),
+    ) > 0n
+  )
+    return true;
   const history = cycles
     .filter(
       (cycle) =>
-        cycle.projectId === project.id && cycle.kind === "monthly-pool",
+        cycle.projectId === project.id &&
+        cycle.kind === "monthly-pool" &&
+        cycle.cycleId < displayCycleId,
     )
     .sort((left, right) => right.cycleId.localeCompare(left.cycleId));
   let consecutive = 0;

--- a/src/lib/allocation-funding.ts
+++ b/src/lib/allocation-funding.ts
@@ -2,11 +2,11 @@
 import type { CycleIndexEntry } from "./cycle-index";
 import type { ProjectDefinition } from "./projects.mjs";
 
-export interface AllocationFundingBasis {
-  fundingState: "committed" | "pledged";
-  committedMinor: string;
-  monthlyCapMinor: string;
-}
+export type { AllocationFundingBasis } from "./allocation-funding-basis.mjs";
+export {
+  assertAllocationFundingBasis,
+  deriveAllocationFundingBasis,
+} from "./allocation-funding-basis.mjs";
 
 // July is the final historical cap-based cycle. Its artifacts are never rewritten.
 export const LAST_LEGACY_CAP_CYCLE = "2026-07";
@@ -16,7 +16,7 @@ export function allocationFundingMinor(basis: {
   committedMinor: string;
   monthlyCapMinor: string;
 }): bigint {
-  const validated = assertAllocationFundingBasis({
+  const validated = assertFundingAmounts({
     fundingState: basis.fundingState,
     committedMinor: basis.committedMinor,
     monthlyCapMinor: basis.monthlyCapMinor,
@@ -27,9 +27,11 @@ export function allocationFundingMinor(basis: {
   return committed < cap ? committed : cap;
 }
 
-export function assertAllocationFundingBasis(
-  value: unknown,
-): AllocationFundingBasis {
+function assertFundingAmounts(value: unknown): {
+  fundingState: "committed" | "pledged";
+  committedMinor: string;
+  monthlyCapMinor: string;
+} {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     throw new TypeError("allocation funding basis must be an object");
   }

--- a/src/lib/cycle-index.test.ts
+++ b/src/lib/cycle-index.test.ts
@@ -79,6 +79,78 @@ function index(cycles: CycleIndexEntry[] = [entry()]): CycleIndex {
 }
 
 describe("public cycle index", () => {
+  function approvedCarry(
+    shared: bigint,
+    review: bigint | null = null,
+  ): CycleIndex {
+    const value = entry();
+    const total = shared + (review ?? 0n);
+    value.state = "payment-ready";
+    value.approvedAt = "2026-08-16T00:00:00.000Z";
+    value.files.allocation = {
+      sha256: DIGEST,
+      url: "/data/cycles/eliza/2026-07/allocation.json",
+    };
+    value.reward.capMinor = "1000000";
+    value.reward.fundingBasis = {
+      fundingState: "committed",
+      committedMinor: "1000000",
+      monthlyCapMinor: "10000000000",
+    };
+    value.reward.carriedMinor = "2000000";
+    value.reward.suggestedMinor = total.toString();
+    value.reward.approvedMinor = total.toString();
+    value.reward.feeMinor = (total / 100n).toString();
+    value.contributors[0].state = "approved";
+    value.contributors[0].suggestedMinor = total.toString();
+    value.contributors[0].approvedMinor = total.toString();
+    if (review !== null) {
+      value.reward.reviewBudgetCapMinor = "700000";
+      value.reward.lines = {
+        sharedPool: {
+          suggestedMinor: shared.toString(),
+          approvedMinor: shared.toString(),
+          paidMinor: "0",
+        },
+        reviewBudget: {
+          suggestedMinor: review.toString(),
+          approvedMinor: review.toString(),
+          paidMinor: "0",
+        },
+      };
+      value.contributors[0].lines = structuredClone(value.reward.lines);
+    }
+    return { ...index([value]), generatedAt: "2026-08-20T00:00:00.000Z" };
+  }
+
+  it("accepts exactly cap plus carry and rejects one micro-unit more", () => {
+    const exact = approvedCarry(3000000n);
+    expect(() => assertCycleIndex(exact)).not.toThrow();
+    expect(() => assertCycleIndex(approvedCarry(3000001n))).toThrow(
+      /money totals do not reconcile/u,
+    );
+    exact.cycles[0].reward.capMinor = "0";
+    exact.cycles[0].reward.fundingBasis = {
+      fundingState: "pledged",
+      committedMinor: "0",
+      monthlyCapMinor: "10000000000",
+    };
+    exact.cycles[0].reward.carriedMinor = "3000000";
+    expect(() => assertCycleIndex(exact)).not.toThrow();
+  });
+
+  it("applies carry only to the shared-pool cap and independently caps additive review", () => {
+    expect(() =>
+      assertCycleIndex(approvedCarry(3000000n, 700000n)),
+    ).not.toThrow();
+    expect(() => assertCycleIndex(approvedCarry(3000001n, 700000n))).toThrow(
+      /money totals do not reconcile/u,
+    );
+    expect(() => assertCycleIndex(approvedCarry(1000000n, 700001n))).toThrow(
+      /review budget exceeds its separate allocation cap/u,
+    );
+  });
+
   it("accepts a bounded public review state", () => {
     const value: unknown = index();
     expect(() => assertCycleIndex(value)).not.toThrow();
@@ -86,6 +158,7 @@ describe("public cycle index", () => {
 
   it("publishes additive review-budget money as reconciled line items", () => {
     const additive = entry();
+    additive.reward.reviewBudgetCapMinor = "500000000";
     additive.reward.suggestedMinor = "10500000000";
     additive.reward.lines = {
       sharedPool: {

--- a/src/lib/cycle-index.test.ts
+++ b/src/lib/cycle-index.test.ts
@@ -365,6 +365,31 @@ describe("public cycle index", () => {
     });
 
     expect(() => assertCycleIndex(index([external]))).not.toThrow();
+    for (const monthlyFields of [
+      { carriedMinor: "2000000" },
+      { carriedMinor: "0" },
+      {
+        fundingBasis: {
+          fundingState: "committed" as const,
+          committedMinor: "2000000",
+          monthlyCapMinor: "2000000",
+        },
+      },
+      {
+        fundingBasis: {
+          fundingState: "pledged" as const,
+          committedMinor: "0",
+          monthlyCapMinor: "0",
+        },
+      },
+      { reviewBudgetCapMinor: "2000000" },
+    ]) {
+      const invalid = structuredClone(external);
+      Object.assign(invalid.reward, monthlyFields);
+      expect(() => assertCycleIndex(index([invalid]))).toThrow(
+        /reward differs from project policy/u,
+      );
+    }
     const dollarLarp = structuredClone(external);
     dollarLarp.reward.currency = "USDC";
     dollarLarp.reward.capMinor = "1";

--- a/src/lib/cycle-index.test.ts
+++ b/src/lib/cycle-index.test.ts
@@ -93,6 +93,8 @@ describe("public cycle index", () => {
     };
     value.reward.capMinor = "1000000";
     value.reward.fundingBasis = {
+      cycleId: value.cycleId,
+      instrumentId: `sablier-lockup-v4:base:0x${"1".repeat(40)}:1`,
       fundingState: "committed",
       committedMinor: "1000000",
       monthlyCapMinor: "10000000000",
@@ -131,6 +133,8 @@ describe("public cycle index", () => {
     );
     exact.cycles[0].reward.capMinor = "0";
     exact.cycles[0].reward.fundingBasis = {
+      cycleId: "2026-07",
+      instrumentId: null,
       fundingState: "pledged",
       committedMinor: "0",
       monthlyCapMinor: "10000000000",
@@ -371,6 +375,8 @@ describe("public cycle index", () => {
       {
         fundingBasis: {
           fundingState: "committed" as const,
+          cycleId: "2026-07",
+          instrumentId: `sablier-lockup-v4:base:0x${"1".repeat(40)}:1`,
           committedMinor: "2000000",
           monthlyCapMinor: "2000000",
         },
@@ -378,6 +384,8 @@ describe("public cycle index", () => {
       {
         fundingBasis: {
           fundingState: "pledged" as const,
+          cycleId: "2026-07",
+          instrumentId: null,
           committedMinor: "0",
           monthlyCapMinor: "0",
         },

--- a/src/lib/cycle-index.ts
+++ b/src/lib/cycle-index.ts
@@ -8,6 +8,7 @@ import {
   type AllocationFundingBasis,
   allocationFundingMinor,
   assertAllocationFundingBasis,
+  LAST_LEGACY_CAP_CYCLE,
 } from "./allocation-funding";
 import { findProject } from "./projects.mjs";
 import { isSolanaAddress, WALLET_CLAIM_REPOSITORY } from "./wallets";
@@ -739,6 +740,10 @@ function cycleEntry(value: unknown, index: number): CycleIndexEntry {
   }
   const isExternal = entry.kind === "external-prize-share";
   const hasExternalMoney =
+    hasFundingBasis ||
+    hasCarry ||
+    hasReviewBudgetCap ||
+    hasRewardLines ||
     normalizedReward.currency !== null ||
     normalizedReward.capMinor !== "0" ||
     normalizedReward.suggestedMinor !== "0" ||
@@ -750,7 +755,9 @@ function cycleEntry(value: unknown, index: number): CycleIndexEntry {
     normalizedReward.capMinor !==
       (normalizedReward.fundingBasis
         ? allocationFundingMinor(normalizedReward.fundingBasis).toString()
-        : project.reward.monthlyCapMinor) ||
+        : cycleId <= LAST_LEGACY_CAP_CYCLE
+          ? normalizedReward.capMinor
+          : project.reward.monthlyCapMinor) ||
     normalizedReward.sharePartsPerMillion !== null ||
     BigInt(normalizedReward.feeMinor) !==
       (BigInt(normalizedReward.approvedMinor) *

--- a/src/lib/cycle-index.ts
+++ b/src/lib/cycle-index.ts
@@ -6,6 +6,7 @@
 
 import {
   type AllocationFundingBasis,
+  allocationFundingMinor,
   assertAllocationFundingBasis,
 } from "./allocation-funding";
 import { findProject } from "./projects.mjs";
@@ -74,6 +75,7 @@ export interface CycleIndexEntry {
   reward: {
     fundingBasis?: AllocationFundingBasis;
     carriedMinor?: string;
+    reviewBudgetCapMinor?: string;
     currency: "USDC" | null;
     capMinor: string;
     suggestedMinor: string;
@@ -476,6 +478,7 @@ function cycleEntry(value: unknown, index: number): CycleIndexEntry {
   const hasRewardLines = "lines" in reward;
   const hasFundingBasis = "fundingBasis" in reward;
   const hasCarry = "carriedMinor" in reward;
+  const hasReviewBudgetCap = "reviewBudgetCapMinor" in reward;
   exact(
     reward,
     [
@@ -489,6 +492,7 @@ function cycleEntry(value: unknown, index: number): CycleIndexEntry {
       ...(hasRewardLines ? ["lines"] : []),
       ...(hasFundingBasis ? ["fundingBasis"] : []),
       ...(hasCarry ? ["carriedMinor"] : []),
+      ...(hasReviewBudgetCap ? ["reviewBudgetCapMinor"] : []),
     ],
     `${field}.reward`,
   );
@@ -505,6 +509,14 @@ function cycleEntry(value: unknown, index: number): CycleIndexEntry {
     throw new TypeError(`${field}.reward.sharePartsPerMillion is invalid`);
   }
   const normalizedReward = {
+    ...(hasReviewBudgetCap
+      ? {
+          reviewBudgetCapMinor: minor(
+            reward.reviewBudgetCapMinor,
+            `${field}.reward.reviewBudgetCapMinor`,
+          ),
+        }
+      : {}),
     ...(hasCarry
       ? {
           carriedMinor: minor(
@@ -558,6 +570,18 @@ function cycleEntry(value: unknown, index: number): CycleIndexEntry {
     BigInt(normalizedReward.paidMinor) > BigInt(normalizedReward.approvedMinor)
   ) {
     throw new TypeError(`${field}.reward money totals do not reconcile`);
+  }
+  if (
+    normalizedReward.lines &&
+    (normalizedReward.reviewBudgetCapMinor === undefined ||
+      BigInt(normalizedReward.lines.reviewBudget.approvedMinor) >
+        BigInt(normalizedReward.reviewBudgetCapMinor) ||
+      BigInt(normalizedReward.lines.reviewBudget.suggestedMinor) >
+        BigInt(normalizedReward.reviewBudgetCapMinor))
+  ) {
+    throw new TypeError(
+      `${field}.review budget exceeds its separate allocation cap`,
+    );
   }
   if (!Array.isArray(entry.contributors)) {
     throw new TypeError(`${field}.contributors must be an array`);
@@ -723,7 +747,10 @@ function cycleEntry(value: unknown, index: number): CycleIndexEntry {
     normalizedReward.feeMinor !== "0";
   const hasMonthlyPolicyMismatch =
     normalizedReward.currency !== "USDC" ||
-    normalizedReward.capMinor !== project.reward.monthlyCapMinor ||
+    normalizedReward.capMinor !==
+      (normalizedReward.fundingBasis
+        ? allocationFundingMinor(normalizedReward.fundingBasis).toString()
+        : project.reward.monthlyCapMinor) ||
     normalizedReward.sharePartsPerMillion !== null ||
     BigInt(normalizedReward.feeMinor) !==
       (BigInt(normalizedReward.approvedMinor) *

--- a/src/lib/cycle-index.ts
+++ b/src/lib/cycle-index.ts
@@ -4,6 +4,10 @@
  * files while this index drives lifecycle labels and aggregate totals.
  */
 
+import {
+  type AllocationFundingBasis,
+  assertAllocationFundingBasis,
+} from "./allocation-funding";
 import { findProject } from "./projects.mjs";
 import { isSolanaAddress, WALLET_CLAIM_REPOSITORY } from "./wallets";
 
@@ -68,6 +72,8 @@ export interface CycleIndexEntry {
   approvedAt: string | null;
   settledAt: string | null;
   reward: {
+    fundingBasis?: AllocationFundingBasis;
+    carriedMinor?: string;
     currency: "USDC" | null;
     capMinor: string;
     suggestedMinor: string;
@@ -468,6 +474,8 @@ function cycleEntry(value: unknown, index: number): CycleIndexEntry {
   }
   const reward = record(entry.reward, `${field}.reward`);
   const hasRewardLines = "lines" in reward;
+  const hasFundingBasis = "fundingBasis" in reward;
+  const hasCarry = "carriedMinor" in reward;
   exact(
     reward,
     [
@@ -479,6 +487,8 @@ function cycleEntry(value: unknown, index: number): CycleIndexEntry {
       "sharePartsPerMillion",
       "suggestedMinor",
       ...(hasRewardLines ? ["lines"] : []),
+      ...(hasFundingBasis ? ["fundingBasis"] : []),
+      ...(hasCarry ? ["carriedMinor"] : []),
     ],
     `${field}.reward`,
   );
@@ -495,6 +505,17 @@ function cycleEntry(value: unknown, index: number): CycleIndexEntry {
     throw new TypeError(`${field}.reward.sharePartsPerMillion is invalid`);
   }
   const normalizedReward = {
+    ...(hasCarry
+      ? {
+          carriedMinor: minor(
+            reward.carriedMinor,
+            `${field}.reward.carriedMinor`,
+          ),
+        }
+      : {}),
+    ...(hasFundingBasis
+      ? { fundingBasis: assertAllocationFundingBasis(reward.fundingBasis) }
+      : {}),
     currency: reward.currency as "USDC" | null,
     capMinor: minor(reward.capMinor, `${field}.reward.capMinor`),
     suggestedMinor: minor(
@@ -528,10 +549,12 @@ function cycleEntry(value: unknown, index: number): CycleIndexEntry {
   if (
     (!normalizedReward.lines &&
       BigInt(normalizedReward.approvedMinor) >
-        BigInt(normalizedReward.capMinor)) ||
+        BigInt(normalizedReward.capMinor) +
+          BigInt(normalizedReward.carriedMinor ?? "0")) ||
     (normalizedReward.lines &&
       BigInt(normalizedReward.lines.sharedPool.approvedMinor) >
-        BigInt(normalizedReward.capMinor)) ||
+        BigInt(normalizedReward.capMinor) +
+          BigInt(normalizedReward.carriedMinor ?? "0")) ||
     BigInt(normalizedReward.paidMinor) > BigInt(normalizedReward.approvedMinor)
   ) {
     throw new TypeError(`${field}.reward money totals do not reconcile`);

--- a/src/lib/cycle-index.ts
+++ b/src/lib/cycle-index.ts
@@ -751,6 +751,9 @@ function cycleEntry(value: unknown, index: number): CycleIndexEntry {
     normalizedReward.paidMinor !== "0" ||
     normalizedReward.feeMinor !== "0";
   const hasMonthlyPolicyMismatch =
+    (!normalizedReward.fundingBasis && cycleId > LAST_LEGACY_CAP_CYCLE) ||
+    (normalizedReward.fundingBasis !== undefined &&
+      normalizedReward.fundingBasis.cycleId !== cycleId) ||
     normalizedReward.currency !== "USDC" ||
     normalizedReward.capMinor !==
       (normalizedReward.fundingBasis

--- a/src/lib/exact-cycle-funding.test.ts
+++ b/src/lib/exact-cycle-funding.test.ts
@@ -1,0 +1,263 @@
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { validateProposalFundingTransitions } from "../../scripts/check-project-transitions.mjs";
+import { loadPriorCycleAccrual } from "../../scripts/prior-cycle-accrual";
+import { snapshotFixture } from "../../tests/fixtures";
+import {
+  assertAllocationFundingBasis,
+  deriveAllocationFundingBasis,
+} from "./allocation-funding";
+import { assertProjectDefinition } from "./project-schema.mjs";
+import * as projects from "./projects.mjs";
+import { createRewardCycleProposal } from "./reward-cycle";
+import { finalizeRewardAllocation } from "./reward-finalization";
+import { assertRewardAllocationManifest } from "./rewards";
+
+const original = projects.findProject("eliza") as projects.ProjectDefinition;
+function fundedProject() {
+  return assertProjectDefinition({
+    ...original,
+    reward: {
+      ...original.reward,
+      fundingState: "committed",
+      committedMinor: "5000000",
+      paymentMode: "disabled",
+    },
+    funding: {
+      ...original.funding,
+      commitments: [
+        {
+          kind: "squads-v4-vault",
+          network: "solana",
+          asset: "USDC",
+          multisig: "11111111111111111111111111111111",
+          vault: "Vote111111111111111111111111111111111111111",
+          vaultIndex: 0,
+          funderMember: "Stake11111111111111111111111111111111111111",
+          stewardMember: "SysvarRent111111111111111111111111111111111",
+          funderActorId: "18633264",
+          stewardGithub: {
+            actorId: "42",
+            nodeId: "U_fixture_42",
+            login: "independent-fixture",
+          },
+          monthlyCommitment: {
+            cycleId: "2026-08",
+            amountMinor: "5000000",
+            accessibility: "unknown",
+          },
+          effectiveAt: "2026-08-01T00:00:00.000Z",
+          deadline: "2026-09-01T00:00:00.000Z",
+          replacedAt: null,
+        },
+      ],
+    },
+  });
+}
+function proposal(cycleId: string) {
+  const snapshot = snapshotFixture();
+  const next = cycleId === "2026-07" ? "2026-08" : "2026-09";
+  snapshot.window = {
+    days: 35,
+    from:
+      cycleId === "2026-07"
+        ? "2026-06-28T00:00:00.000Z"
+        : "2026-07-28T00:00:00.000Z",
+    to: `${next}-02T00:00:00.000Z`,
+  };
+  snapshot.source.verificationWindow = { ...snapshot.window };
+  snapshot.ledger = snapshot.ledger.map((event) => ({
+    ...event,
+    occurredAt: event.occurredAt.replace("2026-07", cycleId),
+  }));
+  const result = createRewardCycleProposal({
+    cycleId,
+    generatedAt: `${next}-02T00:00:00.000Z`,
+    projectId: "eliza",
+    snapshot,
+    sourceSnapshotSha256: "a".repeat(64),
+  });
+  if (result.kind !== "reward-allocation") throw new Error("wrong proposal");
+  return result;
+}
+afterEach(() => vi.restoreAllMocks());
+describe("exact-cycle reviewed funding", () => {
+  it("does not borrow a later month's instrument and freezes exact-month identity", () => {
+    const project = fundedProject();
+    vi.spyOn(projects, "findProject").mockReturnValue(project);
+    expect(proposal("2026-07").capMinor).toBe("0");
+    const august = proposal("2026-08");
+    expect(august.capMinor).toBe("5000000");
+    const unbound = structuredClone(august);
+    delete unbound.fundingBasis;
+    expect(() => assertRewardAllocationManifest(unbound)).toThrow(
+      /exact-cycle funding basis/u,
+    );
+    expect(august.fundingBasis).toMatchObject({
+      cycleId: "2026-08",
+      instrumentId:
+        "squads-v4-vault:solana:11111111111111111111111111111111:0:Vote111111111111111111111111111111111111111",
+    });
+    expect(
+      deriveAllocationFundingBasis(project, "2026-09").committedMinor,
+    ).toBe("0");
+    const altered = structuredClone(august);
+    if (!altered.fundingBasis) throw new Error("missing basis");
+    altered.fundingBasis.cycleId = "2026-09";
+    expect(() => assertRewardAllocationManifest(altered)).toThrow(
+      /basis cycle/u,
+    );
+    expect(() =>
+      finalizeRewardAllocation(
+        altered,
+        "2026-09-17T00:00:00.000Z",
+        Date.parse("2026-09-17T00:00:00.000Z"),
+      ),
+    ).toThrow(/basis cycle/u);
+    expect(() =>
+      assertAllocationFundingBasis({
+        ...august.fundingBasis,
+        instrumentId: null,
+      }),
+    ).toThrow(/funding basis/u);
+    const instrument = project.funding.commitments?.[0];
+    if (!instrument) throw new Error("missing instrument");
+    expect(
+      deriveAllocationFundingBasis(
+        {
+          ...project,
+          funding: {
+            ...project.funding,
+            commitments: [
+              { ...instrument, replacedAt: "2026-09-01T00:00:00.000Z" },
+            ],
+          },
+        },
+        "2026-08",
+      ).committedMinor,
+    ).toBe("0");
+    expect(() =>
+      deriveAllocationFundingBasis(
+        {
+          ...project,
+          funding: {
+            ...project.funding,
+            commitments: [instrument, instrument],
+          },
+        },
+        "2026-08",
+      ),
+    ).toThrow(/ambiguous/u);
+  });
+  it("transition authority rejects month substitution, changed instruments and self-declared principal", () => {
+    const project = fundedProject();
+    const entry = (value: unknown): [string, string] => [
+      "projects/eliza/project.json",
+      JSON.stringify(value),
+    ];
+    const check = (cycleId: string, basis: unknown, next = project) =>
+      validateProposalFundingTransitions(
+        [entry(project)],
+        [entry(next)],
+        [],
+        [
+          [
+            `cycles/eliza/${cycleId}/proposal.json`,
+            JSON.stringify({
+              kind: "reward-allocation",
+              projectId: "eliza",
+              cycleId,
+              fundingBasis: basis,
+            }),
+          ],
+        ],
+      );
+    const august = deriveAllocationFundingBasis(project, "2026-08");
+    expect(() => check("2026-08", august)).not.toThrow();
+    expect(() =>
+      check("2026-07", deriveAllocationFundingBasis(project, "2026-07")),
+    ).not.toThrow();
+    expect(() => check("2026-07", { ...august, cycleId: "2026-07" })).toThrow(
+      /immutable base/u,
+    );
+    expect(() =>
+      check("2026-08", { ...august, instrumentId: `${august.instrumentId}1` }),
+    ).toThrow(/immutable base/u);
+    const instrument = project.funding.commitments?.[0];
+    if (!instrument) throw new Error("missing instrument");
+    const changed = {
+      ...project,
+      funding: {
+        ...project.funding,
+        commitments: [{ ...instrument, vaultIndex: 1 }],
+      },
+    };
+    expect(() => check("2026-08", august, changed)).toThrow(
+      /separate reviewed/u,
+    );
+  });
+  it.each(["unclaimed", "held-below-minimum"] as const)(
+    "carries only shared principal from %s additive rows",
+    async (state) => {
+      const funded = fundedProject();
+      // Future reviewed accessibility authority is not available today. Inject only
+      // a deterministic policy fixture to exercise the legacy line-aware reader.
+      const project = {
+        ...funded,
+        reward: {
+          ...funded.reward,
+          reviewBudget: {
+            effectiveAt: "2026-08-01T00:00:00.000Z",
+            fundingState: "committed" as const,
+            paymentMode: "enabled" as const,
+            monthlyCapMinor: "1000000",
+            monthlyCapDisplay: "$1",
+            committedMinor: "1000000",
+            unusedFunds: "rollover-without-cap-increase" as const,
+          },
+        },
+      };
+      vi.spyOn(projects, "findProject").mockReturnValue(project);
+      const result = proposal("2026-08");
+      const row = result.allocations[0];
+      row.state = state;
+      row.suggestedMinor = "1500000";
+      row.accruedMinor = "1500000";
+      row.lines = {
+        sharedPool: { suggestedMinor: "1000000", approvedMinor: "0" },
+        reviewBudget: {
+          suggestedMinor: "500000",
+          approvedMinor: "0",
+          evidenceEventIds: row.evidenceEventIds,
+        },
+      };
+      result.rewardLines = {
+        sharedPool: {
+          capMinor: "5000000",
+          suggestedMinor: "1000000",
+          approvedMinor: "0",
+        },
+        reviewBudget: {
+          capMinor: "1000000",
+          committedMinor: "1000000",
+          suggestedMinor: "500000",
+          approvedMinor: "0",
+        },
+      };
+      result.totals.suggestedMinor = "1500000";
+      const root = await mkdtemp(join(tmpdir(), "slop-shared-carry-"));
+      const directory = join(root, "eliza", "2026-08");
+      await mkdir(directory, { recursive: true });
+      await writeFile(join(directory, "proposal.json"), JSON.stringify(result));
+      const carry = await loadPriorCycleAccrual({
+        cyclesRoot: root,
+        projectId: "eliza",
+        cycleId: "2026-09",
+        asOf: "2026-09-18T00:00:00.000Z",
+      });
+      expect([...carry.accruedMinor.values()]).toEqual(["1000000"]);
+    },
+  );
+});

--- a/src/lib/exact-cycle-funding.test.ts
+++ b/src/lib/exact-cycle-funding.test.ts
@@ -8,6 +8,7 @@ import { snapshotFixture } from "../../tests/fixtures";
 import {
   assertAllocationFundingBasis,
   deriveAllocationFundingBasis,
+  projectPromotionEligible,
 } from "./allocation-funding";
 import { assertProjectDefinition } from "./project-schema.mjs";
 import * as projects from "./projects.mjs";
@@ -84,6 +85,55 @@ function proposal(cycleId: string) {
 }
 afterEach(() => vi.restoreAllMocks());
 describe("exact-cycle reviewed funding", () => {
+  it("keeps September promotion paused when only June was funded", () => {
+    const project = fundedProject();
+    const instrument = project.funding.commitments?.[0];
+    if (!instrument?.monthlyCommitment) throw new Error("missing instrument");
+    const june = assertProjectDefinition({
+      ...project,
+      funding: {
+        ...project.funding,
+        commitments: [
+          {
+            ...instrument,
+            effectiveAt: "2026-06-01T00:00:00.000Z",
+            deadline: "2026-07-01T00:00:00.000Z",
+            monthlyCommitment: {
+              ...instrument.monthlyCommitment,
+              cycleId: "2026-06",
+            },
+          },
+        ],
+      },
+    });
+    const history = ["2026-07", "2026-08"].map((cycleId) => ({
+      projectId: project.id,
+      cycleId,
+      kind: "monthly-pool" as const,
+      reward: { fundingBasis: deriveAllocationFundingBasis(june, cycleId) },
+    }));
+    expect(projectPromotionEligible(june, history, "2026-09")).toBe(false);
+    expect(projectPromotionEligible(june, history, null)).toBe(false);
+    expect(projectPromotionEligible(june, [], "2026-06")).toBe(true);
+    const september = assertProjectDefinition({
+      ...project,
+      funding: {
+        ...project.funding,
+        commitments: [
+          {
+            ...instrument,
+            effectiveAt: "2026-09-01T00:00:00.000Z",
+            deadline: "2026-10-01T00:00:00.000Z",
+            monthlyCommitment: {
+              ...instrument.monthlyCommitment,
+              cycleId: "2026-09",
+            },
+          },
+        ],
+      },
+    });
+    expect(projectPromotionEligible(september, history, "2026-09")).toBe(true);
+  });
   it("does not borrow a later month's instrument and freezes exact-month identity", () => {
     const project = fundedProject();
     vi.spyOn(projects, "findProject").mockReturnValue(project);

--- a/src/lib/legacy-funding.test.ts
+++ b/src/lib/legacy-funding.test.ts
@@ -1,0 +1,36 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it, vi } from "vitest";
+import { assertCycleIndex } from "./cycle-index";
+import { assertRewardAllocationManifest } from "./rewards";
+
+vi.mock("./projects.mjs", async (importOriginal) => {
+  const original = await importOriginal<typeof import("./projects.mjs")>();
+  return {
+    ...original,
+    findProject(id: Parameters<typeof original.findProject>[0]) {
+      const project = original.findProject(id);
+      return (
+        project && {
+          ...project,
+          reward: { ...project.reward, monthlyCapMinor: "20000000000" },
+        }
+      );
+    },
+  };
+});
+
+describe("immutable historical funding basis", () => {
+  it("keeps unchanged July proposal and public index valid after a project cap change", async () => {
+    const path = "cycles/eliza/2026-07/proposal.json";
+    const bytes = await readFile(path);
+    const proposal = JSON.parse(bytes.toString("utf8"));
+    expect(proposal.capMinor).toBe("10000000000");
+    expect(proposal.fundingBasis).toBeUndefined();
+    expect(() => assertRewardAllocationManifest(proposal)).not.toThrow();
+    const index = JSON.parse(
+      await readFile("public/data/cycles/index.json", "utf8"),
+    );
+    expect(() => assertCycleIndex(index)).not.toThrow();
+    expect(await readFile(path)).toEqual(bytes);
+  });
+});

--- a/src/lib/project-view.test.ts
+++ b/src/lib/project-view.test.ts
@@ -94,8 +94,8 @@ describe("project views", () => {
 
     expect(eliza.leaders[0]).toMatchObject({
       score: 24,
-      projectedMinor: "10000000000",
-      projectedDisplayMinor: "10000000000",
+      projectedMinor: "0",
+      projectedDisplayMinor: "0",
       projectedSharePartsPerMillion: null,
     });
     expect(eliza.ledger).toHaveLength(6);
@@ -104,8 +104,8 @@ describe("project views", () => {
     ).toBe(true);
     expect(eliza.reward).toMatchObject({
       kind: "monthly-pool",
-      projectedPrincipalMinor: "10000000000",
-      platformFeeMinor: "100000000",
+      projectedPrincipalMinor: "0",
+      platformFeeMinor: "0",
     });
 
     expect(delta.leaders[0]).toMatchObject({
@@ -372,7 +372,11 @@ describe("project views", () => {
       reason: "Pull request merged during the rolling window.",
     });
 
-    const view = createProjectView(snapshot, "eliza", "2026-07");
+    const view = createProjectView(snapshot, "eliza", "2026-07", {
+      fundingState: "committed",
+      committedMinor: "10000000000",
+      monthlyCapMinor: "10000000000",
+    });
     expect(
       view.leaders.reduce(
         (total, entry) => total + BigInt(entry.projectedMinor ?? "0"),

--- a/src/lib/project-view.ts
+++ b/src/lib/project-view.ts
@@ -4,6 +4,10 @@
  * trace can earn a fixed evidence bonus; token usage never changes scoring.
  */
 
+import {
+  type AllocationFundingBasis,
+  allocationFundingMinor,
+} from "./allocation-funding";
 import type {
   CapUsageStatus,
   GitHubActor,
@@ -517,6 +521,7 @@ export function createProjectView(
   snapshot: LeaderboardSnapshot,
   projectId: ProjectId,
   requestedCycleId?: string,
+  fundingBasis?: AllocationFundingBasis,
 ): ProjectView {
   const project = findProject(projectId);
   if (!project) throw new TypeError(`Unknown project: ${projectId}`);
@@ -637,7 +642,9 @@ export function createProjectView(
 
   let reward: ProjectRewardProjection;
   if (project.reward.kind === "monthly-pool") {
-    const monthlyCapMinor = BigInt(project.reward.monthlyCapMinor);
+    const monthlyCapMinor = allocationFundingMinor(
+      fundingBasis ?? project.reward,
+    );
     const projected = allocateIntegerTotal(monthlyCapMinor, leaders);
     const projectedCents = allocateIntegerTotal(
       monthlyCapMinor / 10_000n,
@@ -658,8 +665,7 @@ export function createProjectView(
         .reduce((total, amount) => total + amount, 0n)
         .toString(),
       platformFeeMinor: (
-        (BigInt(project.reward.monthlyCapMinor) *
-          BigInt(project.reward.feeBasisPoints)) /
+        (monthlyCapMinor * BigInt(project.reward.feeBasisPoints)) /
         10_000n
       ).toString(),
       status: "simulation",

--- a/src/lib/project-view.ts
+++ b/src/lib/project-view.ts
@@ -7,6 +7,7 @@
 import {
   type AllocationFundingBasis,
   allocationFundingMinor,
+  deriveAllocationFundingBasis,
 } from "./allocation-funding";
 import type {
   CapUsageStatus,
@@ -521,7 +522,10 @@ export function createProjectView(
   snapshot: LeaderboardSnapshot,
   projectId: ProjectId,
   requestedCycleId?: string,
-  fundingBasis?: AllocationFundingBasis,
+  fundingBasis?: Pick<
+    AllocationFundingBasis,
+    "fundingState" | "committedMinor" | "monthlyCapMinor"
+  >,
 ): ProjectView {
   const project = findProject(projectId);
   if (!project) throw new TypeError(`Unknown project: ${projectId}`);
@@ -643,7 +647,7 @@ export function createProjectView(
   let reward: ProjectRewardProjection;
   if (project.reward.kind === "monthly-pool") {
     const monthlyCapMinor = allocationFundingMinor(
-      fundingBasis ?? project.reward,
+      fundingBasis ?? deriveAllocationFundingBasis(project, cycleId),
     );
     const projected = allocateIntegerTotal(monthlyCapMinor, leaders);
     const projectedCents = allocateIntegerTotal(

--- a/src/lib/reward-cycle.test.ts
+++ b/src/lib/reward-cycle.test.ts
@@ -2,6 +2,8 @@
 
 import { describe, expect, it } from "vitest";
 import { snapshotFixture } from "../../tests/fixtures";
+import { projectPromotionEligible } from "./allocation-funding";
+import { findProject } from "./projects.mjs";
 import {
   additiveReviewBudgetWeights,
   allocateReviewBudgetMinor,
@@ -32,6 +34,55 @@ function wallet(): WalletProof {
 }
 
 describe("reward cycle proposals", () => {
+  it("closes a third unfunded cycle with score and evidence while promotion is paused", () => {
+    const project = findProject("eliza");
+    if (!project) throw new Error("Missing Eliza fixture");
+    const basis = {
+      fundingState: "pledged" as const,
+      committedMinor: "0",
+      monthlyCapMinor: project.reward.monthlyCapMinor,
+    };
+    expect(
+      projectPromotionEligible(
+        project,
+        ["2026-07", "2026-08"].map((cycleId) => ({
+          projectId: project.id,
+          cycleId,
+          kind: "monthly-pool" as const,
+          reward: { fundingBasis: basis },
+        })),
+      ),
+    ).toBe(false);
+    const snapshot = closedSnapshot();
+    snapshot.window = {
+      days: 35,
+      from: "2026-08-28T00:00:00.000Z",
+      to: "2026-10-02T00:00:00.000Z",
+    };
+    snapshot.source.verificationWindow = {
+      days: 35,
+      from: snapshot.window.from,
+      to: snapshot.window.to,
+    };
+    snapshot.ledger = snapshot.ledger.map((event) => ({
+      ...event,
+      occurredAt: event.occurredAt.replace("2026-07", "2026-09"),
+    }));
+    const original = JSON.stringify(snapshot);
+    const proposal = createRewardCycleProposal({
+      cycleId: "2026-09",
+      generatedAt: "2026-10-02T00:00:00.000Z",
+      projectId: "eliza",
+      snapshot,
+      sourceSnapshotSha256: SOURCE_SHA,
+    });
+    if (proposal.kind !== "reward-allocation")
+      throw new Error("wrong proposal");
+    expect(proposal.totals.suggestedMinor).toBe("0");
+    expect(proposal.allocations[0].score).toBeGreaterThan(0);
+    expect(proposal.allocations[0].evidenceEventIds.length).toBeGreaterThan(0);
+    expect(JSON.stringify(snapshot)).toBe(original);
+  });
   it("allocates an additive review line with deterministic largest remainder", () => {
     expect(
       Object.fromEntries(
@@ -91,7 +142,7 @@ describe("reward cycle proposals", () => {
     ).toEqual({ "actor-a": 5n, "actor-b": 5n });
   });
 
-  it("proposes the exact Eliza pool without approving a payment", () => {
+  it("preserves scored contributors in an unfunded zero-dollar proposal", () => {
     const wallets = new Map([["U_fixture", wallet()]]);
     const proposal = createRewardCycleProposal({
       cycleId: "2026-07",
@@ -108,12 +159,12 @@ describe("reward cycle proposals", () => {
     expect(proposal.totals).toEqual({
       approvedMinor: "0",
       feeMinor: "0",
-      suggestedMinor: "10000000000",
+      suggestedMinor: "0",
     });
     expect(proposal.allocations[0]).toMatchObject({
       approvedMinor: "0",
-      state: "proposed",
-      suggestedMinor: "10000000000",
+      state: "held-below-minimum",
+      suggestedMinor: "0",
       wallet: wallet(),
     });
     expect(proposal.review.endsAt).toBe("2026-08-16T00:00:00.000Z");

--- a/src/lib/reward-cycle.test.ts
+++ b/src/lib/reward-cycle.test.ts
@@ -53,6 +53,7 @@ describe("reward cycle proposals", () => {
           kind: "monthly-pool" as const,
           reward: { fundingBasis: { ...basis, cycleId } },
         })),
+        "2026-09",
       ),
     ).toBe(false);
     const snapshot = closedSnapshot();

--- a/src/lib/reward-cycle.test.ts
+++ b/src/lib/reward-cycle.test.ts
@@ -38,6 +38,8 @@ describe("reward cycle proposals", () => {
     const project = findProject("eliza");
     if (!project) throw new Error("Missing Eliza fixture");
     const basis = {
+      cycleId: "2026-09",
+      instrumentId: null,
       fundingState: "pledged" as const,
       committedMinor: "0",
       monthlyCapMinor: project.reward.monthlyCapMinor,
@@ -49,7 +51,7 @@ describe("reward cycle proposals", () => {
           projectId: project.id,
           cycleId,
           kind: "monthly-pool" as const,
-          reward: { fundingBasis: basis },
+          reward: { fundingBasis: { ...basis, cycleId } },
         })),
       ),
     ).toBe(false);

--- a/src/lib/reward-cycle.ts
+++ b/src/lib/reward-cycle.ts
@@ -4,9 +4,14 @@
  * human review and on-chain settlement remain separate, auditable transitions.
  */
 
+import {
+  type AllocationFundingBasis,
+  allocationFundingMinor,
+} from "./allocation-funding";
 import type { LeaderboardSnapshot } from "./leaderboard";
 import { createProjectView } from "./project-view";
 import type { ProjectId } from "./projects.mjs";
+import { findProject } from "./projects.mjs";
 import {
   assertExternalContributionShareManifest,
   assertRewardAllocationManifest,
@@ -32,6 +37,7 @@ export interface CreateRewardCycleProposalInput {
   wallets?: ReadonlyMap<string, WalletProof>;
   priorAccruedMinor?: ReadonlyMap<string, string>;
   priorActorLogins?: ReadonlyMap<string, string>;
+  fundingBasis?: AllocationFundingBasis;
 }
 
 export function allocateReviewBudgetMinor(
@@ -181,10 +187,23 @@ function ensureCompleteCycle(
 export function createRewardCycleProposal(
   input: CreateRewardCycleProposalInput,
 ): RewardCycleProposal {
+  const project = findProject(input.projectId);
+  const fundingBasis: AllocationFundingBasis | undefined =
+    project?.reward.kind === "monthly-pool"
+      ? (input.fundingBasis ?? {
+          fundingState:
+            project.reward.fundingState === "committed"
+              ? "committed"
+              : "pledged",
+          committedMinor: project.reward.committedMinor,
+          monthlyCapMinor: project.reward.monthlyCapMinor,
+        })
+      : undefined;
   const view = createProjectView(
     input.snapshot,
     input.projectId,
     input.cycleId,
+    fundingBasis,
   );
   ensureCompleteCycle(input, view);
 
@@ -215,8 +234,9 @@ export function createRewardCycleProposal(
     });
   }
 
-  // Accrual is a debt to the actor, not a reward for this cycle's activity:
-  // a positive prior balance must survive a quiet month, so carried-only
+  if (!fundingBasis)
+    throw new TypeError("Monthly proposal needs a funding basis");
+  // A previously reviewed balance survives a quiet month, so carried-only
   // actors get their own allocation rows after the leaders.
   const leaderIds = new Set(view.leaders.map((leader) => leader.actor.id));
   const carriedOnly = [...(input.priorAccruedMinor ?? [])]
@@ -289,7 +309,8 @@ export function createRewardCycleProposal(
     },
     currency: "USDC",
     chain: "solana",
-    capMinor: view.project.reward.monthlyCapMinor,
+    capMinor: allocationFundingMinor(fundingBasis).toString(),
+    fundingBasis,
     carriedMinor,
     minimumTransferMinor: MINIMUM_TRANSFER_MINOR,
     feeBasisPoints: view.project.reward.feeBasisPoints,
@@ -386,7 +407,7 @@ export function createRewardCycleProposal(
       ? {
           rewardLines: {
             sharedPool: {
-              capMinor: view.project.reward.monthlyCapMinor,
+              capMinor: allocationFundingMinor(fundingBasis).toString(),
               suggestedMinor,
               approvedMinor: "0",
             },

--- a/src/lib/reward-cycle.ts
+++ b/src/lib/reward-cycle.ts
@@ -7,6 +7,9 @@
 import {
   type AllocationFundingBasis,
   allocationFundingMinor,
+  assertAllocationFundingBasis,
+  deriveAllocationFundingBasis,
+  LAST_LEGACY_CAP_CYCLE,
 } from "./allocation-funding";
 import type { LeaderboardSnapshot } from "./leaderboard";
 import { createProjectView } from "./project-view";
@@ -38,6 +41,8 @@ export interface CreateRewardCycleProposalInput {
   priorAccruedMinor?: ReadonlyMap<string, string>;
   priorActorLogins?: ReadonlyMap<string, string>;
   fundingBasis?: AllocationFundingBasis;
+  /** Reconstruction only: immutable trial records predate instrument binding. */
+  legacyCapMinor?: string;
 }
 
 export function allocateReviewBudgetMinor(
@@ -190,20 +195,30 @@ export function createRewardCycleProposal(
   const project = findProject(input.projectId);
   const fundingBasis: AllocationFundingBasis | undefined =
     project?.reward.kind === "monthly-pool"
-      ? (input.fundingBasis ?? {
-          fundingState:
-            project.reward.fundingState === "committed"
-              ? "committed"
-              : "pledged",
-          committedMinor: project.reward.committedMinor,
-          monthlyCapMinor: project.reward.monthlyCapMinor,
-        })
+      ? input.fundingBasis
+        ? assertAllocationFundingBasis(input.fundingBasis)
+        : deriveAllocationFundingBasis(project, input.cycleId)
       : undefined;
+  if (fundingBasis && fundingBasis.cycleId !== input.cycleId)
+    throw new TypeError("funding basis cycle differs from proposal cycle");
+  if (
+    input.legacyCapMinor !== undefined &&
+    (input.cycleId > LAST_LEGACY_CAP_CYCLE || input.fundingBasis)
+  )
+    throw new TypeError(
+      "legacy cap reconstruction is restricted to historical trials",
+    );
   const view = createProjectView(
     input.snapshot,
     input.projectId,
     input.cycleId,
-    fundingBasis,
+    input.legacyCapMinor === undefined
+      ? fundingBasis
+      : {
+          fundingState: "committed",
+          committedMinor: input.legacyCapMinor,
+          monthlyCapMinor: input.legacyCapMinor,
+        },
   );
   ensureCompleteCycle(input, view);
 
@@ -309,8 +324,9 @@ export function createRewardCycleProposal(
     },
     currency: "USDC",
     chain: "solana",
-    capMinor: allocationFundingMinor(fundingBasis).toString(),
-    fundingBasis,
+    capMinor:
+      input.legacyCapMinor ?? allocationFundingMinor(fundingBasis).toString(),
+    ...(input.legacyCapMinor === undefined ? { fundingBasis } : {}),
     carriedMinor,
     minimumTransferMinor: MINIMUM_TRANSFER_MINOR,
     feeBasisPoints: view.project.reward.feeBasisPoints,
@@ -407,7 +423,9 @@ export function createRewardCycleProposal(
       ? {
           rewardLines: {
             sharedPool: {
-              capMinor: allocationFundingMinor(fundingBasis).toString(),
+              capMinor:
+                input.legacyCapMinor ??
+                allocationFundingMinor(fundingBasis).toString(),
               suggestedMinor,
               approvedMinor: "0",
             },

--- a/src/lib/rewards.test.ts
+++ b/src/lib/rewards.test.ts
@@ -39,6 +39,13 @@ function allocationManifest() {
     currency: "USDC",
     chain: "solana",
     capMinor: "10000000000",
+    fundingBasis: {
+      cycleId: "2026-08",
+      instrumentId: `sablier-lockup-v4:base:0x${"1".repeat(40)}:1`,
+      fundingState: "committed",
+      committedMinor: "10000000000",
+      monthlyCapMinor: "10000000000",
+    },
     feeBasisPoints: 100,
     scoringRuleVersion: "outcome-compute-v1",
     sourceSnapshotSha256: "a".repeat(64),

--- a/src/lib/rewards.ts
+++ b/src/lib/rewards.ts
@@ -4,6 +4,11 @@
  * amount is tied to one immutable payout intent.
  */
 
+import {
+  type AllocationFundingBasis,
+  allocationFundingMinor,
+  assertAllocationFundingBasis,
+} from "./allocation-funding";
 import { assertExactModelIdentity } from "./model-identity";
 import { findProject, type ProjectId } from "./projects.mjs";
 import { isSolanaAddress, WALLET_CLAIM_REPOSITORY } from "./wallets";
@@ -84,6 +89,7 @@ export interface RewardAllocation {
 }
 
 export interface RewardAllocationManifest {
+  fundingBasis?: AllocationFundingBasis;
   schemaVersion: typeof REWARD_PROTOCOL_VERSION;
   kind: "reward-allocation";
   projectId: string;
@@ -734,6 +740,7 @@ export function assertRewardAllocationManifest(
   const hasAccrual =
     "carriedMinor" in manifest || "minimumTransferMinor" in manifest;
   const hasRewardLines = "rewardLines" in manifest;
+  const hasFundingBasis = "fundingBasis" in manifest;
   exactKeys(
     manifest,
     [
@@ -756,6 +763,7 @@ export function assertRewardAllocationManifest(
       "totals",
       ...(hasAccrual ? ["carriedMinor", "minimumTransferMinor"] : []),
       ...(hasRewardLines ? ["rewardLines"] : []),
+      ...(hasFundingBasis ? ["fundingBasis"] : []),
     ],
     "allocation manifest",
   );
@@ -853,7 +861,15 @@ export function assertRewardAllocationManifest(
     throw new TypeError("allocation fee differs from project policy");
   }
   const capMinor = minor(manifest.capMinor, "allocation manifest.capMinor");
-  if (capMinor !== project.reward.monthlyCapMinor) {
+  const fundingBasis = hasFundingBasis
+    ? assertAllocationFundingBasis(manifest.fundingBasis)
+    : undefined;
+  if (
+    capMinor !==
+    (fundingBasis
+      ? allocationFundingMinor(fundingBasis).toString()
+      : project.reward.monthlyCapMinor)
+  ) {
     throw new TypeError("allocation cap differs from project policy");
   }
   const carriedMinor = hasAccrual
@@ -1050,6 +1066,7 @@ export function assertRewardAllocationManifest(
     currency: "USDC",
     chain: "solana",
     capMinor,
+    ...(fundingBasis ? { fundingBasis } : {}),
     ...(hasAccrual
       ? {
           carriedMinor,

--- a/src/lib/rewards.ts
+++ b/src/lib/rewards.ts
@@ -8,6 +8,7 @@ import {
   type AllocationFundingBasis,
   allocationFundingMinor,
   assertAllocationFundingBasis,
+  LAST_LEGACY_CAP_CYCLE,
 } from "./allocation-funding";
 import { assertExactModelIdentity } from "./model-identity";
 import { findProject, type ProjectId } from "./projects.mjs";
@@ -868,7 +869,9 @@ export function assertRewardAllocationManifest(
     capMinor !==
     (fundingBasis
       ? allocationFundingMinor(fundingBasis).toString()
-      : project.reward.monthlyCapMinor)
+      : cycleId <= LAST_LEGACY_CAP_CYCLE
+        ? capMinor
+        : project.reward.monthlyCapMinor)
   ) {
     throw new TypeError("allocation cap differs from project policy");
   }

--- a/src/lib/rewards.ts
+++ b/src/lib/rewards.ts
@@ -865,6 +865,12 @@ export function assertRewardAllocationManifest(
   const fundingBasis = hasFundingBasis
     ? assertAllocationFundingBasis(manifest.fundingBasis)
     : undefined;
+  if (!fundingBasis && cycleId > LAST_LEGACY_CAP_CYCLE)
+    throw new TypeError("new allocation requires an exact-cycle funding basis");
+  if (fundingBasis && fundingBasis.cycleId !== cycleId)
+    throw new TypeError(
+      "allocation funding basis cycle differs from manifest cycle",
+    );
   if (
     capMinor !==
     (fundingBasis

--- a/tests/app.test.tsx
+++ b/tests/app.test.tsx
@@ -1571,6 +1571,8 @@ describe("direct project funding", () => {
       kind: "monthly-pool" as const,
       reward: {
         fundingBasis: {
+          cycleId,
+          instrumentId: null,
           fundingState: "pledged" as const,
           committedMinor: "0",
           monthlyCapMinor: "10000000000",

--- a/tests/app.test.tsx
+++ b/tests/app.test.tsx
@@ -1580,16 +1580,44 @@ describe("direct project funding", () => {
       },
     }));
     const { rerender } = render(
-      <ProjectParticipation project={project} cycles={cycles.slice(0, 1)} />,
+      <ProjectParticipation
+        project={project}
+        cycles={cycles.slice(0, 1)}
+        displayCycleId="2026-09"
+      />,
     );
     expect(screen.getByLabelText("Manual install command")).toBeInTheDocument();
-    rerender(<ProjectParticipation project={project} cycles={cycles} />);
+    rerender(
+      <ProjectParticipation
+        project={project}
+        cycles={cycles}
+        displayCycleId="2026-09"
+      />,
+    );
     expect(
       screen.queryByLabelText("Manual install command"),
     ).not.toBeInTheDocument();
     expect(
       screen.getByText(/Accepted work and scores continue to be recorded/u),
     ).toBeVisible();
+    const committedWithoutCurrentInstrument = {
+      ...project,
+      reward: {
+        ...project.reward,
+        fundingState: "committed" as const,
+        committedMinor: "5000000",
+      },
+    };
+    rerender(
+      <ProjectParticipation
+        project={committedWithoutCurrentInstrument}
+        cycles={cycles}
+        displayCycleId="2026-09"
+      />,
+    );
+    expect(
+      screen.queryByLabelText("Manual install command"),
+    ).not.toBeInTheDocument();
   });
 
   it("shows an exact address, QR, copy feedback, and explorer without wallet control", async () => {

--- a/tests/app.test.tsx
+++ b/tests/app.test.tsx
@@ -21,6 +21,7 @@ import {
   monthlyPoolLabel,
   ProjectFunding,
   ProjectManagePage,
+  ProjectParticipation,
   publicFooterDomain,
   readBoundedJson,
   reviewBudgetLabel,
@@ -1049,7 +1050,7 @@ describe("public records", () => {
       await screen.findByRole("heading", { name: "finish-line" }),
     ).toBeInTheDocument();
     expect(screen.getByText("34")).toBeInTheDocument();
-    expect(screen.getAllByText("$10,000").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("$0").length).toBeGreaterThan(0);
     expect(screen.getByText("Eliza")).toBeInTheDocument();
     expect(screen.getByText("Delta Star")).toBeInTheDocument();
     expect(
@@ -1543,6 +1544,50 @@ describe("direct project funding", () => {
     expect(screen.getByRole("alert")).toHaveTextContent(
       "Funding records unavailable: funding request timed out",
     );
+  });
+
+  it("shows pledged zero funding and disabled payments when there is no route", () => {
+    const project = PROJECTS.find((candidate) => candidate.id === "eliza");
+    if (!project) throw new Error("Missing fixture project");
+    render(<ProjectFunding project={project} />);
+    expect(screen.getByText("Fund this project")).toBeVisible();
+    expect(
+      screen.getByText(
+        /Funding: pledged · Committed: \$0 · Payments: disabled/u,
+      ),
+    ).toBeVisible();
+    expect(screen.getByText(/Not accepting direct funding yet/u)).toBeVisible();
+    expect(
+      screen.queryByRole("button", { name: "Copy address" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("removes the skill CTA after two unfunded cycles while explaining continued records", () => {
+    const project = PROJECTS.find((candidate) => candidate.id === "eliza");
+    if (!project) throw new Error("Missing fixture project");
+    const cycles = ["2026-07", "2026-08"].map((cycleId) => ({
+      projectId: project.id,
+      cycleId,
+      kind: "monthly-pool" as const,
+      reward: {
+        fundingBasis: {
+          fundingState: "pledged" as const,
+          committedMinor: "0",
+          monthlyCapMinor: "10000000000",
+        },
+      },
+    }));
+    const { rerender } = render(
+      <ProjectParticipation project={project} cycles={cycles.slice(0, 1)} />,
+    );
+    expect(screen.getByLabelText("Manual install command")).toBeInTheDocument();
+    rerender(<ProjectParticipation project={project} cycles={cycles} />);
+    expect(
+      screen.queryByLabelText("Manual install command"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/Accepted work and scores continue to be recorded/u),
+    ).toBeVisible();
   });
 
   it("shows an exact address, QR, copy feedback, and explorer without wallet control", async () => {

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -428,7 +428,9 @@ test("starts Eliza with one prompt and no separate payout form", async ({
         );
       }, 0),
     );
-  expect(displayedProjectionCents).toBe(1_000_000);
+  // The project cap is policy, not funded principal. With no reviewed
+  // commitment, the leaderboard must not turn that cap into projected money.
+  expect(displayedProjectionCents).toBe(0);
   await expect(page.getByText("Live from GitHub")).toHaveCount(0);
   await expect(page.getByText("How credit survives review")).toHaveCount(0);
 });

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -10,6 +10,7 @@
     "types": ["node", "bun-types"]
   },
   "include": [
+    "src/lib/allocation-funding.ts",
     "vite.config.ts",
     "vitest.config.ts",
     "playwright.config.ts",


### PR DESCRIPTION
Monthly reward proposals now use committed principal from the instrument bound to that exact month. A pledge, missing instrument, replaced instrument, or instrument for another month produces a zero-dollar score record. Positive proposals freeze the cycle and instrument identity, and the trusted base transition checker verifies that binding.

Shared-pool carry excludes the separate reviewer budget. Historical July trial artifacts remain unchanged and create no monetary carry. Promotion uses the displayed cycle, so an expired commitment cannot reactivate a project after two unfunded cycles.

Closes #331.

Validation at `3ced3178f040673266130dad6ecc5e39e5c6592b`: full `bun run verify` passed, including 780 unit/integration tests, 124 skill tests, and production build. Independent review reproduced and confirmed the fixes for wrong-month allocation, reviewer-budget carry, and stale-month promotion. Combined browser validation with the allocation editor repair is in progress.
