### PR TITLE
Allow the public wallet API in Pages CSP

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -4,7 +4,7 @@
   Strict-Transport-Security: max-age=31536000; includeSubDomains
   Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=()
   Cross-Origin-Opener-Policy: same-origin
-  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data: https://avatars.githubusercontent.com; connect-src 'self'; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'; frame-ancestors 'none'; upgrade-insecure-requests
+  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data: https://avatars.githubusercontent.com; connect-src 'self' https://api.slop.cash; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'; frame-ancestors 'none'; upgrade-insecure-requests
 
 /assets/*
   Cache-Control: public, max-age=31536000, immutable

--- a/scripts/deployment-contract.test.mjs
+++ b/scripts/deployment-contract.test.mjs
@@ -368,7 +368,7 @@ describe("slop.cash deployment contract", () => {
     );
     expect(evidenceRecorder).not.toContain("env: process.env");
     expect(e2eRunner).toContain('"--grep-invert", artifactContract');
-    expect(e2eRunner).toContain('"--grep",\n    artifactContract');
+    expect(e2eRunner).toContain('"--grep",\n    pagesContracts');
     expect(qualityJob).toContain("run: bun run test:e2e");
     expect(qualityJob).toContain(
       "timeout --signal=TERM 10m ./node_modules/.bin/playwright install --with-deps chromium",

--- a/scripts/run-e2e.mjs
+++ b/scripts/run-e2e.mjs
@@ -1,6 +1,6 @@
 /**
  * Runs the complete browser matrix against the stable built-site preview, then
- * gives the one redirect/header/artifact contract a focused Pages-emulator run.
+ * checks redirects, artifacts, and contributor API access with Pages headers.
  * Wrangler can terminate during long browser sessions on constrained hosted
  * runners, while that focused check still exercises the behavior only Pages
  * supplies instead of replacing it with a generic static-server assertion.
@@ -15,6 +15,11 @@ const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const playwright = join(packageRoot, "node_modules", ".bin", "playwright");
 const artifactContract =
   "serves byte-consistent install and read-only artifacts for every project";
+
+const pagesContracts = [
+  artifactContract,
+  "renders contributor and cycle records from validated public data",
+].join("|");
 
 function run(command, args, env = childEnvironment()) {
   const result = spawnSync(command, args, {
@@ -45,7 +50,7 @@ run(
     "test",
     "--project=wide-desktop-chromium",
     "--grep",
-    artifactContract,
+    pagesContracts,
     ...process.argv.slice(2),
   ],
   {

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -626,6 +626,19 @@ test("serves byte-consistent install and read-only artifacts for every project",
   baseURL,
   request,
 }) => {
+  const documentResponse = await request.get("/");
+  const policy = documentResponse.headers()["content-security-policy"];
+  expect(policy).toBeDefined();
+  const connectSources = policy
+    .split(";")
+    .map((directive) => directive.trim().split(/\s+/u))
+    .find(([name]) => name === "connect-src");
+  expect(connectSources).toEqual([
+    "connect-src",
+    "'self'",
+    "https://api.slop.cash",
+  ]);
+
   const privateApiResponse = await request.post("/api/v1/runs", {
     data: {},
   });


### PR DESCRIPTION
Contributor wallet reads are blocked in production because Pages sends `connect-src 'self'`, while the application requests the public wallet API at `https://api.slop.cash`. Permit that exact HTTPS origin and retain the existing restrictions on every other connection origin.

The browser runner now includes the contributor page in its Pages-emulator pass, and the artifact contract asserts the rendered connection allowlist. This covers the security header that the Vite preview does not serve.

Validation at final rebased head `12339c9ef8c1b9c0768dc3aceb5a83ffc720f379`: full `bun run verify` passed (694 Vitest tests and 103 skill tests). Canonical `bun run test:e2e` on the immediately preceding CSP head passed all 36 viewport checks plus both Pages checks, with zero application console errors; the intervening base change is the separately verified non-UI receiving-route authority gate. The preceding Pages run reproduced the CSP failure at all four viewports.
