### PR TITLE
Add trusted read-only funding eligibility evidence gate

### DIFF
--- a/.github/workflows/funding-eligibility.yml
+++ b/.github/workflows/funding-eligibility.yml
@@ -1,0 +1,58 @@
+name: Trusted funding eligibility
+
+on:
+  pull_request_target:
+    branches: [develop]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: trusted-funding-eligibility-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  funding-eligibility:
+    name: Trusted funding eligibility (evidence only)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout immutable trusted base
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+          submodules: false
+
+      - name: Install pinned Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: 1.3.14
+
+      - name: Install trusted dependencies without lifecycle scripts
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      - name: Verify head as data using trusted-base code
+        env:
+          FUNDING_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          FUNDING_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          FUNDING_PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$FUNDING_BASE_SHA"
+          git fetch --no-tags origin \
+            "+refs/pull/$FUNDING_PR_NUMBER/head:refs/remotes/origin/slop-funding-head"
+          test "$(git rev-parse refs/remotes/origin/slop-funding-head)" = "$FUNDING_HEAD_SHA"
+          bun scripts/check-funding-eligibility.ts \
+            "$FUNDING_BASE_SHA" "$FUNDING_HEAD_SHA" > funding-eligibility.json
+          cat funding-eligibility.json
+
+      - name: Preserve exact decision and verifier output bytes
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: funding-eligibility-${{ github.event.pull_request.head.sha }}
+          path: funding-eligibility.json
+          if-no-files-found: error
+          retention-days: 14

--- a/funding/README.md
+++ b/funding/README.md
@@ -23,6 +23,32 @@ GitHub authentication identifies the author but does not prove control of the
 sending or receiving wallet. Never put private keys, seed phrases, private
 wallet metadata, or signing material in a record or pull request.
 
+## Trusted funding eligibility (evidence only)
+
+The `Trusted funding eligibility` workflow runs the immutable base branch's
+checker and lockfile dependencies; the proposed head is Git object data only.
+Its JSON artifact binds the exact base and head SHA and includes each fresh
+verifier's version, exact output bytes, and SHA-256 digest. It has read-only
+repository permissions and cannot approve, merge, sign, or broadcast.
+
+The initial gate accepts only up to 100 new anonymous `verified-on-chain`
+direct-funding records, with no other diff. Historical and current manifest
+routes must validate, the head must include its base, and transaction and record
+identities must be unused across the ledger (including commitments). Verifier
+failure or disagreement fails the check. Confirmation counts must match exactly;
+a later chain observation may therefore require a refreshed candidate record.
+The verifier's fresh `checkedAt` is logged, not required to equal the candidate's
+earlier check time; future candidate observations are rejected.
+
+Corrections, public donor attribution, commitments, mixed changes, and
+non-verified records remain on human review. An ineligible decision is not an
+approval, even when the workflow finishes successfully. Every decision currently
+has `mergeAuthorized: false`: connecting the separate protected approver and
+proving its exact-head positive and negative live canaries remain required by
+#368. That approver must re-read the current base/head, required terminal checks,
+and trusted workflow provenance before any SHA-locked merge. A green check alone
+must never be treated as permission to merge.
+
 The public states are deliberately separate:
 
 - `self-reported`: a donor or project supplied the transaction ID; Slop has not

--- a/funding/README.md
+++ b/funding/README.md
@@ -40,7 +40,7 @@ a later chain observation may therefore require a refreshed candidate record.
 The verifier's fresh `checkedAt` is logged, not required to equal the candidate's
 earlier check time; future candidate observations are rejected.
 
-Corrections, public donor attribution, commitments, mixed changes, and
+Retired receiving routes, corrections, public donor attribution, commitments, mixed changes, and
 non-verified records remain on human review. An ineligible decision is not an
 approval, even when the workflow finishes successfully. Every decision currently
 has `mergeAuthorized: false`: connecting the separate protected approver and

--- a/scripts/check-funding-eligibility.test.ts
+++ b/scripts/check-funding-eligibility.test.ts
@@ -1,7 +1,13 @@
 /** Trusted Git objects, exact chain evidence, and human-review exclusions. */
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -236,6 +242,7 @@ describe("trusted funding eligibility", () => {
   it("rejects executable record blobs", async () => {
     const f = fixture();
     f.put(PATH, f.record);
+    chmodSync(join(f.git("rev-parse", "--show-toplevel"), PATH), 0o755);
     f.git("add", ".");
     f.git("update-index", "--chmod=+x", PATH);
     f.git("commit", "-qm", "executable candidate");
@@ -261,6 +268,31 @@ describe("trusted funding eligibility", () => {
     await expect(
       checkFundingEligibility({ ...f.head(), verifyRecord }),
     ).rejects.toThrow(/fresh verifier/);
+  });
+  it("keeps retired routes on human review even with a backdated observation", async () => {
+    const f = fixture();
+    f.put("projects/sample/project.json", {
+      id: "sample",
+      funding: {
+        recordsPath: "funding/sample",
+        addresses: [
+          {
+            network: "solana",
+            asset: "USDC",
+            address: RECIPIENT,
+            effectiveAt: "2026-01-01T00:00:00.000Z",
+            replacedAt: "2026-08-02T00:00:00.000Z",
+          },
+        ],
+      },
+    });
+    f.git("add", ".");
+    f.git("commit", "-qm", "retire receiving route");
+    const baseSha = f.git("rev-parse", "HEAD");
+    f.put(PATH, f.record);
+    const input = { ...f.head(), baseSha, verifyRecord };
+    f.git("checkout", "--detach", baseSha);
+    expect((await checkFundingEligibility(input)).eligible).toBe(false);
   });
   it.each([
     "",

--- a/scripts/check-funding-eligibility.test.ts
+++ b/scripts/check-funding-eligibility.test.ts
@@ -1,0 +1,276 @@
+/** Trusted Git objects, exact chain evidence, and human-review exclusions. */
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { ProjectFundingRecord } from "../src/lib/funding";
+import { SOLANA_MAINNET_USDC_MINT } from "../src/lib/settlement-plan";
+import {
+  checkFundingEligibility,
+  fundingAdditionPaths,
+} from "./check-funding-eligibility";
+import { verifyFundingSolana } from "./verify-funding-solana";
+
+const RECIPIENT = "11111111111111111111111111111111";
+const SIGNATURE = "3".repeat(88);
+const PATH = `funding/sample/solana/${SIGNATURE}/fund_sample1.json`;
+const roots: string[] = [];
+afterEach(() => {
+  for (const root of roots.splice(0))
+    rmSync(root, { recursive: true, force: true });
+});
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), "slop-funding-gate-"));
+  roots.push(root);
+  const git = (...args: string[]) =>
+    execFileSync("git", args, {
+      cwd: root,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+  const put = (path: string, value: unknown) => {
+    mkdirSync(dirname(join(root, path)), { recursive: true });
+    writeFileSync(join(root, path), JSON.stringify(value));
+  };
+  git("init", "-q");
+  git("config", "user.name", "Test");
+  git("config", "user.email", "test@example.invalid");
+  put("projects/sample/project.json", {
+    id: "sample",
+    funding: {
+      recordsPath: "funding/sample",
+      addresses: [
+        {
+          network: "solana",
+          asset: "USDC",
+          address: RECIPIENT,
+          effectiveAt: "2026-01-01T00:00:00.000Z",
+          replacedAt: null,
+        },
+      ],
+    },
+  });
+  git("add", ".");
+  git("commit", "-qm", "base");
+  const baseSha = git("rev-parse", "HEAD");
+  const record: ProjectFundingRecord = {
+    schemaVersion: "1",
+    kind: "project-funding",
+    recordId: "fund_sample1",
+    projectId: "sample",
+    manifestRevision: baseSha,
+    network: "solana",
+    asset: "USDC",
+    transactionId: SIGNATURE,
+    recipient: RECIPIENT,
+    amountMinor: "1000000",
+    observedAt: "2026-08-01T00:00:00.000Z",
+    state: "verified-on-chain",
+    donor: { attribution: "anonymous" },
+    finality: { kind: "finalized" },
+    verifier: {
+      version: "funding-solana-v1",
+      checkedAt: "2026-08-01T00:00:00.000Z",
+      evidenceUrl: `https://solscan.io/tx/${SIGNATURE}`,
+      reason: null,
+    },
+    supersedes: null,
+  };
+  const head = () => {
+    git("add", ".");
+    git("commit", "-qm", "addition");
+    const headSha = git("rev-parse", "HEAD");
+    git("checkout", "--detach", baseSha);
+    return { root, baseSha, headSha };
+  };
+  return { git, put, record, head };
+}
+
+// Exercise the production verifier with deterministic RPC responses, not a
+// predeclared success result. An off-by-one amount must fail inside it.
+function verifyRecord(record: ProjectFundingRecord) {
+  const balance = (accountIndex: number, owner: string, amount: string) => ({
+    accountIndex,
+    owner,
+    mint: SOLANA_MAINNET_USDC_MINT,
+    uiTokenAmount: { amount, decimals: 6 },
+  });
+  const source = "Vote111111111111111111111111111111111111111";
+  return verifyFundingSolana({
+    signature: record.transactionId,
+    recipient: record.recipient,
+    amountMinor: record.amountMinor,
+    fetchImpl: async () =>
+      new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: SIGNATURE,
+          result: {
+            slot: 123,
+            blockTime: 1786000000,
+            transaction: { signatures: [SIGNATURE] },
+            meta: {
+              err: null,
+              preTokenBalances: [
+                balance(0, source, "1000000"),
+                balance(1, RECIPIENT, "0"),
+              ],
+              postTokenBalances: [
+                balance(0, source, "0"),
+                balance(1, RECIPIENT, "1000000"),
+              ],
+            },
+          },
+        }),
+      ),
+  });
+}
+
+describe("trusted funding eligibility", () => {
+  it("accepts exact verified additions and hashes the exact output bytes without authorizing a merge", async () => {
+    const f = fixture();
+    f.put(PATH, f.record);
+    const result = await checkFundingEligibility({ ...f.head(), verifyRecord });
+    expect(result.eligible).toBe(true);
+    expect(result.mergeAuthorized).toBe(false);
+    expect(result.records).toHaveLength(1);
+    const evidence = result.records[0];
+    expect(evidence?.verifierVersion).toBe("funding-solana-v1");
+    expect(evidence?.outputSha256).toBe(
+      createHash("sha256")
+        .update(evidence?.outputJson ?? "")
+        .digest("hex"),
+    );
+  });
+  it("fails an amount off by one minor unit", async () => {
+    const f = fixture();
+    f.put(PATH, { ...f.record, amountMinor: "1000001" });
+    await expect(
+      checkFundingEligibility({ ...f.head(), verifyRecord }),
+    ).rejects.toThrow();
+  });
+  it("does not query the chain for mixed manifest changes", async () => {
+    const f = fixture();
+    f.put(PATH, f.record);
+    f.put("projects/other/project.json", {});
+    const result = await checkFundingEligibility({
+      ...f.head(),
+      verifyRecord: async () => {
+        throw new Error("must not query");
+      },
+    });
+    expect(result.eligible).toBe(false);
+  });
+  it.each([
+    {
+      donor: {
+        attribution: "github",
+        actorId: "1",
+        actorNodeId: "MDQ6VXNlcjE=",
+        login: "donor",
+      },
+    },
+    { supersedes: "fund_previous" },
+    {
+      state: "self-reported",
+      verifier: null,
+      finality: { kind: "unverified" },
+    },
+  ])("keeps judgment-dependent records on human review: %j", async (change) => {
+    const f = fixture();
+    f.put(PATH, { ...f.record, ...change });
+    expect(
+      (await checkFundingEligibility({ ...f.head(), verifyRecord })).eligible,
+    ).toBe(false);
+  });
+  it("rejects a mismatched record path", async () => {
+    const f = fixture();
+    f.put(PATH, { ...f.record, recordId: "fund_wrongid" });
+    await expect(
+      checkFundingEligibility({ ...f.head(), verifyRecord }),
+    ).rejects.toThrow(/path/);
+  });
+  it("rejects reuse within the same PR", async () => {
+    const f = fixture();
+    f.put(PATH, f.record);
+    f.put(PATH.replace("sample1", "sample2"), {
+      ...f.record,
+      recordId: "fund_sample2",
+    });
+    await expect(
+      checkFundingEligibility({ ...f.head(), verifyRecord }),
+    ).rejects.toThrow(/already recorded/);
+  });
+  it("fails closed when the verifier is unavailable", async () => {
+    const f = fixture();
+    f.put(PATH, f.record);
+    await expect(
+      checkFundingEligibility({
+        ...f.head(),
+        verifyRecord: async () => {
+          throw new Error("RPC unavailable");
+        },
+      }),
+    ).rejects.toThrow("RPC unavailable");
+  });
+  it("rejects a transaction already present in a trusted commitment ledger", async () => {
+    const f = fixture();
+    f.put(`funding/other/commitments/solana/${SIGNATURE}/cmt_previous.json`, {
+      network: "solana",
+      transactionId: SIGNATURE,
+      recordId: "cmt_previous",
+    });
+    f.git("add", ".");
+    f.git("commit", "-qm", "prior trusted commitment");
+    const baseSha = f.git("rev-parse", "HEAD");
+    f.put(PATH, f.record);
+    const input = { ...f.head(), baseSha, verifyRecord };
+    f.git("checkout", "--detach", baseSha);
+    await expect(checkFundingEligibility(input)).rejects.toThrow(
+      /already recorded/,
+    );
+  });
+  it("rejects executable record blobs", async () => {
+    const f = fixture();
+    f.put(PATH, f.record);
+    f.git("add", ".");
+    f.git("update-index", "--chmod=+x", PATH);
+    f.git("commit", "-qm", "executable candidate");
+    const headSha = f.git("rev-parse", "HEAD");
+    const baseSha = f.git("rev-parse", "HEAD^");
+    f.git("checkout", "--detach", baseSha);
+    await expect(
+      checkFundingEligibility({
+        root: f.git("rev-parse", "--show-toplevel"),
+        baseSha,
+        headSha,
+        verifyRecord,
+      }),
+    ).rejects.toThrow(/regular/);
+  });
+  it("rejects future observation claims even when the transfer matches", async () => {
+    const f = fixture();
+    f.put(PATH, {
+      ...f.record,
+      observedAt: "2099-01-01T00:00:00.000Z",
+      verifier: { ...f.record.verifier, checkedAt: "2099-01-01T00:00:00.000Z" },
+    });
+    await expect(
+      checkFundingEligibility({ ...f.head(), verifyRecord }),
+    ).rejects.toThrow(/fresh verifier/);
+  });
+  it.each([
+    "",
+    `M\0${PATH}\0`,
+    `D\0${PATH}\0`,
+    `A\0${PATH}\0A\0README.md\0`,
+    "A\0funding/sample/commitments/solana/tx/id.json\0",
+    `A\0${PATH}`,
+    `A\0${PATH}\0A\0${PATH}\0`,
+  ])("keeps non-addition or malformed diffs on human review", (diff) => {
+    expect(fundingAdditionPaths(diff)).toBeNull();
+  });
+});

--- a/scripts/check-funding-eligibility.ts
+++ b/scripts/check-funding-eligibility.ts
@@ -188,6 +188,17 @@ export async function checkFundingEligibility(input: {
       record,
       assertProjectFundingAddresses(current.funding.addresses),
     );
+    const activeRoute = assertProjectFundingAddresses(
+      current.funding.addresses,
+    ).find(
+      (route) =>
+        route.network === record.network &&
+        route.asset === record.asset &&
+        route.address === record.recipient &&
+        route.replacedAt === null,
+    );
+    if (!activeRoute)
+      return human("retired receiving routes need human review");
     if (record.state !== "verified-on-chain")
       return human("unverified or disputed evidence needs human review");
     if (record.supersedes !== null)

--- a/scripts/check-funding-eligibility.ts
+++ b/scripts/check-funding-eligibility.ts
@@ -1,0 +1,255 @@
+/** Read-only, trusted-base evidence gate. Never checks out or executes PR code. */
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { isDeepStrictEqual } from "node:util";
+import {
+  assertProjectFundingAddresses,
+  assertProjectFundingRecord,
+  type ProjectFundingRecord,
+} from "../src/lib/funding";
+import { verifyFundingBitcoin } from "./verify-funding-bitcoin";
+import { verifyFundingEvm } from "./verify-funding-evm";
+import { verifyFundingSolana } from "./verify-funding-solana";
+
+const SHA = /^[0-9a-f]{40}$/u;
+const RECORD_PATH =
+  /^funding\/([a-z0-9][a-z0-9-]*)\/(solana|base|ethereum|bitcoin)\/([A-Za-z0-9]+)\/(fund_[a-z0-9][a-z0-9_-]{6,79})\.json$/u;
+const MAX_ADDITIONS = 100;
+
+function git(root: string, args: string[], maxBuffer = 8 * 1024 * 1024) {
+  return execFileSync("git", args, {
+    cwd: root,
+    encoding: "utf8",
+    maxBuffer,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function jsonBlob(root: string, revision: string, path: string) {
+  const entry = git(root, ["ls-tree", revision, "--", path]);
+  if (!entry.startsWith("100644 blob ")) {
+    throw new TypeError(
+      "funding evidence must be a regular non-executable blob",
+    );
+  }
+  return JSON.parse(git(root, ["show", `${revision}:${path}`], 64 * 1024));
+}
+
+export function fundingAdditionPaths(diff: string): string[] | null {
+  const fields = diff.split("\0");
+  if (fields.pop() !== "" || fields.length === 0 || fields.length % 2 !== 0) {
+    return null;
+  }
+  const paths: string[] = [];
+  for (let i = 0; i < fields.length; i += 2) {
+    const path = fields[i + 1];
+    if (fields[i] !== "A" || !path || !RECORD_PATH.test(path)) return null;
+    paths.push(path);
+  }
+  return paths.length <= MAX_ADDITIONS && new Set(paths).size === paths.length
+    ? paths
+    : null;
+}
+
+async function verify(record: ProjectFundingRecord) {
+  const common = {
+    amountMinor: record.amountMinor,
+    recipient: record.recipient,
+  };
+  switch (record.network) {
+    case "solana":
+      return verifyFundingSolana({
+        ...common,
+        signature: record.transactionId,
+      });
+    case "bitcoin":
+      return verifyFundingBitcoin({
+        ...common,
+        transactionId: record.transactionId,
+      });
+    default:
+      return verifyFundingEvm({
+        ...common,
+        network: record.network,
+        transactionHash: record.transactionId,
+      });
+  }
+}
+
+export function matchFundingVerification(
+  record: ProjectFundingRecord,
+  output: Awaited<ReturnType<typeof verify>>,
+) {
+  if (
+    record.state !== output.state ||
+    !isDeepStrictEqual(record.finality, output.finality) ||
+    record.verifier?.version !== output.verifier.version ||
+    record.verifier.evidenceUrl !== output.verifier.evidenceUrl ||
+    record.verifier.reason !== output.verifier.reason ||
+    Date.parse(record.observedAt) > Date.parse(output.verifier.checkedAt) ||
+    Date.parse(record.verifier.checkedAt) >
+      Date.parse(output.verifier.checkedAt)
+  ) {
+    throw new TypeError(
+      "funding record does not match fresh verifier evidence",
+    );
+  }
+  // Hash the exact bytes emitted below, including the independently checked
+  // chain evidence and fresh observation time, not a contributor-supplied hash.
+  const outputJson = `${JSON.stringify(output)}\n`;
+  return {
+    verifierVersion: output.verifier.version,
+    outputSha256: createHash("sha256").update(outputJson).digest("hex"),
+    outputJson,
+  };
+}
+
+export async function checkFundingEligibility(input: {
+  root: string;
+  baseSha: string;
+  headSha: string;
+  verifyRecord?: typeof verify;
+}) {
+  const { root, baseSha, headSha } = input;
+  if (!SHA.test(baseSha) || !SHA.test(headSha)) {
+    throw new TypeError("immutable base and head SHAs are required");
+  }
+  if (git(root, ["rev-parse", "HEAD"]).trim() !== baseSha) {
+    throw new TypeError("checker must run from the trusted base checkout");
+  }
+  const decision = {
+    schemaVersion: "1",
+    baseSha,
+    headSha,
+    // The separate approver must still authorize and SHA-lock a merge after
+    // re-reading live required checks. This read-only gate has no merge power.
+    mergeAuthorized: false,
+  } as const;
+  const human = (reason: string) => ({
+    ...decision,
+    eligible: false as const,
+    reason,
+    records: [],
+  });
+  try {
+    git(root, ["merge-base", "--is-ancestor", baseSha, headSha]);
+  } catch {
+    return human("head must include the exact current base");
+  }
+  const paths = fundingAdditionPaths(
+    git(root, [
+      "diff",
+      "--no-renames",
+      "--name-status",
+      "-z",
+      baseSha,
+      headSha,
+    ]),
+  );
+  if (!paths)
+    return human("only bounded direct-funding JSON additions qualify");
+
+  const records: ProjectFundingRecord[] = [];
+  for (const path of paths) {
+    const match = RECORD_PATH.exec(path);
+    if (!match) throw new TypeError("invalid funding path");
+    const [, projectId, network, transactionId, recordId] = match;
+    const raw = jsonBlob(root, headSha, path);
+    if (
+      raw.projectId !== projectId ||
+      raw.network !== network ||
+      raw.transactionId !== transactionId ||
+      raw.recordId !== recordId
+    ) {
+      throw new TypeError("funding record does not match its path");
+    }
+    if (
+      typeof raw.manifestRevision !== "string" ||
+      !SHA.test(raw.manifestRevision)
+    ) {
+      throw new TypeError("invalid funding manifest revision");
+    }
+    git(root, ["merge-base", "--is-ancestor", raw.manifestRevision, baseSha]);
+    const manifestPath = `projects/${projectId}/project.json`;
+    const current = jsonBlob(root, baseSha, manifestPath);
+    const historical = jsonBlob(root, raw.manifestRevision, manifestPath);
+    if (
+      current.id !== projectId ||
+      historical.id !== projectId ||
+      current.funding.recordsPath !== `funding/${projectId}`
+    ) {
+      throw new TypeError("funding project is not in the trusted inventory");
+    }
+    const record = assertProjectFundingRecord(
+      raw,
+      assertProjectFundingAddresses(historical.funding.addresses),
+    );
+    assertProjectFundingRecord(
+      record,
+      assertProjectFundingAddresses(current.funding.addresses),
+    );
+    if (record.state !== "verified-on-chain")
+      return human("unverified or disputed evidence needs human review");
+    if (record.supersedes !== null)
+      return human("corrections need human review");
+    if (record.donor.attribution !== "anonymous")
+      return human("public donor attribution needs independent consent review");
+    records.push(record);
+  }
+
+  // Compare against all prior direct and commitment records, across projects.
+  // A historical transfer cannot become a new donation by changing its path.
+  const usedTransactions = new Set<string>();
+  const usedIds = new Set<string>();
+  const existing = git(root, [
+    "ls-tree",
+    "-r",
+    "--name-only",
+    "-z",
+    baseSha,
+    "--",
+    "funding/",
+  ])
+    .split("\0")
+    .filter((path) => path.endsWith(".json"));
+  for (const path of existing) {
+    const record = jsonBlob(root, baseSha, path);
+    usedTransactions.add(`${record.network}:${record.transactionId}`);
+    usedIds.add(record.recordId);
+  }
+  for (const record of records) {
+    const key = `${record.network}:${record.transactionId}`;
+    if (usedTransactions.has(key) || usedIds.has(record.recordId)) {
+      throw new TypeError(
+        "funding transaction or record id is already recorded",
+      );
+    }
+    usedTransactions.add(key);
+    usedIds.add(record.recordId);
+  }
+  const evidence = [];
+  for (const [index, record] of records.entries()) {
+    const output = await (input.verifyRecord ?? verify)(record);
+    evidence.push({
+      path: paths[index],
+      ...matchFundingVerification(record, output),
+    });
+  }
+  return {
+    ...decision,
+    eligible: true as const,
+    reason: "fresh verifier evidence matches every addition",
+    records: evidence,
+  };
+}
+
+if (import.meta.main) {
+  const [baseSha, headSha, ...extra] = process.argv.slice(2);
+  if (!baseSha || !headSha || extra.length)
+    throw new TypeError(
+      "usage: check-funding-eligibility.ts <base-sha> <head-sha>",
+    );
+  process.stdout.write(
+    `${JSON.stringify(await checkFundingEligibility({ root: process.cwd(), baseSha, headSha }), null, 2)}\n`,
+  );
+}


### PR DESCRIPTION
## Scope
Partial implementation of #368, not an automatic merge or issue closure.

Runs only immutable trusted-base code and dependencies. Fetches PR head as Git object data, never checks out or executes it. Only bounded append-only direct-funding records qualify. Revalidates historical/current manifest routes, rejects transaction reuse across direct funding and commitments, and runs existing read-only Solana/EVM/Bitcoin verifiers. Decision artifact binds base/head SHA, verifier version, exact output bytes and SHA-256.

Corrections, donor attribution, retired routes, commitments, non-verified records, and mixed diffs stay on human review. Off-by-one amount, malformed blobs, future observations, and verifier failures fail closed. Workflow has contents:read only; mergeAuthorized is always false.

## Validation
20 gate tests and 53 application tests passed before the latest rebase. Full verification is running on the rebased head; final exact-head evidence will follow. Initial full run exposed an executable-mode test-fixture error (fixed) and an unrelated wallet loading timeout (focused rerun passed). These are not represented as a clean initial run.

Browser/build evidence remains pending. UI screenshots/keyboard/zoom changes: N/A - no UI implementation changes in this PR. Production deployment, DNS/TLS, signing and payment evidence: N/A - this PR does not deploy or move funds.

## Remaining boundary
The existing separate protected approver is not in this repository. Its integration must consume the decision (not merely a green job), verify trusted workflow provenance and live required terminal checks, re-read current base/head, and SHA-lock the merge. Real positive/negative hosted canaries remain required before #368 can close. No authority or live transfer evidence is fabricated.