### PR TITLE
Fix narrow and enlarged-text reflow

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -57,6 +57,8 @@ textarea:focus-visible {
 .shell {
   width: min(1180px, calc(100% - 48px));
   margin-inline: auto;
+  /* Enlarged text and public identifiers must not set a page-wide minimum. */
+  overflow-wrap: anywhere;
 }
 
 .site-header {
@@ -161,7 +163,7 @@ textarea:focus-visible {
 .proof-object-grid,
 .audience-grid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 18px;
 }
 
@@ -657,17 +659,13 @@ p {
 
 .hero-switch {
   display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  min-width: 0;
   color: var(--orange-dark);
   font-size: clamp(30px, 7vw, 94px);
   letter-spacing: -0.065em;
   line-height: 0.88;
   text-wrap: balance;
-}
-
-@media (min-width: 681px) {
-  .hero-switch {
-    white-space: nowrap;
-  }
 }
 
 .hero-switch-sizer,
@@ -1072,6 +1070,8 @@ p {
 .project-card {
   min-height: 190px;
   display: grid;
+  min-width: 0;
+  grid-template-columns: minmax(0, 1fr);
   grid-template-rows: auto 1fr;
   gap: 32px;
   padding: 28px;
@@ -2138,13 +2138,18 @@ small {
 
 .proposal-grid {
   display: grid;
-  grid-template-columns: 0.8fr 1.2fr;
+  grid-template-columns: minmax(0, 0.8fr) minmax(0, 1.2fr);
   gap: 24px;
   align-items: start;
 }
 
 .proposal-grid form {
+  min-width: 0;
   padding: 0;
+}
+
+.proposal-grid fieldset {
+  min-inline-size: 0;
 }
 
 .proposal-grid label {
@@ -2712,7 +2717,7 @@ small {
   .proposal-grid,
   .home-section-heading,
   .owner-section {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .cycle-status-grid,
@@ -2776,7 +2781,7 @@ small {
   }
 
   .project-card-content {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
     gap: 32px;
   }
 
@@ -2976,7 +2981,7 @@ small {
   .project-grid,
   .cycle-status-grid,
   .proposal-checklist > div {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .project-card {

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -926,6 +926,75 @@ test("shows an explicit error for invalid data and retries", async ({
   expect(attempts).toBe(failedAttempts + 1);
 });
 
+test("reflows at 320 CSS pixels and with independently enlarged text", async ({
+  page,
+}, testInfo) => {
+  // The scenarios set their own viewport; do not repeat them for each device.
+  test.skip(testInfo.project.name !== "wide-desktop-chromium");
+  // WCAG 1.4.10: 320 CSS px is equivalent to 1280px at 400% browser zoom.
+  // Text enlargement is a deterministic typography fixture, not native browser
+  // zoom. The combined scenario is additional stress coverage, not a claim
+  // that the reflow criterion requires an effective viewport below 320 CSS px.
+  for (const scenario of [
+    { name: "320 CSS px reflow", width: 320, textScale: 1 },
+    { name: "200% text enlargement", width: 1280, textScale: 2 },
+    { name: "combined narrow enlarged-text stress", width: 320, textScale: 2 },
+  ]) {
+    await page.setViewportSize({ width: scenario.width, height: 1000 });
+    for (const path of [
+      "/",
+      "/projects/eliza",
+      "/projects/new",
+      "/projects/eliza/funding",
+    ]) {
+      await page.goto(path, { waitUntil: "networkidle" });
+      if (scenario.textScale === 2) {
+        await page.evaluate(() => {
+          // Capture every original computed size before changing any ancestor,
+          // so nested text receives exactly 200%, not compounded enlargement.
+          const typography = [
+            ...document.querySelectorAll<HTMLElement>("body *"),
+          ]
+            .filter((element) => element instanceof HTMLElement)
+            .map((element) => ({
+              element,
+              font: getComputedStyle(element).fontSize,
+              line: getComputedStyle(element).lineHeight,
+            }));
+          for (const { element, font, line } of typography) {
+            element.style.setProperty(
+              "font-size",
+              `${Number.parseFloat(font) * 2}px`,
+            );
+            if (line !== "normal")
+              element.style.setProperty(
+                "line-height",
+                `${Number.parseFloat(line) * 2}px`,
+              );
+          }
+        });
+      }
+      await page.keyboard.press("Tab");
+      await expect(page.locator(":focus")).toHaveAttribute("href", "/");
+      const accessibility = await new AxeBuilder({ page })
+        .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
+        .analyze();
+      expect(
+        accessibility.violations,
+        `${scenario.name} ${path} accessibility`,
+      ).toEqual([]);
+      const geometry = await page.evaluate(() => ({
+        viewport: innerWidth,
+        page: document.documentElement.scrollWidth,
+      }));
+      expect(
+        geometry.page,
+        `${scenario.name} ${path} horizontal overflow`,
+      ).toBeLessThanOrEqual(geometry.viewport);
+    }
+  }
+});
+
 test("keeps primary routes accessible and inside the viewport", async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary

Repairs horizontal overflow that appears when text is enlarged independently of viewport width.

- Makes grid tracks and cards shrinkable with `minmax(0, 1fr)` and explicit zero minimums.
- Allows long public identifiers to wrap inside the site shell instead of setting a page-wide minimum.
- Lets the animated hero phrase wrap when enlargement requires it; the ordinary desktop/mobile presentation is unchanged.
- Preserves the correct 320 CSS-pixel body minimum and adds separate coverage for 320px reflow, 200% enlarged text, and a combined stress case.

## Verification

Final rebased head `6da7043bd20c1bd7d2b797988b180bdd44a30838`, based on `a587215f3c19163a54b8fa5f2ecd4e602ec50b5c`:

- `bun run verify` passed: 694 Vitest tests, 103 skill tests, all registry/protocol/audit/type/format/lint checks, and the production build.
- Canonical E2E passed 37 browser cases plus the Pages artifact test.
- Sixteen route/viewport/text-enlargement screenshot scenarios had `scrollWidth === innerWidth`, zero Axe AA violations, and zero application or first-party request failures.
- Mobile keyboard navigation passed with normal and 200% text: Tab/Enter opens navigation and focuses Home.
- `AGENTS.md` and `CLAUDE.md` remain byte-identical; generated outputs are untouched.

Evidence is captured outside the repository. Final visual review is complete.
