### PR TITLE
Bind monthly funding to active reviewed instruments

### DIFF
--- a/funding/README.md
+++ b/funding/README.md
@@ -98,7 +98,7 @@ A project may additionally declare reviewed commitment instruments in
 `project.funding.commitments`. Each instrument is a third-party on-chain
 mechanism that Slop does not control: an autonomous Squads v4 multisig vault
 holding USDC on Solana or a Sablier Lockup v4 USDC stream on Base or Ethereum.
-A Squads commitment requires an exact 2-of-2 funder and project-steward
+A Squads commitment requires an exact 2-of-2 funder and independently reviewed steward
 multisig with no configuration authority; a Sablier commitment uses a
 non-upgradeable, non-cancelable stream. Slop holds no key, admin, or fee position in any
 instrument; it publishes the reviewed reference and read-only evidence only.
@@ -184,6 +184,67 @@ A manifest may set `fundingState: "committed"` only while an active instrument
 is declared and the verified commitment ledger (deposits minus releases and
 refunds) covers `committedMinor`. The check is deterministic ledger arithmetic
 and fails closed in CI.
+
+### Monthly instrument review and accessibility boundary
+
+Current active instruments must declare `monthlyCommitment` with an exact
+`cycleId` (`YYYY-MM`), positive integer USDC `amountMinor`, and
+`accessibility: "unknown"`. `effectiveAt` is that month's UTC start and
+`deadline` the following month's UTC start. These are reviewed funding-period
+boundaries, not an automatic refund, on-chain spending limit, or expiry of an
+earned allocation. Exactly one instrument may back a monthly commitment across
+all networks. An instrument identity cannot be reused in another month.
+The declared amount may not exceed the shared-pool plus additive-review caps;
+the active instrument amount must equal the sum of amounts claimed committed.
+Only that active instrument's verified ledger can cover the claim. Donations,
+old vault balances, and other instruments cannot cover a new monthly claim.
+
+A current Squads instrument also names `stewardGithub` with the reviewed
+numeric `actorId`, immutable `nodeId`, and display `login`. The actor must
+differ from the declared funder actor and project steward; project node-ID and
+case-insensitive login collisions are rejected too. Its `stewardMember` must
+differ from every manifest receiving address (including replaced routes) and
+every declared Squads funder, multisig, and vault address. These are only
+deterministic contradiction checks. Distinct keys and GitHub identities do not
+prove independent control. The manifest PR must review the identity-to-key
+binding and actual independence. The current project schema does not declare a
+settler wallet or the funder's separate wallet claims, so those exclusions
+remain an activation blocker; no values are inferred or fabricated.
+
+The public distinction is explicit: a pledge is a target without committed
+backing; committed is a verified instrument-balance claim; accessible would
+add authenticated evidence that the required signers can act. No such
+accessibility evidence protocol has been reviewed in this version. Therefore
+the funding index always publishes `commitmentAccessibility: "unknown"`, all
+new instrument bindings retain `accessibility: "unknown"`, and current project
+policy rejects payment activation, including an additive review budget.
+Committed balances may still be disclosed with payments disabled. Neither a
+balance nor a GitHub statement is automatically upgraded to accessible.
+
+Historical manifests and ledger records are not rewritten. Legacy instrument
+references remain parseable for historical verification; a replaced legacy
+reference may remain in current history but cannot back a current commitment.
+New monthly references cannot be used to relabel old records or move balances
+between months. Existing approved and paid allocation rows are unchanged.
+
+### Still unresolved: authenticated loss and immutable lifecycle overlay
+
+Issue #333 remains open. Loss of either key in the reviewed no-config-authority
+2-of-2 can strand funds; no unilateral recovery, auto-refund, or new recovery
+authority is introduced. Monthly-sized, distinct instruments bound the declared
+exposure, but do not prove an on-chain balance cannot exceed that amount.
+
+A future reviewed protocol must bind each signer identity to its member key,
+authenticate a capability-loss report without requiring a lost key, identify
+the exact instrument and affected cycle funding basis, and retain the public
+reason in an append-only inaccessible-state record. It must distinguish
+pre-approval holds from already approved, scheduled, partially settled, or paid
+intents: approved/paid history must never be rewritten. A settlement gate and
+exact-once carry must prevent both old-intent payment and successor-cycle
+payment of the same principal; review-budget amounts must not carry. The new
+cycle must use a fresh instrument. Until that protocol and authority are
+reviewed, `inaccessible` and `accessible` claims are rejected, no report changes
+allocations automatically, and no new held/carry behavior is enabled here.
 
 Project payout plans remain unsigned and are executed outside Slop by the
 declared project settler. A transaction signature is only reported evidence;

--- a/funding/README.md
+++ b/funding/README.md
@@ -229,6 +229,22 @@ between months. Existing approved and paid allocation rows are unchanged.
 
 ### Still unresolved: authenticated loss and immutable lifecycle overlay
 
+The current schema also has an executable archival blocker: sixteen distinct
+monthly instruments fit the bounded manifest, but a seventeenth cannot be added.
+Deleting an old entry would violate the immutable prefix and make current public
+ledger validation lose its instrument reference. This draft intentionally does
+not increase the limit or permit deletion. It is not ready for ongoing monthly
+operation until a reviewed archive protocol exists.
+
+That protocol needs an append-only archive record binding the exact instrument,
+monthly period and amount to immutable reviewed manifest bytes, plus verifiable
+lifecycle references proving no open proposal, approved unpaid intent, or carry
+still depends on it. Existing commitment transaction records do not contain that
+complete monthly binding, and cycle records do not identify their backing
+instrument. Resolving those missing references is a schema decision; an archive
+marker alone cannot authorize removal. Historical readers must resolve archived
+instruments while active backing calculations continue to exclude them.
+
 Issue #333 remains open. Loss of either key in the reviewed no-config-authority
 2-of-2 can strand funds; no unilateral recovery, auto-refund, or new recovery
 authority is introduced. Monthly-sized, distinct instruments bound the declared

--- a/scripts/check-project-transitions.test.ts
+++ b/scripts/check-project-transitions.test.ts
@@ -155,11 +155,11 @@ describe("project transition gate", () => {
     ).toThrow(/open or past cycle/u);
 
     const funded = structuredClone(withPledgedReview);
-    funded.reward.paymentMode = "enabled";
+    funded.reward.paymentMode = "disabled";
     funded.reward.fundingState = "committed";
     funded.reward.committedMinor = "5000000";
     funded.reward.reviewBudget.fundingState = "committed";
-    funded.reward.reviewBudget.paymentMode = "enabled";
+    funded.reward.reviewBudget.paymentMode = "disabled";
     funded.reward.reviewBudget.committedMinor = "1000000";
     funded.reward.monthlyCapMinor = "9999000000";
     funded.reward.monthlyCapDisplay = "$9,999";
@@ -176,7 +176,17 @@ describe("project transition gate", () => {
         funderMember: "Stake11111111111111111111111111111111111111",
         stewardMember: "SysvarRent111111111111111111111111111111111",
         funderActorId: "18633264",
-        deadline: "2026-12-01T00:00:00.000Z",
+        stewardGithub: {
+          actorId: "42",
+          nodeId: "U_fixture_42",
+          login: "independent-fixture",
+        },
+        monthlyCommitment: {
+          cycleId: "2026-08",
+          amountMinor: "6000000",
+          accessibility: "unknown",
+        },
+        deadline: "2026-09-01T00:00:00.000Z",
         effectiveAt: "2026-08-01T00:00:00.000Z",
         replacedAt: null,
       },

--- a/scripts/sync-funding-index.test.ts
+++ b/scripts/sync-funding-index.test.ts
@@ -157,6 +157,15 @@ describe("funding manifest history", () => {
     expect(resolved.records).toEqual([]);
     expect(resolved.commitments).toEqual([record]);
     expect(resolved.generatedAt).toBe("2026-08-02T00:00:00.000Z");
+    expect(resolved.commitmentAccessibility).toBe("unknown");
+
+    const additive = committedProject();
+    Object.assign(additive.reward, {
+      reviewBudget: { committedMinor: "1", fundingState: "committed" },
+    });
+    await expect(
+      buildFundingIndex({ repositoryRoot: root, projects: [additive] }),
+    ).rejects.toThrow(/exceeds the verified commitment balance/u);
 
     const overcommitted = committedProject();
     overcommitted.reward.committedMinor = "5000001";

--- a/scripts/sync-funding-index.ts
+++ b/scripts/sync-funding-index.ts
@@ -34,6 +34,10 @@ interface FundingIndexProject {
   readonly reward: {
     readonly committedMinor: string;
     readonly fundingState: string;
+    readonly reviewBudget?: {
+      readonly committedMinor: string;
+      readonly fundingState: string;
+    };
   };
 }
 
@@ -346,7 +350,17 @@ export async function buildFundingIndex(
   for (const project of projects) {
     assertCommittedFundingBound(
       project.id,
-      project.reward,
+      {
+        fundingState:
+          project.reward.fundingState === "committed" ||
+          project.reward.reviewBudget?.fundingState === "committed"
+            ? "committed"
+            : project.reward.fundingState,
+        committedMinor: (
+          BigInt(project.reward.committedMinor) +
+          BigInt(project.reward.reviewBudget?.committedMinor ?? "0")
+        ).toString(),
+      },
       project.funding.commitments ?? [],
       index.commitments.filter((record) => record.projectId === project.id),
     );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -483,14 +483,13 @@ export function reviewBudgetLabel(
   reviewBudget: NonNullable<ProjectDefinition["reward"]["reviewBudget"]>,
 ): string {
   return reviewBudget.fundingState === "committed"
-    ? `${formatMicroUsdc(reviewBudget.committedMinor)} committed of ${reviewBudget.monthlyCapDisplay} cap · additive review line`
+    ? `${formatMicroUsdc(reviewBudget.committedMinor)} committed of ${reviewBudget.monthlyCapDisplay} cap · accessibility unknown · additive review line`
     : `${reviewBudget.monthlyCapDisplay} cap · additive review line · uncommitted pledge`;
 }
 
 /**
- * A monthly pool prints a dollar figure only once funding is committed. A
- * pledged pool, or a committed one with nothing behind it, is unfunded: its
- * cap is a target, never a pool.
+ * Commitment is a balance claim, never proof that signers can act. This
+ * protocol has no authenticated accessibility evidence type yet.
  */
 export function monthlyPoolUnfunded(
   reward: Pick<ProjectDefinition["reward"], "committedMinor" | "fundingState">,
@@ -508,7 +507,7 @@ export function monthlyPoolLabel(
 ): string {
   return monthlyPoolUnfunded(reward)
     ? `unfunded, target ${reward.monthlyCapDisplay}`
-    : `${reward.monthlyCapDisplay} monthly pool`;
+    : `${formatMicroUsdc(reward.committedMinor)} committed · accessibility unknown · target ${reward.monthlyCapDisplay}`;
 }
 
 function formatPercent(partsPerMillion: number): string {
@@ -747,7 +746,7 @@ function ProjectCard({ project }: { project: ProjectDefinition }) {
     project.reward.kind === "monthly-pool"
       ? unfunded
         ? "Unfunded"
-        : project.reward.monthlyCapDisplay
+        : "Accessibility unknown"
       : (project.reward.externalOpportunity?.advertisedAmountDisplay ??
         "External");
   return (
@@ -771,7 +770,7 @@ function ProjectCard({ project }: { project: ProjectDefinition }) {
             {project.reward.kind === "monthly-pool"
               ? unfunded
                 ? `target ${project.reward.monthlyCapDisplay} / month`
-                : "/ month"
+                : `${formatMicroUsdc(project.reward.committedMinor)} committed`
               : "external prize"}
           </span>
         </p>
@@ -779,7 +778,7 @@ function ProjectCard({ project }: { project: ProjectDefinition }) {
           {project.reward.kind === "monthly-pool"
             ? unfunded
               ? "Target cap · no funding committed"
-              : "Committed funding · payment state published per cycle"
+              : "Committed balance · accessibility unknown · payments disabled"
             : "External sponsor controls eligibility and payment"}
         </small>
         {project.reward.reviewBudget ? (
@@ -1300,7 +1299,7 @@ function HomePage({ state, retry }: { state: DataState; retry: () => void }) {
               <strong>
                 {featuredProjects[0] &&
                 !monthlyPoolUnfunded(featuredProjects[0].reward)
-                  ? featuredProjects[0].reward.monthlyCapDisplay
+                  ? "Accessibility unknown"
                   : "Unfunded"}
               </strong>
               <dl>
@@ -1315,7 +1314,7 @@ function HomePage({ state, retry }: { state: DataState; retry: () => void }) {
                   <dt>Funding</dt>
                   <dd>
                     {featuredProjects[0]?.reward.fundingState === "committed"
-                      ? "Committed"
+                      ? "Committed · accessibility unknown"
                       : "Uncommitted"}
                   </dd>
                 </div>
@@ -2155,6 +2154,11 @@ function ProjectFundingPage({ project }: { project: ProjectDefinition }) {
         login or submitted transaction ID does not prove wallet ownership or
         payment.
       </p>
+      <p>
+        Commitment accessibility: unknown. On-chain balance does not establish
+        that both signers can act. No commitment is available payout funding
+        until an authenticated accessibility evidence protocol is reviewed.
+      </p>
       {funding.status === "loading" ? (
         <div className="data-notice" role="status">
           <span className="pulse" /> Reading funding records…
@@ -2302,14 +2306,14 @@ function ProjectPage({
                 {project.reward.kind === "monthly-pool"
                   ? monthlyPoolUnfunded(project.reward)
                     ? "Unfunded"
-                    : project.reward.monthlyCapDisplay
+                    : "Accessibility unknown"
                   : project.reward.externalOpportunity?.advertisedAmountDisplay}
               </strong>
               <p>
                 {project.reward.kind === "monthly-pool"
                   ? monthlyPoolUnfunded(project.reward)
                     ? `Target ${project.reward.monthlyCapDisplay} per month. No funding is committed, so no payment is scheduled until the project commits funds.`
-                    : "Up to this amount is allocated each month. Unused funding rolls forward without raising the cap."
+                    : `${formatMicroUsdc(project.reward.committedMinor)} committed against a ${project.reward.monthlyCapDisplay} monthly target. Accessibility is unknown; no payment is enabled.`
                   : "10% of an award actually received is allocated to Slop Cash; the remaining 90% is shared among accepted contributors. The prize sponsor controls eligibility and payment."}
               </p>
               <div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2928,6 +2928,10 @@ function CyclePage({
     record?.state ?? (view?.cycle.status === "live" ? "live" : "closed");
   const reminder = cycleSettlementReminder({
     closesAt: to,
+    fundingState:
+      project.reward.reviewBudget?.fundingState === "committed"
+        ? "committed"
+        : project.reward.fundingState,
     kind:
       record?.kind ??
       (view?.reward.kind === "external-prize-share"

--- a/src/lib/funding-accessibility.test.ts
+++ b/src/lib/funding-accessibility.test.ts
@@ -52,6 +52,42 @@ function fixture() {
 }
 
 describe("monthly commitment accessibility boundary", () => {
+  it("demonstrates the unresolved seventeenth-month archival ceiling without deleting history", () => {
+    const withMonths = (count: number) => {
+      const project = fixture();
+      const commitments = Array.from({ length: count }, (_, index) => {
+        const effectiveAt = new Date(
+          Date.UTC(2026, 7 + index, 1),
+        ).toISOString();
+        const deadline = new Date(Date.UTC(2026, 8 + index, 1)).toISOString();
+        return {
+          kind: "sablier-lockup-v4",
+          network: "base",
+          asset: "USDC",
+          contract: "0xc19a09a66887017f603e5df420ed3cb9a5c07c0a",
+          streamId: String(index + 1),
+          monthlyCommitment: {
+            cycleId: effectiveAt.slice(0, 7),
+            amountMinor: "5000000",
+            accessibility: "unknown",
+          },
+          effectiveAt,
+          deadline,
+          replacedAt: index < count - 1 ? deadline : null,
+        };
+      });
+      return { ...project, funding: { ...project.funding, commitments } };
+    };
+    const sixteen = withMonths(16);
+    const seventeen = withMonths(17);
+    expect(assertProjectDefinition(sixteen).funding.commitments).toHaveLength(
+      16,
+    );
+    expect(() => assertProjectDefinition(seventeen)).toThrow(/at most 16/u);
+    expect(() => assertProjectPolicyTransition(sixteen, seventeen)).toThrow(
+      /at most 16/u,
+    );
+  });
   it("requires append-only monthly history and refuses relabeling an old instrument", () => {
     const before = fixture();
     const changed = fixture();

--- a/src/lib/funding-accessibility.test.ts
+++ b/src/lib/funding-accessibility.test.ts
@@ -1,0 +1,271 @@
+/** Synthetic policy fixtures only: no production identity or wallet claim. */
+import { describe, expect, it } from "vitest";
+import eliza from "../../projects/eliza/project.json";
+import { assertProjectFundingIndex } from "./funding";
+import { assertFundingCommitments } from "./funding-instruments.mjs";
+import { assertProjectPolicyTransition } from "./project-policy.mjs";
+import {
+  assertHistoricalProjectDefinition,
+  assertProjectDefinition,
+} from "./project-schema.mjs";
+
+const independent = "SysvarRent111111111111111111111111111111111";
+function fixture() {
+  return {
+    ...structuredClone(eliza),
+    reward: {
+      ...eliza.reward,
+      paymentMode: "disabled",
+      fundingState: "committed",
+      committedMinor: "5000000",
+    },
+    funding: {
+      ...structuredClone(eliza.funding),
+      commitments: [
+        {
+          kind: "squads-v4-vault",
+          network: "solana",
+          asset: "USDC",
+          multisig: "11111111111111111111111111111111",
+          vault: "Vote111111111111111111111111111111111111111",
+          vaultIndex: 0,
+          funderMember: "Stake11111111111111111111111111111111111111",
+          funderActorId: "18633264",
+          stewardMember: independent,
+          stewardGithub: {
+            actorId: "42",
+            nodeId: "U_fixture_42",
+            login: "independent-fixture",
+          },
+          monthlyCommitment: {
+            cycleId: "2026-08",
+            amountMinor: "5000000",
+            accessibility: "unknown",
+          },
+          effectiveAt: "2026-08-01T00:00:00.000Z",
+          deadline: "2026-09-01T00:00:00.000Z",
+          replacedAt: null as string | null,
+        },
+      ],
+    },
+  };
+}
+
+describe("monthly commitment accessibility boundary", () => {
+  it("requires append-only monthly history and refuses relabeling an old instrument", () => {
+    const before = fixture();
+    const changed = fixture();
+    changed.funding.commitments[0].monthlyCommitment.cycleId = "2026-09";
+    changed.funding.commitments[0].effectiveAt = "2026-09-01T00:00:00.000Z";
+    changed.funding.commitments[0].deadline = "2026-10-01T00:00:00.000Z";
+    expect(() => assertProjectPolicyTransition(before, changed)).toThrow(
+      /historical commitment.*immutable/u,
+    );
+    const next = structuredClone(changed);
+    next.funding.commitments[0].multisig =
+      "SysvarC1ock11111111111111111111111111111111";
+    next.funding.commitments[0].vaultIndex = 1;
+    const retired = structuredClone(before.funding.commitments[0]);
+    retired.replacedAt = next.funding.commitments[0].effectiveAt;
+    next.funding.commitments.unshift(retired);
+    expect(() => assertProjectPolicyTransition(before, next)).not.toThrow();
+    const deleted = fixture();
+    deleted.reward.committedMinor = "0";
+    deleted.reward.fundingState = "pledged";
+    deleted.funding.commitments = [];
+    expect(() => assertProjectPolicyTransition(before, deleted)).toThrow(
+      /append-only prefix/u,
+    );
+    const drifted = structuredClone(next);
+    drifted.funding.commitments[0].monthlyCommitment.amountMinor = "1";
+    expect(() => assertProjectPolicyTransition(before, drifted)).toThrow(
+      /historical commitment.*immutable/u,
+    );
+  });
+  it("keeps the current empty pledge valid and a committed unknown balance disabled", () => {
+    expect(assertProjectDefinition(eliza).reward.paymentMode).toBe("disabled");
+    const project = assertProjectDefinition(fixture());
+    expect(
+      project.funding.commitments?.[0].monthlyCommitment?.accessibility,
+    ).toBe("unknown");
+    expect(project.reward.paymentMode).toBe("disabled");
+  });
+
+  it("rejects activation and every invented accessible or inaccessible claim", () => {
+    const enabled = fixture();
+    enabled.reward.paymentMode = "enabled";
+    expect(() => assertProjectDefinition(enabled)).toThrow(
+      /accessibility is unknown/u,
+    );
+    for (const state of [
+      "accessible",
+      "inaccessible",
+      "verified",
+      "",
+      null,
+      true,
+    ]) {
+      const project = fixture();
+      Object.assign(project.funding.commitments[0].monthlyCommitment, {
+        accessibility: state,
+      });
+      expect(() => assertProjectDefinition(project)).toThrow(
+        /accessibility must remain unknown/u,
+      );
+    }
+    const forged = fixture();
+    Object.assign(forged.funding.commitments[0].monthlyCommitment, {
+      capabilityEvidence: "signed",
+    });
+    expect(() => assertProjectDefinition(forged)).toThrow(
+      /unexpected or missing/u,
+    );
+  });
+
+  it("keeps old instrument bytes readable only through the historical boundary", () => {
+    const old = fixture();
+    old.reward.paymentMode = "enabled";
+    const instrument = old.funding.commitments[0] as unknown as Record<
+      string,
+      unknown
+    >;
+    delete instrument.monthlyCommitment;
+    delete instrument.stewardGithub;
+    instrument.deadline = "2026-12-01T00:00:00.000Z";
+    const bytes = JSON.stringify(old);
+    expect(assertHistoricalProjectDefinition(old).reward.paymentMode).toBe(
+      "enabled",
+    );
+    expect(JSON.stringify(old)).toBe(bytes);
+    expect(() => assertProjectDefinition(old)).toThrow(
+      /monthly instrument binding/u,
+    );
+    old.reward.paymentMode = "disabled";
+    old.reward.committedMinor = "0";
+    old.reward.fundingState = "pledged";
+    instrument.replacedAt = "2026-09-01T00:00:00.000Z";
+    expect(assertProjectDefinition(old).funding.commitments).toHaveLength(1);
+  });
+
+  it("binds exact month, amount, and single active instrument", () => {
+    for (const mutate of [
+      (p: ReturnType<typeof fixture>) => {
+        p.funding.commitments[0].effectiveAt = "2026-08-02T00:00:00.000Z";
+      },
+      (p: ReturnType<typeof fixture>) => {
+        p.funding.commitments[0].deadline = "2026-10-01T00:00:00.000Z";
+      },
+      (p: ReturnType<typeof fixture>) => {
+        p.funding.commitments[0].monthlyCommitment.amountMinor = "4999999";
+      },
+      (p: ReturnType<typeof fixture>) => {
+        p.funding.commitments[0].monthlyCommitment.amountMinor =
+          "999999999999999";
+      },
+      (p: ReturnType<typeof fixture>) => {
+        p.funding.commitments[0].monthlyCommitment.amountMinor = "0";
+      },
+    ]) {
+      const project = fixture();
+      mutate(project);
+      expect(() => assertProjectDefinition(project)).toThrow(/month|amount/u);
+    }
+    const duplicate = fixture();
+    const extra = structuredClone(duplicate.funding.commitments[0]);
+    extra.multisig = "SysvarC1ock11111111111111111111111111111111";
+    extra.vaultIndex = 1;
+    extra.replacedAt = "2026-08-15T00:00:00.000Z";
+    // Use a second network to ensure per-network overlap checks are insufficient.
+    (duplicate.funding.commitments as unknown[]).push({
+      kind: "sablier-lockup-v4",
+      network: "base",
+      asset: "USDC",
+      contract: "0xc19a09a66887017f603e5df420ed3cb9a5c07c0a",
+      streamId: "42",
+      monthlyCommitment: extra.monthlyCommitment,
+      effectiveAt: extra.effectiveAt,
+      deadline: extra.deadline,
+      replacedAt: null,
+    });
+    expect(() => assertProjectDefinition(duplicate)).toThrow(/one instrument/u);
+  });
+
+  it("rejects project or funder identity aliases without claiming control from distinct IDs", () => {
+    for (const identity of [
+      { actorId: eliza.steward.github.actorId },
+      { nodeId: eliza.steward.github.nodeId },
+      { login: eliza.steward.github.login.toUpperCase() },
+      { actorId: "18633264" },
+    ]) {
+      const project = fixture();
+      Object.assign(project.funding.commitments[0].stewardGithub, identity);
+      expect(() => assertProjectDefinition(project)).toThrow(
+        /identity must differ/u,
+      );
+    }
+    const missing = fixture();
+    delete (
+      missing.funding.commitments[0] as unknown as Record<string, unknown>
+    ).stewardGithub;
+    expect(() => assertProjectDefinition(missing)).toThrow(
+      /named independent steward/u,
+    );
+  });
+
+  it("excludes even replaced receiving routes and every declared project/funder key", () => {
+    const project = fixture();
+    project.funding.addresses = [
+      {
+        network: "solana",
+        asset: "USDC",
+        address: independent,
+        effectiveAt: "2026-07-01T00:00:00.000Z",
+        replacedAt: "2026-08-01T00:00:00.000Z",
+      },
+    ] as never;
+    expect(() => assertProjectDefinition(project)).toThrow(
+      /manifest-attributed/u,
+    );
+    for (const key of ["multisig", "vault", "funderMember"] as const) {
+      const collision = fixture();
+      collision.funding.commitments[0].stewardMember =
+        collision.funding.commitments[0][key];
+      expect(() => assertProjectDefinition(collision)).toThrow(
+        /manifest-attributed|distinct/u,
+      );
+    }
+  });
+
+  it("cannot reuse the same instrument in a successor month", () => {
+    const first = fixture().funding.commitments[0];
+    first.replacedAt = "2026-09-01T00:00:00.000Z";
+    const next = structuredClone(first);
+    next.effectiveAt = "2026-09-01T00:00:00.000Z";
+    next.deadline = "2026-10-01T00:00:00.000Z";
+    next.replacedAt = null;
+    next.monthlyCommitment.cycleId = "2026-09";
+    expect(() => assertFundingCommitments([first, next])).toThrow(
+      /duplicate instrument/u,
+    );
+  });
+
+  it("publishes unknown for legacy indexes and refuses an accessible claim", () => {
+    const old = {
+      schemaVersion: "1",
+      generatedAt: null,
+      records: [],
+      commitments: [],
+    };
+    expect(
+      assertProjectFundingIndex(old, new Map(), new Map())
+        .commitmentAccessibility,
+    ).toBe("unknown");
+    expect(() =>
+      assertProjectFundingIndex(
+        { ...old, commitmentAccessibility: "accessible" },
+        new Map(),
+        new Map(),
+      ),
+    ).toThrow(/accessibility must remain unknown/u);
+  });
+});

--- a/src/lib/funding-commitment.test.ts
+++ b/src/lib/funding-commitment.test.ts
@@ -91,6 +91,48 @@ function record(overrides: Record<string, unknown> = {}) {
 }
 
 describe("funding commitment instruments", () => {
+  it("never backs a monthly claim with a replaced instrument's balance", () => {
+    const original = assertProjectCommitmentRecord(record(), instruments);
+    const current = squadsInstrument({
+      multisig: "SysvarC1ock11111111111111111111111111111111",
+      vaultIndex: 1,
+      effectiveAt: "2026-09-01T00:00:00.000Z",
+      deadline: "2026-10-01T00:00:00.000Z",
+      monthlyCommitment: {
+        cycleId: "2026-09",
+        amountMinor: "5000000",
+        accessibility: "unknown",
+      },
+    });
+    const history = [
+      squadsInstrument({ replacedAt: "2026-09-01T00:00:00.000Z" }),
+      current,
+    ];
+    expect(() =>
+      assertCommittedFundingBound(
+        "eliza",
+        { committedMinor: "5000000", fundingState: "committed" },
+        history,
+        [original],
+      ),
+    ).toThrow(/exceeds the verified commitment balance 0/u);
+    const matched = {
+      ...original,
+      instrument: {
+        ...original.instrument,
+        multisig: current.multisig,
+        vaultIndex: 1,
+      },
+    };
+    expect(() =>
+      assertCommittedFundingBound(
+        "eliza",
+        { committedMinor: "5000000", fundingState: "committed" },
+        history,
+        [matched],
+      ),
+    ).not.toThrow();
+  });
   it("accepts only the reviewed instrument kinds with exact fields", () => {
     expect(instruments).toHaveLength(2);
     expect(hasActiveFundingCommitment(instruments)).toBe(true);

--- a/src/lib/funding-commitment.ts
+++ b/src/lib/funding-commitment.ts
@@ -500,7 +500,21 @@ export function assertCommittedFundingBound(
     );
   }
   const committed = BigInt(reward.committedMinor);
-  const verifiedNet = commitmentVerifiedNetMinor(records);
+  // A monthly claim cannot borrow deposits from an old or unrelated vault.
+  // Legacy immutable manifests remain readable under their original contract.
+  const monthly = instruments.filter(
+    (instrument) =>
+      instrument.replacedAt === null && instrument.monthlyCommitment,
+  );
+  const backingRecords =
+    monthly.length > 0
+      ? records.filter((record) =>
+          monthly.some((instrument) =>
+            matchesInstrument(instrument, record.network, record.instrument),
+          ),
+        )
+      : records;
+  const verifiedNet = commitmentVerifiedNetMinor(backingRecords);
   if (committed > verifiedNet) {
     throw new TypeError(
       `project ${projectId} committedMinor ${committed} exceeds the verified commitment balance ${verifiedNet}`,

--- a/src/lib/funding-instruments.d.mts
+++ b/src/lib/funding-instruments.d.mts
@@ -1,5 +1,11 @@
 /** Types the shared reviewed committed-funding instrument validator. */
 
+export interface MonthlyCommitmentBinding {
+  readonly cycleId: string;
+  readonly amountMinor: string;
+  readonly accessibility: "unknown";
+}
+
 export interface SquadsV4VaultInstrument {
   readonly kind: "squads-v4-vault";
   readonly network: "solana";
@@ -10,12 +16,19 @@ export interface SquadsV4VaultInstrument {
   readonly funderActorId: string;
   readonly funderMember: string;
   readonly stewardMember: string;
+  readonly stewardGithub?: {
+    readonly actorId: string;
+    readonly nodeId: string;
+    readonly login: string;
+  };
+  readonly monthlyCommitment?: MonthlyCommitmentBinding;
   readonly deadline: string;
   readonly effectiveAt: string;
   readonly replacedAt: string | null;
 }
 
 export interface SablierLockupV4Instrument {
+  readonly monthlyCommitment?: MonthlyCommitmentBinding;
   readonly kind: "sablier-lockup-v4";
   readonly network: "base" | "ethereum";
   readonly asset: "USDC";
@@ -43,3 +56,7 @@ export declare function assertFundingCommitments(
 ): readonly FundingCommitmentInstrument[];
 
 export declare function hasActiveFundingCommitment(value: unknown): boolean;
+
+export declare function assertMonthlyCommitmentPolicy(
+  value: import("./projects.mjs").ProjectDefinition,
+): void;

--- a/src/lib/funding-instruments.mjs
+++ b/src/lib/funding-instruments.mjs
@@ -72,10 +72,14 @@ function validateSquadsInstrument(candidate, field) {
       "funderActorId",
       "funderMember",
       "kind",
+      ...(Object.hasOwn(candidate, "monthlyCommitment")
+        ? ["monthlyCommitment"]
+        : []),
       "multisig",
       "network",
       "replacedAt",
       "stewardMember",
+      ...(Object.hasOwn(candidate, "stewardGithub") ? ["stewardGithub"] : []),
       "vault",
       "vaultIndex",
     ],
@@ -124,6 +128,10 @@ function validateSquadsInstrument(candidate, field) {
     funderActorId: candidate.funderActorId,
     funderMember: candidate.funderMember,
     stewardMember: candidate.stewardMember,
+    ...(Object.hasOwn(candidate, "stewardGithub")
+      ? { stewardGithub: validateStewardGithub(candidate.stewardGithub, field) }
+      : {}),
+    ...monthlyCommitment(candidate, field),
     ...window,
   };
 }
@@ -137,6 +145,9 @@ function validateSablierInstrument(candidate, field) {
       "deadline",
       "effectiveAt",
       "kind",
+      ...(Object.hasOwn(candidate, "monthlyCommitment")
+        ? ["monthlyCommitment"]
+        : []),
       "network",
       "replacedAt",
       "streamId",
@@ -168,8 +179,175 @@ function validateSablierInstrument(candidate, field) {
     asset: "USDC",
     contract: candidate.contract,
     streamId: candidate.streamId,
+    ...monthlyCommitment(candidate, field),
     ...window,
   };
+}
+
+function validateStewardGithub(value, field) {
+  const identity = commitmentRecord(value, `${field}.stewardGithub`);
+  exactCommitmentKeys(
+    identity,
+    ["actorId", "nodeId", "login"],
+    `${field}.stewardGithub`,
+  );
+  if (
+    typeof identity.actorId !== "string" ||
+    !/^[1-9]\d{0,19}$/u.test(identity.actorId) ||
+    typeof identity.nodeId !== "string" ||
+    !/^[A-Za-z0-9_=-]{1,100}$/u.test(identity.nodeId) ||
+    typeof identity.login !== "string" ||
+    !/^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/u.test(identity.login)
+  )
+    throw new TypeError(`${field}.stewardGithub is invalid`);
+  return {
+    actorId: identity.actorId,
+    nodeId: identity.nodeId,
+    login: identity.login,
+  };
+}
+
+/** Legacy references stay parseable, but cannot activate a current commitment. */
+function monthlyCommitment(candidate, field) {
+  if (!Object.hasOwn(candidate, "monthlyCommitment")) return {};
+  const monthly = commitmentRecord(
+    candidate.monthlyCommitment,
+    `${field}.monthlyCommitment`,
+  );
+  exactCommitmentKeys(
+    monthly,
+    ["cycleId", "amountMinor", "accessibility"],
+    `${field}.monthlyCommitment`,
+  );
+  if (
+    typeof monthly.cycleId !== "string" ||
+    !/^\d{4}-(?:0[1-9]|1[0-2])$/u.test(monthly.cycleId)
+  ) {
+    throw new TypeError(`${field}.monthlyCommitment.cycleId is invalid`);
+  }
+  if (
+    typeof monthly.amountMinor !== "string" ||
+    !/^[1-9]\d{0,39}$/u.test(monthly.amountMinor)
+  ) {
+    throw new TypeError(
+      `${field}.monthlyCommitment.amountMinor must be positive integer minor units`,
+    );
+  }
+  if (monthly.accessibility !== "unknown") {
+    throw new TypeError(
+      `${field} accessibility must remain unknown until an authenticated evidence protocol is reviewed`,
+    );
+  }
+  const start = `${monthly.cycleId}-01T00:00:00.000Z`;
+  const end = new Date(start);
+  end.setUTCMonth(end.getUTCMonth() + 1);
+  if (
+    candidate.effectiveAt !== start ||
+    candidate.deadline !== end.toISOString()
+  ) {
+    throw new TypeError(
+      `${field} instrument period must match exactly one calendar month`,
+    );
+  }
+  return {
+    monthlyCommitment: {
+      cycleId: monthly.cycleId,
+      amountMinor: monthly.amountMinor,
+      accessibility: "unknown",
+    },
+  };
+}
+
+/**
+ * Current manifest policy, not a claim of independent control or key access.
+ * Identity/key control still requires human review; inequalities only reject
+ * contradictions already visible in the manifest. No accessibility evidence
+ * type is accepted in this version, so all payment activation fails closed.
+ */
+export function assertMonthlyCommitmentPolicy(project) {
+  const instruments = assertFundingCommitments(
+    project.funding.commitments ?? [],
+  );
+  const attributed = new Set(
+    project.funding.addresses.map(({ address }) => address),
+  );
+  for (const instrument of instruments) {
+    if (instrument.kind === "squads-v4-vault") {
+      attributed.add(instrument.funderMember);
+      attributed.add(instrument.multisig);
+      attributed.add(instrument.vault);
+    }
+  }
+  const cycles = new Set();
+  const cap =
+    BigInt(project.reward.monthlyCapMinor) +
+    BigInt(project.reward.reviewBudget?.monthlyCapMinor ?? "0");
+  for (const instrument of instruments) {
+    const monthly = instrument.monthlyCommitment;
+    if (!monthly) {
+      if (instrument.replacedAt !== null) continue;
+      throw new TypeError(
+        "active commitment requires a monthly instrument binding",
+      );
+    }
+    if (cycles.has(monthly.cycleId))
+      throw new TypeError(
+        "only one instrument may back each monthly commitment across all networks",
+      );
+    cycles.add(monthly.cycleId);
+    // Do not reinterpret immutable historical authority or caps under today's policy.
+    if (instrument.replacedAt !== null) continue;
+    if (BigInt(monthly.amountMinor) > cap)
+      throw new TypeError(
+        "monthly instrument amount exceeds the monthly reward caps",
+      );
+    if (instrument.kind === "squads-v4-vault") {
+      const identity = instrument.stewardGithub;
+      if (!identity)
+        throw new TypeError(
+          "monthly Squads commitment requires a named independent steward GitHub identity",
+        );
+      if (
+        identity.actorId === instrument.funderActorId ||
+        identity.actorId === project.steward.github.actorId ||
+        identity.nodeId === project.steward.github.nodeId ||
+        identity.login.toLowerCase() ===
+          project.steward.github.login.toLowerCase()
+      ) {
+        throw new TypeError(
+          "Squads steward identity must differ from the project steward and funder",
+        );
+      }
+      if (attributed.has(instrument.stewardMember))
+        throw new TypeError(
+          "Squads steward member must differ from every manifest-attributed project or funder address",
+        );
+    }
+  }
+  if (
+    project.reward.paymentMode === "enabled" ||
+    project.reward.reviewBudget?.paymentMode === "enabled"
+  ) {
+    throw new TypeError(
+      "funding accessibility is unknown; payment activation requires a reviewed authenticated evidence protocol",
+    );
+  }
+  const claimed =
+    BigInt(project.reward.committedMinor) +
+    BigInt(project.reward.reviewBudget?.committedMinor ?? "0");
+  if (claimed > 0n) {
+    const active = instruments.filter(
+      (instrument) => instrument.replacedAt === null,
+    );
+    if (
+      active.length !== 1 ||
+      BigInt(active[0].monthlyCommitment?.amountMinor ?? "0") !== claimed
+    ) {
+      throw new TypeError(
+        "committed amounts must bind exactly one active monthly instrument amount",
+      );
+    }
+  }
 }
 
 function instrumentIdentity(instrument) {

--- a/src/lib/funding-reminders.test.ts
+++ b/src/lib/funding-reminders.test.ts
@@ -43,6 +43,7 @@ describe("funding cycle reminders", () => {
         kind,
         now: "2026-08-05T00:00:00.000Z",
         paymentMode: "enabled",
+        fundingState: "committed",
         settledAt: null,
         state,
       });
@@ -55,6 +56,7 @@ describe("funding cycle reminders", () => {
         kind: "monthly-pool",
         now: "2026-08-05T00:00:00.000Z",
         paymentMode: "enabled",
+        fundingState: "committed",
         settledAt: null,
         state: "payment-ready",
       })?.kind,
@@ -68,6 +70,7 @@ describe("funding cycle reminders", () => {
         kind: "monthly-pool",
         now,
         paymentMode: "disabled",
+        fundingState: "pledged",
         settledAt: null,
         state: "review",
       });
@@ -83,6 +86,7 @@ describe("funding cycle reminders", () => {
         kind: "monthly-pool",
         now: "2026-08-05T00:00:00.000Z",
         paymentMode: "disabled",
+        fundingState: "pledged",
         settledAt: "2026-08-03T00:00:00.000Z",
         state: "review",
       }),
@@ -93,5 +97,30 @@ describe("funding cycle reminders", () => {
     expect(() =>
       settlementReminder(close, "2026-08-02T00:00:00.000Z", "not-a-date"),
     ).toThrow(/timestamps are invalid/u);
+  });
+
+  it("keeps committed disabled funds constrained without calling them unfunded or payable", () => {
+    for (const now of [
+      "2026-07-25T00:00:00.000Z",
+      "2026-08-05T00:00:00.000Z",
+    ]) {
+      const reminder = cycleSettlementReminder({
+        closesAt: close,
+        kind: "monthly-pool",
+        now,
+        paymentMode: "disabled",
+        fundingState: "committed",
+        settledAt: null,
+        state: "review",
+      });
+      expect(reminder?.kind).toBe("accessibility-unknown");
+      expect(reminder?.message).toMatch(/funds remain constrained/u);
+      expect(reminder?.message).toMatch(
+        /accessibility and payability are not proven/u,
+      );
+      expect(reminder?.message).not.toMatch(
+        /unfunded|no funding is committed|ready.to.sign|overdue|begin once/u,
+      );
+    }
   });
 });

--- a/src/lib/funding-reminders.ts
+++ b/src/lib/funding-reminders.ts
@@ -1,6 +1,7 @@
 /** Deterministic, non-custodial cycle and settler reminder copy. */
 
 export type SettlementReminder =
+  | { kind: "accessibility-unknown"; message: string }
   | { kind: "cycle-close"; message: string }
   | { kind: "overdue"; message: string }
   | { kind: "ready-to-sign"; message: string }
@@ -74,12 +75,12 @@ export function settlementReminder(
 
 /**
  * Suppresses signing language for cycles that never enter platform settlement
- * and replaces settler-deadline copy with the unfunded state while the pool
- * has no committed funding: a settlement can only be late once payments are
- * enabled.
+ * and distinguishes an unfunded pledge from committed but constrained funds.
+ * Disabled payments never imply an absent commitment or a settlement deadline.
  */
 export function cycleSettlementReminder(input: {
   closesAt: string;
+  fundingState: "committed" | "pledged" | "external-opportunity";
   kind: "external-prize-share" | "monthly-pool";
   now: string;
   paymentMode: "disabled" | "enabled";
@@ -101,10 +102,17 @@ export function cycleSettlementReminder(input: {
   );
   if (reminder === null) return null;
   if (input.paymentMode === "disabled") {
+    if (input.fundingState === "committed") {
+      return {
+        kind: "accessibility-unknown",
+        message:
+          "Committed funding reminder: funds remain constrained; accessibility and payability are not proven. Payments are disabled pending a reviewed authenticated accessibility evidence protocol.",
+      };
+    }
     return {
       kind: "unfunded",
       message:
-        "Unfunded pool reminder: no funding is committed and payments are disabled. Allocations remain projected; settlement deadlines begin once the project commits funding.",
+        "Unfunded pool reminder: no funding is committed and payments are disabled. Allocations remain projected; payments require reviewed accessibility evidence and activation.",
     };
   }
   return reminder;

--- a/src/lib/funding.ts
+++ b/src/lib/funding.ts
@@ -62,6 +62,7 @@ export interface ProjectFundingRecord {
 }
 
 export interface ProjectFundingIndex {
+  commitmentAccessibility?: "unknown";
   schemaVersion: typeof FUNDING_PROTOCOL_VERSION;
   generatedAt: string | null;
   records: readonly ProjectFundingRecord[];
@@ -474,11 +475,27 @@ export function assertProjectFundingIndex(
   const index = object(value, "funding index");
   exactKeys(
     index,
-    ["commitments", "generatedAt", "records", "schemaVersion"],
+    [
+      "commitments",
+      "generatedAt",
+      "records",
+      "schemaVersion",
+      ...(Object.hasOwn(index, "commitmentAccessibility")
+        ? ["commitmentAccessibility"]
+        : []),
+    ],
     "funding index",
   );
   if (index.schemaVersion !== FUNDING_PROTOCOL_VERSION) {
     throw new TypeError("funding index protocol is unsupported");
+  }
+  if (
+    Object.hasOwn(index, "commitmentAccessibility") &&
+    index.commitmentAccessibility !== "unknown"
+  ) {
+    throw new TypeError(
+      "funding index commitment accessibility must remain unknown",
+    );
   }
   const generatedAt =
     index.generatedAt === null
@@ -549,6 +566,7 @@ export function assertProjectFundingIndex(
   }
   return {
     schemaVersion: FUNDING_PROTOCOL_VERSION,
+    commitmentAccessibility: "unknown",
     generatedAt,
     records,
     commitments,

--- a/src/lib/project-policy.mjs
+++ b/src/lib/project-policy.mjs
@@ -87,6 +87,32 @@ function canonical(value) {
   return JSON.stringify(value);
 }
 
+function assertCommitmentTransition(previous, next) {
+  if (next.length < previous.length || next.length > previous.length + 1) {
+    throw new TypeError(
+      "commitment history must remain an append-only prefix with at most one successor",
+    );
+  }
+  const successor = next[previous.length];
+  if (successor && successor.replacedAt !== null)
+    throw new TypeError("new commitment must be active");
+  for (let index = 0; index < previous.length; index += 1) {
+    const { replacedAt: before, ...priorIdentity } = previous[index];
+    const { replacedAt: after, ...nextIdentity } = next[index];
+    if (canonical(priorIdentity) !== canonical(nextIdentity)) {
+      throw new TypeError(
+        "historical commitment identity, monthly binding, and authority are immutable",
+      );
+    }
+    if (before === after) continue;
+    if (before !== null || !successor || after !== successor.effectiveAt) {
+      throw new TypeError(
+        "a commitment may close only at an appended successor's activation; closed history is immutable",
+      );
+    }
+  }
+}
+
 function assertRepositoryTransition(previousRepositories, nextRepositories) {
   if (previousRepositories.length !== nextRepositories.length) {
     throw new TypeError("repository inventory cannot change");
@@ -152,6 +178,10 @@ export function assertProjectPolicyTransition(previousValue, nextValue) {
   assertFundingRouteTransition(
     previous.funding.addresses,
     next.funding.addresses,
+  );
+  assertCommitmentTransition(
+    previous.funding.commitments ?? [],
+    next.funding.commitments ?? [],
   );
   if (
     previous.authority.repositoryId !== next.authority.repositoryId ||

--- a/src/lib/project-schema.mjs
+++ b/src/lib/project-schema.mjs
@@ -7,6 +7,7 @@
 import { assertFundingAddresses } from "./funding-address.mjs";
 import {
   assertFundingCommitments,
+  assertMonthlyCommitmentPolicy,
   hasActiveFundingCommitment,
 } from "./funding-instruments.mjs";
 
@@ -797,7 +798,10 @@ function validateReviewBudget(value, field, poolPaymentMode) {
     !effectiveAt.endsWith("-01T00:00:00.000Z") ||
     budget.unusedFunds !== "rollover-without-cap-increase" ||
     (paymentsDisabled
-      ? budget.fundingState !== "pledged" || committedMinor !== "0"
+      ? !(
+          (budget.fundingState === "pledged" && committedMinor === "0") ||
+          (budget.fundingState === "committed" && BigInt(committedMinor) > 0n)
+        )
       : budget.fundingState !== "committed" || BigInt(committedMinor) <= 0n) ||
     (budget.paymentMode === "enabled" && poolPaymentMode !== "enabled") ||
     budget.monthlyCapDisplay !== formatMonthlyCapDisplay(monthlyCapMinor)
@@ -869,7 +873,10 @@ function validateReward(
       reward.chain !== "solana" ||
       reward.unusedFunds !== "rollover-without-cap-increase" ||
       (paymentsDisabled
-        ? reward.fundingState !== "pledged" || committedMinor !== "0"
+        ? !(
+            (reward.fundingState === "pledged" && committedMinor === "0") ||
+            (reward.fundingState === "committed" && BigInt(committedMinor) > 0n)
+          )
         : reward.fundingState !== "committed" ||
           BigInt(committedMinor) <= 0n) ||
       reward.monthlyCapDisplay !== formatMonthlyCapDisplay(monthlyCapMinor)
@@ -961,6 +968,7 @@ function validateProjectDefinition(
     allowLegacyMissingPublishAtRoot = false,
     allowLegacyExternalPrizeFee = false,
     allowLegacyUnsupportedOwnershipClaim = false,
+    allowLegacyCommitmentPolicy = false,
   } = {},
 ) {
   const project = record(value, "project");
@@ -1035,6 +1043,7 @@ function validateProjectDefinition(
     );
   }
   validateSteward(project.steward);
+  if (!allowLegacyCommitmentPolicy) assertMonthlyCommitmentPolicy(project);
   validateAuthority(project.authority, repositories[0]);
   validateTerms(
     project.terms,
@@ -1111,6 +1120,7 @@ export function assertHistoricalProjectDefinition(value) {
     allowLegacyMissingPublishAtRoot: true,
     allowLegacyExternalPrizeFee: true,
     allowLegacyUnsupportedOwnershipClaim: true,
+    allowLegacyCommitmentPolicy: true,
   });
 }
 

--- a/src/lib/project-schema.test.ts
+++ b/src/lib/project-schema.test.ts
@@ -375,7 +375,17 @@ describe("project proposal schema", () => {
       funderMember: "Stake11111111111111111111111111111111111111",
       stewardMember: "SysvarRent111111111111111111111111111111111",
       funderActorId: "18633264",
-      deadline: "2026-12-01T00:00:00.000Z",
+      stewardGithub: {
+        actorId: "42",
+        nodeId: "U_fixture_42",
+        login: "independent-fixture",
+      },
+      monthlyCommitment: {
+        cycleId: "2026-08",
+        amountMinor: "5000000",
+        accessibility: "unknown",
+      },
+      deadline: "2026-09-01T00:00:00.000Z",
       effectiveAt: "2026-08-01T00:00:00.000Z",
       replacedAt: null,
     };
@@ -383,7 +393,7 @@ describe("project proposal schema", () => {
       reward: Record<string, unknown>;
       funding: Record<string, unknown>;
     };
-    committed.reward.paymentMode = "enabled";
+    committed.reward.paymentMode = "disabled";
     committed.reward.fundingState = "committed";
     committed.reward.committedMinor = "5000000";
     committed.funding.commitments = [instrument];

--- a/tests/app.test.tsx
+++ b/tests/app.test.tsx
@@ -61,7 +61,9 @@ describe("review budget display", () => {
         unusedFunds: "rollover-without-cap-increase",
         fundingState: "committed",
       }),
-    ).toBe("$1 committed of $50 cap · additive review line");
+    ).toBe(
+      "$1 committed of $50 cap · accessibility unknown · additive review line",
+    );
     expect(
       reviewBudgetLabel({
         effectiveAt: "2026-10-01T00:00:00.000Z",
@@ -93,7 +95,7 @@ describe("monthly pool display", () => {
         committedMinor: "1000000",
         fundingState: "committed",
       }),
-    ).toBe("$10,000 monthly pool");
+    ).toBe("$1 committed · accessibility unknown · target $10,000");
   });
 });
 
@@ -1615,6 +1617,9 @@ describe("direct project funding", () => {
     ).toBeInTheDocument();
     expect(
       screen.getByText(/Funds go directly to the project wallet/u),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Commitment accessibility: unknown/u),
     ).toBeInTheDocument();
     expect(
       screen.getByText(

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -1019,6 +1019,9 @@ test("keeps primary routes accessible and inside the viewport", async ({
       await expect(
         page.getByRole("heading", { exact: true, name: "Project funding" }),
       ).toBeVisible();
+      await expect(
+        page.getByText(/Commitment accessibility: unknown/u),
+      ).toBeVisible();
     }
     const results = await new AxeBuilder({ page })
       .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])


### PR DESCRIPTION
## Summary

Implements the safe, bounded subset of #333 without claiming that the full funding-accessibility lifecycle is complete.

- Binds each monthly funding instrument to immutable manifest identity, network, reviewed evidence, amount, and active monthly use.
- Requires one instrument per project cycle across networks and counts only the active instrument toward committed backing, including the additive review budget.
- Publishes accessibility as `unknown` unless independently established and fails payment activation closed when accessibility is unknown.
- Distinguishes a committed but constrained instrument from a project with no committed funding; it no longer emits the false "Unfunded" reminder.
- Preserves deterministic Squads steward/address exclusions and the existing no-keys/no-admin boundary.
- Adds an executable month-17 regression and documents why the current 16-instrument ceiling cannot safely be lifted with the existing schema.

## Remaining blocker

This does **not** close #333. Safely retiring a historical instrument requires an immutable archive snapshot bound to source manifest bytes plus instrument/month/amount, and lifecycle records that identify the backing instrument and prove there is no unpaid, approved, or carried dependency. The current schemas cannot prove that. Authenticated capability-loss reporting, identity/key-control binding, and allocation hold/carry behavior also remain open.

## Verification

Final head `08316215a6513db5932e065628c6c0eac36d6189` is rebased on `a11607270033e51de104c09115a8f1f4b491df8b`.

- Canonical `bun run verify` passed, including registry/protocol checks, typecheck, format/lint, 706 Vitest tests, 103 skill tests, and production build.
- 51 focused implementation regressions passed; an independent adversarial pass ran 104 focused tests with no new blocker.
- Desktop/mobile Chromium route, cycle, and Axe AA checks passed 4/4 with zero application console or first-party request failures.
- `AGENTS.md` and `CLAUDE.md` remain byte-identical; generated outputs are untouched.

No funding instrument, address, commitment, payment, deployment authority, or immutable cycle record is activated.
