### PR TITLE
Add a trusted read-only funding-record gate

### DIFF
--- a/.github/workflows/funding-records.yml
+++ b/.github/workflows/funding-records.yml
@@ -1,0 +1,61 @@
+name: Trusted funding record verification
+
+on:
+  pull_request_target:
+    branches: [develop]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+# This job has no approval, merge, deployment, or signing authority.
+permissions:
+  contents: read
+
+concurrency:
+  group: trusted-funding-records-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  funding-records:
+    name: Trusted funding record verification
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Checkout immutable trusted base only
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+          submodules: false
+
+      - name: Install pinned Bun for the trusted verifier
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: "1.3.14"
+
+      # Fetch the PR as Git objects. Never checkout its tree, install its
+      # dependencies, run its scripts, or derive an RPC endpoint from its files.
+      - name: Verify the exact funding-record proposal
+        env:
+          FUNDING_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          FUNDING_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          FUNDING_PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$FUNDING_BASE_SHA"
+          git fetch --no-tags origin \
+            "+refs/pull/$FUNDING_PR_NUMBER/head:refs/remotes/origin/slop-funding-head"
+          test "$(git rev-parse refs/remotes/origin/slop-funding-head)" = "$FUNDING_HEAD_SHA"
+          bun scripts/check-funding-record-pr.ts \
+            --base-sha "$FUNDING_BASE_SHA" \
+            --head-sha "$FUNDING_HEAD_SHA" \
+            --pr-number "$FUNDING_PR_NUMBER" \
+            --output "$RUNNER_TEMP/funding-record-decision.json"
+
+      - name: Retain the exact-head decision without approving or merging
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: funding-record-decision-${{ github.event.pull_request.head.sha }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/funding-record-decision.json
+          if-no-files-found: error
+          retention-days: 30

--- a/funding/README.md
+++ b/funding/README.md
@@ -17,6 +17,11 @@ integer minor-unit amount, observation time, attribution choice, finality, and
 verifier version. A correction appends a new record that names the prior record
 in `supersedes`; committed records are never edited in place.
 
+The [trusted funding-record PR gate](../protocol/funding-record-pr-verification.md) can independently
+reverify a narrow append-only proposal and retain an exact-head decision log.
+It has no review-approval or merge authority; every decision preserves human
+and repository-controlled merge review.
+
 An authenticated GitHub user reports a transfer by opening a pull request that
 adds the first record at this path. The pull request is the public human review;
 GitHub authentication identifies the author but does not prove control of the

--- a/protocol/funding-record-pr-verification.md
+++ b/protocol/funding-record-pr-verification.md
@@ -1,0 +1,92 @@
+# Trusted funding-record verification
+
+`Trusted funding record verification` produces read-only evidence for a narrow
+subset of funding PRs. It does not approve reviews, enable auto-merge, merge a
+PR, or invoke a deployment environment. Repository maintainers and repository
+rules retain merge authority.
+
+## Scope and evidence
+
+The `pull_request_target` workflow checks out the immutable base commit and
+executes only its checker and verifier modules. The PR head is fetched as Git
+objects and checked against the event's exact SHA. Its tree is never checked
+out, its code never runs, and its dependencies are never installed. The head
+must descend from the trusted base. A newer base or head requires a new
+decision; this artifact is not a transferable approval.
+
+The complete base-to-head diff must contain 1–20 added regular `100644` files
+at `funding/<project>/<network>/<transaction>/<record-id>.json`. Mixed changes,
+modified or deleted files, renames, executable files, symlinks, and commitments
+go to human review. There is no path-filter shortcut that could conceal another
+file in the same PR.
+
+For the automatic-verification subset:
+
+- Each record must be canonical UTF-8 JSON: lexicographically sorted object
+  keys, two-space indentation, and one final newline. The checker compares the
+  actual bytes, rejecting duplicate keys and alternate encodings instead of
+  silently rewriting a proposed record. `canonicalFundingDecisionBytes` in
+  `scripts/check-funding-record-pr.ts` implements this serialization.
+- Every record must be `verified-on-chain`, anonymous, and have `supersedes:
+  null`. Self-reported, disputed, corrected, and GitHub-attributed records
+  require human review. A chain verifier cannot establish a donor's GitHub
+  attribution or permission to publish it.
+- The project must exist in the trusted base inventory. The record's manifest
+  revision must already be an ancestor of that base, and its recipient must be
+  active at the observation time under that immutable manifest. A manifest
+  commit present only in a PR or fork is insufficient. Future observations or
+  verification timestamps are rejected.
+- Transaction identity and record IDs must not repeat within the proposal or
+  the complete existing non-commitment funding inventory, including across
+  projects. Any correction-chain ambiguity remains outside this subset.
+- The applicable existing Solana, Base, Ethereum, or Bitcoin verifier receives
+  the exact recipient, amount in integer minor units, and transaction identity.
+  Only the verifier's fixed read-only mainnet endpoints are used; records cannot
+  select RPC URLs or executable commands. Network errors and verifier failures
+  fail closed.
+- The new output must match the record's state, transaction, verifier version,
+  evidence URL, and finality exactly. The fresh check may occur later than the
+  recorded check. An increased EVM or Bitcoin confirmation count is therefore
+  an explicit finality mismatch requiring a refreshed record or human review;
+  it is not silently substituted into the proposed bytes.
+
+The decision artifact binds the exact PR number, base SHA, head SHA, checker
+revision and version, and check time. Each processed record binds its immutable
+Git blob ID and SHA-256 of its raw bytes. Each attempted verification names the
+verifier version and exact input; successful verifier returns also retain the
+canonical output bytes and their SHA-256, even if the subsequent finality
+comparison refuses the record. A verifier that throws has no fabricated output
+or output hash.
+
+## Decisions and merge authority
+
+`verified-records` means every proposed record passed this bounded verification.
+`verification-failed` produces a failing job. `human-review-required` means the
+proposal is outside the unattended subset; it completes without treating the
+PR as verified. Consumers must inspect the decision and its exact SHA bindings,
+not infer approval from a green job or the presence of an artifact.
+
+Every decision currently says `mergeAuthorized: false`. The workflow token has
+only `contents: read`; there is no review-approval call, merge call, signing
+material, or deployment reviewer in this path. Artifacts are retained for 30
+days and are evidence, not permanent settlement records.
+
+The #302 unattended approver was disclosed as an external service acting as a
+named deployment reviewer. Its observed `slop-approver:` decisions approve only
+scheduled re-deployments of a previously human-approved revision. Deployment
+reviewer membership does not grant this checker PR merge authority, and that
+service's private credentials or source are not available in this repository.
+
+The implementation-time read-only repository audit found auto-merge disabled,
+default Actions workflow permissions set to read, no returned rulesets, and no
+classic protection on `develop`. The permission to create PR reviews does not
+establish a safe merge policy. Enabling autonomous merges requires an explicit
+maintainer-controlled identity and ruleset design, including exact-head checks,
+required review/check policy, and revocation. This checker does not create or
+infer that authority. The no-human-merge acceptance criterion in #368 therefore
+remains unfulfilled by this verification-only implementation.
+
+Merge the trusted checker before relying on its workflow for new proposals.
+Repository publication and on-chain verification do not prove private-key
+control, legal authority, or permission to send funds. Nothing in this path
+signs, broadcasts, transfers funds, or marks a platform payout as paid.

--- a/protocol/funding-record-pr-verification.md
+++ b/protocol/funding-record-pr-verification.md
@@ -32,10 +32,14 @@ For the automatic-verification subset:
   require human review. A chain verifier cannot establish a donor's GitHub
   attribution or permission to publish it.
 - The project must exist in the trusted base inventory. The record's manifest
-  revision must already be an ancestor of that base, and its recipient must be
-  active at the observation time under that immutable manifest. A manifest
-  commit present only in a PR or fork is insufficient. Future observations or
-  verification timestamps are rejected.
+  revision must already be an ancestor of that base. Its recipient must be
+  active at chain inclusion and observation under that immutable manifest,
+  and at observation under the trusted base's current address history. An old
+  manifest cannot revive a route after maintainers replace it. Observations
+  before replacement remain eligible; already-accepted historical records are
+  not reclassified by this new-record check. A manifest commit present only in
+  a PR or fork is insufficient. Future observations or verification timestamps
+  are rejected.
 - Transaction identity and record IDs must not repeat within the proposal or
   the complete existing non-commitment funding inventory, including across
   projects. Any correction-chain ambiguity remains outside this subset.

--- a/protocol/funding-record-pr-verification.md
+++ b/protocol/funding-record-pr-verification.md
@@ -44,6 +44,13 @@ For the automatic-verification subset:
   Only the verifier's fixed read-only mainnet endpoints are used; records cannot
   select RPC URLs or executable commands. Network errors and verifier failures
   fail closed.
+- Every successful output must contain a bounded integer inclusion block time.
+  Solana supplies `blockTime`; Bitcoin supplies `status.block_time`; EVM supplies
+  the timestamp of the canonical receipt block. EVM and Bitcoin authorities must
+  agree on that timestamp as well as the block identity. Missing timestamps,
+  future inclusion, observations before inclusion, and verification checks before
+  inclusion fail closed. This proves temporal consistency with inclusion, not the
+  historical instant that finality was reached; finality is independently rechecked.
 - The new output must match the record's state, transaction, verifier version,
   evidence URL, and finality exactly. The fresh check may occur later than the
   recorded check. An increased EVM or Bitcoin confirmation count is therefore

--- a/scripts/check-funding-record-pr.test.ts
+++ b/scripts/check-funding-record-pr.test.ts
@@ -24,6 +24,7 @@ import {
 } from "./check-funding-record-pr";
 
 const SIGNATURE = "3".repeat(88);
+const BLOCK_TIME = Date.parse("2026-07-31T00:00:00.000Z") / 1000;
 const SOLANA_RECIPIENT = "11111111111111111111111111111111";
 const SOLANA_SOURCE = "Vote111111111111111111111111111111111111111";
 const EVM_RECIPIENT = `0x${"1".repeat(40)}`;
@@ -175,6 +176,7 @@ function chainFetcher(network: FundingNetwork) {
               status: {
                 confirmed: true,
                 block_height: 800000,
+                block_time: BLOCK_TIME,
                 block_hash: "f".repeat(64),
               },
               vin: [
@@ -214,7 +216,7 @@ function chainFetcher(network: FundingNetwork) {
         });
         result = {
           slot: 123,
-          blockTime: 1786000000,
+          blockTime: BLOCK_TIME,
           meta: {
             err: null,
             preTokenBalances: [
@@ -234,7 +236,11 @@ function chainFetcher(network: FundingNetwork) {
         result =
           body.params[0] === "finalized"
             ? { number: "0x163", hash: `0x${"c".repeat(64)}` }
-            : { number: "0x100", hash: `0x${"b".repeat(64)}` };
+            : {
+                number: "0x100",
+                hash: `0x${"b".repeat(64)}`,
+                timestamp: `0x${BLOCK_TIME.toString(16)}`,
+              };
       else if (body.method === "eth_getTransactionReceipt") {
         const transactionHash = `0x${"a".repeat(64)}`;
         const blockHash = `0x${"b".repeat(64)}`;
@@ -268,6 +274,60 @@ function chainFetcher(network: FundingNetwork) {
 }
 
 describe("trusted funding-record PR gate", () => {
+  for (const network of ["solana", "base", "ethereum", "bitcoin"] as const) {
+    for (const temporalFault of [
+      "pre-inclusion",
+      "missing-inclusion",
+      "future-inclusion",
+    ] as const) {
+      it(`rejects ${network} ${temporalFault} evidence without granting authority`, async () => {
+        const repo = fixture();
+        try {
+          const record = repo.record(network);
+          if (temporalFault === "pre-inclusion") {
+            record.observedAt = "2026-07-30T00:00:00.000Z";
+            if (!record.verifier) throw new Error("missing fixture verifier");
+            record.verifier.checkedAt = record.observedAt;
+          }
+          const headSha = repo.proposal([record]);
+          const chain = chainFetcher(network);
+          const result = await checkFundingRecordPr({
+            repositoryRoot: repo.root,
+            baseSha: repo.baseSha,
+            headSha,
+            pullRequestNumber: 368,
+            fetchImpl: async (url, init) => {
+              const response = await chain.fetchImpl(url, init);
+              if (temporalFault === "pre-inclusion") return response;
+              const text = await response.text();
+              if (!text.startsWith("{")) return new Response(text);
+              const body = JSON.parse(text);
+              const value =
+                temporalFault === "missing-inclusion"
+                  ? undefined
+                  : Math.floor(Date.now() / 1000) + 86400;
+              if (network === "solana") body.result.blockTime = value;
+              else if (network === "bitcoin" && body.status)
+                body.status.block_time = value;
+              else if (
+                (network === "base" || network === "ethereum") &&
+                body.result?.number === "0x100"
+              )
+                body.result.timestamp =
+                  value === undefined ? undefined : `0x${value.toString(16)}`;
+              return new Response(JSON.stringify(body));
+            },
+          });
+          expect(result.decision, result.reason).toBe("verification-failed");
+          expect(result.mergeAuthorized).toBe(false);
+          if (temporalFault === "pre-inclusion")
+            expect(result.reason).toMatch(/predates chain inclusion/u);
+        } finally {
+          repo.cleanup();
+        }
+      });
+    }
+  }
   for (const network of ["solana", "base", "ethereum", "bitcoin"] as const) {
     it(`verifies a pure ${network} addition through its real read-only verifier`, async () => {
       const repo = fixture();

--- a/scripts/check-funding-record-pr.test.ts
+++ b/scripts/check-funding-record-pr.test.ts
@@ -403,6 +403,145 @@ describe("trusted funding-record PR gate", () => {
     }
   });
 
+  for (const replacedAt of [
+    "2026-07-01T00:00:00.000Z",
+    "2026-08-01T00:00:00.000Z",
+    "2026-08-02T00:00:00.000Z",
+  ]) {
+    it(`binds historical route observations to the trusted-base replacement at ${replacedAt}`, async () => {
+      const repo = fixture();
+      try {
+        const record = repo.record();
+        const current = structuredClone(repo.project);
+        const route = current.funding.addresses.find(
+          (address) => address.network === "solana",
+        );
+        if (!route) throw new Error("missing fixture route");
+        // The earlier manifest still has replacedAt:null, as it did when
+        // reviewed. A new record must also honor later reviewed history.
+        const addresses = current.funding.addresses.map((address) =>
+          address.network === "solana" ? { ...address, replacedAt } : address,
+        );
+        addresses.push({
+          ...route,
+          address: SOLANA_SOURCE,
+          effectiveAt: replacedAt,
+          replacedAt: null,
+        });
+        repo.write(
+          "projects/eliza/project.json",
+          JSON.stringify({
+            ...current,
+            funding: { ...current.funding, addresses },
+          }),
+        );
+        repo.commitBase([]);
+        const headSha = repo.proposal([record]);
+        const chain = chainFetcher("solana");
+        const result = await checkFundingRecordPr({
+          repositoryRoot: repo.root,
+          baseSha: repo.baseSha,
+          headSha,
+          pullRequestNumber: 368,
+          fetchImpl: chain.fetchImpl,
+        });
+        const beforeReplacement = record.observedAt < replacedAt;
+        expect(result.decision, result.reason).toBe(
+          beforeReplacement ? "verified-records" : "verification-failed",
+        );
+        expect(result.mergeAuthorized).toBe(false);
+        expect(chain.requests.length).toBe(beforeReplacement ? 1 : 0);
+      } finally {
+        repo.cleanup();
+      }
+    });
+  }
+
+  for (const offsetSeconds of [0, 1]) {
+    it(`requires the historical route to be active at inclusion, offset ${offsetSeconds}`, async () => {
+      const repo = fixture();
+      try {
+        const project = structuredClone(repo.project);
+        const route = project.funding.addresses.find(
+          (address) => address.network === "solana",
+        );
+        if (!route) throw new Error("missing fixture route");
+        route.effectiveAt = new Date(
+          (BLOCK_TIME + offsetSeconds) * 1000,
+        ).toISOString();
+        repo.write("projects/eliza/project.json", JSON.stringify(project));
+        repo.commitBase([]);
+        const headSha = repo.proposal([repo.record()]);
+        const chain = chainFetcher("solana");
+        const result = await checkFundingRecordPr({
+          repositoryRoot: repo.root,
+          baseSha: repo.baseSha,
+          headSha,
+          pullRequestNumber: 368,
+          fetchImpl: chain.fetchImpl,
+        });
+        expect(result.decision, result.reason).toBe(
+          offsetSeconds === 0 ? "verified-records" : "verification-failed",
+        );
+        expect(result.mergeAuthorized).toBe(false);
+        expect(chain.requests.length).toBe(1);
+      } finally {
+        repo.cleanup();
+      }
+    });
+  }
+
+  it("preserves accepted historical records without reviving their removed route for new records", async () => {
+    const repo = fixture();
+    try {
+      const previous = repo.record("bitcoin");
+      repo.commitBase([previous]);
+      const historicalRecord = repo.record("bitcoin");
+      const project = structuredClone(repo.project);
+      project.funding.addresses = project.funding.addresses.filter(
+        (address) => address.network !== "bitcoin",
+      );
+      repo.write("projects/eliza/project.json", JSON.stringify(project));
+      repo.commitBase([]);
+      const newRecord = { ...repo.record(), recordId: "fund_fixture02" };
+      const headSha = repo.proposal([newRecord]);
+      const chain = chainFetcher("solana");
+      const result = await checkFundingRecordPr({
+        repositoryRoot: repo.root,
+        baseSha: repo.baseSha,
+        headSha,
+        pullRequestNumber: 368,
+        fetchImpl: chain.fetchImpl,
+      });
+      expect(result.decision, result.reason).toBe("verified-records");
+      expect(chain.requests.length).toBe(1);
+      if (!historicalRecord.verifier)
+        throw new Error("missing fixture verifier");
+      const removedRouteRecord = {
+        ...historicalRecord,
+        recordId: "fund_fixture03",
+        transactionId: "b".repeat(64),
+        verifier: {
+          ...historicalRecord.verifier,
+          evidenceUrl: `https://mempool.space/tx/${"b".repeat(64)}`,
+        },
+      };
+      const removedRouteHead = repo.proposal([removedRouteRecord]);
+      const rejected = await checkFundingRecordPr({
+        repositoryRoot: repo.root,
+        baseSha: repo.baseSha,
+        headSha: removedRouteHead,
+        pullRequestNumber: 368,
+        fetchImpl: chain.fetchImpl,
+      });
+      expect(rejected.decision, rejected.reason).toBe("verification-failed");
+      expect(rejected.reason).toMatch(/recipient was not active/u);
+      expect(chain.requests.length).toBe(1);
+    } finally {
+      repo.cleanup();
+    }
+  });
+
   it("rejects a fresh confirmation count different from the submitted finality", async () => {
     const repo = fixture();
     try {

--- a/scripts/check-funding-record-pr.test.ts
+++ b/scripts/check-funding-record-pr.test.ts
@@ -1,0 +1,669 @@
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+import eliza from "../projects/eliza/project.json";
+import { EVM_FUNDING_USDC_CONTRACTS } from "../src/lib/evm-funding";
+import type { FundingNetwork, ProjectFundingRecord } from "../src/lib/funding";
+import { SOLANA_MAINNET_USDC_MINT } from "../src/lib/settlement-plan";
+import {
+  canonicalFundingDecisionBytes,
+  checkFundingRecordPr,
+} from "./check-funding-record-pr";
+
+const SIGNATURE = "3".repeat(88);
+const SOLANA_RECIPIENT = "11111111111111111111111111111111";
+const SOLANA_SOURCE = "Vote111111111111111111111111111111111111111";
+const EVM_RECIPIENT = `0x${"1".repeat(40)}`;
+const BITCOIN_RECIPIENT = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
+const BTC_SOURCE = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4";
+const RECIPIENTS = {
+  solana: SOLANA_RECIPIENT,
+  bitcoin: BITCOIN_RECIPIENT,
+  base: EVM_RECIPIENT,
+  ethereum: EVM_RECIPIENT,
+};
+
+function pathFor(record: ProjectFundingRecord): string {
+  return `funding/${record.projectId}/${record.network}/${record.transactionId}/${record.recordId}.json`;
+}
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), "slop-funding-pr-"));
+  const git = (...args: string[]) =>
+    execFileSync("git", args, {
+      cwd: root,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+  const write = (path: string, bytes: string) => {
+    mkdirSync(dirname(join(root, path)), { recursive: true });
+    writeFileSync(join(root, path), bytes);
+  };
+  git("init", "--initial-branch=develop");
+  git("config", "user.name", "Funding Gate Test");
+  git("config", "user.email", "funding-gate@example.invalid");
+  git("config", "commit.gpgsign", "false");
+  git("config", "core.hooksPath", join(root, "no-hooks"));
+  const project = {
+    ...structuredClone(eliza),
+    funding: {
+      ...eliza.funding,
+      addresses: (Object.keys(RECIPIENTS) as FundingNetwork[]).map(
+        (network) => ({
+          network,
+          asset: network === "bitcoin" ? "BTC" : "USDC",
+          address: RECIPIENTS[network],
+          effectiveAt: "2026-01-01T00:00:00.000Z",
+          replacedAt: null,
+        }),
+      ),
+    },
+  };
+  write("projects/eliza/project.json", JSON.stringify(project));
+  write("funding/README.md", "Reviewed funding history.\n");
+  git("add", ".");
+  git("commit", "-qm", "reviewed base");
+  let baseSha = git("rev-parse", "HEAD");
+  function record(network: FundingNetwork = "solana"): ProjectFundingRecord {
+    const transactionId =
+      network === "solana"
+        ? SIGNATURE
+        : network === "bitcoin"
+          ? "a".repeat(64)
+          : `0x${"a".repeat(64)}`;
+    const origin =
+      network === "solana"
+        ? "https://solscan.io"
+        : network === "bitcoin"
+          ? "https://mempool.space"
+          : network === "base"
+            ? "https://basescan.org"
+            : "https://etherscan.io";
+    return {
+      kind: "project-funding",
+      schemaVersion: "1",
+      recordId: "fund_fixture01",
+      projectId: "eliza",
+      manifestRevision: baseSha,
+      network,
+      asset: network === "bitcoin" ? "BTC" : "USDC",
+      transactionId,
+      recipient: RECIPIENTS[network],
+      amountMinor: network === "bitcoin" ? "150000" : "1000000",
+      observedAt: "2026-08-01T00:00:00.000Z",
+      state: "verified-on-chain",
+      donor: { attribution: "anonymous" },
+      finality:
+        network === "solana"
+          ? { kind: "finalized" }
+          : {
+              kind: "confirmations",
+              confirmations: network === "bitcoin" ? 11 : 100,
+            },
+      verifier: {
+        version: `funding-${network}-v1`,
+        checkedAt: "2026-08-01T00:00:00.000Z",
+        evidenceUrl: `${origin}/tx/${transactionId}`,
+        reason: null,
+      },
+      supersedes: null,
+    };
+  }
+  return {
+    root,
+    git,
+    write,
+    project,
+    record,
+    get baseSha() {
+      return baseSha;
+    },
+    commitBase(records: ProjectFundingRecord[]) {
+      for (const item of records)
+        write(pathFor(item), canonicalFundingDecisionBytes(item));
+      git("add", ".");
+      git("commit", "-qm", "accepted funding records");
+      baseSha = git("rev-parse", "HEAD");
+    },
+    proposal(records: ProjectFundingRecord[], extra?: () => void) {
+      for (const item of records)
+        write(pathFor(item), canonicalFundingDecisionBytes(item));
+      extra?.();
+      git("add", "--all");
+      git("commit", "-qm", "untrusted proposal");
+      const headSha = git("rev-parse", "HEAD");
+      git("switch", "--detach", baseSha);
+      return headSha;
+    },
+    cleanup() {
+      rmSync(root, { recursive: true, force: true });
+    },
+  };
+}
+
+function chainFetcher(network: FundingNetwork) {
+  const requests: string[] = [];
+  return {
+    requests,
+    fetchImpl: async (url: RequestInfo | URL, init?: RequestInit) => {
+      const source = new URL(String(url));
+      requests.push(source.href);
+      expect(init?.redirect).toBe("error");
+      if (network === "bitcoin") {
+        const path = source.pathname.replace(/^\/api/u, "");
+        expect(init?.method).toBe("GET");
+        if (path === "/blocks/tip/height") return new Response("800010");
+        if (path === "/block-height/800000")
+          return new Response("f".repeat(64));
+        if (path === `/tx/${"a".repeat(64)}`)
+          return new Response(
+            JSON.stringify({
+              txid: "a".repeat(64),
+              status: {
+                confirmed: true,
+                block_height: 800000,
+                block_hash: "f".repeat(64),
+              },
+              vin: [
+                {
+                  is_coinbase: false,
+                  prevout: { scriptpubkey_address: BTC_SOURCE, value: 200000 },
+                },
+              ],
+              vout: [
+                { scriptpubkey_address: BITCOIN_RECIPIENT, value: 150000 },
+                { scriptpubkey_address: BTC_SOURCE, value: 49000 },
+              ],
+              fee: 1000,
+            }),
+          );
+        throw new Error(`unexpected Bitcoin request ${path}`);
+      }
+      const body = JSON.parse(String(init?.body));
+      expect(init?.method).toBe("POST");
+      let result: unknown;
+      if (network === "solana") {
+        expect(source.href).toBe("https://api.mainnet-beta.solana.com/");
+        expect(body.method).toBe("getTransaction");
+        expect(body.params).toMatchObject([
+          SIGNATURE,
+          { commitment: "finalized", encoding: "jsonParsed" },
+        ]);
+        const balance = (
+          accountIndex: number,
+          owner: string,
+          amount: string,
+        ) => ({
+          accountIndex,
+          mint: SOLANA_MAINNET_USDC_MINT,
+          owner,
+          uiTokenAmount: { amount, decimals: 6 },
+        });
+        result = {
+          slot: 123,
+          blockTime: 1786000000,
+          meta: {
+            err: null,
+            preTokenBalances: [
+              balance(0, SOLANA_SOURCE, "2000000"),
+              balance(1, SOLANA_RECIPIENT, "0"),
+            ],
+            postTokenBalances: [
+              balance(0, SOLANA_SOURCE, "1000000"),
+              balance(1, SOLANA_RECIPIENT, "1000000"),
+            ],
+          },
+          transaction: { signatures: [SIGNATURE] },
+        };
+      } else if (body.method === "eth_chainId")
+        result = network === "base" ? "0x2105" : "0x1";
+      else if (body.method === "eth_getBlockByNumber")
+        result =
+          body.params[0] === "finalized"
+            ? { number: "0x163", hash: `0x${"c".repeat(64)}` }
+            : { number: "0x100", hash: `0x${"b".repeat(64)}` };
+      else if (body.method === "eth_getTransactionReceipt") {
+        const transactionHash = `0x${"a".repeat(64)}`;
+        const blockHash = `0x${"b".repeat(64)}`;
+        result = {
+          status: "0x1",
+          transactionHash,
+          blockNumber: "0x100",
+          blockHash,
+          logs: [
+            {
+              address: EVM_FUNDING_USDC_CONTRACTS[network],
+              topics: [
+                "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+                `0x${"0".repeat(24)}${"2".repeat(40)}`,
+                `0x${"0".repeat(24)}${"1".repeat(40)}`,
+              ],
+              data: `0x${1000000n.toString(16).padStart(64, "0")}`,
+              removed: false,
+              transactionHash,
+              blockNumber: "0x100",
+              blockHash,
+            },
+          ],
+        };
+      } else throw new Error(`unexpected RPC method ${body.method}`);
+      return new Response(
+        JSON.stringify({ jsonrpc: "2.0", id: body.id, result }),
+      );
+    },
+  };
+}
+
+describe("trusted funding-record PR gate", () => {
+  for (const network of ["solana", "base", "ethereum", "bitcoin"] as const) {
+    it(`verifies a pure ${network} addition through its real read-only verifier`, async () => {
+      const repo = fixture();
+      try {
+        const record = repo.record(network);
+        const headSha = repo.proposal([record]);
+        const rpc = chainFetcher(network);
+        const result = await checkFundingRecordPr({
+          repositoryRoot: repo.root,
+          baseSha: repo.baseSha,
+          headSha,
+          pullRequestNumber: 368,
+          fetchImpl: rpc.fetchImpl,
+        });
+        expect(result.decision, result.reason).toBe("verified-records");
+        expect(result.mergeAuthorized).toBe(false);
+        expect(result.headSha).toBe(headSha);
+        expect(result.checkerRevision).toBe(repo.baseSha);
+        const evidence = result.records[0];
+        expect(evidence.recordBytesSha256).toBe(
+          createHash("sha256")
+            .update(canonicalFundingDecisionBytes(record))
+            .digest("hex"),
+        );
+        expect(evidence.recordBlobOid).toBe(
+          repo.git("rev-parse", `${headSha}:${pathFor(record)}`),
+        );
+        expect(evidence.verificationInput).toMatchObject({
+          projectId: record.projectId,
+          recipient: record.recipient,
+          asset: record.asset,
+          amountMinor: record.amountMinor,
+          transactionId: record.transactionId,
+        });
+        expect(evidence.verifierVersion).toBe(record.verifier?.version);
+        if (!evidence.verifierOutputCanonical)
+          throw new Error("missing verifier output");
+        expect(evidence.verifierOutputSha256).toBe(
+          createHash("sha256")
+            .update(evidence.verifierOutputCanonical)
+            .digest("hex"),
+        );
+        expect(JSON.parse(evidence.verifierOutputCanonical)).toMatchObject({
+          state: "verified-on-chain",
+          finality: record.finality,
+        });
+        expect(rpc.requests.length).toBeGreaterThan(0);
+      } finally {
+        repo.cleanup();
+      }
+    });
+  }
+
+  it("fails the exact-amount claim when Solana credits one fewer minor unit", async () => {
+    const repo = fixture();
+    try {
+      const record = { ...repo.record(), amountMinor: "1000001" };
+      const headSha = repo.proposal([record]);
+      const rpc = chainFetcher("solana");
+      const result = await checkFundingRecordPr({
+        repositoryRoot: repo.root,
+        baseSha: repo.baseSha,
+        headSha,
+        pullRequestNumber: 368,
+        fetchImpl: rpc.fetchImpl,
+      });
+      expect(result.decision).toBe("verification-failed");
+      expect(result.reason).toMatch(/exact amount/u);
+      expect(result.records[0].verifierVersion).toBe("funding-solana-v1");
+      expect(result.records[0].verifierOutputSha256).toBeNull();
+    } finally {
+      repo.cleanup();
+    }
+  });
+
+  it("rejects a fresh confirmation count different from the submitted finality", async () => {
+    const repo = fixture();
+    try {
+      const record = {
+        ...repo.record("bitcoin"),
+        finality: { kind: "confirmations" as const, confirmations: 10 },
+      };
+      const headSha = repo.proposal([record]);
+      const result = await checkFundingRecordPr({
+        repositoryRoot: repo.root,
+        baseSha: repo.baseSha,
+        headSha,
+        pullRequestNumber: 368,
+        fetchImpl: chainFetcher("bitcoin").fetchImpl,
+      });
+      expect(result.decision).toBe("verification-failed");
+      expect(result.reason).toMatch(/finality/u);
+      expect(result.records[0].verifierOutputSha256).toMatch(/^[a-f0-9]{64}$/u);
+    } finally {
+      repo.cleanup();
+    }
+  });
+
+  for (const kind of [
+    "manifest",
+    "modified",
+    "deleted",
+    "symlink",
+    "executable",
+    "commitment",
+    "script",
+  ] as const) {
+    it(`leaves ${kind} changes on human review without calling a verifier`, async () => {
+      const repo = fixture();
+      try {
+        const record = repo.record();
+        const headSha = repo.proposal([record], () => {
+          if (kind === "manifest")
+            repo.write(
+              "projects/eliza/project.json",
+              JSON.stringify({ ...repo.project, name: "Different" }),
+            );
+          if (kind === "modified") repo.write("funding/README.md", "changed\n");
+          if (kind === "deleted")
+            unlinkSync(join(repo.root, "funding/README.md"));
+          if (kind === "symlink") {
+            unlinkSync(join(repo.root, pathFor(record)));
+            symlinkSync(
+              "../../../../projects/eliza/project.json",
+              join(repo.root, pathFor(record)),
+            );
+          }
+          if (kind === "executable")
+            chmodSync(join(repo.root, pathFor(record)), 0o755);
+          if (kind === "commitment")
+            repo.write("funding/eliza/commitments/record.json", "{}\n");
+          if (kind === "script")
+            repo.write(
+              "scripts/attacker.ts",
+              `require("node:fs").writeFileSync(${JSON.stringify(join(repo.root, "executed"))}, "bad")`,
+            );
+        });
+        let fetched = false;
+        const result = await checkFundingRecordPr({
+          repositoryRoot: repo.root,
+          baseSha: repo.baseSha,
+          headSha,
+          pullRequestNumber: 368,
+          fetchImpl: async () => {
+            fetched = true;
+            throw new Error("must not fetch");
+          },
+        });
+        expect(result.decision).toBe("human-review-required");
+        expect(result.mergeAuthorized).toBe(false);
+        expect(fetched).toBe(false);
+        expect(existsSync(join(repo.root, "executed"))).toBe(false);
+        expect(repo.git("rev-parse", "HEAD")).toBe(repo.baseSha);
+      } finally {
+        repo.cleanup();
+      }
+    });
+  }
+
+  for (const kind of [
+    "self-reported",
+    "disputed",
+    "supersedes",
+    "attributed",
+  ] as const) {
+    it(`keeps ${kind} records outside unattended verification`, async () => {
+      const repo = fixture();
+      try {
+        const record = repo.record();
+        if (kind === "self-reported") {
+          record.state = kind;
+          record.finality = { kind: "unverified" };
+          record.verifier = null;
+        }
+        if (kind === "disputed") {
+          record.state = kind;
+          if (!record.verifier) throw new Error("missing fixture verifier");
+          record.verifier.reason = "disputed by a later observation";
+        }
+        if (kind === "supersedes") record.supersedes = "fund_previous01";
+        if (kind === "attributed")
+          record.donor = {
+            attribution: "github",
+            actorId: "42",
+            actorNodeId: "MDQ6VXNlcjQy",
+            login: "someone",
+          };
+        const headSha = repo.proposal([record]);
+        const result = await checkFundingRecordPr({
+          repositoryRoot: repo.root,
+          baseSha: repo.baseSha,
+          headSha,
+          pullRequestNumber: 368,
+          fetchImpl: async () => {
+            throw new Error("must not fetch");
+          },
+        });
+        expect(result.decision, result.reason).toBe("human-review-required");
+        expect(result.records[0].verifierOutputSha256).toBeNull();
+      } finally {
+        repo.cleanup();
+      }
+    });
+  }
+
+  it("rejects duplicate transactions against the base and within the same proposal", async () => {
+    for (const existing of [true, false]) {
+      const repo = fixture();
+      try {
+        const previous = repo.record();
+        if (existing) repo.commitBase([previous]);
+        const next = { ...repo.record(), recordId: "fund_fixture02" };
+        const headSha = repo.proposal(existing ? [next] : [previous, next]);
+        const result = await checkFundingRecordPr({
+          repositoryRoot: repo.root,
+          baseSha: repo.baseSha,
+          headSha,
+          pullRequestNumber: 368,
+        });
+        expect(result.decision).toBe("verification-failed");
+        expect(result.reason).toMatch(/duplicates/u);
+      } finally {
+        repo.cleanup();
+      }
+    }
+  });
+
+  it("refuses a manifest commit present only in unreviewed PR history", async () => {
+    const repo = fixture();
+    try {
+      const unreviewed = repo.git(
+        "commit-tree",
+        `${repo.baseSha}^{tree}`,
+        "-p",
+        repo.baseSha,
+        "-m",
+        "unreviewed manifest state",
+      );
+      const record = { ...repo.record(), manifestRevision: unreviewed };
+      const headSha = repo.proposal([record]);
+      const result = await checkFundingRecordPr({
+        repositoryRoot: repo.root,
+        baseSha: repo.baseSha,
+        headSha,
+        pullRequestNumber: 368,
+      });
+      expect(result.decision).toBe("verification-failed");
+      expect(result.records[0].verifierOutputCanonical).toBeNull();
+    } finally {
+      repo.cleanup();
+    }
+  });
+
+  it("binds verification to the trusted checkout and rejects a non-descendant PR head", async () => {
+    const repo = fixture();
+    try {
+      const headSha = repo.proposal([repo.record()]);
+      repo.git("switch", "--detach", headSha);
+      const wrongCheckout = await checkFundingRecordPr({
+        repositoryRoot: repo.root,
+        baseSha: repo.baseSha,
+        headSha,
+        pullRequestNumber: 368,
+      });
+      expect(wrongCheckout.reason).toMatch(/exact trusted base/u);
+      repo.git("switch", "--detach", repo.baseSha);
+      const unrelated = repo.git(
+        "commit-tree",
+        `${headSha}^{tree}`,
+        "-m",
+        "unrelated history",
+      );
+      const result = await checkFundingRecordPr({
+        repositoryRoot: repo.root,
+        baseSha: repo.baseSha,
+        headSha: unrelated,
+        pullRequestNumber: 368,
+      });
+      expect(result.decision).toBe("verification-failed");
+      expect(result.records).toEqual([]);
+    } finally {
+      repo.cleanup();
+    }
+  });
+
+  it("rejects ambiguous JSON and preserves the hash of the actual proposed bytes", async () => {
+    const repo = fixture();
+    try {
+      const record = repo.record();
+      const bytes = canonicalFundingDecisionBytes(record).replace(
+        '"amountMinor": "1000000"',
+        '"amountMinor": "1", "amountMinor": "1000000"',
+      );
+      const headSha = repo.proposal([record], () =>
+        repo.write(pathFor(record), bytes),
+      );
+      const result = await checkFundingRecordPr({
+        repositoryRoot: repo.root,
+        baseSha: repo.baseSha,
+        headSha,
+        pullRequestNumber: 368,
+      });
+      expect(result.decision).toBe("human-review-required");
+      expect(result.reason).toMatch(/canonical UTF-8/u);
+      expect(result.records[0].recordBytesSha256).toBe(
+        createHash("sha256").update(bytes).digest("hex"),
+      );
+    } finally {
+      repo.cleanup();
+    }
+  });
+
+  for (const kind of [
+    "project",
+    "recipient",
+    "asset",
+    "transaction",
+    "future",
+    "oversized",
+    "invalid-utf8",
+  ] as const) {
+    it(`rejects ${kind} evidence before any network request`, async () => {
+      const repo = fixture();
+      try {
+        const record = repo.record();
+        const path = pathFor(record);
+        if (kind === "project") record.projectId = "not-the-project";
+        if (kind === "recipient") record.recipient = SOLANA_SOURCE;
+        if (kind === "asset") record.asset = "BTC";
+        if (kind === "transaction") record.transactionId = "4".repeat(88);
+        if (kind === "future") record.observedAt = "2999-01-01T00:00:00.000Z";
+        const headSha = repo.proposal([], () => {
+          repo.write(
+            path,
+            kind === "oversized"
+              ? " ".repeat(65537)
+              : canonicalFundingDecisionBytes(record),
+          );
+          if (kind === "invalid-utf8")
+            writeFileSync(join(repo.root, path), Buffer.from([0xff, 0xfe]));
+        });
+        let requests = 0;
+        const result = await checkFundingRecordPr({
+          repositoryRoot: repo.root,
+          baseSha: repo.baseSha,
+          headSha,
+          pullRequestNumber: 368,
+          fetchImpl: async () => {
+            requests += 1;
+            throw new Error("unexpected network request");
+          },
+        });
+        expect(result.decision).toBe("verification-failed");
+        expect(result.mergeAuthorized).toBe(false);
+        expect(requests).toBe(0);
+      } finally {
+        repo.cleanup();
+      }
+    });
+  }
+
+  it("fails closed when the read-only verifier cannot reach its authority", async () => {
+    const repo = fixture();
+    try {
+      const headSha = repo.proposal([repo.record()]);
+      const result = await checkFundingRecordPr({
+        repositoryRoot: repo.root,
+        baseSha: repo.baseSha,
+        headSha,
+        pullRequestNumber: 368,
+        fetchImpl: async () => new Response("unavailable", { status: 503 }),
+      });
+      expect(result.decision).toBe("verification-failed");
+      expect(result.mergeAuthorized).toBe(false);
+    } finally {
+      repo.cleanup();
+    }
+  });
+
+  it("keeps the workflow on trusted-base code with read-only permissions and no merge API", () => {
+    const workflow = readFileSync(
+      join(process.cwd(), ".github/workflows/funding-records.yml"),
+      "utf8",
+    );
+    expect(workflow).toContain("pull_request_target:");
+    expect(workflow).toContain(
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: literal GitHub Actions expression
+      "ref: ${{ github.event.pull_request.base.sha }}",
+    );
+    expect(workflow).toContain("persist-credentials: false");
+    expect(workflow).toContain("contents: read");
+    expect(workflow).toContain(
+      'test "$(git rev-parse refs/remotes/origin/slop-funding-head)" = "$FUNDING_HEAD_SHA"',
+    );
+    expect(workflow).not.toMatch(
+      /contents: write|pull-requests: write|gh pr merge|gh pr review|environment:|bun install|ref:.*head.sha/u,
+    );
+  });
+});

--- a/scripts/check-funding-record-pr.ts
+++ b/scripts/check-funding-record-pr.ts
@@ -1,0 +1,449 @@
+/** Trusted-base, read-only verification of narrowly scoped funding-record PRs. */
+
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  assertProjectFundingAddresses,
+  assertProjectFundingRecord,
+  type ProjectFundingRecord,
+} from "../src/lib/funding";
+import {
+  assertHistoricalProjectDefinition,
+  assertProjectDefinition,
+} from "../src/lib/project-schema.mjs";
+import { verifyFundingBitcoin } from "./verify-funding-bitcoin";
+import { verifyFundingEvm } from "./verify-funding-evm";
+import { verifyFundingSolana } from "./verify-funding-solana";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const SHA = /^[0-9a-f]{40}$/u;
+const RECORD_PATH =
+  /^funding\/([a-z0-9](?:[a-z0-9-]{0,46}[a-z0-9])?)\/(base|bitcoin|ethereum|solana)\/([A-Za-z0-9]+)\/(fund_[a-z0-9][a-z0-9_-]{6,79})\.json$/u;
+const MAX_RECORD_BYTES = 64 * 1024;
+const MAX_RECORDS = 20;
+export const FUNDING_RECORD_GATE_VERSION = "funding-record-gate-v1";
+
+type FetchLike = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<Response>;
+interface BlobEntry {
+  mode: string;
+  oid: string;
+  path: string;
+}
+interface RecordDecision {
+  path: string;
+  recordBlobOid: string;
+  recordBytesSha256: string;
+  verificationInput: null | {
+    projectId: string;
+    manifestRevision: string;
+    network: string;
+    asset: string;
+    transactionId: string;
+    recipient: string;
+    amountMinor: string;
+  };
+  verifierVersion: string | null;
+  verifierOutputCanonical: string | null;
+  verifierOutputSha256: string | null;
+}
+export interface FundingRecordDecision {
+  kind: "funding-record-pr-decision";
+  schemaVersion: "1";
+  checkerVersion: typeof FUNDING_RECORD_GATE_VERSION;
+  checkerRevision: string;
+  baseSha: string;
+  headSha: string;
+  pullRequestNumber: number;
+  checkedAt: string;
+  decision:
+    | "human-review-required"
+    | "verification-failed"
+    | "verified-records";
+  mergeAuthorized: false;
+  reason: string;
+  records: RecordDecision[];
+}
+
+class HumanReviewRequired extends Error {}
+
+/** Canonical UTF-8 JSON: sorted object keys, two-space indentation, one LF. */
+export function canonicalFundingDecisionBytes(value: unknown): string {
+  const ordered = (entry: unknown): unknown => {
+    if (Array.isArray(entry)) return entry.map(ordered);
+    if (entry !== null && typeof entry === "object") {
+      return Object.fromEntries(
+        Object.entries(entry)
+          .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+          .map(([key, item]) => [key, ordered(item)]),
+      );
+    }
+    return entry;
+  };
+  return `${JSON.stringify(ordered(value), null, 2)}\n`;
+}
+
+function digest(bytes: Uint8Array | string): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function git(
+  root: string,
+  args: string[],
+  maxBuffer = 16 * 1024 * 1024,
+): Buffer {
+  return execFileSync("git", ["--literal-pathspecs", ...args], {
+    cwd: root,
+    maxBuffer,
+    stdio: ["ignore", "pipe", "pipe"],
+    env: { ...process.env, GIT_NO_REPLACE_OBJECTS: "1" },
+  });
+}
+
+function treeEntries(
+  root: string,
+  revision: string,
+  path: string,
+): BlobEntry[] {
+  return git(root, ["ls-tree", "-r", "-z", "--full-tree", revision, "--", path])
+    .toString("utf8")
+    .split("\0")
+    .filter(Boolean)
+    .map((entry) => {
+      const match = entry.match(/^(\d{6}) blob ([0-9a-f]{40})\t(.+)$/u);
+      if (!match)
+        throw new TypeError("funding tree contains an unsupported Git object");
+      return { mode: match[1], oid: match[2], path: match[3] };
+    });
+}
+
+function blobBytes(root: string, oid: string, limit: number): Buffer {
+  const size = Number(
+    git(root, ["cat-file", "-s", oid], 1024).toString("utf8").trim(),
+  );
+  if (!Number.isSafeInteger(size) || size <= 0 || size > limit)
+    throw new TypeError("funding gate object exceeds its byte limit");
+  return git(root, ["cat-file", "blob", oid], limit);
+}
+
+function jsonBytes(bytes: Buffer): unknown {
+  const source = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  return JSON.parse(source);
+}
+
+function manifest(
+  root: string,
+  revision: string,
+  projectId: string,
+  historical = false,
+) {
+  const path = `projects/${projectId}/project.json`;
+  const entries = treeEntries(root, revision, path);
+  const entry = entries[0];
+  if (entries.length !== 1 || entry?.path !== path || entry.mode !== "100644")
+    throw new TypeError(
+      "funding record project manifest is missing or not a regular file",
+    );
+  const value = jsonBytes(blobBytes(root, entry.oid, 1024 * 1024));
+  const project = historical
+    ? assertHistoricalProjectDefinition(value)
+    : assertProjectDefinition(value);
+  if (
+    project.id !== projectId ||
+    project.funding.recordsPath !== `funding/${projectId}`
+  )
+    throw new TypeError(
+      "funding record project does not match its reviewed manifest",
+    );
+  return project;
+}
+
+function additions(root: string, base: string, head: string): BlobEntry[] {
+  const fields = git(root, [
+    "diff",
+    "--raw",
+    "--no-abbrev",
+    "--no-renames",
+    "--no-ext-diff",
+    "--no-textconv",
+    "-z",
+    base,
+    head,
+    "--",
+  ])
+    .toString("utf8")
+    .split("\0");
+  if (fields.pop() !== "" || fields.length % 2 !== 0)
+    throw new TypeError("funding diff is malformed");
+  if (fields.length === 0 || fields.length > MAX_RECORDS * 2)
+    throw new HumanReviewRequired(
+      `funding gate requires 1 to ${MAX_RECORDS} added records`,
+    );
+  const result: BlobEntry[] = [];
+  for (let index = 0; index < fields.length; index += 2) {
+    const header = fields[index].match(
+      /^:000000 100644 0{40} ([0-9a-f]{40}) A$/u,
+    );
+    const path = fields[index + 1];
+    if (!header || !RECORD_PATH.test(path))
+      throw new HumanReviewRequired(
+        "only added regular non-commitment funding records qualify; every other diff requires human review",
+      );
+    result.push({ mode: "100644", oid: header[1], path });
+  }
+  return result;
+}
+
+async function verify(record: ProjectFundingRecord, fetchImpl?: FetchLike) {
+  const input = {
+    amountMinor: record.amountMinor,
+    recipient: record.recipient,
+    fetchImpl,
+  };
+  if (record.network === "solana")
+    return verifyFundingSolana({ ...input, signature: record.transactionId });
+  if (record.network === "bitcoin")
+    return verifyFundingBitcoin({
+      ...input,
+      transactionId: record.transactionId,
+    });
+  return verifyFundingEvm({
+    ...input,
+    network: record.network,
+    transactionHash: record.transactionId,
+  });
+}
+
+export async function checkFundingRecordPr(input: {
+  baseSha: string;
+  headSha: string;
+  pullRequestNumber: number;
+  repositoryRoot?: string;
+  fetchImpl?: FetchLike;
+  now?: number;
+}): Promise<FundingRecordDecision> {
+  const root = input.repositoryRoot ?? ROOT;
+  const now = input.now ?? Date.now();
+  const decision: FundingRecordDecision = {
+    kind: "funding-record-pr-decision",
+    schemaVersion: "1",
+    checkerVersion: FUNDING_RECORD_GATE_VERSION,
+    checkerRevision: input.baseSha,
+    baseSha: input.baseSha,
+    headSha: input.headSha,
+    pullRequestNumber: input.pullRequestNumber,
+    checkedAt: new Date(now).toISOString(),
+    decision: "verification-failed",
+    mergeAuthorized: false,
+    reason: "verification did not complete",
+    records: [],
+  };
+  try {
+    if (
+      !SHA.test(input.baseSha) ||
+      !SHA.test(input.headSha) ||
+      !Number.isSafeInteger(input.pullRequestNumber) ||
+      input.pullRequestNumber <= 0
+    )
+      throw new TypeError(
+        "funding gate requires immutable base/head SHAs and a pull request number",
+      );
+    if (
+      git(root, ["rev-parse", "HEAD"]).toString("utf8").trim() !== input.baseSha
+    )
+      throw new TypeError(
+        "funding checker must run from the exact trusted base checkout",
+      );
+    git(root, ["cat-file", "-e", `${input.headSha}^{commit}`]);
+    git(root, ["merge-base", "--is-ancestor", input.baseSha, input.headSha]);
+    const added = additions(root, input.baseSha, input.headSha);
+    const transactions = new Set<string>();
+    const recordIds = new Set<string>();
+    for (const entry of treeEntries(root, input.baseSha, "funding")) {
+      if (
+        entry.path === "funding/README.md" ||
+        /^funding\/[^/]+\/commitments\//u.test(entry.path)
+      )
+        continue;
+      const path = entry.path.match(RECORD_PATH);
+      if (!path || entry.mode !== "100644")
+        throw new HumanReviewRequired(
+          "existing funding inventory has ambiguous paths or file modes",
+        );
+      transactions.add(`${path[2]}:${path[3]}`);
+      recordIds.add(path[4]);
+    }
+    const pending = added.map((entry) => {
+      const bytes = blobBytes(root, entry.oid, MAX_RECORD_BYTES);
+      const evidence: RecordDecision = {
+        path: entry.path,
+        recordBlobOid: entry.oid,
+        recordBytesSha256: digest(bytes),
+        verificationInput: null,
+        verifierVersion: null,
+        verifierOutputCanonical: null,
+        verifierOutputSha256: null,
+      };
+      decision.records.push(evidence);
+      return { entry, bytes, evidence };
+    });
+    const records: ProjectFundingRecord[] = [];
+    for (const { entry, bytes, evidence } of pending) {
+      const parsed = jsonBytes(bytes);
+      if (!bytes.equals(Buffer.from(canonicalFundingDecisionBytes(parsed))))
+        throw new HumanReviewRequired(
+          "automatic verification requires canonical UTF-8 record JSON without duplicate keys",
+        );
+      const path = entry.path.match(RECORD_PATH);
+      if (!path) throw new TypeError("funding record path changed");
+      const project = manifest(root, input.baseSha, path[1]);
+      const candidate = parsed as Partial<ProjectFundingRecord> | null;
+      const manifestRevision = candidate?.manifestRevision;
+      if (typeof manifestRevision !== "string" || !SHA.test(manifestRevision))
+        throw new TypeError("funding record manifest revision is invalid");
+      git(root, [
+        "merge-base",
+        "--is-ancestor",
+        manifestRevision,
+        input.baseSha,
+      ]);
+      const historical = manifest(root, manifestRevision, path[1], true);
+      const record = assertProjectFundingRecord(
+        parsed,
+        assertProjectFundingAddresses(historical.funding.addresses),
+      );
+      if (
+        record.projectId !== project.id ||
+        record.network !== path[2] ||
+        record.transactionId !== path[3] ||
+        record.recordId !== path[4]
+      )
+        throw new TypeError(
+          "funding record identity does not match its immutable path",
+        );
+      if (
+        record.state !== "verified-on-chain" ||
+        record.supersedes !== null ||
+        record.donor.attribution !== "anonymous"
+      )
+        throw new HumanReviewRequired(
+          "self-reported, disputed, correction, and attributed records require human review",
+        );
+      if (!record.verifier)
+        throw new TypeError("verified funding record has no verifier evidence");
+      if (
+        Date.parse(record.observedAt) > now ||
+        Date.parse(record.verifier.checkedAt) > now
+      )
+        throw new TypeError(
+          "funding record claims a future observation or verification",
+        );
+      const transactionKey = `${record.network}:${record.transactionId}`;
+      if (transactions.has(transactionKey) || recordIds.has(record.recordId))
+        throw new TypeError(
+          "funding record duplicates an existing or proposed transaction or record ID",
+        );
+      transactions.add(transactionKey);
+      recordIds.add(record.recordId);
+      evidence.verificationInput = {
+        projectId: record.projectId,
+        manifestRevision: record.manifestRevision,
+        network: record.network,
+        asset: record.asset,
+        transactionId: record.transactionId,
+        recipient: record.recipient,
+        amountMinor: record.amountMinor,
+      };
+      evidence.verifierVersion = record.verifier.version;
+      records.push(record);
+    }
+    for (const [index, record] of records.entries()) {
+      if (!record.verifier)
+        throw new TypeError("verified funding record has no verifier evidence");
+      const output = await verify(record, input.fetchImpl);
+      const chain = output.chainEvidence;
+      const transaction =
+        "signature" in chain
+          ? chain.signature
+          : "transactionId" in chain
+            ? chain.transactionId
+            : chain.transactionHash;
+      const evidence = pending[index].evidence;
+      evidence.verifierVersion = output.verifier.version;
+      evidence.verifierOutputCanonical = canonicalFundingDecisionBytes(output);
+      evidence.verifierOutputSha256 = digest(evidence.verifierOutputCanonical);
+      if (
+        output.state !== record.state ||
+        transaction !== record.transactionId ||
+        output.verifier.version !== record.verifier.version ||
+        output.verifier.evidenceUrl !== record.verifier.evidenceUrl ||
+        output.verifier.reason !== null ||
+        Date.parse(output.verifier.checkedAt) <
+          Date.parse(record.verifier.checkedAt) ||
+        canonicalFundingDecisionBytes(output.finality) !==
+          canonicalFundingDecisionBytes(record.finality)
+      )
+        throw new TypeError(
+          "fresh verifier output does not exactly match the record identity, version, or finality",
+        );
+    }
+    decision.decision = "verified-records";
+    decision.reason =
+      "all added records verified; repository-controlled merge authority remains required";
+  } catch (error) {
+    decision.decision =
+      error instanceof HumanReviewRequired
+        ? "human-review-required"
+        : "verification-failed";
+    decision.reason =
+      error instanceof Error
+        ? error.message
+        : "unknown funding verification failure";
+  }
+  return decision;
+}
+
+if (import.meta.main) {
+  const values = new Map<string, string>();
+  const allowed = new Set([
+    "--base-sha",
+    "--head-sha",
+    "--pr-number",
+    "--output",
+  ]);
+  for (let index = 2; index < process.argv.length; index += 2) {
+    const key = process.argv[index];
+    const value = process.argv[index + 1];
+    if (!allowed.has(key) || values.has(key) || !value)
+      throw new TypeError(
+        "Usage: check-funding-record-pr.ts --base-sha <sha> --head-sha <sha> --pr-number <number> --output <path>",
+      );
+    values.set(key, value);
+  }
+  if (values.size !== allowed.size)
+    throw new TypeError("funding gate requires every CLI argument");
+  const required = (key: string): string => {
+    const value = values.get(key);
+    if (!value) throw new TypeError(`funding gate requires ${key}`);
+    return value;
+  };
+  const decision = await checkFundingRecordPr({
+    baseSha: required("--base-sha"),
+    headSha: required("--head-sha"),
+    pullRequestNumber: Number(required("--pr-number")),
+  });
+  await writeFile(
+    required("--output"),
+    canonicalFundingDecisionBytes(decision),
+    { flag: "wx", mode: 0o600 },
+  );
+  process.stdout.write(
+    `${JSON.stringify({ headSha: decision.headSha, decision: decision.decision, reason: decision.reason, mergeAuthorized: false })}\n`,
+  );
+  if (decision.decision === "verification-failed") process.exitCode = 1;
+}

--- a/scripts/check-funding-record-pr.ts
+++ b/scripts/check-funding-record-pr.ts
@@ -293,7 +293,10 @@ export async function checkFundingRecordPr(input: {
       decision.records.push(evidence);
       return { entry, bytes, evidence };
     });
-    const records: ProjectFundingRecord[] = [];
+    const records: Array<{
+      record: ProjectFundingRecord;
+      historicalAddresses: ReturnType<typeof assertProjectFundingAddresses>;
+    }> = [];
     for (const { entry, bytes, evidence } of pending) {
       const parsed = jsonBytes(bytes);
       if (!bytes.equals(Buffer.from(canonicalFundingDecisionBytes(parsed))))
@@ -314,9 +317,15 @@ export async function checkFundingRecordPr(input: {
         input.baseSha,
       ]);
       const historical = manifest(root, manifestRevision, path[1], true);
-      const record = assertProjectFundingRecord(
+      const historicalAddresses = assertProjectFundingAddresses(
+        historical.funding.addresses,
+      );
+      const record = assertProjectFundingRecord(parsed, historicalAddresses);
+      // An older manifest cannot undo a reviewed route replacement. This
+      // applies only to new proposals, not already-accepted historical records.
+      assertProjectFundingRecord(
         parsed,
-        assertProjectFundingAddresses(historical.funding.addresses),
+        assertProjectFundingAddresses(project.funding.addresses),
       );
       if (
         record.projectId !== project.id ||
@@ -361,9 +370,9 @@ export async function checkFundingRecordPr(input: {
         amountMinor: record.amountMinor,
       };
       evidence.verifierVersion = record.verifier.version;
-      records.push(record);
+      records.push({ record, historicalAddresses });
     }
-    for (const [index, record] of records.entries()) {
+    for (const [index, { record, historicalAddresses }] of records.entries()) {
       if (!record.verifier)
         throw new TypeError("verified funding record has no verifier evidence");
       const output = await verify(record, input.fetchImpl);
@@ -393,6 +402,12 @@ export async function checkFundingRecordPr(input: {
           "funding observation or verification predates chain inclusion or claims a future time",
         );
       }
+      // Observing an old transfer after a route becomes active does not turn
+      // that transfer into funding sent under the reviewed receiving policy.
+      assertProjectFundingRecord(
+        { ...record, observedAt: new Date(includedAt).toISOString() },
+        historicalAddresses,
+      );
       if (
         output.state !== record.state ||
         transaction !== record.transactionId ||

--- a/scripts/check-funding-record-pr.ts
+++ b/scripts/check-funding-record-pr.ts
@@ -14,6 +14,7 @@ import {
   assertHistoricalProjectDefinition,
   assertProjectDefinition,
 } from "../src/lib/project-schema.mjs";
+import { assertFundingBlockTime } from "./funding-block-time";
 import { verifyFundingBitcoin } from "./verify-funding-bitcoin";
 import { verifyFundingEvm } from "./verify-funding-evm";
 import { verifyFundingSolana } from "./verify-funding-solana";
@@ -377,6 +378,21 @@ export async function checkFundingRecordPr(input: {
       evidence.verifierVersion = output.verifier.version;
       evidence.verifierOutputCanonical = canonicalFundingDecisionBytes(output);
       evidence.verifierOutputSha256 = digest(evidence.verifierOutputCanonical);
+      const includedAt = assertFundingBlockTime(chain.blockTime) * 1000;
+      const freshCheckedAt = Date.parse(output.verifier.checkedAt);
+      const completedNow = input.now ?? Date.now();
+      if (
+        includedAt > completedNow ||
+        Date.parse(record.observedAt) < includedAt ||
+        Date.parse(record.verifier.checkedAt) < includedAt ||
+        !Number.isFinite(freshCheckedAt) ||
+        freshCheckedAt < includedAt ||
+        freshCheckedAt > completedNow
+      ) {
+        throw new TypeError(
+          "funding observation or verification predates chain inclusion or claims a future time",
+        );
+      }
       if (
         output.state !== record.state ||
         transaction !== record.transactionId ||
@@ -405,6 +421,7 @@ export async function checkFundingRecordPr(input: {
         ? error.message
         : "unknown funding verification failure";
   }
+  decision.checkedAt = new Date(input.now ?? Date.now()).toISOString();
   return decision;
 }
 

--- a/scripts/funding-block-time.ts
+++ b/scripts/funding-block-time.ts
@@ -1,0 +1,12 @@
+/** Integer Unix inclusion seconds supplied by the fixed chain authorities. */
+export function assertFundingBlockTime(value: unknown): number {
+  if (
+    typeof value !== "number" ||
+    !Number.isSafeInteger(value) ||
+    value <= 0 ||
+    value > 253_402_300_799
+  ) {
+    throw new TypeError("funding chain inclusion time is missing or invalid");
+  }
+  return value;
+}

--- a/scripts/verify-funding-bitcoin.test.ts
+++ b/scripts/verify-funding-bitcoin.test.ts
@@ -16,7 +16,12 @@ const BLOCK_HASH = "f".repeat(64);
 function transactionBody(blockHash = BLOCK_HASH) {
   return JSON.stringify({
     txid: TXID,
-    status: { confirmed: true, block_height: 800_000, block_hash: blockHash },
+    status: {
+      confirmed: true,
+      block_height: 800_000,
+      block_hash: blockHash,
+      block_time: 1700000000,
+    },
     vin: [
       {
         is_coinbase: false,
@@ -66,6 +71,26 @@ function allHosts(responses: Record<string, string>) {
 }
 
 describe("Bitcoin funding verifier", () => {
+  it("requires authorities to agree on the inclusion timestamp", async () => {
+    const perHost = Object.fromEntries(
+      HOSTS.map((host, index) => {
+        const transaction = JSON.parse(transactionBody());
+        transaction.status.block_time += index;
+        return [
+          host,
+          authorityResponses({ [`/tx/${TXID}`]: JSON.stringify(transaction) }),
+        ];
+      }),
+    );
+    await expect(
+      verifyFundingBitcoin({
+        transactionId: TXID,
+        recipient: RECIPIENT,
+        amountMinor: "150000",
+        fetchImpl: fetchFor(perHost),
+      }),
+    ).rejects.toThrow(/quorum/u);
+  });
   it("reaches quorum across fixed authorities and emits reviewed fields", async () => {
     const requests: string[] = [];
     const redirects: Array<RequestRedirect | undefined> = [];
@@ -93,6 +118,7 @@ describe("Bitcoin funding verifier", () => {
         transactionId: TXID,
         blockHeight: 800_000,
         blockHash: BLOCK_HASH,
+        blockTime: 1700000000,
       },
     });
     expect(result.chainEvidence.authorities).toHaveLength(HOSTS.length);

--- a/scripts/verify-funding-bitcoin.ts
+++ b/scripts/verify-funding-bitcoin.ts
@@ -7,6 +7,7 @@ import {
   isBitcoinTransactionId,
 } from "../src/lib/bitcoin-funding";
 import { isFundingAddress } from "../src/lib/funding-address.mjs";
+import { assertFundingBlockTime } from "./funding-block-time";
 
 export const BITCOIN_FUNDING_API_AUTHORITIES = [
   "https://mempool.space/api",
@@ -137,6 +138,11 @@ async function verifyWithAuthority(
     typeof status === "object" && status !== null
       ? (status as Record<string, unknown>).block_height
       : null;
+  const blockTime = assertFundingBlockTime(
+    typeof status === "object" && status !== null
+      ? (status as Record<string, unknown>).block_time
+      : null,
+  );
   if (!Number.isSafeInteger(blockHeight) || Number(blockHeight) < 0) {
     throw new TypeError("Bitcoin transaction is unconfirmed");
   }
@@ -154,7 +160,11 @@ async function verifyWithAuthority(
     tipHeight,
     bestChainHash,
   );
-  return { authority: api.toString(), tipHeight, verified };
+  return {
+    authority: api.toString(),
+    tipHeight,
+    verified: { ...verified, blockTime },
+  };
 }
 
 export async function verifyFundingBitcoin(input: {
@@ -184,7 +194,7 @@ export async function verifyFundingBitcoin(input: {
   for (const result of settled) {
     if (result.status !== "fulfilled") continue;
     const { verified } = result.value;
-    const key = `${verified.transactionId}:${verified.blockHeight}:${verified.blockHash}`;
+    const key = `${verified.transactionId}:${verified.blockHeight}:${verified.blockHash}:${verified.blockTime}`;
     const group = groups.get(key) ?? [];
     group.push(result.value);
     groups.set(key, group);

--- a/scripts/verify-funding-evm.test.ts
+++ b/scripts/verify-funding-evm.test.ts
@@ -32,7 +32,11 @@ function chainResponses(
       number: overrides.finalizedNumber ?? "0x1000",
       hash: FINALIZED_HASH,
     },
-    canonicalBlock: { number: "0x100", hash: blockHash },
+    canonicalBlock: {
+      number: "0x100",
+      hash: blockHash,
+      timestamp: "0x6553f100",
+    },
     receipt:
       overrides.receipt === undefined
         ? {
@@ -112,6 +116,20 @@ function verification(fetchImpl: ReturnType<typeof fetchFor>) {
 }
 
 describe("EVM funding verifier", () => {
+  it("requires authorities to agree on the canonical inclusion timestamp", async () => {
+    await expect(
+      verification(
+        fetchFor((url) => {
+          const responses = chainResponses();
+          const index = EVM_FUNDING_RPC_AUTHORITIES.ethereum.findIndex(
+            (authority) => new URL(authority).hostname === url.hostname,
+          );
+          responses.canonicalBlock.timestamp = `0x${(1700000000 + index).toString(16)}`;
+          return responses;
+        }),
+      ),
+    ).rejects.toThrow(/quorum/u);
+  });
   it("requires fixed authorities and emits conservative canonical evidence", async () => {
     const calls: RpcCall[] = [];
     const result = await verification(
@@ -146,6 +164,7 @@ describe("EVM funding verifier", () => {
         transactionHash: HASH,
         blockNumber: 0x100,
         blockHash: BLOCK_HASH,
+        blockTime: 1700000000,
         authorities: [{}, {}, {}],
       },
     });

--- a/scripts/verify-funding-evm.ts
+++ b/scripts/verify-funding-evm.ts
@@ -11,6 +11,7 @@ import {
   isEvmTransactionHash,
 } from "../src/lib/evm-funding";
 import { isFundingAddress } from "../src/lib/funding-address.mjs";
+import { assertFundingBlockTime } from "./funding-block-time";
 
 export const EVM_FUNDING_RPC_AUTHORITIES = {
   base: [
@@ -202,9 +203,21 @@ async function verifyWithAuthority(
   }
   const receiptBlockNumber = (receipt as Record<string, unknown>).blockNumber;
   evmQuantity(receiptBlockNumber, "receipt.blockNumber");
+  const receiptBlockValue = await request("eth_getBlockByNumber", [
+    receiptBlockNumber,
+    false,
+  ]);
   const receiptBlock = assertEvmCanonicalBlock(
-    await request("eth_getBlockByNumber", [receiptBlockNumber, false]),
+    receiptBlockValue,
     "canonical receipt block",
+  );
+  const blockTime = assertFundingBlockTime(
+    Number(
+      evmQuantity(
+        (receiptBlockValue as Record<string, unknown>).timestamp,
+        "canonical receipt block.timestamp",
+      ),
+    ),
   );
   const verified = assertConfirmedUsdcFundingTransfer(
     receipt,
@@ -215,7 +228,11 @@ async function verifyWithAuthority(
     finalizedBlock,
     receiptBlock,
   );
-  return { authority: rpc.toString(), finalizedBlock, verified };
+  return {
+    authority: rpc.toString(),
+    finalizedBlock,
+    verified: { ...verified, blockTime },
+  };
 }
 
 export async function verifyFundingEvm(input: {
@@ -250,7 +267,7 @@ export async function verifyFundingEvm(input: {
   for (const result of settled) {
     if (result.status !== "fulfilled") continue;
     const { verified } = result.value;
-    const key = `${verified.transactionHash}:${verified.blockNumber}:${verified.blockHash}`;
+    const key = `${verified.transactionHash}:${verified.blockNumber}:${verified.blockHash}:${verified.blockTime}`;
     const group = groups.get(key) ?? [];
     group.push(result.value);
     groups.set(key, group);


### PR DESCRIPTION
Implements the safe, read-only half of #368 without granting merge authority.

- validates candidate funding records from an immutable trusted develop checkout
- binds record chronology to actual chain inclusion
- enforces both historical and current receiving-route authority
- keeps `mergeAuthorized: false`; maintainers remain the decision authority

Exact-head validation at c2123875afb83fda3fd3301e74720b3b92e4c25a:
- `bun run verify` — passed (756 Vitest tests, 112 skill tests, production build)
- focused funding verifier suite — passed (68 tests)
- frozen-lockfile install, diff check, AGENTS/CLAUDE parity — passed

Issue #368 intentionally remains open because automatic merge authority is not implemented.