### PR TITLE
Serialize live-report discovery and survive interrupted helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "audit:dependencies": "bun audit",
     "verify": "bun run brand:check && bun run projects:check && bun run evaluations:check && bun run funding:check && bun run cycles:check && bun run protocol:check && bun run audit:dependencies && bun run typecheck && bun run format:check && bun run lint:check && bun run test && bun run build",
     "typecheck": "tsc -b",
-    "test": "vitest run && bun test --timeout 30000 ./skill-tests",
+    "test": "vitest run && bun test --timeout 30000 --max-concurrency 1 ./skill-tests",
     "test:e2e": "node scripts/run-e2e.mjs",
     "test:e2e:record": "node scripts/record-evidence.mjs --local",
     "test:e2e:record:production": "node scripts/record-evidence.mjs --production",

--- a/skill-tests/contribute-to-eliza.test.ts
+++ b/skill-tests/contribute-to-eliza.test.ts
@@ -68,6 +68,27 @@ const NOW = new Date("2026-01-20T12:00:00.000Z");
 const HEAD_SHA = "a".repeat(40);
 const PRIOR_SHA = "b".repeat(40);
 
+const configuredNodeExecutable = process.env.SLOP_TEST_NODE ?? "node";
+const configuredNodeRuntime = spawnSync(
+  configuredNodeExecutable,
+  [
+    "-p",
+    "JSON.stringify({ executable: process.execPath, version: process.versions.node })",
+  ],
+  { encoding: "utf8" },
+);
+assert.strictEqual(
+  configuredNodeRuntime.status,
+  0,
+  configuredNodeRuntime.stderr,
+);
+const nodeRuntime = JSON.parse(configuredNodeRuntime.stdout) as {
+  executable: string;
+  version: string;
+};
+assert.strictEqual(nodeRuntime.version, "24.15.0");
+const nodeExecutable = nodeRuntime.executable;
+
 function createLiveReportGhFixture() {
   const root = mkdtempSync(join(tmpdir(), "slop-live-report-lock-test-"));
   const shimDirectory = join(root, "bin");
@@ -127,7 +148,7 @@ if (args.at(-1) === "user") {
     donePath,
     environment: {
       ...process.env,
-      PATH: `${shimDirectory}${delimiter}${process.env.PATH ?? ""}`,
+      PATH: `${shimDirectory}${delimiter}${dirname(nodeExecutable)}${delimiter}${process.env.PATH ?? ""}`,
       SLOP_GH_LOG: logPath,
       SLOP_GH_READY: readyPath,
       SLOP_GH_RELEASE: releasePath,
@@ -1906,7 +1927,7 @@ describe("live report behavior", () => {
       "scripts",
       "live-report.mjs",
     );
-    const first = spawn(process.execPath, [liveReportPath, "--json"], {
+    const first = spawn(nodeExecutable, [liveReportPath, "--json"], {
       env: { ...fixture.environment, SLOP_GH_HOLD: "1" },
       stdio: ["ignore", "pipe", "pipe"],
     });
@@ -1914,7 +1935,7 @@ describe("live report behavior", () => {
     let testError: unknown = null;
     try {
       await waitForFixturePath(fixture.readyPath);
-      const second = spawnSync(process.execPath, [asiReportPath, "--json"], {
+      const second = spawnSync(nodeExecutable, [asiReportPath, "--json"], {
         encoding: "utf8",
         env: fixture.environment,
       });
@@ -1950,13 +1971,13 @@ describe("live report behavior", () => {
       "live-report.mjs",
     );
     try {
-      const first = spawnSync(process.execPath, [liveReportPath, "--json"], {
+      const first = spawnSync(nodeExecutable, [liveReportPath, "--json"], {
         encoding: "utf8",
         env: fixture.environment,
       });
       assert.strictEqual(first.status, 0, first.stderr);
       const second = spawnSync(
-        process.execPath,
+        nodeExecutable,
         [deltaStarReportPath, "--json"],
         {
           encoding: "utf8",
@@ -1991,13 +2012,13 @@ describe("live report behavior", () => {
       "live-report.mjs",
     );
     try {
-      const failed = spawnSync(process.execPath, [liveReportPath, "--json"], {
+      const failed = spawnSync(nodeExecutable, [liveReportPath, "--json"], {
         encoding: "utf8",
         env: { ...fixture.environment, SLOP_GH_FAIL_RATE: "1" },
       });
       assert.strictEqual(failed.status, 1);
       assert.match(failed.stderr, /fixture rate-limit failure/u);
-      const recovered = spawnSync(process.execPath, [asiReportPath, "--json"], {
+      const recovered = spawnSync(nodeExecutable, [asiReportPath, "--json"], {
         encoding: "utf8",
         env: fixture.environment,
       });
@@ -2026,25 +2047,55 @@ describe("live report behavior", () => {
       "scripts",
       "live-report.mjs",
     );
-    const interrupted = spawn(process.execPath, [liveReportPath, "--json"], {
+    const interrupted = spawn(nodeExecutable, [liveReportPath, "--json"], {
       env: { ...fixture.environment, SLOP_GH_HOLD: "1" },
       stdio: ["ignore", "pipe", "pipe"],
     });
     const interruptedResult = collectChild(interrupted);
+    let testError: unknown = null;
     try {
       await waitForFixturePath(fixture.readyPath);
       assert.strictEqual(interrupted.kill("SIGKILL"), true);
-      writeFileSync(fixture.releasePath, "release\n");
-      await waitForFixturePath(fixture.donePath);
       const killed = await interruptedResult;
       assert.strictEqual(killed.status, null);
       assert.strictEqual(killed.signal, "SIGKILL");
 
-      const recovered = spawnSync(
-        process.execPath,
-        [heirReportPath, "--json"],
-        { encoding: "utf8", env: fixture.environment },
+      const contending = spawnSync(nodeExecutable, [heirReportPath, "--json"], {
+        encoding: "utf8",
+        env: fixture.environment,
+      });
+      assert.strictEqual(contending.status, 2, contending.stderr);
+      assert.match(contending.stderr, /live report lock contention/iu);
+      const calls = readFileSync(fixture.logPath, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as string[]);
+      assert.strictEqual(
+        calls.filter((args) => args.at(-1) === "rate_limit").length,
+        1,
+        "a surviving GitHub child must keep replacement discovery out",
       );
+    } catch (error) {
+      testError = error;
+    } finally {
+      if (interrupted.exitCode === null) interrupted.kill("SIGKILL");
+      if (!existsSync(fixture.releasePath)) {
+        writeFileSync(fixture.releasePath, "release\n");
+      }
+      await waitForFixturePath(fixture.donePath);
+    }
+    try {
+      if (testError) throw testError;
+      const recoveryDeadline = Date.now() + 5_000;
+      let recovered;
+      do {
+        recovered = spawnSync(nodeExecutable, [heirReportPath, "--json"], {
+          encoding: "utf8",
+          env: fixture.environment,
+        });
+        if (recovered.status !== 2) break;
+        await new Promise((resolvePromise) => setTimeout(resolvePromise, 20));
+      } while (Date.now() < recoveryDeadline);
       assert.strictEqual(recovered.status, 0, recovered.stderr);
       const calls = readFileSync(fixture.logPath, "utf8")
         .trim()
@@ -2055,10 +2106,6 @@ describe("live report behavior", () => {
         2,
       );
     } finally {
-      if (interrupted.exitCode === null) interrupted.kill("SIGKILL");
-      if (!existsSync(fixture.releasePath)) {
-        writeFileSync(fixture.releasePath, "release\n");
-      }
       rmSync(fixture.root, { force: true, recursive: true });
     }
   });

--- a/skill-tests/contribute-to-eliza.test.ts
+++ b/skill-tests/contribute-to-eliza.test.ts
@@ -73,27 +73,33 @@ const HEAD_SHA = "a".repeat(40);
 const PRIOR_SHA = "b".repeat(40);
 
 const configuredNodeExecutable = process.env.SLOP_TEST_NODE ?? "node";
-const configuredNodeRuntime = spawnSync(
-  configuredNodeExecutable,
-  [
-    "-p",
-    "JSON.stringify({ executable: process.execPath, version: process.versions.node })",
-  ],
-  { encoding: "utf8" },
-);
-assert.strictEqual(
-  configuredNodeRuntime.status,
-  0,
-  configuredNodeRuntime.stderr,
-);
-const nodeRuntime = JSON.parse(configuredNodeRuntime.stdout) as {
-  executable: string;
-  version: string;
-};
-assert.strictEqual(nodeRuntime.version, "24.15.0");
-const nodeExecutable = nodeRuntime.executable;
+const nodeExecutable = configuredNodeExecutable;
+let pinnedNodeRuntimeChecked = false;
+
+function assertPinnedNodeRuntime(): void {
+  if (pinnedNodeRuntimeChecked) return;
+  const configuredNodeRuntime = spawnSync(
+    configuredNodeExecutable,
+    [
+      "-p",
+      "JSON.stringify({ executable: process.execPath, version: process.versions.node })",
+    ],
+    { encoding: "utf8" },
+  );
+  assert.strictEqual(
+    configuredNodeRuntime.status,
+    0,
+    configuredNodeRuntime.stderr,
+  );
+  const nodeRuntime = JSON.parse(configuredNodeRuntime.stdout) as {
+    version: string;
+  };
+  assert.strictEqual(nodeRuntime.version, "24.15.0");
+  pinnedNodeRuntimeChecked = true;
+}
 
 function createLiveReportGhFixture() {
+  assertPinnedNodeRuntime();
   const root = mkdtempSync(join(tmpdir(), "slop-live-report-lock-test-"));
   const identityId = Number.parseInt(randomBytes(6).toString("hex"), 16);
   const shimDirectory = join(root, "bin");

--- a/skill-tests/contribute-to-eliza.test.ts
+++ b/skill-tests/contribute-to-eliza.test.ts
@@ -2040,6 +2040,8 @@ describe("live report behavior", () => {
 
     assert.deepStrictEqual(report, { coherent: true });
     assert.deepStrictEqual(attemptBudgets, [MAX_API_READS, MAX_API_READS]);
+  });
+
   it("pins the authenticated identity lookup to github.com", () => {
     const calls: Array<{ command: string; args: string[] }> = [];
     const identity = readGhAuthenticatedIdentity((command, args) => {

--- a/skill-tests/contribute-to-eliza.test.ts
+++ b/skill-tests/contribute-to-eliza.test.ts
@@ -227,6 +227,92 @@ function liveReportLockPath(root: string, identityId: number) {
   return join(root, `${key}.lock`);
 }
 
+function createStaleLiveReportLockFixture() {
+  const root = mkdtempSync(join(tmpdir(), "slop-live-report-reclaim-test-"));
+  const identity = { host: "github.com", id: 42, login: "fixture-user" };
+  const lockPath = liveReportLockPath(root, identity.id);
+  const ownerPath = join(lockPath, "owner.json");
+  const scriptPath = join(root, "reclaimer.mjs");
+  const readyPath = join(root, "reclaim-ready");
+  const resumePath = join(root, "reclaim-resume");
+  const acquiredPath = join(root, "acquired");
+  const releasePath = join(root, "release");
+  mkdirSync(join(lockPath, "commands"), { recursive: true, mode: 0o700 });
+  const currentIdentity = readLiveReportProcessIdentity(process.pid);
+  assert.ok(currentIdentity);
+  writeFileSync(
+    ownerPath,
+    JSON.stringify({
+      schemaVersion: 2,
+      pid: process.pid,
+      processIdentity:
+        currentIdentity === "0".repeat(64) ? "1".repeat(64) : "0".repeat(64),
+      ownerToken: randomBytes(16).toString("hex"),
+    }),
+    { mode: 0o600 },
+  );
+  writeFileSync(
+    scriptPath,
+    `import fs from "node:fs";
+import { syncBuiltinESMExports } from "node:module";
+const [reportUrl, root, lockPath, ready, resume, acquired, release, role] = process.argv.slice(2);
+const rename = fs.renameSync.bind(fs);
+const sleeper = new Int32Array(new SharedArrayBuffer(4));
+fs.renameSync = (source, target) => {
+  if (role === "paused" && source === lockPath && target.includes(".stale-")) {
+    fs.writeFileSync(ready, "ready");
+    const deadline = Date.now() + 10000;
+    while (!fs.existsSync(resume)) {
+      if (Date.now() > deadline) throw new Error("reclaimer resume timed out");
+      Atomics.wait(sleeper, 0, 0, 10);
+    }
+  }
+  return rename(source, target);
+};
+syncBuiltinESMExports();
+const { acquireLiveReportLock } = await import(reportUrl);
+try {
+  const lock = acquireLiveReportLock({ host: "github.com", id: 42, login: "fixture-user" }, { rootPath: root });
+  if (role === "paused") {
+    fs.writeFileSync(acquired, "acquired");
+    const deadline = Date.now() + 10000;
+    while (!fs.existsSync(release)) {
+      if (Date.now() > deadline) throw new Error("report release timed out");
+      Atomics.wait(sleeper, 0, 0, 10);
+    }
+  }
+  lock.release();
+} catch (error) {
+  process.stderr.write(error.message);
+  process.exitCode = 2;
+}
+`,
+  );
+  return {
+    root,
+    identity,
+    lockPath,
+    ownerPath,
+    readyPath,
+    resumePath,
+    acquiredPath,
+    releasePath,
+    arguments(role: string, reportPath = liveReportPath) {
+      return [
+        scriptPath,
+        pathToFileURL(reportPath).href,
+        root,
+        lockPath,
+        readyPath,
+        resumePath,
+        acquiredPath,
+        releasePath,
+        role,
+      ];
+    },
+  };
+}
+
 function account(login: string, type = "User") {
   const id = [...login.toLowerCase()].reduce(
     (value, character) => (value * 31 + character.charCodeAt(0)) % 1_000_000,
@@ -2100,6 +2186,83 @@ describe("live report behavior", () => {
       }
     } finally {
       rmSync(fixtureRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("serializes stale reclaimers before they can rename a live replacement", {
+    timeout: 15_000,
+  }, async () => {
+    const fixture = createStaleLiveReportLockFixture();
+    const originalOwner = readFileSync(fixture.ownerPath);
+    const child = spawn(nodeExecutable, fixture.arguments("paused"), {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const completion = collectChild(child);
+    try {
+      await waitForFixturePath(fixture.readyPath);
+      const otherReport = join(
+        skillDir,
+        "..",
+        "contribute-to-asi",
+        "scripts",
+        "live-report.mjs",
+      );
+      const contender = spawnSync(
+        nodeExecutable,
+        fixture.arguments("contender", otherReport),
+        { encoding: "utf8", timeout: 5_000 },
+      );
+      assert.strictEqual(contender.status, 2, contender.stderr);
+      assert.match(contender.stderr, /lock contention: transition guard/iu);
+      assert.deepStrictEqual(readFileSync(fixture.ownerPath), originalOwner);
+
+      writeFileSync(fixture.resumePath, "resume");
+      await waitForFixturePath(fixture.acquiredPath);
+      const replacementOwner = readFileSync(fixture.ownerPath);
+      assert.notDeepStrictEqual(replacementOwner, originalOwner);
+      assert.strictEqual(existsSync(`${fixture.lockPath}.transition`), false);
+      assert.throws(
+        () =>
+          acquireLiveReportLock(fixture.identity, { rootPath: fixture.root }),
+        /another report.*already discovering/iu,
+      );
+      assert.deepStrictEqual(readFileSync(fixture.ownerPath), replacementOwner);
+      writeFileSync(fixture.releasePath, "release");
+      const completed = await completion;
+      assert.strictEqual(completed.status, 0, completed.stderr);
+      assert.strictEqual(existsSync(fixture.lockPath), false);
+    } finally {
+      writeFileSync(fixture.resumePath, "resume");
+      writeFileSync(fixture.releasePath, "release");
+      await completion;
+      rmSync(fixture.root, { force: true, recursive: true });
+    }
+  });
+
+  it("preserves an interrupted transition guard and fails closed", {
+    timeout: 15_000,
+  }, async () => {
+    const fixture = createStaleLiveReportLockFixture();
+    const originalOwner = readFileSync(fixture.ownerPath);
+    const child = spawn(nodeExecutable, fixture.arguments("paused"), {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const completion = collectChild(child);
+    try {
+      await waitForFixturePath(fixture.readyPath);
+      child.kill("SIGKILL");
+      await completion;
+      assert.throws(
+        () =>
+          acquireLiveReportLock(fixture.identity, { rootPath: fixture.root }),
+        /stop all local reports before manually removing this guard/iu,
+      );
+      assert.strictEqual(existsSync(`${fixture.lockPath}.transition`), true);
+      assert.deepStrictEqual(readFileSync(fixture.ownerPath), originalOwner);
+    } finally {
+      child.kill("SIGKILL");
+      await completion;
+      rmSync(fixture.root, { force: true, recursive: true });
     }
   });
 

--- a/skill-tests/contribute-to-eliza.test.ts
+++ b/skill-tests/contribute-to-eliza.test.ts
@@ -2407,6 +2407,95 @@ describe("live report behavior", () => {
     }
   });
 
+  it("retains a surviving GitHub child when its helper is interrupted", {
+    timeout: 15_000,
+  }, async () => {
+    const fixture = createLiveReportGhFixture();
+    const rootPath = join(fixture.root, "locks");
+    const identity = {
+      host: "github.com",
+      id: fixture.identityId,
+      login: "fixture-user",
+    };
+    const owner = spawn(
+      nodeExecutable,
+      [
+        "--input-type=module",
+        "-e",
+        `
+      import { acquireLiveReportLock } from ${JSON.stringify(pathToFileURL(liveReportPath).href)};
+      const lock = acquireLiveReportLock(${JSON.stringify(identity)}, { rootPath: ${JSON.stringify(rootPath)} });
+      try {
+        const result = lock.spawn("gh", ["api", "rate_limit"], { encoding: "utf8" });
+        process.exitCode = result.status ?? 1;
+      } finally {
+        lock.release();
+      }
+    `,
+      ],
+      {
+        env: { ...fixture.environment, SLOP_GH_HOLD: "1" },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    const ownerResult = collectChild(owner);
+    let childPid: number | null = null;
+    let childIdentity: string | null = null;
+    try {
+      await waitForFixturePath(fixture.readyPath);
+      childPid = Number(readFileSync(fixture.pidPath, "utf8").trim());
+      childIdentity = readLiveReportProcessIdentity(childPid);
+      assert.ok(childIdentity);
+      const commands = join(
+        liveReportLockPath(rootPath, identity.id),
+        "commands",
+      );
+      let helperPid: number | null = null;
+      const deadline = Date.now() + 5_000;
+      while (helperPid === null) {
+        for (const file of readdirSync(commands)) {
+          if (!/^lease-[a-f0-9]{32}\.json$/u.test(file)) continue;
+          const lease = JSON.parse(readFileSync(join(commands, file), "utf8"));
+          if (lease.child?.pid === childPid) helperPid = lease.helper.pid;
+        }
+        if (Date.now() >= deadline)
+          assert.fail("GitHub child lease was not published");
+        if (helperPid === null)
+          await new Promise((done) => setTimeout(done, 10));
+      }
+      process.kill(helperPid, "SIGKILL");
+      const result = await ownerResult;
+      assert.strictEqual(result.status, 1, result.stderr);
+      assert.strictEqual(
+        readLiveReportProcessIdentity(childPid),
+        childIdentity,
+      );
+      assert.throws(
+        () => acquireLiveReportLock(identity, { rootPath }),
+        /live report lock contention/u,
+        "owner cleanup must retain the lease of its surviving GitHub child",
+      );
+      writeFileSync(fixture.releasePath, "release\n");
+      await waitForFixturePath(fixture.donePath);
+      await waitForProcessExit(childPid, childIdentity);
+      const recovered = acquireLiveReportLock(identity, { rootPath });
+      recovered.release();
+      assert.strictEqual(
+        existsSync(liveReportLockPath(rootPath, identity.id)),
+        false,
+      );
+    } finally {
+      writeFileSync(fixture.releasePath, "release\n");
+      if (owner.exitCode === null && owner.signalCode === null)
+        owner.kill("SIGKILL");
+      await ownerResult;
+      if (childPid !== null && childIdentity !== null) {
+        await waitForProcessExit(childPid, childIdentity);
+      }
+      rmSync(fixture.root, { force: true, recursive: true });
+    }
+  });
+
   it("recovers the identity lock after an interrupted report", {
     timeout: 15_000,
   }, async () => {

--- a/skill-tests/contribute-to-eliza.test.ts
+++ b/skill-tests/contribute-to-eliza.test.ts
@@ -5,7 +5,7 @@
 
 import assert from "node:assert";
 import { spawn, spawnSync } from "node:child_process";
-import { createHash } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import {
   chmodSync,
   cpSync,
@@ -25,6 +25,7 @@ import { delimiter, dirname, join, resolve } from "node:path";
 import { describe, it } from "node:test";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import {
+  acquireLiveReportLock,
   auditCommentDisclosures,
   auditPrEvidence,
   CLAIM_RECENCY_DAYS,
@@ -33,6 +34,7 @@ import {
   completeReviewEpoch,
   createGhCommandBudget,
   createReviewEpoch,
+  ensureLiveReportLockRoot,
   isBotAccount,
   LiveInventoryChangedError,
   MAX_ACTIVITY_CONNECTION_ITEMS,
@@ -45,9 +47,11 @@ import {
   parseModelDisclosure,
   parsePaginatedJson,
   REQUIRED_EVIDENCE_ROWS,
+  readGhAuthenticatedIdentity,
   readGhOpenActivity,
   readGhPages,
   readLivePullHead,
+  readLiveReportProcessIdentity,
   readProjectSelectionPolicy,
   recheckReviewEpochCandidate,
   renderMarkdown,
@@ -91,11 +95,13 @@ const nodeExecutable = nodeRuntime.executable;
 
 function createLiveReportGhFixture() {
   const root = mkdtempSync(join(tmpdir(), "slop-live-report-lock-test-"));
+  const identityId = Number.parseInt(randomBytes(6).toString("hex"), 16);
   const shimDirectory = join(root, "bin");
   const logPath = join(root, "gh-commands.ndjson");
   const readyPath = join(root, "discovery-ready");
   const releasePath = join(root, "discovery-release");
   const donePath = join(root, "discovery-done");
+  const pidPath = join(root, "discovery-pid");
   const scriptPath = join(shimDirectory, "gh-fixture.mjs");
   mkdirSync(shimDirectory);
   writeFileSync(
@@ -103,12 +109,15 @@ function createLiveReportGhFixture() {
     `#!/usr/bin/env node
 import { appendFileSync, existsSync, writeFileSync } from "node:fs";
 const args = process.argv.slice(2);
-const graphqlRemaining = Number(process.env.SLOP_GH_GRAPHQL_REMAINING ?? "5000");
+const identityId = Number(process.env.SLOP_GH_ID);
+const restGraphqlRemaining = Number(process.env.SLOP_GH_REST_GRAPHQL_REMAINING ?? "5000");
+const directGraphqlRemaining = Number(process.env.SLOP_GH_DIRECT_GRAPHQL_REMAINING ?? "5000");
 appendFileSync(process.env.SLOP_GH_LOG, \`\${JSON.stringify(args)}\\n\`);
 if (args.at(-1) === "user") {
-  process.stdout.write('{"id":4242,"login":"fixture-user"}\\n');
+  process.stdout.write(\`\${JSON.stringify({ id: identityId, login: "fixture-user" })}\\n\`);
 } else if (args.at(-1) === "rate_limit") {
   if (process.env.SLOP_GH_HOLD === "1") {
+    writeFileSync(process.env.SLOP_GH_PID, \`\${process.pid}\\n\`);
     writeFileSync(process.env.SLOP_GH_READY, "ready\\n");
     const sleeper = new Int32Array(new SharedArrayBuffer(4));
     while (!existsSync(process.env.SLOP_GH_RELEASE)) {
@@ -121,12 +130,12 @@ if (args.at(-1) === "user") {
     process.exit(9);
   }
   process.stdout.write(JSON.stringify({ resources: {
-    graphql: { limit: 5000, remaining: graphqlRemaining, reset: 1800000000 },
+    graphql: { limit: 5000, remaining: restGraphqlRemaining, reset: 1800000000 },
     core: { limit: 5000, remaining: 5000, reset: 1800000000 },
     search: { limit: 30, remaining: 30, reset: 1800000000 }
   } }));
 } else if (args.some((value) => value.includes("SlopActivityRateLimit"))) {
-  process.stdout.write(\`\${JSON.stringify({ limit: 5000, remaining: graphqlRemaining, resetAt: "2027-01-15T08:00:00.000Z" })}\\n\`);
+  process.stdout.write(\`\${JSON.stringify({ limit: 5000, remaining: directGraphqlRemaining, resetAt: "2027-01-15T08:00:00.000Z" })}\\n\`);
 }
 `,
   );
@@ -153,10 +162,14 @@ if (args.at(-1) === "user") {
       SLOP_GH_READY: readyPath,
       SLOP_GH_RELEASE: releasePath,
       SLOP_GH_DONE: donePath,
+      SLOP_GH_ID: String(identityId),
+      SLOP_GH_PID: pidPath,
       TMPDIR: root,
       TEMP: root,
       TMP: root,
     },
+    identityId,
+    pidPath,
   };
 }
 
@@ -187,6 +200,25 @@ async function waitForFixturePath(path: string, timeoutMs = 5_000) {
     if (Date.now() >= deadline) assert.fail(`timed out waiting for ${path}`);
     await new Promise((resolvePromise) => setTimeout(resolvePromise, 10));
   }
+}
+
+async function waitForProcessExit(
+  pid: number,
+  expectedIdentity: string,
+  timeoutMs = 5_000,
+) {
+  const deadline = Date.now() + timeoutMs;
+  while (readLiveReportProcessIdentity(pid) === expectedIdentity) {
+    if (Date.now() >= deadline) assert.fail(`timed out waiting for PID ${pid}`);
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 10));
+  }
+}
+
+function liveReportLockPath(root: string, identityId: number) {
+  const key = createHash("sha256")
+    .update(`github.com:${identityId}`)
+    .digest("hex");
+  return join(root, `${key}.lock`);
 }
 
 function account(login: string, type = "User") {
@@ -1916,6 +1948,155 @@ describe("live report behavior", () => {
 
     assert.deepStrictEqual(report, { coherent: true });
     assert.deepStrictEqual(attemptBudgets, [MAX_API_READS, MAX_API_READS]);
+  it("pins the authenticated identity lookup to github.com", () => {
+    const calls: Array<{ command: string; args: string[] }> = [];
+    const identity = readGhAuthenticatedIdentity((command, args) => {
+      calls.push({ command, args });
+      return {
+        status: 0,
+        stderr: "",
+        stdout: '{"id":42,"login":"fixture-user"}\n',
+      };
+    });
+
+    assert.deepStrictEqual(identity, {
+      host: "github.com",
+      id: 42,
+      login: "fixture-user",
+    });
+    assert.deepStrictEqual(calls, [
+      {
+        command: "gh",
+        args: [
+          "api",
+          "--hostname",
+          "github.com",
+          "--method",
+          "GET",
+          "--jq",
+          "{id: .id, login: .login}",
+          "user",
+        ],
+      },
+    ]);
+  });
+
+  it("keeps all four live-report implementations byte-identical", () => {
+    const implementations = [
+      "contribute-to-asi",
+      "contribute-to-delta-star",
+      "contribute-to-eliza",
+      "contribute-to-heir-elements-sdk",
+    ].map((skill) =>
+      readFileSync(join(skillDir, "..", skill, "scripts", "live-report.mjs")),
+    );
+
+    for (const implementation of implementations.slice(1)) {
+      assert.deepStrictEqual(implementation, implementations[0]);
+    }
+  });
+
+  it("executes locked commands from an explicit secure root", () => {
+    const fixture = createLiveReportGhFixture();
+    const lockRoot = join(fixture.root, "locks");
+    mkdirSync(lockRoot, { mode: 0o700 });
+    const lock = acquireLiveReportLock(
+      {
+        host: "github.com",
+        id: fixture.identityId,
+        login: "fixture-user",
+      },
+      { rootPath: lockRoot },
+    );
+    try {
+      const result = lock.spawn("gh", ["api", "user"], {
+        encoding: "utf8",
+        env: fixture.environment,
+      });
+      assert.strictEqual(result.status, 0, result.stderr);
+      assert.deepStrictEqual(JSON.parse(result.stdout), {
+        id: fixture.identityId,
+        login: "fixture-user",
+      });
+    } finally {
+      lock.release();
+      rmSync(fixture.root, { force: true, recursive: true });
+    }
+  });
+
+  it("reclaims a stale reused PID but preserves malformed lock evidence", () => {
+    const root = mkdtempSync(join(tmpdir(), "slop-live-report-metadata-test-"));
+    const identity = {
+      host: "github.com",
+      id: Number.parseInt(randomBytes(6).toString("hex"), 16),
+      login: "fixture-user",
+    };
+    const lockPath = liveReportLockPath(root, identity.id);
+    const ownerPath = join(lockPath, "owner.json");
+    try {
+      mkdirSync(join(lockPath, "commands"), { recursive: true, mode: 0o700 });
+      writeFileSync(ownerPath, "{malformed\n", { mode: 0o600 });
+      const malformed = readFileSync(ownerPath);
+      assert.throws(
+        () => acquireLiveReportLock(identity, { rootPath: root }),
+        SyntaxError,
+      );
+      assert.deepStrictEqual(readFileSync(ownerPath), malformed);
+
+      rmSync(lockPath, { force: true, recursive: true });
+      mkdirSync(join(lockPath, "commands"), { recursive: true, mode: 0o700 });
+      const currentIdentity = readLiveReportProcessIdentity(process.pid);
+      assert.ok(currentIdentity);
+      const staleIdentity =
+        currentIdentity === "0".repeat(64) ? "1".repeat(64) : "0".repeat(64);
+      writeFileSync(
+        ownerPath,
+        `${JSON.stringify({
+          schemaVersion: 2,
+          pid: process.pid,
+          processIdentity: staleIdentity,
+          ownerToken: randomBytes(16).toString("hex"),
+        })}\n`,
+        { mode: 0o600 },
+      );
+
+      const recovered = acquireLiveReportLock(identity, { rootPath: root });
+      recovered.release();
+      assert.strictEqual(existsSync(lockPath), false);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects symlinked and group-readable lock roots", () => {
+    const fixtureRoot = mkdtempSync(
+      join(tmpdir(), "slop-live-report-root-test-"),
+    );
+    const target = join(fixtureRoot, "target");
+    const symlink = join(fixtureRoot, "symlink");
+    const permissive = join(fixtureRoot, "permissive");
+    try {
+      mkdirSync(target, { mode: 0o700 });
+      symlinkSync(target, symlink);
+      assert.throws(
+        () => ensureLiveReportLockRoot(symlink),
+        /must be a real directory/u,
+      );
+      assert.deepStrictEqual(readdirSync(target), []);
+
+      mkdirSync(permissive, { mode: 0o700 });
+      chmodSync(permissive, 0o755);
+      if (process.platform !== "win32") {
+        assert.throws(
+          () => ensureLiveReportLockRoot(permissive),
+          /permissions must/u,
+        );
+      }
+    } finally {
+      rmSync(fixtureRoot, { force: true, recursive: true });
+    }
+  });
+
   it("keeps same-identity project reports out of simultaneous discovery", {
     timeout: 15_000,
   }, async () => {
@@ -1927,18 +2108,33 @@ describe("live report behavior", () => {
       "scripts",
       "live-report.mjs",
     );
-    const first = spawn(nodeExecutable, [liveReportPath, "--json"], {
-      env: { ...fixture.environment, SLOP_GH_HOLD: "1" },
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+    const first = spawn(
+      nodeExecutable,
+      [liveReportPath, "--repo", "alpha/one", "--json"],
+      {
+        env: { ...fixture.environment, SLOP_GH_HOLD: "1" },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
     const firstResult = collectChild(first);
     let testError: unknown = null;
     try {
       await waitForFixturePath(fixture.readyPath);
-      const second = spawnSync(nodeExecutable, [asiReportPath, "--json"], {
-        encoding: "utf8",
-        env: fixture.environment,
-      });
+      const alternateTmp = join(fixture.root, "alternate-tmp");
+      mkdirSync(alternateTmp, { mode: 0o700 });
+      const second = spawnSync(
+        nodeExecutable,
+        [asiReportPath, "--repo", "beta/two", "--json"],
+        {
+          encoding: "utf8",
+          env: {
+            ...fixture.environment,
+            TEMP: alternateTmp,
+            TMP: alternateTmp,
+            TMPDIR: alternateTmp,
+          },
+        },
+      );
       assert.strictEqual(second.status, 2, second.stderr);
       assert.match(second.stderr, /live report lock contention/iu);
       const calls = readFileSync(fixture.logPath, "utf8")
@@ -1983,7 +2179,7 @@ describe("live report behavior", () => {
           encoding: "utf8",
           env: {
             ...fixture.environment,
-            SLOP_GH_GRAPHQL_REMAINING: "999",
+            SLOP_GH_DIRECT_GRAPHQL_REMAINING: "999",
           },
         },
       );
@@ -1995,6 +2191,12 @@ describe("live report behavior", () => {
         .map((line) => JSON.parse(line) as string[]);
       assert.strictEqual(
         calls.filter((args) => args.at(-1) === "rate_limit").length,
+        2,
+      );
+      assert.strictEqual(
+        calls.filter((args) =>
+          args.some((value) => value.includes("SlopActivityRateLimit")),
+        ).length,
         2,
       );
     } finally {
@@ -2052,13 +2254,31 @@ describe("live report behavior", () => {
       stdio: ["ignore", "pipe", "pipe"],
     });
     const interruptedResult = collectChild(interrupted);
+    let heldGhPid: number | null = null;
+    let heldGhIdentity: string | null = null;
+    let discoveryStarted = false;
     let testError: unknown = null;
     try {
       await waitForFixturePath(fixture.readyPath);
+      discoveryStarted = true;
+      heldGhPid = Number(readFileSync(fixture.pidPath, "utf8").trim());
+      assert.strictEqual(Number.isInteger(heldGhPid) && heldGhPid > 0, true);
+      heldGhIdentity = readLiveReportProcessIdentity(heldGhPid);
+      assert.ok(heldGhIdentity);
       assert.strictEqual(interrupted.kill("SIGKILL"), true);
       const killed = await interruptedResult;
       assert.strictEqual(killed.status, null);
       assert.strictEqual(killed.signal, "SIGKILL");
+      assert.strictEqual(
+        readLiveReportProcessIdentity(heldGhPid),
+        heldGhIdentity,
+      );
+      await new Promise((resolvePromise) => setTimeout(resolvePromise, 1_200));
+      assert.strictEqual(
+        readLiveReportProcessIdentity(heldGhPid),
+        heldGhIdentity,
+        "the held GitHub child must outlive the killed report owner",
+      );
 
       const contending = spawnSync(nodeExecutable, [heirReportPath, "--json"], {
         encoding: "utf8",
@@ -2082,12 +2302,15 @@ describe("live report behavior", () => {
       if (!existsSync(fixture.releasePath)) {
         writeFileSync(fixture.releasePath, "release\n");
       }
-      await waitForFixturePath(fixture.donePath);
+      if (discoveryStarted) await waitForFixturePath(fixture.donePath);
+      if (heldGhPid !== null && heldGhIdentity !== null) {
+        await waitForProcessExit(heldGhPid, heldGhIdentity);
+      }
     }
     try {
       if (testError) throw testError;
       const recoveryDeadline = Date.now() + 5_000;
-      let recovered;
+      let recovered: ReturnType<typeof spawnSync>;
       do {
         recovered = spawnSync(nodeExecutable, [heirReportPath, "--json"], {
           encoding: "utf8",

--- a/skill-tests/contribute-to-eliza.test.ts
+++ b/skill-tests/contribute-to-eliza.test.ts
@@ -21,7 +21,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { delimiter, dirname, join, resolve } from "node:path";
 import { describe, it } from "node:test";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import {
@@ -67,6 +67,106 @@ const runReceiptPath = join(skillDir, "scripts", "run-receipt.mjs");
 const NOW = new Date("2026-01-20T12:00:00.000Z");
 const HEAD_SHA = "a".repeat(40);
 const PRIOR_SHA = "b".repeat(40);
+
+function createLiveReportGhFixture() {
+  const root = mkdtempSync(join(tmpdir(), "slop-live-report-lock-test-"));
+  const shimDirectory = join(root, "bin");
+  const logPath = join(root, "gh-commands.ndjson");
+  const readyPath = join(root, "discovery-ready");
+  const releasePath = join(root, "discovery-release");
+  const donePath = join(root, "discovery-done");
+  const scriptPath = join(shimDirectory, "gh-fixture.mjs");
+  mkdirSync(shimDirectory);
+  writeFileSync(
+    scriptPath,
+    `#!/usr/bin/env node
+import { appendFileSync, existsSync, writeFileSync } from "node:fs";
+const args = process.argv.slice(2);
+const graphqlRemaining = Number(process.env.SLOP_GH_GRAPHQL_REMAINING ?? "5000");
+appendFileSync(process.env.SLOP_GH_LOG, \`\${JSON.stringify(args)}\\n\`);
+if (args.at(-1) === "user") {
+  process.stdout.write('{"id":4242,"login":"fixture-user"}\\n');
+} else if (args.at(-1) === "rate_limit") {
+  if (process.env.SLOP_GH_HOLD === "1") {
+    writeFileSync(process.env.SLOP_GH_READY, "ready\\n");
+    const sleeper = new Int32Array(new SharedArrayBuffer(4));
+    while (!existsSync(process.env.SLOP_GH_RELEASE)) {
+      Atomics.wait(sleeper, 0, 0, 10);
+    }
+    writeFileSync(process.env.SLOP_GH_DONE, "done\\n");
+  }
+  if (process.env.SLOP_GH_FAIL_RATE === "1") {
+    process.stderr.write("fixture rate-limit failure\\n");
+    process.exit(9);
+  }
+  process.stdout.write(JSON.stringify({ resources: {
+    graphql: { limit: 5000, remaining: graphqlRemaining, reset: 1800000000 },
+    core: { limit: 5000, remaining: 5000, reset: 1800000000 },
+    search: { limit: 30, remaining: 30, reset: 1800000000 }
+  } }));
+} else if (args.some((value) => value.includes("SlopActivityRateLimit"))) {
+  process.stdout.write(\`\${JSON.stringify({ limit: 5000, remaining: graphqlRemaining, resetAt: "2027-01-15T08:00:00.000Z" })}\\n\`);
+}
+`,
+  );
+  const shimPath = join(
+    shimDirectory,
+    process.platform === "win32" ? "gh.cmd" : "gh",
+  );
+  if (process.platform === "win32") {
+    writeFileSync(shimPath, `@node "%~dp0\\gh-fixture.mjs" %*\r\n`);
+  } else {
+    symlinkSync(scriptPath, shimPath);
+    chmodSync(scriptPath, 0o755);
+  }
+  return {
+    root,
+    logPath,
+    readyPath,
+    releasePath,
+    donePath,
+    environment: {
+      ...process.env,
+      PATH: `${shimDirectory}${delimiter}${process.env.PATH ?? ""}`,
+      SLOP_GH_LOG: logPath,
+      SLOP_GH_READY: readyPath,
+      SLOP_GH_RELEASE: releasePath,
+      SLOP_GH_DONE: donePath,
+      TMPDIR: root,
+      TEMP: root,
+      TMP: root,
+    },
+  };
+}
+
+function collectChild(child: ReturnType<typeof spawn>) {
+  return new Promise<{
+    status: number | null;
+    signal: NodeJS.Signals | null;
+    stderr: string;
+    stdout: string;
+  }>((resolvePromise) => {
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr?.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("close", (status, signal) => {
+      resolvePromise({ status, signal, stderr, stdout });
+    });
+  });
+}
+
+async function waitForFixturePath(path: string, timeoutMs = 5_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (!existsSync(path)) {
+    if (Date.now() >= deadline) assert.fail(`timed out waiting for ${path}`);
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 10));
+  }
+}
 
 function account(login: string, type = "User") {
   const id = [...login.toLowerCase()].reduce(
@@ -1795,6 +1895,172 @@ describe("live report behavior", () => {
 
     assert.deepStrictEqual(report, { coherent: true });
     assert.deepStrictEqual(attemptBudgets, [MAX_API_READS, MAX_API_READS]);
+  it("keeps same-identity project reports out of simultaneous discovery", {
+    timeout: 15_000,
+  }, async () => {
+    const fixture = createLiveReportGhFixture();
+    const asiReportPath = join(
+      skillDir,
+      "..",
+      "contribute-to-asi",
+      "scripts",
+      "live-report.mjs",
+    );
+    const first = spawn(process.execPath, [liveReportPath, "--json"], {
+      env: { ...fixture.environment, SLOP_GH_HOLD: "1" },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const firstResult = collectChild(first);
+    let testError: unknown = null;
+    try {
+      await waitForFixturePath(fixture.readyPath);
+      const second = spawnSync(process.execPath, [asiReportPath, "--json"], {
+        encoding: "utf8",
+        env: fixture.environment,
+      });
+      assert.strictEqual(second.status, 2, second.stderr);
+      assert.match(second.stderr, /live report lock contention/iu);
+      const calls = readFileSync(fixture.logPath, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as string[]);
+      assert.strictEqual(
+        calls.filter((args) => args.at(-1) === "rate_limit").length,
+        1,
+        "the contending report must stop before rate-budget discovery",
+      );
+    } catch (error) {
+      testError = error;
+    } finally {
+      writeFileSync(fixture.releasePath, "release\n");
+    }
+    const completed = await firstResult;
+    rmSync(fixture.root, { force: true, recursive: true });
+    if (testError) throw testError;
+    assert.strictEqual(completed.status, 0, completed.stderr);
+  });
+
+  it("releases the identity lock after a successful report", () => {
+    const fixture = createLiveReportGhFixture();
+    const deltaStarReportPath = join(
+      skillDir,
+      "..",
+      "contribute-to-delta-star",
+      "scripts",
+      "live-report.mjs",
+    );
+    try {
+      const first = spawnSync(process.execPath, [liveReportPath, "--json"], {
+        encoding: "utf8",
+        env: fixture.environment,
+      });
+      assert.strictEqual(first.status, 0, first.stderr);
+      const second = spawnSync(
+        process.execPath,
+        [deltaStarReportPath, "--json"],
+        {
+          encoding: "utf8",
+          env: {
+            ...fixture.environment,
+            SLOP_GH_GRAPHQL_REMAINING: "999",
+          },
+        },
+      );
+      assert.strictEqual(second.status, 0, second.stderr);
+      assert.match(second.stderr, /GraphQL 999\/5000.*activity source rest/su);
+      const calls = readFileSync(fixture.logPath, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as string[]);
+      assert.strictEqual(
+        calls.filter((args) => args.at(-1) === "rate_limit").length,
+        2,
+      );
+    } finally {
+      rmSync(fixture.root, { force: true, recursive: true });
+    }
+  });
+
+  it("releases the identity lock after a handled discovery failure", () => {
+    const fixture = createLiveReportGhFixture();
+    const asiReportPath = join(
+      skillDir,
+      "..",
+      "contribute-to-asi",
+      "scripts",
+      "live-report.mjs",
+    );
+    try {
+      const failed = spawnSync(process.execPath, [liveReportPath, "--json"], {
+        encoding: "utf8",
+        env: { ...fixture.environment, SLOP_GH_FAIL_RATE: "1" },
+      });
+      assert.strictEqual(failed.status, 1);
+      assert.match(failed.stderr, /fixture rate-limit failure/u);
+      const recovered = spawnSync(process.execPath, [asiReportPath, "--json"], {
+        encoding: "utf8",
+        env: fixture.environment,
+      });
+      assert.strictEqual(recovered.status, 0, recovered.stderr);
+      const calls = readFileSync(fixture.logPath, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as string[]);
+      assert.strictEqual(
+        calls.filter((args) => args.at(-1) === "rate_limit").length,
+        2,
+      );
+    } finally {
+      rmSync(fixture.root, { force: true, recursive: true });
+    }
+  });
+
+  it("recovers the identity lock after an interrupted report", {
+    timeout: 15_000,
+  }, async () => {
+    const fixture = createLiveReportGhFixture();
+    const heirReportPath = join(
+      skillDir,
+      "..",
+      "contribute-to-heir-elements-sdk",
+      "scripts",
+      "live-report.mjs",
+    );
+    const interrupted = spawn(process.execPath, [liveReportPath, "--json"], {
+      env: { ...fixture.environment, SLOP_GH_HOLD: "1" },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const interruptedResult = collectChild(interrupted);
+    try {
+      await waitForFixturePath(fixture.readyPath);
+      assert.strictEqual(interrupted.kill("SIGKILL"), true);
+      writeFileSync(fixture.releasePath, "release\n");
+      await waitForFixturePath(fixture.donePath);
+      const killed = await interruptedResult;
+      assert.strictEqual(killed.status, null);
+      assert.strictEqual(killed.signal, "SIGKILL");
+
+      const recovered = spawnSync(
+        process.execPath,
+        [heirReportPath, "--json"],
+        { encoding: "utf8", env: fixture.environment },
+      );
+      assert.strictEqual(recovered.status, 0, recovered.stderr);
+      const calls = readFileSync(fixture.logPath, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as string[]);
+      assert.strictEqual(
+        calls.filter((args) => args.at(-1) === "rate_limit").length,
+        2,
+      );
+    } finally {
+      if (interrupted.exitCode === null) interrupted.kill("SIGKILL");
+      if (!existsSync(fixture.releasePath)) {
+        writeFileSync(fixture.releasePath, "release\n");
+      }
+      rmSync(fixture.root, { force: true, recursive: true });
+    }
   });
 
   it("freezes a finite oldest-first epoch and defers arrivals and overflow", () => {
@@ -3125,7 +3391,7 @@ describe("run receipt CLI", () => {
   });
 
   it("starts and finishes a measured run without passing --project to ccusage", {
-    timeout: 0,
+    timeout: 30_000,
   }, async () => {
     const fixtureRoot = realpathSync(
       mkdtempSync(join(tmpdir(), "contribute-to-eliza-start-")),

--- a/skills/contribute-to-asi/scripts/live-report.mjs
+++ b/skills/contribute-to-asi/scripts/live-report.mjs
@@ -16,6 +16,7 @@ import {
   readFileSync,
   realpathSync,
   renameSync,
+  rmdirSync,
   rmSync,
   statSync,
   writeFileSync,
@@ -67,7 +68,6 @@ export class LiveInventoryChangedError extends Error {
 const LIVE_REPORT_LOCK_DIRECTORY = "slop-live-report-locks-v2";
 const LIVE_REPORT_LOCK_OWNER_FILE = "owner.json";
 const LIVE_REPORT_LOCK_COMMAND_DIRECTORY = "commands";
-const LIVE_REPORT_LOCK_ACQUIRE_ATTEMPTS = 8;
 const LIVE_REPORT_ORPHAN_COMMAND_GRACE_MS = 5 * 60 * 1_000;
 const LIVE_REPORT_LOCKED_GH_ARGUMENT = "--slop-internal-locked-gh-v1";
 const LIVE_REPORT_PROCESS_IDENTITY_RE = /^[a-f0-9]{64}$/u;
@@ -1344,10 +1344,10 @@ export function createGhCommandBudget(spawn = spawnSync) {
 }
 
 export class LiveReportLockContentionError extends Error {
-  constructor() {
-    super(
-      "live report lock contention: another report for this GitHub identity is already discovering activity",
-    );
+  constructor(
+    message = "live report lock contention: another report for this GitHub identity is already discovering activity",
+  ) {
+    super(message);
     this.name = "LiveReportLockContentionError";
   }
 }
@@ -1661,6 +1661,27 @@ function assertLiveReportLockDirectory(lockPath) {
   assertLiveReportPrivatePath(lockPath, "live report lock", "directory");
 }
 
+function withLiveReportLockTransition(lockPath, operation) {
+  const transitionPath = `${lockPath}.transition`;
+  // Every lock-path mutation participates in this atomic mkdir guard. Never
+  // reclaim the guard: checking a token or dead PID before renaming it would
+  // recreate the same ABA race that this guard prevents for the report lock.
+  // A crash here requires manual recovery after all local reports are stopped.
+  try {
+    mkdirSync(transitionPath, { mode: 0o700 });
+  } catch (error) {
+    if (fileSystemErrorCode(error) !== "EEXIST") throw error;
+    throw new LiveReportLockContentionError(
+      `live report lock contention: transition guard exists at ${transitionPath}; retry after the other report finishes. If it persists, stop all local reports before manually removing this guard`,
+    );
+  }
+  try {
+    return operation();
+  } finally {
+    rmdirSync(transitionPath);
+  }
+}
+
 function prepareLiveReportLockCandidate(lockPath, ownerToken, processIdentity) {
   const candidatePath = `${lockPath}.candidate-${process.pid}-${ownerToken}`;
   mkdirSync(candidatePath, { mode: 0o700 });
@@ -1784,31 +1805,20 @@ export function acquireLiveReportLock(identity, options = {}) {
   if (processIdentity === null) {
     throw new Error("could not establish the live report process identity");
   }
-  let acquired = false;
-  for (
-    let attempt = 0;
-    attempt < LIVE_REPORT_LOCK_ACQUIRE_ATTEMPTS;
-    attempt += 1
-  ) {
+  withLiveReportLockTransition(lockPath, () => {
     const candidatePath = prepareLiveReportLockCandidate(
       lockPath,
       ownerToken,
       processIdentity,
     );
     try {
-      renameSync(candidatePath, lockPath);
-      acquired = true;
-      break;
-    } catch (error) {
-      rmSync(candidatePath, { force: true, recursive: true });
       if (!existsSync(lockPath)) {
-        if (fileSystemErrorCode(error) === "ENOENT") continue;
-        throw error;
+        renameSync(candidatePath, lockPath);
+        return;
       }
       assertLiveReportLockDirectory(lockPath);
       const currentOwner = readLiveReportLockOwner(lockPath);
       if (currentOwner === null) {
-        if (!existsSync(lockPath)) continue;
         throw new Error("live report lock owner is missing");
       }
       if (
@@ -1818,18 +1828,13 @@ export function acquireLiveReportLock(identity, options = {}) {
         throw new LiveReportLockContentionError();
       }
       const stalePath = `${lockPath}.stale-${process.pid}-${randomBytes(16).toString("hex")}`;
-      try {
-        renameSync(lockPath, stalePath);
-      } catch (renameError) {
-        if (fileSystemErrorCode(renameError) === "ENOENT") continue;
-        throw renameError;
-      }
+      renameSync(lockPath, stalePath);
+      renameSync(candidatePath, lockPath);
       rmSync(stalePath, { force: true, recursive: true });
+    } finally {
+      rmSync(candidatePath, { force: true, recursive: true });
     }
-  }
-  if (!acquired) {
-    throw new Error("live report lock changed too often to acquire safely");
-  }
+  });
   let released = false;
   return {
     spawn(command, args, options) {
@@ -1837,19 +1842,21 @@ export function acquireLiveReportLock(identity, options = {}) {
     },
     release() {
       if (released) return;
-      const owner = readLiveReportLockOwner(lockPath);
-      if (
-        owner === null ||
-        owner.pid !== process.pid ||
-        owner.processIdentity !== processIdentity ||
-        owner.ownerToken !== ownerToken
-      ) {
-        throw new Error("live report lock ownership changed before release");
-      }
-      const releasedPath = `${lockPath}.released-${process.pid}-${ownerToken}`;
-      renameSync(lockPath, releasedPath);
-      rmSync(releasedPath, { force: true, recursive: true });
-      released = true;
+      withLiveReportLockTransition(lockPath, () => {
+        const owner = readLiveReportLockOwner(lockPath);
+        if (
+          owner === null ||
+          owner.pid !== process.pid ||
+          owner.processIdentity !== processIdentity ||
+          owner.ownerToken !== ownerToken
+        ) {
+          throw new Error("live report lock ownership changed before release");
+        }
+        const releasedPath = `${lockPath}.released-${process.pid}-${ownerToken}`;
+        renameSync(lockPath, releasedPath);
+        rmSync(releasedPath, { force: true, recursive: true });
+        released = true;
+      });
     },
   };
 }

--- a/skills/contribute-to-asi/scripts/live-report.mjs
+++ b/skills/contribute-to-asi/scripts/live-report.mjs
@@ -6,7 +6,18 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { createHash, randomBytes } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -49,6 +60,10 @@ export class LiveInventoryChangedError extends Error {
     this.name = "LiveInventoryChangedError";
   }
 }
+
+const LIVE_REPORT_LOCK_DIRECTORY = "slop-live-report-locks-v1";
+const LIVE_REPORT_LOCK_OWNER_FILE = "owner.json";
+const LIVE_REPORT_LOCK_ACQUIRE_ATTEMPTS = 8;
 
 const REPOSITORY_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const PLACEHOLDER_RE =
@@ -1316,6 +1331,193 @@ export function createGhCommandBudget(spawn = spawnSync) {
       }
       count += 1;
       return spawn(command, args, options);
+    },
+  };
+}
+
+export class LiveReportLockContentionError extends Error {
+  constructor() {
+    super(
+      "live report lock contention: another report for this GitHub identity is already discovering activity",
+    );
+    this.name = "LiveReportLockContentionError";
+  }
+}
+
+export function readGhAuthenticatedIdentity(spawn = spawnSync) {
+  const result = spawn(
+    "gh",
+    ["api", "--method", "GET", "--jq", "{id: .id, login: .login}", "user"],
+    {
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024,
+      windowsHide: true,
+    },
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const detail =
+      result.stderr.trim().length > 0 ? `: ${result.stderr.trim()}` : "";
+    throw new Error(`gh api failed for authenticated identity${detail}`);
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(result.stdout);
+  } catch (cause) {
+    throw new SyntaxError(
+      "gh api returned malformed JSON for authenticated identity",
+      { cause },
+    );
+  }
+  const identity = asRecord(parsed, "GitHub authenticated identity");
+  const id = asNumberField(identity, "id", "GitHub authenticated identity");
+  const login = asStringField(
+    identity,
+    "login",
+    "GitHub authenticated identity",
+  );
+  if (id <= 0 || login.length === 0) {
+    throw new TypeError("GitHub authenticated identity is invalid");
+  }
+  return { id, login };
+}
+
+function fileSystemErrorCode(error) {
+  return error && typeof error === "object" && "code" in error
+    ? error.code
+    : null;
+}
+
+function readLiveReportLockOwner(lockPath) {
+  try {
+    const owner = asRecord(
+      JSON.parse(
+        readFileSync(join(lockPath, LIVE_REPORT_LOCK_OWNER_FILE), "utf8"),
+      ),
+      "live report lock owner",
+    );
+    const schemaVersion = asNumberField(
+      owner,
+      "schemaVersion",
+      "live report lock owner",
+    );
+    const pid = asNumberField(owner, "pid", "live report lock owner");
+    const ownerToken = asStringField(
+      owner,
+      "ownerToken",
+      "live report lock owner",
+    );
+    if (
+      schemaVersion !== 1 ||
+      pid <= 0 ||
+      !/^[a-f0-9]{32}$/u.test(ownerToken)
+    ) {
+      return null;
+    }
+    return { pid, ownerToken };
+  } catch {
+    // error-policy:J3 A corrupt or incomplete lease cannot claim live ownership.
+    return null;
+  }
+}
+
+function processIsRunning(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (fileSystemErrorCode(error) === "ESRCH") return false;
+    if (fileSystemErrorCode(error) === "EPERM") return true;
+    throw error;
+  }
+}
+
+function lockOwnerIsActive(owner) {
+  return owner !== null && processIsRunning(owner.pid);
+}
+
+function prepareLiveReportLockCandidate(lockPath, ownerToken) {
+  const candidatePath = `${lockPath}.candidate-${process.pid}-${ownerToken}`;
+  mkdirSync(candidatePath, { mode: 0o700 });
+  try {
+    writeFileSync(
+      join(candidatePath, LIVE_REPORT_LOCK_OWNER_FILE),
+      `${JSON.stringify({
+        schemaVersion: 1,
+        pid: process.pid,
+        ownerToken,
+      })}\n`,
+      { flag: "wx", mode: 0o600 },
+    );
+    return candidatePath;
+  } catch (error) {
+    rmSync(candidatePath, { force: true, recursive: true });
+    throw error;
+  }
+}
+
+export function acquireLiveReportLock(identity) {
+  const record = asRecord(identity, "GitHub authenticated identity");
+  const id = asNumberField(record, "id", "GitHub authenticated identity");
+  const login = asStringField(record, "login", "GitHub authenticated identity");
+  if (id <= 0 || login.length === 0) {
+    throw new TypeError("GitHub authenticated identity is invalid");
+  }
+  const root = join(tmpdir(), LIVE_REPORT_LOCK_DIRECTORY);
+  mkdirSync(root, { mode: 0o700, recursive: true });
+  const key = createHash("sha256").update(`github.com:${id}`).digest("hex");
+  const lockPath = join(root, `${key}.lock`);
+  const ownerToken = randomBytes(16).toString("hex");
+  let acquired = false;
+  for (
+    let attempt = 0;
+    attempt < LIVE_REPORT_LOCK_ACQUIRE_ATTEMPTS;
+    attempt += 1
+  ) {
+    const candidatePath = prepareLiveReportLockCandidate(lockPath, ownerToken);
+    try {
+      renameSync(candidatePath, lockPath);
+      acquired = true;
+      break;
+    } catch (error) {
+      rmSync(candidatePath, { force: true, recursive: true });
+      if (!existsSync(lockPath)) {
+        if (fileSystemErrorCode(error) === "ENOENT") continue;
+        throw error;
+      }
+      const currentOwner = readLiveReportLockOwner(lockPath);
+      if (lockOwnerIsActive(currentOwner)) {
+        throw new LiveReportLockContentionError();
+      }
+      const stalePath = `${lockPath}.stale-${process.pid}-${randomBytes(16).toString("hex")}`;
+      try {
+        renameSync(lockPath, stalePath);
+      } catch (renameError) {
+        if (fileSystemErrorCode(renameError) === "ENOENT") continue;
+        throw renameError;
+      }
+      rmSync(stalePath, { force: true, recursive: true });
+    }
+  }
+  if (!acquired) {
+    throw new Error("live report lock changed too often to acquire safely");
+  }
+  let released = false;
+  return {
+    release() {
+      if (released) return;
+      const owner = readLiveReportLockOwner(lockPath);
+      if (
+        owner === null ||
+        owner.pid !== process.pid ||
+        owner.ownerToken !== ownerToken
+      ) {
+        throw new Error("live report lock ownership changed before release");
+      }
+      const releasedPath = `${lockPath}.released-${process.pid}-${ownerToken}`;
+      renameSync(lockPath, releasedPath);
+      rmSync(releasedPath, { force: true, recursive: true });
+      released = true;
     },
   };
 }
@@ -2813,51 +3015,57 @@ export function main(args = process.argv.slice(2)) {
     if (!result.publishable) process.exitCode = 2;
     return;
   }
-  let rateLimits = { preflight: true };
-  const { report } = retryChangedLiveInventory(
-    ({ commandBudget }) => {
-      const boundedRead = (endpoint) => {
-        return readGhPages(endpoint, commandBudget.run);
-      };
-      const openActivity = readGhOpenActivity(
-        options.repo,
-        commandBudget.run,
-        rateLimits,
-      );
-      rateLimits = openActivity.rateLimits;
-      const limits = asRecord(openActivity.rateLimits, "GitHub rate limits");
-      process.stderr.write(
-        `[Slop] GitHub budgets: GraphQL ${limits.graphqlRemaining}/${limits.graphqlLimit} (${limits.graphqlBudgetSource}); REST ${limits.restRemaining}/${limits.restLimit}; Search ${limits.searchRemaining}/${limits.searchLimit}; activity source ${openActivity.source}\n`,
-      );
-      return {
-        report: collectLiveReport(
+  const authenticatedIdentity = readGhAuthenticatedIdentity();
+  const liveReportLock = acquireLiveReportLock(authenticatedIdentity);
+  try {
+    let rateLimits = { preflight: true };
+    const { report } = retryChangedLiveInventory(
+      ({ commandBudget }) => {
+        const boundedRead = (endpoint) => {
+          return readGhPages(endpoint, commandBudget.run);
+        };
+        const openActivity = readGhOpenActivity(
           options.repo,
-          boundedRead,
-          new Date(),
-          ({ phase, current, total }) => {
-            if (current === 0 || current === total || current % 10 === 0) {
-              process.stderr.write(
-                `[Slop] scanning ${phase}: ${current}/${total} (${commandBudget.count} bounded GitHub commands)\n`,
-              );
-            }
-          },
-          openActivity,
-          selectionPolicy.eligibleIssueLabels,
+          commandBudget.run,
+          rateLimits,
+        );
+        rateLimits = openActivity.rateLimits;
+        const limits = asRecord(openActivity.rateLimits, "GitHub rate limits");
+        process.stderr.write(
+          `[Slop] GitHub budgets: GraphQL ${limits.graphqlRemaining}/${limits.graphqlLimit} (${limits.graphqlBudgetSource}); REST ${limits.restRemaining}/${limits.restLimit}; Search ${limits.searchRemaining}/${limits.searchLimit}; activity source ${openActivity.source}\n`,
+        );
+        return {
+          report: collectLiveReport(
+            options.repo,
+            boundedRead,
+            new Date(),
+            ({ phase, current, total }) => {
+              if (current === 0 || current === total || current % 10 === 0) {
+                process.stderr.write(
+                  `[Slop] scanning ${phase}: ${current}/${total} (${commandBudget.count} bounded GitHub commands)\n`,
+                );
+              }
+            },
+            openActivity,
+            selectionPolicy.eligibleIssueLabels,
+          ),
+        };
+      },
+      ({ attempt }) =>
+        process.stderr.write(
+          `[Slop] open-item inventory changed during snapshot attempt ${attempt}; retrying one complete read\n`,
         ),
-      };
-    },
-    ({ attempt }) =>
-      process.stderr.write(
-        `[Slop] open-item inventory changed during snapshot attempt ${attempt}; retrying one complete read\n`,
-      ),
-  );
-  process.stdout.write(
-    options.epochOnly
-      ? `${JSON.stringify(report.selection.reviewEpoch, null, 2)}\n`
-      : options.json
-        ? `${JSON.stringify(report, null, 2)}\n`
-        : renderMarkdown(report),
-  );
+    );
+    process.stdout.write(
+      options.epochOnly
+        ? `${JSON.stringify(report.selection.reviewEpoch, null, 2)}\n`
+        : options.json
+          ? `${JSON.stringify(report, null, 2)}\n`
+          : renderMarkdown(report),
+    );
+  } finally {
+    liveReportLock.release();
+  }
 }
 
 const invokedDirectly =
@@ -2872,7 +3080,12 @@ if (invokedDirectly) {
   } catch (error) {
     // error-policy:J1 The CLI boundary turns a failed read/audit into a non-zero exit.
     const message = error instanceof Error ? error.message : String(error);
-    process.stderr.write(`Slop live report failed: ${message}\n`);
-    process.exitCode = 1;
+    if (error instanceof LiveReportLockContentionError) {
+      process.stderr.write(`Slop live report deferred: ${message}\n`);
+      process.exitCode = 2;
+    } else {
+      process.stderr.write(`Slop live report failed: ${message}\n`);
+      process.exitCode = 1;
+    }
   }
 }

--- a/skills/contribute-to-asi/scripts/live-report.mjs
+++ b/skills/contribute-to-asi/scripts/live-report.mjs
@@ -5,20 +5,22 @@
  * adapter; GraphQL uses explicit read-only queries over GitHub's POST endpoint.
  */
 
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { createHash, randomBytes } from "node:crypto";
 import {
   existsSync,
+  lstatSync,
   mkdirSync,
   readFileSync,
+  readdirSync,
   realpathSync,
   renameSync,
   rmSync,
   statSync,
   writeFileSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { platform, userInfo } from "node:os";
+import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 export const MODEL_DISCLOSURE_PREFIX = "AI provider/model:";
@@ -61,9 +63,18 @@ export class LiveInventoryChangedError extends Error {
   }
 }
 
-const LIVE_REPORT_LOCK_DIRECTORY = "slop-live-report-locks-v1";
+const LIVE_REPORT_LOCK_DIRECTORY = "slop-live-report-locks-v2";
 const LIVE_REPORT_LOCK_OWNER_FILE = "owner.json";
+const LIVE_REPORT_LOCK_HEARTBEAT_FILE = "heartbeat.json";
+const LIVE_REPORT_LOCK_COMMAND_DIRECTORY = "commands";
 const LIVE_REPORT_LOCK_ACQUIRE_ATTEMPTS = 8;
+const LIVE_REPORT_HEARTBEAT_INTERVAL_MS = 200;
+const LIVE_REPORT_HEARTBEAT_STALE_MS = 1_000;
+const LIVE_REPORT_ORPHAN_COMMAND_GRACE_MS = 5 * 60 * 1_000;
+const LIVE_REPORT_LOCKED_GH_ARGUMENT = "--slop-internal-locked-gh-v1";
+const LIVE_REPORT_LOCK_HEARTBEAT_ARGUMENT =
+  "--slop-internal-lock-heartbeat-v1";
+const LIVE_REPORT_TOKEN_RE = /^[a-f0-9]{32}$/u;
 
 const REPOSITORY_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const PLACEHOLDER_RE =
@@ -1347,7 +1358,16 @@ export class LiveReportLockContentionError extends Error {
 export function readGhAuthenticatedIdentity(spawn = spawnSync) {
   const result = spawn(
     "gh",
-    ["api", "--method", "GET", "--jq", "{id: .id, login: .login}", "user"],
+    [
+      "api",
+      "--hostname",
+      "github.com",
+      "--method",
+      "GET",
+      "--jq",
+      "{id: .id, login: .login}",
+      "user",
+    ],
     {
       encoding: "utf8",
       maxBuffer: 1024 * 1024,
@@ -1379,7 +1399,7 @@ export function readGhAuthenticatedIdentity(spawn = spawnSync) {
   if (id <= 0 || login.length === 0) {
     throw new TypeError("GitHub authenticated identity is invalid");
   }
-  return { id, login };
+  return { host: "github.com", id, login };
 }
 
 function fileSystemErrorCode(error) {
@@ -1388,63 +1408,166 @@ function fileSystemErrorCode(error) {
     : null;
 }
 
-function readLiveReportLockOwner(lockPath) {
-  try {
-    const owner = asRecord(
-      JSON.parse(
-        readFileSync(join(lockPath, LIVE_REPORT_LOCK_OWNER_FILE), "utf8"),
-      ),
-      "live report lock owner",
-    );
-    const schemaVersion = asNumberField(
-      owner,
-      "schemaVersion",
-      "live report lock owner",
-    );
-    const pid = asNumberField(owner, "pid", "live report lock owner");
-    const ownerToken = asStringField(
-      owner,
-      "ownerToken",
-      "live report lock owner",
-    );
-    if (
-      schemaVersion !== 1 ||
-      pid <= 0 ||
-      !/^[a-f0-9]{32}$/u.test(ownerToken)
-    ) {
-      return null;
-    }
-    return { pid, ownerToken };
-  } catch {
-    // error-policy:J3 A corrupt or incomplete lease cannot claim live ownership.
-    return null;
-  }
+function heartbeatTimestampIsFresh(observedAtMs) {
+  const age = Date.now() - observedAtMs;
+  return age >= -LIVE_REPORT_HEARTBEAT_STALE_MS &&
+    age <= LIVE_REPORT_HEARTBEAT_STALE_MS;
 }
 
-function processIsRunning(pid) {
+export function defaultLiveReportLockRoot() {
+  const uid = typeof process.getuid === "function" ? process.getuid() : null;
+  if (Number.isInteger(uid) && uid >= 0) {
+    return join("/tmp", `${LIVE_REPORT_LOCK_DIRECTORY}-${uid}`);
+  }
+  const identity = userInfo();
+  const key = createHash("sha256")
+    .update(`${identity.username}\0${identity.homedir}`)
+    .digest("hex")
+    .slice(0, 16);
+  return join(identity.homedir, `.${LIVE_REPORT_LOCK_DIRECTORY}-${key}`);
+}
+
+export function ensureLiveReportLockRoot(
+  rootPath = defaultLiveReportLockRoot(),
+) {
   try {
-    process.kill(pid, 0);
-    return true;
+    mkdirSync(rootPath, { mode: 0o700 });
   } catch (error) {
-    if (fileSystemErrorCode(error) === "ESRCH") return false;
-    if (fileSystemErrorCode(error) === "EPERM") return true;
+    if (fileSystemErrorCode(error) !== "EEXIST") throw error;
+  }
+  const stats = lstatSync(rootPath);
+  if (stats.isSymbolicLink() || !stats.isDirectory()) {
+    throw new TypeError("live report lock root must be a real directory");
+  }
+  const uid = typeof process.getuid === "function" ? process.getuid() : null;
+  if (Number.isInteger(uid) && stats.uid !== uid) {
+    throw new TypeError(
+      "live report lock root must belong to the current user",
+    );
+  }
+  if (platform() !== "win32" && (stats.mode & 0o077) !== 0) {
+    throw new TypeError("live report lock root permissions must be 0700");
+  }
+  return rootPath;
+}
+
+function readLiveReportLockOwner(lockPath) {
+  let source;
+  try {
+    source = readFileSync(join(lockPath, LIVE_REPORT_LOCK_OWNER_FILE), "utf8");
+  } catch (error) {
+    if (fileSystemErrorCode(error) === "ENOENT") return null;
     throw error;
   }
+  const owner = asRecord(JSON.parse(source), "live report lock owner");
+  const schemaVersion = asNumberField(
+    owner,
+    "schemaVersion",
+    "live report lock owner",
+  );
+  const processLease = readProcessLease(owner, "live report lock owner");
+  const ownerToken = asStringField(
+    owner,
+    "ownerToken",
+    "live report lock owner",
+  );
+  if (schemaVersion !== 2 || !LIVE_REPORT_TOKEN_RE.test(ownerToken)) {
+    throw new TypeError("live report lock owner is invalid");
+  }
+  return { ...processLease, ownerToken };
 }
 
-function lockOwnerIsActive(owner) {
-  return owner !== null && processIsRunning(owner.pid);
+function liveReportCommandDirectory(lockPath) {
+  return join(lockPath, LIVE_REPORT_LOCK_COMMAND_DIRECTORY);
 }
 
-function prepareLiveReportLockCandidate(lockPath, ownerToken) {
+function readLiveReportCommandLease(path) {
+  const record = asRecord(
+    JSON.parse(readFileSync(path, "utf8")),
+    "live report command lease",
+  );
+  const schemaVersion = asNumberField(
+    record,
+    "schemaVersion",
+    "live report command lease",
+  );
+  const ownerToken = asStringField(
+    record,
+    "ownerToken",
+    "live report command lease",
+  );
+  const startedAtMs = asNumberField(
+    record,
+    "startedAtMs",
+    "live report command lease",
+  );
+  const helper = readProcessLease(record.helper, "live report command helper");
+  const child =
+    record.child === null
+      ? null
+      : readProcessLease(record.child, "live report GitHub child");
+  if (
+    schemaVersion !== 1 ||
+    !LIVE_REPORT_TOKEN_RE.test(ownerToken) ||
+    !Number.isSafeInteger(startedAtMs) ||
+    startedAtMs <= 0
+  ) {
+    throw new TypeError("live report command lease is invalid");
+  }
+  return { child, helper, ownerToken, startedAtMs };
+}
+
+function liveReportCommandIsActive(lease, ownerToken) {
+  if (lease.ownerToken !== ownerToken) {
+    throw new TypeError("live report command lease owner does not match");
+  }
+  if (processLeaseIsActive(lease.helper)) return true;
+  if (lease.child !== null && processLeaseIsActive(lease.child)) return true;
+  return Date.now() - lease.startedAtMs < LIVE_REPORT_ORPHAN_COMMAND_GRACE_MS;
+}
+
+function liveReportHasActiveCommand(lockPath, ownerToken) {
+  const commandDirectory = liveReportCommandDirectory(lockPath);
+  let entries;
+  try {
+    entries = readdirSync(commandDirectory, { withFileTypes: true });
+  } catch (error) {
+    if (fileSystemErrorCode(error) === "ENOENT" && !existsSync(lockPath)) {
+      return false;
+    }
+    throw error;
+  }
+  for (const entry of entries) {
+    if (entry.isSymbolicLink() || (!entry.isFile() && !entry.isDirectory())) {
+      throw new TypeError("live report command directory is invalid");
+    }
+    if (!/^lease-[a-f0-9]{32}\.json$/u.test(entry.name)) continue;
+    const lease = readLiveReportCommandLease(
+      join(commandDirectory, entry.name),
+    );
+    if (liveReportCommandIsActive(lease, ownerToken)) return true;
+  }
+  return false;
+}
+
+function assertLiveReportLockDirectory(lockPath) {
+  const stats = lstatSync(lockPath);
+  if (stats.isSymbolicLink() || !stats.isDirectory()) {
+    throw new TypeError("live report lock must be a real directory");
+  }
+}
+
+function prepareLiveReportLockCandidate(lockPath, ownerToken, processIdentity) {
   const candidatePath = `${lockPath}.candidate-${process.pid}-${ownerToken}`;
   mkdirSync(candidatePath, { mode: 0o700 });
   try {
+    mkdirSync(liveReportCommandDirectory(candidatePath), { mode: 0o700 });
     writeFileSync(
       join(candidatePath, LIVE_REPORT_LOCK_OWNER_FILE),
       `${JSON.stringify({
-        schemaVersion: 1,
+        schemaVersion: 2,
         pid: process.pid,
+        processIdentity,
         ownerToken,
       })}\n`,
       { flag: "wx", mode: 0o600 },
@@ -1456,25 +1579,113 @@ function prepareLiveReportLockCandidate(lockPath, ownerToken) {
   }
 }
 
-export function acquireLiveReportLock(identity) {
+function liveReportLockKey(identity) {
+  return createHash("sha256")
+    .update(`${identity.host}:${identity.id}`)
+    .digest("hex");
+}
+
+function writeLiveReportCommandLease(path, lease, replace = false) {
+  if (!replace) {
+    writeFileSync(path, `${JSON.stringify(lease)}\n`, {
+      flag: "wx",
+      mode: 0o600,
+    });
+    return;
+  }
+  const nextPath = `${path}.next-${process.pid}-${randomBytes(16).toString("hex")}`;
+  try {
+    writeFileSync(nextPath, `${JSON.stringify(lease)}\n`, {
+      flag: "wx",
+      mode: 0o600,
+    });
+    renameSync(nextPath, path);
+  } catch (error) {
+    rmSync(nextPath, { force: true });
+    throw error;
+  }
+}
+
+function spawnLockedGh(lockPath, ownerToken, command, args, options = {}) {
+  if (
+    command !== "gh" ||
+    !Array.isArray(args) ||
+    args.some((argument) => typeof argument !== "string")
+  ) {
+    throw new TypeError("live report lock may execute only a gh argument list");
+  }
+  if (options.encoding !== undefined && options.encoding !== "utf8") {
+    throw new TypeError("live report gh commands require utf8 output");
+  }
+  const maxBuffer = options.maxBuffer ?? 1024 * 1024;
+  if (
+    !Number.isSafeInteger(maxBuffer) ||
+    maxBuffer <= 0 ||
+    maxBuffer > 256 * 1024 * 1024
+  ) {
+    throw new RangeError("live report gh command maxBuffer is invalid");
+  }
+  const commandToken = randomBytes(16).toString("hex");
+  const requestPath = join(
+    liveReportCommandDirectory(lockPath),
+    `request-${commandToken}.json`,
+  );
+  writeFileSync(
+    requestPath,
+    `${JSON.stringify({ args, maxBuffer, ownerToken, schemaVersion: 1 })}\n`,
+    { flag: "wx", mode: 0o600 },
+  );
+  try {
+    return spawnSync(
+      process.execPath,
+      [
+        fileURLToPath(import.meta.url),
+        LIVE_REPORT_LOCKED_GH_ARGUMENT,
+        lockPath,
+        ownerToken,
+        commandToken,
+      ],
+      {
+        encoding: "utf8",
+        env: { ...(options.env ?? process.env), GH_HOST: "github.com" },
+        maxBuffer: Math.min(maxBuffer + 1024 * 1024, 256 * 1024 * 1024),
+        windowsHide: true,
+      },
+    );
+  } finally {
+    rmSync(requestPath, { force: true });
+  }
+}
+
+export function acquireLiveReportLock(identity, options = {}) {
   const record = asRecord(identity, "GitHub authenticated identity");
   const id = asNumberField(record, "id", "GitHub authenticated identity");
   const login = asStringField(record, "login", "GitHub authenticated identity");
-  if (id <= 0 || login.length === 0) {
+  const host = asStringField(record, "host", "GitHub authenticated identity");
+  if (id <= 0 || login.length === 0 || host !== "github.com") {
     throw new TypeError("GitHub authenticated identity is invalid");
   }
-  const root = join(tmpdir(), LIVE_REPORT_LOCK_DIRECTORY);
-  mkdirSync(root, { mode: 0o700, recursive: true });
-  const key = createHash("sha256").update(`github.com:${id}`).digest("hex");
+  const root = ensureLiveReportLockRoot(
+    options.rootPath ?? defaultLiveReportLockRoot(),
+  );
+  const key = liveReportLockKey({ host, id });
   const lockPath = join(root, `${key}.lock`);
   const ownerToken = randomBytes(16).toString("hex");
+  const processIdentity = readLiveReportProcessIdentity(process.pid);
+  if (processIdentity === null) {
+    throw new Error("could not establish the live report process identity");
+  }
   let acquired = false;
   for (
     let attempt = 0;
     attempt < LIVE_REPORT_LOCK_ACQUIRE_ATTEMPTS;
     attempt += 1
   ) {
-    const candidatePath = prepareLiveReportLockCandidate(lockPath, ownerToken);
+    const candidatePath = prepareLiveReportLockCandidate(
+      lockPath,
+      ownerToken,
+      processIdentity,
+    );
     try {
       renameSync(candidatePath, lockPath);
       acquired = true;
@@ -1485,8 +1696,16 @@ export function acquireLiveReportLock(identity) {
         if (fileSystemErrorCode(error) === "ENOENT") continue;
         throw error;
       }
+      assertLiveReportLockDirectory(lockPath);
       const currentOwner = readLiveReportLockOwner(lockPath);
-      if (lockOwnerIsActive(currentOwner)) {
+      if (currentOwner === null) {
+        if (!existsSync(lockPath)) continue;
+        throw new Error("live report lock owner is missing");
+      }
+      if (
+        processLeaseIsActive(currentOwner) ||
+        liveReportHasActiveCommand(lockPath, currentOwner.ownerToken)
+      ) {
         throw new LiveReportLockContentionError();
       }
       const stalePath = `${lockPath}.stale-${process.pid}-${randomBytes(16).toString("hex")}`;
@@ -1504,12 +1723,16 @@ export function acquireLiveReportLock(identity) {
   }
   let released = false;
   return {
+    spawn(command, args, options) {
+      return spawnLockedGh(lockPath, ownerToken, command, args, options);
+    },
     release() {
       if (released) return;
       const owner = readLiveReportLockOwner(lockPath);
       if (
         owner === null ||
         owner.pid !== process.pid ||
+        owner.processIdentity !== processIdentity ||
         owner.ownerToken !== ownerToken
       ) {
         throw new Error("live report lock ownership changed before release");
@@ -1520,6 +1743,173 @@ export function acquireLiveReportLock(identity) {
       released = true;
     },
   };
+}
+
+function readLockedGhRequest(lockPath, ownerToken, commandToken) {
+  if (
+    !LIVE_REPORT_TOKEN_RE.test(ownerToken) ||
+    !LIVE_REPORT_TOKEN_RE.test(commandToken)
+  ) {
+    throw new TypeError("locked GitHub command tokens are invalid");
+  }
+  const root = ensureLiveReportLockRoot();
+  if (
+    dirname(lockPath) !== root ||
+    !/^[a-f0-9]{64}\.lock$/u.test(basename(lockPath))
+  ) {
+    throw new TypeError("locked GitHub command path is invalid");
+  }
+  assertLiveReportLockDirectory(lockPath);
+  const owner = readLiveReportLockOwner(lockPath);
+  if (owner === null || owner.ownerToken !== ownerToken) {
+    throw new Error("live report lock ownership changed before GitHub command");
+  }
+  const requestPath = join(
+    liveReportCommandDirectory(lockPath),
+    `request-${commandToken}.json`,
+  );
+  const request = asRecord(
+    JSON.parse(readFileSync(requestPath, "utf8")),
+    "locked GitHub command request",
+  );
+  const schemaVersion = asNumberField(
+    request,
+    "schemaVersion",
+    "locked GitHub command request",
+  );
+  const requestOwnerToken = asStringField(
+    request,
+    "ownerToken",
+    "locked GitHub command request",
+  );
+  const maxBuffer = asNumberField(
+    request,
+    "maxBuffer",
+    "locked GitHub command request",
+  );
+  if (
+    schemaVersion !== 1 ||
+    requestOwnerToken !== ownerToken ||
+    !Number.isSafeInteger(maxBuffer) ||
+    maxBuffer <= 0 ||
+    maxBuffer > 256 * 1024 * 1024 ||
+    !Array.isArray(request.args) ||
+    request.args.some((argument) => typeof argument !== "string")
+  ) {
+    throw new TypeError("locked GitHub command request is invalid");
+  }
+  return { args: request.args, maxBuffer, requestPath };
+}
+
+function collectBoundedGhChild(child, maxBuffer) {
+  return new Promise((resolvePromise) => {
+    const stdout = [];
+    const stderr = [];
+    let stdoutBytes = 0;
+    let stderrBytes = 0;
+    let overflow = null;
+    let spawnError = null;
+    const collect = (chunks, chunk, stream) => {
+      if (overflow !== null) return;
+      const value = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      if (stream === "stdout") stdoutBytes += value.length;
+      else stderrBytes += value.length;
+      if (stdoutBytes > maxBuffer || stderrBytes > maxBuffer) {
+        overflow = stream;
+        child.kill("SIGTERM");
+        return;
+      }
+      chunks.push(value);
+    };
+    child.stdout.on("data", (chunk) => collect(stdout, chunk, "stdout"));
+    child.stderr.on("data", (chunk) => collect(stderr, chunk, "stderr"));
+    child.once("error", (error) => {
+      spawnError = error;
+    });
+    child.once("close", (status, signal) => {
+      resolvePromise({
+        error: spawnError,
+        overflow,
+        signal,
+        status,
+        stderr: Buffer.concat(stderr),
+        stdout: Buffer.concat(stdout),
+      });
+    });
+  });
+}
+
+function writeProcessDescriptor(descriptor, value) {
+  if (value.length === 0) return;
+  try {
+    writeFileSync(descriptor, value);
+  } catch (error) {
+    if (fileSystemErrorCode(error) !== "EPIPE") throw error;
+  }
+}
+
+async function runLockedGhCommand(lockPath, ownerToken, commandToken) {
+  const request = readLockedGhRequest(lockPath, ownerToken, commandToken);
+  const leasePath = join(
+    liveReportCommandDirectory(lockPath),
+    `lease-${commandToken}.json`,
+  );
+  const helperIdentity = readLiveReportProcessIdentity(process.pid);
+  if (helperIdentity === null) {
+    throw new Error("could not establish the GitHub command helper identity");
+  }
+  const lease = {
+    schemaVersion: 1,
+    ownerToken,
+    startedAtMs: Date.now(),
+    helper: { pid: process.pid, processIdentity: helperIdentity },
+    child: null,
+  };
+  writeLiveReportCommandLease(leasePath, lease);
+  let result;
+  try {
+    const currentOwner = readLiveReportLockOwner(lockPath);
+    if (currentOwner === null || currentOwner.ownerToken !== ownerToken) {
+      throw new Error(
+        "live report lock ownership changed while starting GitHub command",
+      );
+    }
+    const child = spawn("gh", request.args, {
+      env: { ...process.env, GH_HOST: "github.com" },
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+    });
+    const childResult = collectBoundedGhChild(child, request.maxBuffer);
+    if (Number.isInteger(child.pid) && child.pid > 0) {
+      const childIdentity = readLiveReportProcessIdentity(child.pid);
+      if (childIdentity !== null) {
+        writeLiveReportCommandLease(
+          leasePath,
+          {
+            ...lease,
+            child: { pid: child.pid, processIdentity: childIdentity },
+          },
+          true,
+        );
+      }
+    }
+    result = await childResult;
+  } finally {
+    rmSync(leasePath, { force: true });
+    rmSync(request.requestPath, { force: true });
+  }
+  if (result.error) throw result.error;
+  if (result.overflow !== null) {
+    throw new RangeError(
+      `spawn gh ${result.overflow} exceeded the bounded output buffer`,
+    );
+  }
+  writeProcessDescriptor(1, result.stdout);
+  writeProcessDescriptor(2, result.stderr);
+  if (result.status === null) {
+    throw new Error(`gh terminated by ${result.signal ?? "an unknown signal"}`);
+  }
+  process.exitCode = result.status;
 }
 
 function rateResource(value, context) {
@@ -3055,6 +3445,7 @@ export function main(args = process.argv.slice(2)) {
         process.stderr.write(
           `[Slop] open-item inventory changed during snapshot attempt ${attempt}; retrying one complete read\n`,
         ),
+      () => createGhCommandBudget(liveReportLock.spawn),
     );
     process.stdout.write(
       options.epochOnly
@@ -3075,17 +3466,27 @@ const invokedDirectly =
     realpathSync(process.argv[1]);
 
 if (invokedDirectly) {
-  try {
-    main();
-  } catch (error) {
-    // error-policy:J1 The CLI boundary turns a failed read/audit into a non-zero exit.
-    const message = error instanceof Error ? error.message : String(error);
-    if (error instanceof LiveReportLockContentionError) {
-      process.stderr.write(`Slop live report deferred: ${message}\n`);
-      process.exitCode = 2;
-    } else {
-      process.stderr.write(`Slop live report failed: ${message}\n`);
+  const directArguments = process.argv.slice(2);
+  if (directArguments[0] === LIVE_REPORT_LOCKED_GH_ARGUMENT) {
+    runLockedGhCommand(...directArguments.slice(1)).catch((error) => {
+      // error-policy:J1 The internal process boundary fails the owning report.
+      const message = error instanceof Error ? error.message : String(error);
+      process.stderr.write(`Slop locked GitHub command failed: ${message}\n`);
       process.exitCode = 1;
+    });
+  } else {
+    try {
+      main(directArguments);
+    } catch (error) {
+      // error-policy:J1 The CLI boundary turns a failed read/audit into a non-zero exit.
+      const message = error instanceof Error ? error.message : String(error);
+      if (error instanceof LiveReportLockContentionError) {
+        process.stderr.write(`Slop live report deferred: ${message}\n`);
+        process.exitCode = 2;
+      } else {
+        process.stderr.write(`Slop live report failed: ${message}\n`);
+        process.exitCode = 1;
+      }
     }
   }
 }

--- a/skills/contribute-to-asi/scripts/live-report.mjs
+++ b/skills/contribute-to-asi/scripts/live-report.mjs
@@ -3,6 +3,7 @@
  * Builds a stable, read-only inventory of open elizaOS issues and pull requests
  * for contribution selection. REST pagination stays behind one GET-only
  * adapter; GraphQL uses explicit read-only queries over GitHub's POST endpoint.
+ * A user-private process lease serializes complete discovery across skill copies.
  */
 
 import { spawn, spawnSync } from "node:child_process";
@@ -11,8 +12,8 @@ import {
   existsSync,
   lstatSync,
   mkdirSync,
-  readFileSync,
   readdirSync,
+  readFileSync,
   realpathSync,
   renameSync,
   rmSync,
@@ -65,15 +66,11 @@ export class LiveInventoryChangedError extends Error {
 
 const LIVE_REPORT_LOCK_DIRECTORY = "slop-live-report-locks-v2";
 const LIVE_REPORT_LOCK_OWNER_FILE = "owner.json";
-const LIVE_REPORT_LOCK_HEARTBEAT_FILE = "heartbeat.json";
 const LIVE_REPORT_LOCK_COMMAND_DIRECTORY = "commands";
 const LIVE_REPORT_LOCK_ACQUIRE_ATTEMPTS = 8;
-const LIVE_REPORT_HEARTBEAT_INTERVAL_MS = 200;
-const LIVE_REPORT_HEARTBEAT_STALE_MS = 1_000;
 const LIVE_REPORT_ORPHAN_COMMAND_GRACE_MS = 5 * 60 * 1_000;
 const LIVE_REPORT_LOCKED_GH_ARGUMENT = "--slop-internal-locked-gh-v1";
-const LIVE_REPORT_LOCK_HEARTBEAT_ARGUMENT =
-  "--slop-internal-lock-heartbeat-v1";
+const LIVE_REPORT_PROCESS_IDENTITY_RE = /^[a-f0-9]{64}$/u;
 const LIVE_REPORT_TOKEN_RE = /^[a-f0-9]{32}$/u;
 
 const REPOSITORY_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
@@ -1408,10 +1405,121 @@ function fileSystemErrorCode(error) {
     : null;
 }
 
-function heartbeatTimestampIsFresh(observedAtMs) {
-  const age = Date.now() - observedAtMs;
-  return age >= -LIVE_REPORT_HEARTBEAT_STALE_MS &&
-    age <= LIVE_REPORT_HEARTBEAT_STALE_MS;
+function assertLiveReportPrivatePath(path, context, kind) {
+  const stats = lstatSync(path);
+  const kindMatches =
+    kind === "directory" ? stats.isDirectory() : stats.isFile();
+  if (stats.isSymbolicLink() || !kindMatches) {
+    throw new TypeError(`${context} must be a real ${kind}`);
+  }
+  const uid = typeof process.getuid === "function" ? process.getuid() : null;
+  if (Number.isInteger(uid) && stats.uid !== uid) {
+    throw new TypeError(`${context} must belong to the current user`);
+  }
+  if (platform() !== "win32" && (stats.mode & 0o077) !== 0) {
+    throw new TypeError(`${context} permissions must exclude group and others`);
+  }
+  return stats;
+}
+
+function processIsRunning(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (fileSystemErrorCode(error) === "ESRCH") return false;
+    if (fileSystemErrorCode(error) === "EPERM") return true;
+    throw error;
+  }
+}
+
+function hashProcessIdentity(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+export function readLiveReportProcessIdentity(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    throw new TypeError("live report process ID must be a positive integer");
+  }
+  if (!processIsRunning(pid)) return null;
+  const operatingSystem = platform();
+  if (operatingSystem === "linux") {
+    let source;
+    try {
+      source = readFileSync(`/proc/${pid}/stat`, "utf8");
+    } catch (error) {
+      if (fileSystemErrorCode(error) === "ENOENT") return null;
+      throw error;
+    }
+    const commandEnd = source.lastIndexOf(")");
+    const fields = source
+      .slice(commandEnd + 2)
+      .trim()
+      .split(/\s+/u);
+    const startTime = fields[19];
+    if (commandEnd < 1 || !/^\d+$/u.test(startTime ?? "")) {
+      throw new TypeError("Linux returned an invalid process birth identity");
+    }
+    return hashProcessIdentity(`linux:${startTime}`);
+  }
+  if (
+    operatingSystem === "darwin" ||
+    operatingSystem === "freebsd" ||
+    operatingSystem === "openbsd"
+  ) {
+    const result = spawnSync(
+      existsSync("/bin/ps") ? "/bin/ps" : "ps",
+      ["-o", "lstart=", "-p", String(pid)],
+      { encoding: "utf8", maxBuffer: 64 * 1024, windowsHide: true },
+    );
+    if (result.error) throw result.error;
+    if (result.status !== 0 || result.stdout.trim() === "") {
+      if (!processIsRunning(pid)) return null;
+      throw new Error("could not read the process birth identity from ps");
+    }
+    return hashProcessIdentity(`${operatingSystem}:${result.stdout.trim()}`);
+  }
+  if (operatingSystem === "win32") {
+    const result = spawnSync(
+      "powershell.exe",
+      [
+        "-NoLogo",
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        `(Get-Process -Id ${pid} -ErrorAction Stop).StartTime.ToUniversalTime().Ticks`,
+      ],
+      { encoding: "utf8", maxBuffer: 64 * 1024, windowsHide: true },
+    );
+    if (result.error) throw result.error;
+    if (result.status !== 0 || !/^\d+$/u.test(result.stdout.trim())) {
+      if (!processIsRunning(pid)) return null;
+      throw new Error("could not read the Windows process birth identity");
+    }
+    return hashProcessIdentity(`win32:${result.stdout.trim()}`);
+  }
+  throw new Error(
+    `live report locking does not support process identity on ${operatingSystem}`,
+  );
+}
+
+function readProcessLease(value, context) {
+  const record = asRecord(value, context);
+  const pid = asNumberField(record, "pid", context);
+  const processIdentity = asStringField(record, "processIdentity", context);
+  if (
+    !Number.isInteger(pid) ||
+    pid <= 0 ||
+    !LIVE_REPORT_PROCESS_IDENTITY_RE.test(processIdentity)
+  ) {
+    throw new TypeError(`${context} is invalid`);
+  }
+  return { pid, processIdentity };
+}
+
+function processLeaseIsActive(lease) {
+  const currentIdentity = readLiveReportProcessIdentity(lease.pid);
+  return currentIdentity !== null && currentIdentity === lease.processIdentity;
 }
 
 export function defaultLiveReportLockRoot() {
@@ -1435,25 +1543,18 @@ export function ensureLiveReportLockRoot(
   } catch (error) {
     if (fileSystemErrorCode(error) !== "EEXIST") throw error;
   }
-  const stats = lstatSync(rootPath);
-  if (stats.isSymbolicLink() || !stats.isDirectory()) {
-    throw new TypeError("live report lock root must be a real directory");
-  }
-  const uid = typeof process.getuid === "function" ? process.getuid() : null;
-  if (Number.isInteger(uid) && stats.uid !== uid) {
-    throw new TypeError(
-      "live report lock root must belong to the current user",
-    );
-  }
-  if (platform() !== "win32" && (stats.mode & 0o077) !== 0) {
-    throw new TypeError("live report lock root permissions must be 0700");
-  }
+  assertLiveReportPrivatePath(rootPath, "live report lock root", "directory");
   return rootPath;
 }
 
 function readLiveReportLockOwner(lockPath) {
   let source;
   try {
+    assertLiveReportPrivatePath(
+      join(lockPath, LIVE_REPORT_LOCK_OWNER_FILE),
+      "live report lock owner",
+      "file",
+    );
     source = readFileSync(join(lockPath, LIVE_REPORT_LOCK_OWNER_FILE), "utf8");
   } catch (error) {
     if (fileSystemErrorCode(error) === "ENOENT") return null;
@@ -1482,6 +1583,7 @@ function liveReportCommandDirectory(lockPath) {
 }
 
 function readLiveReportCommandLease(path) {
+  assertLiveReportPrivatePath(path, "live report command lease", "file");
   const record = asRecord(
     JSON.parse(readFileSync(path, "utf8")),
     "live report command lease",
@@ -1530,6 +1632,11 @@ function liveReportHasActiveCommand(lockPath, ownerToken) {
   const commandDirectory = liveReportCommandDirectory(lockPath);
   let entries;
   try {
+    assertLiveReportPrivatePath(
+      commandDirectory,
+      "live report command directory",
+      "directory",
+    );
     entries = readdirSync(commandDirectory, { withFileTypes: true });
   } catch (error) {
     if (fileSystemErrorCode(error) === "ENOENT" && !existsSync(lockPath)) {
@@ -1538,7 +1645,7 @@ function liveReportHasActiveCommand(lockPath, ownerToken) {
     throw error;
   }
   for (const entry of entries) {
-    if (entry.isSymbolicLink() || (!entry.isFile() && !entry.isDirectory())) {
+    if (!entry.isFile()) {
       throw new TypeError("live report command directory is invalid");
     }
     if (!/^lease-[a-f0-9]{32}\.json$/u.test(entry.name)) continue;
@@ -1551,10 +1658,7 @@ function liveReportHasActiveCommand(lockPath, ownerToken) {
 }
 
 function assertLiveReportLockDirectory(lockPath) {
-  const stats = lstatSync(lockPath);
-  if (stats.isSymbolicLink() || !stats.isDirectory()) {
-    throw new TypeError("live report lock must be a real directory");
-  }
+  assertLiveReportPrivatePath(lockPath, "live report lock", "directory");
 }
 
 function prepareLiveReportLockCandidate(lockPath, ownerToken, processIdentity) {
@@ -1626,6 +1730,11 @@ function spawnLockedGh(lockPath, ownerToken, command, args, options = {}) {
     throw new RangeError("live report gh command maxBuffer is invalid");
   }
   const commandToken = randomBytes(16).toString("hex");
+  assertLiveReportPrivatePath(
+    liveReportCommandDirectory(lockPath),
+    "live report command directory",
+    "directory",
+  );
   const requestPath = join(
     liveReportCommandDirectory(lockPath),
     `request-${commandToken}.json`,
@@ -1752,7 +1861,7 @@ function readLockedGhRequest(lockPath, ownerToken, commandToken) {
   ) {
     throw new TypeError("locked GitHub command tokens are invalid");
   }
-  const root = ensureLiveReportLockRoot();
+  const root = ensureLiveReportLockRoot(dirname(lockPath));
   if (
     dirname(lockPath) !== root ||
     !/^[a-f0-9]{64}\.lock$/u.test(basename(lockPath))
@@ -1767,6 +1876,11 @@ function readLockedGhRequest(lockPath, ownerToken, commandToken) {
   const requestPath = join(
     liveReportCommandDirectory(lockPath),
     `request-${commandToken}.json`,
+  );
+  assertLiveReportPrivatePath(
+    requestPath,
+    "locked GitHub command request",
+    "file",
   );
   const request = asRecord(
     JSON.parse(readFileSync(requestPath, "utf8")),

--- a/skills/contribute-to-asi/scripts/live-report.mjs
+++ b/skills/contribute-to-asi/scripts/live-report.mjs
@@ -1625,7 +1625,12 @@ function liveReportCommandIsActive(lease, ownerToken) {
   }
   if (processLeaseIsActive(lease.helper)) return true;
   if (lease.child !== null && processLeaseIsActive(lease.child)) return true;
-  return Date.now() - lease.startedAtMs < LIVE_REPORT_ORPHAN_COMMAND_GRACE_MS;
+  // Only an unpublished child needs a grace period. A recorded birth identity
+  // proves a known child is gone, so recovery need not wait for that period.
+  return (
+    lease.child === null &&
+    Date.now() - lease.startedAtMs < LIVE_REPORT_ORPHAN_COMMAND_GRACE_MS
+  );
 }
 
 function liveReportHasActiveCommand(lockPath, ownerToken) {
@@ -1852,6 +1857,10 @@ export function acquireLiveReportLock(identity, options = {}) {
         ) {
           throw new Error("live report lock ownership changed before release");
         }
+        // An interrupted helper can return before its GitHub child exits. Keep
+        // the owner and command leases so a replacement scan still sees it;
+        // normal stale-owner recovery can reclaim the lock after the child exits.
+        if (liveReportHasActiveCommand(lockPath, ownerToken)) return;
         const releasedPath = `${lockPath}.released-${process.pid}-${ownerToken}`;
         renameSync(lockPath, releasedPath);
         rmSync(releasedPath, { force: true, recursive: true });

--- a/skills/contribute-to-delta-star/scripts/live-report.mjs
+++ b/skills/contribute-to-delta-star/scripts/live-report.mjs
@@ -16,6 +16,7 @@ import {
   readFileSync,
   realpathSync,
   renameSync,
+  rmdirSync,
   rmSync,
   statSync,
   writeFileSync,
@@ -67,7 +68,6 @@ export class LiveInventoryChangedError extends Error {
 const LIVE_REPORT_LOCK_DIRECTORY = "slop-live-report-locks-v2";
 const LIVE_REPORT_LOCK_OWNER_FILE = "owner.json";
 const LIVE_REPORT_LOCK_COMMAND_DIRECTORY = "commands";
-const LIVE_REPORT_LOCK_ACQUIRE_ATTEMPTS = 8;
 const LIVE_REPORT_ORPHAN_COMMAND_GRACE_MS = 5 * 60 * 1_000;
 const LIVE_REPORT_LOCKED_GH_ARGUMENT = "--slop-internal-locked-gh-v1";
 const LIVE_REPORT_PROCESS_IDENTITY_RE = /^[a-f0-9]{64}$/u;
@@ -1344,10 +1344,10 @@ export function createGhCommandBudget(spawn = spawnSync) {
 }
 
 export class LiveReportLockContentionError extends Error {
-  constructor() {
-    super(
-      "live report lock contention: another report for this GitHub identity is already discovering activity",
-    );
+  constructor(
+    message = "live report lock contention: another report for this GitHub identity is already discovering activity",
+  ) {
+    super(message);
     this.name = "LiveReportLockContentionError";
   }
 }
@@ -1661,6 +1661,27 @@ function assertLiveReportLockDirectory(lockPath) {
   assertLiveReportPrivatePath(lockPath, "live report lock", "directory");
 }
 
+function withLiveReportLockTransition(lockPath, operation) {
+  const transitionPath = `${lockPath}.transition`;
+  // Every lock-path mutation participates in this atomic mkdir guard. Never
+  // reclaim the guard: checking a token or dead PID before renaming it would
+  // recreate the same ABA race that this guard prevents for the report lock.
+  // A crash here requires manual recovery after all local reports are stopped.
+  try {
+    mkdirSync(transitionPath, { mode: 0o700 });
+  } catch (error) {
+    if (fileSystemErrorCode(error) !== "EEXIST") throw error;
+    throw new LiveReportLockContentionError(
+      `live report lock contention: transition guard exists at ${transitionPath}; retry after the other report finishes. If it persists, stop all local reports before manually removing this guard`,
+    );
+  }
+  try {
+    return operation();
+  } finally {
+    rmdirSync(transitionPath);
+  }
+}
+
 function prepareLiveReportLockCandidate(lockPath, ownerToken, processIdentity) {
   const candidatePath = `${lockPath}.candidate-${process.pid}-${ownerToken}`;
   mkdirSync(candidatePath, { mode: 0o700 });
@@ -1784,31 +1805,20 @@ export function acquireLiveReportLock(identity, options = {}) {
   if (processIdentity === null) {
     throw new Error("could not establish the live report process identity");
   }
-  let acquired = false;
-  for (
-    let attempt = 0;
-    attempt < LIVE_REPORT_LOCK_ACQUIRE_ATTEMPTS;
-    attempt += 1
-  ) {
+  withLiveReportLockTransition(lockPath, () => {
     const candidatePath = prepareLiveReportLockCandidate(
       lockPath,
       ownerToken,
       processIdentity,
     );
     try {
-      renameSync(candidatePath, lockPath);
-      acquired = true;
-      break;
-    } catch (error) {
-      rmSync(candidatePath, { force: true, recursive: true });
       if (!existsSync(lockPath)) {
-        if (fileSystemErrorCode(error) === "ENOENT") continue;
-        throw error;
+        renameSync(candidatePath, lockPath);
+        return;
       }
       assertLiveReportLockDirectory(lockPath);
       const currentOwner = readLiveReportLockOwner(lockPath);
       if (currentOwner === null) {
-        if (!existsSync(lockPath)) continue;
         throw new Error("live report lock owner is missing");
       }
       if (
@@ -1818,18 +1828,13 @@ export function acquireLiveReportLock(identity, options = {}) {
         throw new LiveReportLockContentionError();
       }
       const stalePath = `${lockPath}.stale-${process.pid}-${randomBytes(16).toString("hex")}`;
-      try {
-        renameSync(lockPath, stalePath);
-      } catch (renameError) {
-        if (fileSystemErrorCode(renameError) === "ENOENT") continue;
-        throw renameError;
-      }
+      renameSync(lockPath, stalePath);
+      renameSync(candidatePath, lockPath);
       rmSync(stalePath, { force: true, recursive: true });
+    } finally {
+      rmSync(candidatePath, { force: true, recursive: true });
     }
-  }
-  if (!acquired) {
-    throw new Error("live report lock changed too often to acquire safely");
-  }
+  });
   let released = false;
   return {
     spawn(command, args, options) {
@@ -1837,19 +1842,21 @@ export function acquireLiveReportLock(identity, options = {}) {
     },
     release() {
       if (released) return;
-      const owner = readLiveReportLockOwner(lockPath);
-      if (
-        owner === null ||
-        owner.pid !== process.pid ||
-        owner.processIdentity !== processIdentity ||
-        owner.ownerToken !== ownerToken
-      ) {
-        throw new Error("live report lock ownership changed before release");
-      }
-      const releasedPath = `${lockPath}.released-${process.pid}-${ownerToken}`;
-      renameSync(lockPath, releasedPath);
-      rmSync(releasedPath, { force: true, recursive: true });
-      released = true;
+      withLiveReportLockTransition(lockPath, () => {
+        const owner = readLiveReportLockOwner(lockPath);
+        if (
+          owner === null ||
+          owner.pid !== process.pid ||
+          owner.processIdentity !== processIdentity ||
+          owner.ownerToken !== ownerToken
+        ) {
+          throw new Error("live report lock ownership changed before release");
+        }
+        const releasedPath = `${lockPath}.released-${process.pid}-${ownerToken}`;
+        renameSync(lockPath, releasedPath);
+        rmSync(releasedPath, { force: true, recursive: true });
+        released = true;
+      });
     },
   };
 }

--- a/skills/contribute-to-delta-star/scripts/live-report.mjs
+++ b/skills/contribute-to-delta-star/scripts/live-report.mjs
@@ -6,7 +6,18 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { createHash, randomBytes } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -49,6 +60,10 @@ export class LiveInventoryChangedError extends Error {
     this.name = "LiveInventoryChangedError";
   }
 }
+
+const LIVE_REPORT_LOCK_DIRECTORY = "slop-live-report-locks-v1";
+const LIVE_REPORT_LOCK_OWNER_FILE = "owner.json";
+const LIVE_REPORT_LOCK_ACQUIRE_ATTEMPTS = 8;
 
 const REPOSITORY_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const PLACEHOLDER_RE =
@@ -1316,6 +1331,193 @@ export function createGhCommandBudget(spawn = spawnSync) {
       }
       count += 1;
       return spawn(command, args, options);
+    },
+  };
+}
+
+export class LiveReportLockContentionError extends Error {
+  constructor() {
+    super(
+      "live report lock contention: another report for this GitHub identity is already discovering activity",
+    );
+    this.name = "LiveReportLockContentionError";
+  }
+}
+
+export function readGhAuthenticatedIdentity(spawn = spawnSync) {
+  const result = spawn(
+    "gh",
+    ["api", "--method", "GET", "--jq", "{id: .id, login: .login}", "user"],
+    {
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024,
+      windowsHide: true,
+    },
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const detail =
+      result.stderr.trim().length > 0 ? `: ${result.stderr.trim()}` : "";
+    throw new Error(`gh api failed for authenticated identity${detail}`);
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(result.stdout);
+  } catch (cause) {
+    throw new SyntaxError(
+      "gh api returned malformed JSON for authenticated identity",
+      { cause },
+    );
+  }
+  const identity = asRecord(parsed, "GitHub authenticated identity");
+  const id = asNumberField(identity, "id", "GitHub authenticated identity");
+  const login = asStringField(
+    identity,
+    "login",
+    "GitHub authenticated identity",
+  );
+  if (id <= 0 || login.length === 0) {
+    throw new TypeError("GitHub authenticated identity is invalid");
+  }
+  return { id, login };
+}
+
+function fileSystemErrorCode(error) {
+  return error && typeof error === "object" && "code" in error
+    ? error.code
+    : null;
+}
+
+function readLiveReportLockOwner(lockPath) {
+  try {
+    const owner = asRecord(
+      JSON.parse(
+        readFileSync(join(lockPath, LIVE_REPORT_LOCK_OWNER_FILE), "utf8"),
+      ),
+      "live report lock owner",
+    );
+    const schemaVersion = asNumberField(
+      owner,
+      "schemaVersion",
+      "live report lock owner",
+    );
+    const pid = asNumberField(owner, "pid", "live report lock owner");
+    const ownerToken = asStringField(
+      owner,
+      "ownerToken",
+      "live report lock owner",
+    );
+    if (
+      schemaVersion !== 1 ||
+      pid <= 0 ||
+      !/^[a-f0-9]{32}$/u.test(ownerToken)
+    ) {
+      return null;
+    }
+    return { pid, ownerToken };
+  } catch {
+    // error-policy:J3 A corrupt or incomplete lease cannot claim live ownership.
+    return null;
+  }
+}
+
+function processIsRunning(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (fileSystemErrorCode(error) === "ESRCH") return false;
+    if (fileSystemErrorCode(error) === "EPERM") return true;
+    throw error;
+  }
+}
+
+function lockOwnerIsActive(owner) {
+  return owner !== null && processIsRunning(owner.pid);
+}
+
+function prepareLiveReportLockCandidate(lockPath, ownerToken) {
+  const candidatePath = `${lockPath}.candidate-${process.pid}-${ownerToken}`;
+  mkdirSync(candidatePath, { mode: 0o700 });
+  try {
+    writeFileSync(
+      join(candidatePath, LIVE_REPORT_LOCK_OWNER_FILE),
+      `${JSON.stringify({
+        schemaVersion: 1,
+        pid: process.pid,
+        ownerToken,
+      })}\n`,
+      { flag: "wx", mode: 0o600 },
+    );
+    return candidatePath;
+  } catch (error) {
+    rmSync(candidatePath, { force: true, recursive: true });
+    throw error;
+  }
+}
+
+export function acquireLiveReportLock(identity) {
+  const record = asRecord(identity, "GitHub authenticated identity");
+  const id = asNumberField(record, "id", "GitHub authenticated identity");
+  const login = asStringField(record, "login", "GitHub authenticated identity");
+  if (id <= 0 || login.length === 0) {
+    throw new TypeError("GitHub authenticated identity is invalid");
+  }
+  const root = join(tmpdir(), LIVE_REPORT_LOCK_DIRECTORY);
+  mkdirSync(root, { mode: 0o700, recursive: true });
+  const key = createHash("sha256").update(`github.com:${id}`).digest("hex");
+  const lockPath = join(root, `${key}.lock`);
+  const ownerToken = randomBytes(16).toString("hex");
+  let acquired = false;
+  for (
+    let attempt = 0;
+    attempt < LIVE_REPORT_LOCK_ACQUIRE_ATTEMPTS;
+    attempt += 1
+  ) {
+    const candidatePath = prepareLiveReportLockCandidate(lockPath, ownerToken);
+    try {
+      renameSync(candidatePath, lockPath);
+      acquired = true;
+      break;
+    } catch (error) {
+      rmSync(candidatePath, { force: true, recursive: true });
+      if (!existsSync(lockPath)) {
+        if (fileSystemErrorCode(error) === "ENOENT") continue;
+        throw error;
+      }
+      const currentOwner = readLiveReportLockOwner(lockPath);
+      if (lockOwnerIsActive(currentOwner)) {
+        throw new LiveReportLockContentionError();
+      }
+      const stalePath = `${lockPath}.stale-${process.pid}-${randomBytes(16).toString("hex")}`;
+      try {
+        renameSync(lockPath, stalePath);
+      } catch (renameError) {
+        if (fileSystemErrorCode(renameError) === "ENOENT") continue;
+        throw renameError;
+      }
+      rmSync(stalePath, { force: true, recursive: true });
+    }
+  }
+  if (!acquired) {
+    throw new Error("live report lock changed too often to acquire safely");
+  }
+  let released = false;
+  return {
+    release() {
+      if (released) return;
+      const owner = readLiveReportLockOwner(lockPath);
+      if (
+        owner === null ||
+        owner.pid !== process.pid ||
+        owner.ownerToken !== ownerToken
+      ) {
+        throw new Error("live report lock ownership changed before release");
+      }
+      const releasedPath = `${lockPath}.released-${process.pid}-${ownerToken}`;
+      renameSync(lockPath, releasedPath);
+      rmSync(releasedPath, { force: true, recursive: true });
+      released = true;
     },
   };
 }
@@ -2813,51 +3015,57 @@ export function main(args = process.argv.slice(2)) {
     if (!result.publishable) process.exitCode = 2;
     return;
   }
-  let rateLimits = { preflight: true };
-  const { report } = retryChangedLiveInventory(
-    ({ commandBudget }) => {
-      const boundedRead = (endpoint) => {
-        return readGhPages(endpoint, commandBudget.run);
-      };
-      const openActivity = readGhOpenActivity(
-        options.repo,
-        commandBudget.run,
-        rateLimits,
-      );
-      rateLimits = openActivity.rateLimits;
-      const limits = asRecord(openActivity.rateLimits, "GitHub rate limits");
-      process.stderr.write(
-        `[Slop] GitHub budgets: GraphQL ${limits.graphqlRemaining}/${limits.graphqlLimit} (${limits.graphqlBudgetSource}); REST ${limits.restRemaining}/${limits.restLimit}; Search ${limits.searchRemaining}/${limits.searchLimit}; activity source ${openActivity.source}\n`,
-      );
-      return {
-        report: collectLiveReport(
+  const authenticatedIdentity = readGhAuthenticatedIdentity();
+  const liveReportLock = acquireLiveReportLock(authenticatedIdentity);
+  try {
+    let rateLimits = { preflight: true };
+    const { report } = retryChangedLiveInventory(
+      ({ commandBudget }) => {
+        const boundedRead = (endpoint) => {
+          return readGhPages(endpoint, commandBudget.run);
+        };
+        const openActivity = readGhOpenActivity(
           options.repo,
-          boundedRead,
-          new Date(),
-          ({ phase, current, total }) => {
-            if (current === 0 || current === total || current % 10 === 0) {
-              process.stderr.write(
-                `[Slop] scanning ${phase}: ${current}/${total} (${commandBudget.count} bounded GitHub commands)\n`,
-              );
-            }
-          },
-          openActivity,
-          selectionPolicy.eligibleIssueLabels,
+          commandBudget.run,
+          rateLimits,
+        );
+        rateLimits = openActivity.rateLimits;
+        const limits = asRecord(openActivity.rateLimits, "GitHub rate limits");
+        process.stderr.write(
+          `[Slop] GitHub budgets: GraphQL ${limits.graphqlRemaining}/${limits.graphqlLimit} (${limits.graphqlBudgetSource}); REST ${limits.restRemaining}/${limits.restLimit}; Search ${limits.searchRemaining}/${limits.searchLimit}; activity source ${openActivity.source}\n`,
+        );
+        return {
+          report: collectLiveReport(
+            options.repo,
+            boundedRead,
+            new Date(),
+            ({ phase, current, total }) => {
+              if (current === 0 || current === total || current % 10 === 0) {
+                process.stderr.write(
+                  `[Slop] scanning ${phase}: ${current}/${total} (${commandBudget.count} bounded GitHub commands)\n`,
+                );
+              }
+            },
+            openActivity,
+            selectionPolicy.eligibleIssueLabels,
+          ),
+        };
+      },
+      ({ attempt }) =>
+        process.stderr.write(
+          `[Slop] open-item inventory changed during snapshot attempt ${attempt}; retrying one complete read\n`,
         ),
-      };
-    },
-    ({ attempt }) =>
-      process.stderr.write(
-        `[Slop] open-item inventory changed during snapshot attempt ${attempt}; retrying one complete read\n`,
-      ),
-  );
-  process.stdout.write(
-    options.epochOnly
-      ? `${JSON.stringify(report.selection.reviewEpoch, null, 2)}\n`
-      : options.json
-        ? `${JSON.stringify(report, null, 2)}\n`
-        : renderMarkdown(report),
-  );
+    );
+    process.stdout.write(
+      options.epochOnly
+        ? `${JSON.stringify(report.selection.reviewEpoch, null, 2)}\n`
+        : options.json
+          ? `${JSON.stringify(report, null, 2)}\n`
+          : renderMarkdown(report),
+    );
+  } finally {
+    liveReportLock.release();
+  }
 }
 
 const invokedDirectly =
@@ -2872,7 +3080,12 @@ if (invokedDirectly) {
   } catch (error) {
     // error-policy:J1 The CLI boundary turns a failed read/audit into a non-zero exit.
     const message = error instanceof Error ? error.message : String(error);
-    process.stderr.write(`Slop live report failed: ${message}\n`);
-    process.exitCode = 1;
+    if (error instanceof LiveReportLockContentionError) {
+      process.stderr.write(`Slop live report deferred: ${message}\n`);
+      process.exitCode = 2;
+    } else {
+      process.stderr.write(`Slop live report failed: ${message}\n`);
+      process.exitCode = 1;
+    }
   }
 }

--- a/skills/contribute-to-delta-star/scripts/live-report.mjs
+++ b/skills/contribute-to-delta-star/scripts/live-report.mjs
@@ -5,20 +5,22 @@
  * adapter; GraphQL uses explicit read-only queries over GitHub's POST endpoint.
  */
 
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { createHash, randomBytes } from "node:crypto";
 import {
   existsSync,
+  lstatSync,
   mkdirSync,
   readFileSync,
+  readdirSync,
   realpathSync,
   renameSync,
   rmSync,
   statSync,
   writeFileSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { platform, userInfo } from "node:os";
+import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 export const MODEL_DISCLOSURE_PREFIX = "AI provider/model:";
@@ -61,9 +63,18 @@ export class LiveInventoryChangedError extends Error {
   }
 }
 
-const LIVE_REPORT_LOCK_DIRECTORY = "slop-live-report-locks-v1";
+const LIVE_REPORT_LOCK_DIRECTORY = "slop-live-report-locks-v2";
 const LIVE_REPORT_LOCK_OWNER_FILE = "owner.json";
+const LIVE_REPORT_LOCK_HEARTBEAT_FILE = "heartbeat.json";
+const LIVE_REPORT_LOCK_COMMAND_DIRECTORY = "commands";
 const LIVE_REPORT_LOCK_ACQUIRE_ATTEMPTS = 8;
+const LIVE_REPORT_HEARTBEAT_INTERVAL_MS = 200;
+const LIVE_REPORT_HEARTBEAT_STALE_MS = 1_000;
+const LIVE_REPORT_ORPHAN_COMMAND_GRACE_MS = 5 * 60 * 1_000;
+const LIVE_REPORT_LOCKED_GH_ARGUMENT = "--slop-internal-locked-gh-v1";
+const LIVE_REPORT_LOCK_HEARTBEAT_ARGUMENT =
+  "--slop-internal-lock-heartbeat-v1";
+const LIVE_REPORT_TOKEN_RE = /^[a-f0-9]{32}$/u;
 
 const REPOSITORY_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const PLACEHOLDER_RE =
@@ -1347,7 +1358,16 @@ export class LiveReportLockContentionError extends Error {
 export function readGhAuthenticatedIdentity(spawn = spawnSync) {
   const result = spawn(
     "gh",
-    ["api", "--method", "GET", "--jq", "{id: .id, login: .login}", "user"],
+    [
+      "api",
+      "--hostname",
+      "github.com",
+      "--method",
+      "GET",
+      "--jq",
+      "{id: .id, login: .login}",
+      "user",
+    ],
     {
       encoding: "utf8",
       maxBuffer: 1024 * 1024,
@@ -1379,7 +1399,7 @@ export function readGhAuthenticatedIdentity(spawn = spawnSync) {
   if (id <= 0 || login.length === 0) {
     throw new TypeError("GitHub authenticated identity is invalid");
   }
-  return { id, login };
+  return { host: "github.com", id, login };
 }
 
 function fileSystemErrorCode(error) {
@@ -1388,63 +1408,166 @@ function fileSystemErrorCode(error) {
     : null;
 }
 
-function readLiveReportLockOwner(lockPath) {
-  try {
-    const owner = asRecord(
-      JSON.parse(
-        readFileSync(join(lockPath, LIVE_REPORT_LOCK_OWNER_FILE), "utf8"),
-      ),
-      "live report lock owner",
-    );
-    const schemaVersion = asNumberField(
-      owner,
-      "schemaVersion",
-      "live report lock owner",
-    );
-    const pid = asNumberField(owner, "pid", "live report lock owner");
-    const ownerToken = asStringField(
-      owner,
-      "ownerToken",
-      "live report lock owner",
-    );
-    if (
-      schemaVersion !== 1 ||
-      pid <= 0 ||
-      !/^[a-f0-9]{32}$/u.test(ownerToken)
-    ) {
-      return null;
-    }
-    return { pid, ownerToken };
-  } catch {
-    // error-policy:J3 A corrupt or incomplete lease cannot claim live ownership.
-    return null;
-  }
+function heartbeatTimestampIsFresh(observedAtMs) {
+  const age = Date.now() - observedAtMs;
+  return age >= -LIVE_REPORT_HEARTBEAT_STALE_MS &&
+    age <= LIVE_REPORT_HEARTBEAT_STALE_MS;
 }
 
-function processIsRunning(pid) {
+export function defaultLiveReportLockRoot() {
+  const uid = typeof process.getuid === "function" ? process.getuid() : null;
+  if (Number.isInteger(uid) && uid >= 0) {
+    return join("/tmp", `${LIVE_REPORT_LOCK_DIRECTORY}-${uid}`);
+  }
+  const identity = userInfo();
+  const key = createHash("sha256")
+    .update(`${identity.username}\0${identity.homedir}`)
+    .digest("hex")
+    .slice(0, 16);
+  return join(identity.homedir, `.${LIVE_REPORT_LOCK_DIRECTORY}-${key}`);
+}
+
+export function ensureLiveReportLockRoot(
+  rootPath = defaultLiveReportLockRoot(),
+) {
   try {
-    process.kill(pid, 0);
-    return true;
+    mkdirSync(rootPath, { mode: 0o700 });
   } catch (error) {
-    if (fileSystemErrorCode(error) === "ESRCH") return false;
-    if (fileSystemErrorCode(error) === "EPERM") return true;
+    if (fileSystemErrorCode(error) !== "EEXIST") throw error;
+  }
+  const stats = lstatSync(rootPath);
+  if (stats.isSymbolicLink() || !stats.isDirectory()) {
+    throw new TypeError("live report lock root must be a real directory");
+  }
+  const uid = typeof process.getuid === "function" ? process.getuid() : null;
+  if (Number.isInteger(uid) && stats.uid !== uid) {
+    throw new TypeError(
+      "live report lock root must belong to the current user",
+    );
+  }
+  if (platform() !== "win32" && (stats.mode & 0o077) !== 0) {
+    throw new TypeError("live report lock root permissions must be 0700");
+  }
+  return rootPath;
+}
+
+function readLiveReportLockOwner(lockPath) {
+  let source;
+  try {
+    source = readFileSync(join(lockPath, LIVE_REPORT_LOCK_OWNER_FILE), "utf8");
+  } catch (error) {
+    if (fileSystemErrorCode(error) === "ENOENT") return null;
     throw error;
   }
+  const owner = asRecord(JSON.parse(source), "live report lock owner");
+  const schemaVersion = asNumberField(
+    owner,
+    "schemaVersion",
+    "live report lock owner",
+  );
+  const processLease = readProcessLease(owner, "live report lock owner");
+  const ownerToken = asStringField(
+    owner,
+    "ownerToken",
+    "live report lock owner",
+  );
+  if (schemaVersion !== 2 || !LIVE_REPORT_TOKEN_RE.test(ownerToken)) {
+    throw new TypeError("live report lock owner is invalid");
+  }
+  return { ...processLease, ownerToken };
 }
 
-function lockOwnerIsActive(owner) {
-  return owner !== null && processIsRunning(owner.pid);
+function liveReportCommandDirectory(lockPath) {
+  return join(lockPath, LIVE_REPORT_LOCK_COMMAND_DIRECTORY);
 }
 
-function prepareLiveReportLockCandidate(lockPath, ownerToken) {
+function readLiveReportCommandLease(path) {
+  const record = asRecord(
+    JSON.parse(readFileSync(path, "utf8")),
+    "live report command lease",
+  );
+  const schemaVersion = asNumberField(
+    record,
+    "schemaVersion",
+    "live report command lease",
+  );
+  const ownerToken = asStringField(
+    record,
+    "ownerToken",
+    "live report command lease",
+  );
+  const startedAtMs = asNumberField(
+    record,
+    "startedAtMs",
+    "live report command lease",
+  );
+  const helper = readProcessLease(record.helper, "live report command helper");
+  const child =
+    record.child === null
+      ? null
+      : readProcessLease(record.child, "live report GitHub child");
+  if (
+    schemaVersion !== 1 ||
+    !LIVE_REPORT_TOKEN_RE.test(ownerToken) ||
+    !Number.isSafeInteger(startedAtMs) ||
+    startedAtMs <= 0
+  ) {
+    throw new TypeError("live report command lease is invalid");
+  }
+  return { child, helper, ownerToken, startedAtMs };
+}
+
+function liveReportCommandIsActive(lease, ownerToken) {
+  if (lease.ownerToken !== ownerToken) {
+    throw new TypeError("live report command lease owner does not match");
+  }
+  if (processLeaseIsActive(lease.helper)) return true;
+  if (lease.child !== null && processLeaseIsActive(lease.child)) return true;
+  return Date.now() - lease.startedAtMs < LIVE_REPORT_ORPHAN_COMMAND_GRACE_MS;
+}
+
+function liveReportHasActiveCommand(lockPath, ownerToken) {
+  const commandDirectory = liveReportCommandDirectory(lockPath);
+  let entries;
+  try {
+    entries = readdirSync(commandDirectory, { withFileTypes: true });
+  } catch (error) {
+    if (fileSystemErrorCode(error) === "ENOENT" && !existsSync(lockPath)) {
+      return false;
+    }
+    throw error;
+  }
+  for (const entry of entries) {
+    if (entry.isSymbolicLink() || (!entry.isFile() && !entry.isDirectory())) {
+      throw new TypeError("live report command directory is invalid");
+    }
+    if (!/^lease-[a-f0-9]{32}\.json$/u.test(entry.name)) continue;
+    const lease = readLiveReportCommandLease(
+      join(commandDirectory, entry.name),
+    );
+    if (liveReportCommandIsActive(lease, ownerToken)) return true;
+  }
+  return false;
+}
+
+function assertLiveReportLockDirectory(lockPath) {
+  const stats = lstatSync(lockPath);
+  if (stats.isSymbolicLink() || !stats.isDirectory()) {
+    throw new TypeError("live report lock must be a real directory");
+  }
+}
+
+function prepareLiveReportLockCandidate(lockPath, ownerToken, processIdentity) {
   const candidatePath = `${lockPath}.candidate-${process.pid}-${ownerToken}`;
   mkdirSync(candidatePath, { mode: 0o700 });
   try {
+    mkdirSync(liveReportCommandDirectory(candidatePath), { mode: 0o700 });
     writeFileSync(
       join(candidatePath, LIVE_REPORT_LOCK_OWNER_FILE),
       `${JSON.stringify({
-        schemaVersion: 1,
+        schemaVersion: 2,
         pid: process.pid,
+        processIdentity,
         ownerToken,
       })}\n`,
       { flag: "wx", mode: 0o600 },
@@ -1456,25 +1579,113 @@ function prepareLiveReportLockCandidate(lockPath, ownerToken) {
   }
 }
 
-export function acquireLiveReportLock(identity) {
+function liveReportLockKey(identity) {
+  return createHash("sha256")
+    .update(`${identity.host}:${identity.id}`)
+    .digest("hex");
+}
+
+function writeLiveReportCommandLease(path, lease, replace = false) {
+  if (!replace) {
+    writeFileSync(path, `${JSON.stringify(lease)}\n`, {
+      flag: "wx",
+      mode: 0o600,
+    });
+    return;
+  }
+  const nextPath = `${path}.next-${process.pid}-${randomBytes(16).toString("hex")}`;
+  try {
+    writeFileSync(nextPath, `${JSON.stringify(lease)}\n`, {
+      flag: "wx",
+      mode: 0o600,
+    });
+    renameSync(nextPath, path);
+  } catch (error) {
+    rmSync(nextPath, { force: true });
+    throw error;
+  }
+}
+
+function spawnLockedGh(lockPath, ownerToken, command, args, options = {}) {
+  if (
+    command !== "gh" ||
+    !Array.isArray(args) ||
+    args.some((argument) => typeof argument !== "string")
+  ) {
+    throw new TypeError("live report lock may execute only a gh argument list");
+  }
+  if (options.encoding !== undefined && options.encoding !== "utf8") {
+    throw new TypeError("live report gh commands require utf8 output");
+  }
+  const maxBuffer = options.maxBuffer ?? 1024 * 1024;
+  if (
+    !Number.isSafeInteger(maxBuffer) ||
+    maxBuffer <= 0 ||
+    maxBuffer > 256 * 1024 * 1024
+  ) {
+    throw new RangeError("live report gh command maxBuffer is invalid");
+  }
+  const commandToken = randomBytes(16).toString("hex");
+  const requestPath = join(
+    liveReportCommandDirectory(lockPath),
+    `request-${commandToken}.json`,
+  );
+  writeFileSync(
+    requestPath,
+    `${JSON.stringify({ args, maxBuffer, ownerToken, schemaVersion: 1 })}\n`,
+    { flag: "wx", mode: 0o600 },
+  );
+  try {
+    return spawnSync(
+      process.execPath,
+      [
+        fileURLToPath(import.meta.url),
+        LIVE_REPORT_LOCKED_GH_ARGUMENT,
+        lockPath,
+        ownerToken,
+        commandToken,
+      ],
+      {
+        encoding: "utf8",
+        env: { ...(options.env ?? process.env), GH_HOST: "github.com" },
+        maxBuffer: Math.min(maxBuffer + 1024 * 1024, 256 * 1024 * 1024),
+        windowsHide: true,
+      },
+    );
+  } finally {
+    rmSync(requestPath, { force: true });
+  }
+}
+
+export function acquireLiveReportLock(identity, options = {}) {
   const record = asRecord(identity, "GitHub authenticated identity");
   const id = asNumberField(record, "id", "GitHub authenticated identity");
   const login = asStringField(record, "login", "GitHub authenticated identity");
-  if (id <= 0 || login.length === 0) {
+  const host = asStringField(record, "host", "GitHub authenticated identity");
+  if (id <= 0 || login.length === 0 || host !== "github.com") {
     throw new TypeError("GitHub authenticated identity is invalid");
   }
-  const root = join(tmpdir(), LIVE_REPORT_LOCK_DIRECTORY);
-  mkdirSync(root, { mode: 0o700, recursive: true });
-  const key = createHash("sha256").update(`github.com:${id}`).digest("hex");
+  const root = ensureLiveReportLockRoot(
+    options.rootPath ?? defaultLiveReportLockRoot(),
+  );
+  const key = liveReportLockKey({ host, id });
   const lockPath = join(root, `${key}.lock`);
   const ownerToken = randomBytes(16).toString("hex");
+  const processIdentity = readLiveReportProcessIdentity(process.pid);
+  if (processIdentity === null) {
+    throw new Error("could not establish the live report process identity");
+  }
   let acquired = false;
   for (
     let attempt = 0;
     attempt < LIVE_REPORT_LOCK_ACQUIRE_ATTEMPTS;
     attempt += 1
   ) {
-    const candidatePath = prepareLiveReportLockCandidate(lockPath, ownerToken);
+    const candidatePath = prepareLiveReportLockCandidate(
+      lockPath,
+      ownerToken,
+      processIdentity,
+    );
     try {
       renameSync(candidatePath, lockPath);
       acquired = true;
@@ -1485,8 +1696,16 @@ export function acquireLiveReportLock(identity) {
         if (fileSystemErrorCode(error) === "ENOENT") continue;
         throw error;
       }
+      assertLiveReportLockDirectory(lockPath);
       const currentOwner = readLiveReportLockOwner(lockPath);
-      if (lockOwnerIsActive(currentOwner)) {
+      if (currentOwner === null) {
+        if (!existsSync(lockPath)) continue;
+        throw new Error("live report lock owner is missing");
+      }
+      if (
+        processLeaseIsActive(currentOwner) ||
+        liveReportHasActiveCommand(lockPath, currentOwner.ownerToken)
+      ) {
         throw new LiveReportLockContentionError();
       }
       const stalePath = `${lockPath}.stale-${process.pid}-${randomBytes(16).toString("hex")}`;
@@ -1504,12 +1723,16 @@ export function acquireLiveReportLock(identity) {
   }
   let released = false;
   return {
+    spawn(command, args, options) {
+      return spawnLockedGh(lockPath, ownerToken, command, args, options);
+    },
     release() {
       if (released) return;
       const owner = readLiveReportLockOwner(lockPath);
       if (
         owner === null ||
         owner.pid !== process.pid ||
+        owner.processIdentity !== processIdentity ||
         owner.ownerToken !== ownerToken
       ) {
         throw new Error("live report lock ownership changed before release");
@@ -1520,6 +1743,173 @@ export function acquireLiveReportLock(identity) {
       released = true;
     },
   };
+}
+
+function readLockedGhRequest(lockPath, ownerToken, commandToken) {
+  if (
+    !LIVE_REPORT_TOKEN_RE.test(ownerToken) ||
+    !LIVE_REPORT_TOKEN_RE.test(commandToken)
+  ) {
+    throw new TypeError("locked GitHub command tokens are invalid");
+  }
+  const root = ensureLiveReportLockRoot();
+  if (
+    dirname(lockPath) !== root ||
+    !/^[a-f0-9]{64}\.lock$/u.test(basename(lockPath))
+  ) {
+    throw new TypeError("locked GitHub command path is invalid");
+  }
+  assertLiveReportLockDirectory(lockPath);
+  const owner = readLiveReportLockOwner(lockPath);
+  if (owner === null || owner.ownerToken !== ownerToken) {
+    throw new Error("live report lock ownership changed before GitHub command");
+  }
+  const requestPath = join(
+    liveReportCommandDirectory(lockPath),
+    `request-${commandToken}.json`,
+  );
+  const request = asRecord(
+    JSON.parse(readFileSync(requestPath, "utf8")),
+    "locked GitHub command request",
+  );
+  const schemaVersion = asNumberField(
+    request,
+    "schemaVersion",
+    "locked GitHub command request",
+  );
+  const requestOwnerToken = asStringField(
+    request,
+    "ownerToken",
+    "locked GitHub command request",
+  );
+  const maxBuffer = asNumberField(
+    request,
+    "maxBuffer",
+    "locked GitHub command request",
+  );
+  if (
+    schemaVersion !== 1 ||
+    requestOwnerToken !== ownerToken ||
+    !Number.isSafeInteger(maxBuffer) ||
+    maxBuffer <= 0 ||
+    maxBuffer > 256 * 1024 * 1024 ||
+    !Array.isArray(request.args) ||
+    request.args.some((argument) => typeof argument !== "string")
+  ) {
+    throw new TypeError("locked GitHub command request is invalid");
+  }
+  return { args: request.args, maxBuffer, requestPath };
+}
+
+function collectBoundedGhChild(child, maxBuffer) {
+  return new Promise((resolvePromise) => {
+    const stdout = [];
+    const stderr = [];
+    let stdoutBytes = 0;
+    let stderrBytes = 0;
+    let overflow = null;
+    let spawnError = null;
+    const collect = (chunks, chunk, stream) => {
+      if (overflow !== null) return;
+      const value = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      if (stream === "stdout") stdoutBytes += value.length;
+      else stderrBytes += value.length;
+      if (stdoutBytes > maxBuffer || stderrBytes > maxBuffer) {
+        overflow = stream;
+        child.kill("SIGTERM");
+        return;
+      }
+      chunks.push(value);
+    };
+    child.stdout.on("data", (chunk) => collect(stdout, chunk, "stdout"));
+    child.stderr.on("data", (chunk) => collect(stderr, chunk, "stderr"));
+    child.once("error", (error) => {
+      spawnError = error;
+    });
+    child.once("close", (status, signal) => {
+      resolvePromise({
+        error: spawnError,
+        overflow,
+        signal,
+        status,
+        stderr: Buffer.concat(stderr),
+        stdout: Buffer.concat(stdout),
+      });
+    });
+  });
+}
+
+function writeProcessDescriptor(descriptor, value) {
+  if (value.length === 0) return;
+  try {
+    writeFileSync(descriptor, value);
+  } catch (error) {
+    if (fileSystemErrorCode(error) !== "EPIPE") throw error;
+  }
+}
+
+async function runLockedGhCommand(lockPath, ownerToken, commandToken) {
+  const request = readLockedGhRequest(lockPath, ownerToken, commandToken);
+  const leasePath = join(
+    liveReportCommandDirectory(lockPath),
+    `lease-${commandToken}.json`,
+  );
+  const helperIdentity = readLiveReportProcessIdentity(process.pid);
+  if (helperIdentity === null) {
+    throw new Error("could not establish the GitHub command helper identity");
+  }
+  const lease = {
+    schemaVersion: 1,
+    ownerToken,
+    startedAtMs: Date.now(),
+    helper: { pid: process.pid, processIdentity: helperIdentity },
+    child: null,
+  };
+  writeLiveReportCommandLease(leasePath, lease);
+  let result;
+  try {
+    const currentOwner = readLiveReportLockOwner(lockPath);
+    if (currentOwner === null || currentOwner.ownerToken !== ownerToken) {
+      throw new Error(
+        "live report lock ownership changed while starting GitHub command",
+      );
+    }
+    const child = spawn("gh", request.args, {
+      env: { ...process.env, GH_HOST: "github.com" },
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+    });
+    const childResult = collectBoundedGhChild(child, request.maxBuffer);
+    if (Number.isInteger(child.pid) && child.pid > 0) {
+      const childIdentity = readLiveReportProcessIdentity(child.pid);
+      if (childIdentity !== null) {
+        writeLiveReportCommandLease(
+          leasePath,
+          {
+            ...lease,
+            child: { pid: child.pid, processIdentity: childIdentity },
+          },
+          true,
+        );
+      }
+    }
+    result = await childResult;
+  } finally {
+    rmSync(leasePath, { force: true });
+    rmSync(request.requestPath, { force: true });
+  }
+  if (result.error) throw result.error;
+  if (result.overflow !== null) {
+    throw new RangeError(
+      `spawn gh ${result.overflow} exceeded the bounded output buffer`,
+    );
+  }
+  writeProcessDescriptor(1, result.stdout);
+  writeProcessDescriptor(2, result.stderr);
+  if (result.status === null) {
+    throw new Error(`gh terminated by ${result.signal ?? "an unknown signal"}`);
+  }
+  process.exitCode = result.status;
 }
 
 function rateResource(value, context) {
@@ -3055,6 +3445,7 @@ export function main(args = process.argv.slice(2)) {
         process.stderr.write(
           `[Slop] open-item inventory changed during snapshot attempt ${attempt}; retrying one complete read\n`,
         ),
+      () => createGhCommandBudget(liveReportLock.spawn),
     );
     process.stdout.write(
       options.epochOnly
@@ -3075,17 +3466,27 @@ const invokedDirectly =
     realpathSync(process.argv[1]);
 
 if (invokedDirectly) {
-  try {
-    main();
-  } catch (error) {
-    // error-policy:J1 The CLI boundary turns a failed read/audit into a non-zero exit.
-    const message = error instanceof Error ? error.message : String(error);
-    if (error instanceof LiveReportLockContentionError) {
-      process.stderr.write(`Slop live report deferred: ${message}\n`);
-      process.exitCode = 2;
-    } else {
-      process.stderr.write(`Slop live report failed: ${message}\n`);
+  const directArguments = process.argv.slice(2);
+  if (directArguments[0] === LIVE_REPORT_LOCKED_GH_ARGUMENT) {
+    runLockedGhCommand(...directArguments.slice(1)).catch((error) => {
+      // error-policy:J1 The internal process boundary fails the owning report.
+      const message = error instanceof Error ? error.message : String(error);
+      process.stderr.write(`Slop locked GitHub command failed: ${message}\n`);
       process.exitCode = 1;
+    });
+  } else {
+    try {
+      main(directArguments);
+    } catch (error) {
+      // error-policy:J1 The CLI boundary turns a failed read/audit into a non-zero exit.
+      const message = error instanceof Error ? error.message : String(error);
+      if (error instanceof LiveReportLockContentionError) {
+        process.stderr.write(`Slop live report deferred: ${message}\n`);
+        process.exitCode = 2;
+      } else {
+        process.stderr.write(`Slop live report failed: ${message}\n`);
+        process.exitCode = 1;
+      }
     }
   }
 }

--- a/skills/contribute-to-delta-star/scripts/live-report.mjs
+++ b/skills/contribute-to-delta-star/scripts/live-report.mjs
@@ -3,6 +3,7 @@
  * Builds a stable, read-only inventory of open elizaOS issues and pull requests
  * for contribution selection. REST pagination stays behind one GET-only
  * adapter; GraphQL uses explicit read-only queries over GitHub's POST endpoint.
+ * A user-private process lease serializes complete discovery across skill copies.
  */
 
 import { spawn, spawnSync } from "node:child_process";
@@ -11,8 +12,8 @@ import {
   existsSync,
   lstatSync,
   mkdirSync,
-  readFileSync,
   readdirSync,
+  readFileSync,
   realpathSync,
   renameSync,
   rmSync,
@@ -65,15 +66,11 @@ export class LiveInventoryChangedError extends Error {
 
 const LIVE_REPORT_LOCK_DIRECTORY = "slop-live-report-locks-v2";
 const LIVE_REPORT_LOCK_OWNER_FILE = "owner.json";
-const LIVE_REPORT_LOCK_HEARTBEAT_FILE = "heartbeat.json";
 const LIVE_REPORT_LOCK_COMMAND_DIRECTORY = "commands";
 const LIVE_REPORT_LOCK_ACQUIRE_ATTEMPTS = 8;
-const LIVE_REPORT_HEARTBEAT_INTERVAL_MS = 200;
-const LIVE_REPORT_HEARTBEAT_STALE_MS = 1_000;
 const LIVE_REPORT_ORPHAN_COMMAND_GRACE_MS = 5 * 60 * 1_000;
 const LIVE_REPORT_LOCKED_GH_ARGUMENT = "--slop-internal-locked-gh-v1";
-const LIVE_REPORT_LOCK_HEARTBEAT_ARGUMENT =
-  "--slop-internal-lock-heartbeat-v1";
+const LIVE_REPORT_PROCESS_IDENTITY_RE = /^[a-f0-9]{64}$/u;
 const LIVE_REPORT_TOKEN_RE = /^[a-f0-9]{32}$/u;
 
 const REPOSITORY_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
@@ -1408,10 +1405,121 @@ function fileSystemErrorCode(error) {
     : null;
 }
 
-function heartbeatTimestampIsFresh(observedAtMs) {
-  const age = Date.now() - observedAtMs;
-  return age >= -LIVE_REPORT_HEARTBEAT_STALE_MS &&
-    age <= LIVE_REPORT_HEARTBEAT_STALE_MS;
+function assertLiveReportPrivatePath(path, context, kind) {
+  const stats = lstatSync(path);
+  const kindMatches =
+    kind === "directory" ? stats.isDirectory() : stats.isFile();
+  if (stats.isSymbolicLink() || !kindMatches) {
+    throw new TypeError(`${context} must be a real ${kind}`);
+  }
+  const uid = typeof process.getuid === "function" ? process.getuid() : null;
+  if (Number.isInteger(uid) && stats.uid !== uid) {
+    throw new TypeError(`${context} must belong to the current user`);
+  }
+  if (platform() !== "win32" && (stats.mode & 0o077) !== 0) {
+    throw new TypeError(`${context} permissions must exclude group and others`);
+  }
+  return stats;
+}
+
+function processIsRunning(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (fileSystemErrorCode(error) === "ESRCH") return false;
+    if (fileSystemErrorCode(error) === "EPERM") return true;
+    throw error;
+  }
+}
+
+function hashProcessIdentity(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+export function readLiveReportProcessIdentity(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    throw new TypeError("live report process ID must be a positive integer");
+  }
+  if (!processIsRunning(pid)) return null;
+  const operatingSystem = platform();
+  if (operatingSystem === "linux") {
+    let source;
+    try {
+      source = readFileSync(`/proc/${pid}/stat`, "utf8");
+    } catch (error) {
+      if (fileSystemErrorCode(error) === "ENOENT") return null;
+      throw error;
+    }
+    const commandEnd = source.lastIndexOf(")");
+    const fields = source
+      .slice(commandEnd + 2)
+      .trim()
+      .split(/\s+/u);
+    const startTime = fields[19];
+    if (commandEnd < 1 || !/^\d+$/u.test(startTime ?? "")) {
+      throw new TypeError("Linux returned an invalid process birth identity");
+    }
+    return hashProcessIdentity(`linux:${startTime}`);
+  }
+  if (
+    operatingSystem === "darwin" ||
+    operatingSystem === "freebsd" ||
+    operatingSystem === "openbsd"
+  ) {
+    const result = spawnSync(
+      existsSync("/bin/ps") ? "/bin/ps" : "ps",
+      ["-o", "lstart=", "-p", String(pid)],
+      { encoding: "utf8", maxBuffer: 64 * 1024, windowsHide: true },
+    );
+    if (result.error) throw result.error;
+    if (result.status !== 0 || result.stdout.trim() === "") {
+      if (!processIsRunning(pid)) return null;
+      throw new Error("could not read the process birth identity from ps");
+    }
+    return hashProcessIdentity(`${operatingSystem}:${result.stdout.trim()}`);
+  }
+  if (operatingSystem === "win32") {
+    const result = spawnSync(
+      "powershell.exe",
+      [
+        "-NoLogo",
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        `(Get-Process -Id ${pid} -ErrorAction Stop).StartTime.ToUniversalTime().Ticks`,
+      ],
+      { encoding: "utf8", maxBuffer: 64 * 1024, windowsHide: true },
+    );
+    if (result.error) throw result.error;
+    if (result.status !== 0 || !/^\d+$/u.test(result.stdout.trim())) {
+      if (!processIsRunning(pid)) return null;
+      throw new Error("could not read the Windows process birth identity");
+    }
+    return hashProcessIdentity(`win32:${result.stdout.trim()}`);
+  }
+  throw new Error(
+    `live report locking does not support process identity on ${operatingSystem}`,
+  );
+}
+
+function readProcessLease(value, context) {
+  const record = asRecord(value, context);
+  const pid = asNumberField(record, "pid", context);
+  const processIdentity = asStringField(record, "processIdentity", context);
+  if (
+    !Number.isInteger(pid) ||
+    pid <= 0 ||
+    !LIVE_REPORT_PROCESS_IDENTITY_RE.test(processIdentity)
+  ) {
+    throw new TypeError(`${context} is invalid`);
+  }
+  return { pid, processIdentity };
+}
+
+function processLeaseIsActive(lease) {
+  const currentIdentity = readLiveReportProcessIdentity(lease.pid);
+  return currentIdentity !== null && currentIdentity === lease.processIdentity;
 }
 
 export function defaultLiveReportLockRoot() {
@@ -1435,25 +1543,18 @@ export function ensureLiveReportLockRoot(
   } catch (error) {
     if (fileSystemErrorCode(error) !== "EEXIST") throw error;
   }
-  const stats = lstatSync(rootPath);
-  if (stats.isSymbolicLink() || !stats.isDirectory()) {
-    throw new TypeError("live report lock root must be a real directory");
-  }
-  const uid = typeof process.getuid === "function" ? process.getuid() : null;
-  if (Number.isInteger(uid) && stats.uid !== uid) {
-    throw new TypeError(
-      "live report lock root must belong to the current user",
-    );
-  }
-  if (platform() !== "win32" && (stats.mode & 0o077) !== 0) {
-    throw new TypeError("live report lock root permissions must be 0700");
-  }
+  assertLiveReportPrivatePath(rootPath, "live report lock root", "directory");
   return rootPath;
 }
 
 function readLiveReportLockOwner(lockPath) {
   let source;
   try {
+    assertLiveReportPrivatePath(
+      join(lockPath, LIVE_REPORT_LOCK_OWNER_FILE),
+      "live report lock owner",
+      "file",
+    );
     source = readFileSync(join(lockPath, LIVE_REPORT_LOCK_OWNER_FILE), "utf8");
   } catch (error) {
     if (fileSystemErrorCode(error) === "ENOENT") return null;
@@ -1482,6 +1583,7 @@ function liveReportCommandDirectory(lockPath) {
 }
 
 function readLiveReportCommandLease(path) {
+  assertLiveReportPrivatePath(path, "live report command lease", "file");
   const record = asRecord(
     JSON.parse(readFileSync(path, "utf8")),
     "live report command lease",
@@ -1530,6 +1632,11 @@ function liveReportHasActiveCommand(lockPath, ownerToken) {
   const commandDirectory = liveReportCommandDirectory(lockPath);
   let entries;
   try {
+    assertLiveReportPrivatePath(
+      commandDirectory,
+      "live report command directory",
+      "directory",
+    );
     entries = readdirSync(commandDirectory, { withFileTypes: true });
   } catch (error) {
     if (fileSystemErrorCode(error) === "ENOENT" && !existsSync(lockPath)) {
@@ -1538,7 +1645,7 @@ function liveReportHasActiveCommand(lockPath, ownerToken) {
     throw error;
   }
   for (const entry of entries) {
-    if (entry.isSymbolicLink() || (!entry.isFile() && !entry.isDirectory())) {
+    if (!entry.isFile()) {
       throw new TypeError("live report command directory is invalid");
     }
     if (!/^lease-[a-f0-9]{32}\.json$/u.test(entry.name)) continue;
@@ -1551,10 +1658,7 @@ function liveReportHasActiveCommand(lockPath, ownerToken) {
 }
 
 function assertLiveReportLockDirectory(lockPath) {
-  const stats = lstatSync(lockPath);
-  if (stats.isSymbolicLink() || !stats.isDirectory()) {
-    throw new TypeError("live report lock must be a real directory");
-  }
+  assertLiveReportPrivatePath(lockPath, "live report lock", "directory");
 }
 
 function prepareLiveReportLockCandidate(lockPath, ownerToken, processIdentity) {
@@ -1626,6 +1730,11 @@ function spawnLockedGh(lockPath, ownerToken, command, args, options = {}) {
     throw new RangeError("live report gh command maxBuffer is invalid");
   }
   const commandToken = randomBytes(16).toString("hex");
+  assertLiveReportPrivatePath(
+    liveReportCommandDirectory(lockPath),
+    "live report command directory",
+    "directory",
+  );
   const requestPath = join(
     liveReportCommandDirectory(lockPath),
     `request-${commandToken}.json`,
@@ -1752,7 +1861,7 @@ function readLockedGhRequest(lockPath, ownerToken, commandToken) {
   ) {
     throw new TypeError("locked GitHub command tokens are invalid");
   }
-  const root = ensureLiveReportLockRoot();
+  const root = ensureLiveReportLockRoot(dirname(lockPath));
   if (
     dirname(lockPath) !== root ||
     !/^[a-f0-9]{64}\.lock$/u.test(basename(lockPath))
@@ -1767,6 +1876,11 @@ function readLockedGhRequest(lockPath, ownerToken, commandToken) {
   const requestPath = join(
     liveReportCommandDirectory(lockPath),
     `request-${commandToken}.json`,
+  );
+  assertLiveReportPrivatePath(
+    requestPath,
+    "locked GitHub command request",
+    "file",
   );
   const request = asRecord(
     JSON.parse(readFileSync(requestPath, "utf8")),

--- a/skills/contribute-to-delta-star/scripts/live-report.mjs
+++ b/skills/contribute-to-delta-star/scripts/live-report.mjs
@@ -1625,7 +1625,12 @@ function liveReportCommandIsActive(lease, ownerToken) {
   }
   if (processLeaseIsActive(lease.helper)) return true;
   if (lease.child !== null && processLeaseIsActive(lease.child)) return true;
-  return Date.now() - lease.startedAtMs < LIVE_REPORT_ORPHAN_COMMAND_GRACE_MS;
+  // Only an unpublished child needs a grace period. A recorded birth identity
+  // proves a known child is gone, so recovery need not wait for that period.
+  return (
+    lease.child === null &&
+    Date.now() - lease.startedAtMs < LIVE_REPORT_ORPHAN_COMMAND_GRACE_MS
+  );
 }
 
 function liveReportHasActiveCommand(lockPath, ownerToken) {
@@ -1852,6 +1857,10 @@ export function acquireLiveReportLock(identity, options = {}) {
         ) {
           throw new Error("live report lock ownership changed before release");
         }
+        // An interrupted helper can return before its GitHub child exits. Keep
+        // the owner and command leases so a replacement scan still sees it;
+        // normal stale-owner recovery can reclaim the lock after the child exits.
+        if (liveReportHasActiveCommand(lockPath, ownerToken)) return;
         const releasedPath = `${lockPath}.released-${process.pid}-${ownerToken}`;
         renameSync(lockPath, releasedPath);
         rmSync(releasedPath, { force: true, recursive: true });

--- a/skills/contribute-to-eliza/scripts/live-report.mjs
+++ b/skills/contribute-to-eliza/scripts/live-report.mjs
@@ -16,6 +16,7 @@ import {
   readFileSync,
   realpathSync,
   renameSync,
+  rmdirSync,
   rmSync,
   statSync,
   writeFileSync,
@@ -67,7 +68,6 @@ export class LiveInventoryChangedError extends Error {
 const LIVE_REPORT_LOCK_DIRECTORY = "slop-live-report-locks-v2";
 const LIVE_REPORT_LOCK_OWNER_FILE = "owner.json";
 const LIVE_REPORT_LOCK_COMMAND_DIRECTORY = "commands";
-const LIVE_REPORT_LOCK_ACQUIRE_ATTEMPTS = 8;
 const LIVE_REPORT_ORPHAN_COMMAND_GRACE_MS = 5 * 60 * 1_000;
 const LIVE_REPORT_LOCKED_GH_ARGUMENT = "--slop-internal-locked-gh-v1";
 const LIVE_REPORT_PROCESS_IDENTITY_RE = /^[a-f0-9]{64}$/u;
@@ -1344,10 +1344,10 @@ export function createGhCommandBudget(spawn = spawnSync) {
 }
 
 export class LiveReportLockContentionError extends Error {
-  constructor() {
-    super(
-      "live report lock contention: another report for this GitHub identity is already discovering activity",
-    );
+  constructor(
+    message = "live report lock contention: another report for this GitHub identity is already discovering activity",
+  ) {
+    super(message);
     this.name = "LiveReportLockContentionError";
   }
 }
@@ -1661,6 +1661,27 @@ function assertLiveReportLockDirectory(lockPath) {
   assertLiveReportPrivatePath(lockPath, "live report lock", "directory");
 }
 
+function withLiveReportLockTransition(lockPath, operation) {
+  const transitionPath = `${lockPath}.transition`;
+  // Every lock-path mutation participates in this atomic mkdir guard. Never
+  // reclaim the guard: checking a token or dead PID before renaming it would
+  // recreate the same ABA race that this guard prevents for the report lock.
+  // A crash here requires manual recovery after all local reports are stopped.
+  try {
+    mkdirSync(transitionPath, { mode: 0o700 });
+  } catch (error) {
+    if (fileSystemErrorCode(error) !== "EEXIST") throw error;
+    throw new LiveReportLockContentionError(
+      `live report lock contention: transition guard exists at ${transitionPath}; retry after the other report finishes. If it persists, stop all local reports before manually removing this guard`,
+    );
+  }
+  try {
+    return operation();
+  } finally {
+    rmdirSync(transitionPath);
+  }
+}
+
 function prepareLiveReportLockCandidate(lockPath, ownerToken, processIdentity) {
   const candidatePath = `${lockPath}.candidate-${process.pid}-${ownerToken}`;
   mkdirSync(candidatePath, { mode: 0o700 });
@@ -1784,31 +1805,20 @@ export function acquireLiveReportLock(identity, options = {}) {
   if (processIdentity === null) {
     throw new Error("could not establish the live report process identity");
   }
-  let acquired = false;
-  for (
-    let attempt = 0;
-    attempt < LIVE_REPORT_LOCK_ACQUIRE_ATTEMPTS;
-    attempt += 1
-  ) {
+  withLiveReportLockTransition(lockPath, () => {
     const candidatePath = prepareLiveReportLockCandidate(
       lockPath,
       ownerToken,
       processIdentity,
     );
     try {
-      renameSync(candidatePath, lockPath);
-      acquired = true;
-      break;
-    } catch (error) {
-      rmSync(candidatePath, { force: true, recursive: true });
       if (!existsSync(lockPath)) {
-        if (fileSystemErrorCode(error) === "ENOENT") continue;
-        throw error;
+        renameSync(candidatePath, lockPath);
+        return;
       }
       assertLiveReportLockDirectory(lockPath);
       const currentOwner = readLiveReportLockOwner(lockPath);
       if (currentOwner === null) {
-        if (!existsSync(lockPath)) continue;
         throw new Error("live report lock owner is missing");
       }
       if (
@@ -1818,18 +1828,13 @@ export function acquireLiveReportLock(identity, options = {}) {
         throw new LiveReportLockContentionError();
       }
       const stalePath = `${lockPath}.stale-${process.pid}-${randomBytes(16).toString("hex")}`;
-      try {
-        renameSync(lockPath, stalePath);
-      } catch (renameError) {
-        if (fileSystemErrorCode(renameError) === "ENOENT") continue;
-        throw renameError;
-      }
+      renameSync(lockPath, stalePath);
+      renameSync(candidatePath, lockPath);
       rmSync(stalePath, { force: true, recursive: true });
+    } finally {
+      rmSync(candidatePath, { force: true, recursive: true });
     }
-  }
-  if (!acquired) {
-    throw new Error("live report lock changed too often to acquire safely");
-  }
+  });
   let released = false;
   return {
     spawn(command, args, options) {
@@ -1837,19 +1842,21 @@ export function acquireLiveReportLock(identity, options = {}) {
     },
     release() {
       if (released) return;
-      const owner = readLiveReportLockOwner(lockPath);
-      if (
-        owner === null ||
-        owner.pid !== process.pid ||
-        owner.processIdentity !== processIdentity ||
-        owner.ownerToken !== ownerToken
-      ) {
-        throw new Error("live report lock ownership changed before release");
-      }
-      const releasedPath = `${lockPath}.released-${process.pid}-${ownerToken}`;
-      renameSync(lockPath, releasedPath);
-      rmSync(releasedPath, { force: true, recursive: true });
-      released = true;
+      withLiveReportLockTransition(lockPath, () => {
+        const owner = readLiveReportLockOwner(lockPath);
+        if (
+          owner === null ||
+          owner.pid !== process.pid ||
+          owner.processIdentity !== processIdentity ||
+          owner.ownerToken !== ownerToken
+        ) {
+          throw new Error("live report lock ownership changed before release");
+        }
+        const releasedPath = `${lockPath}.released-${process.pid}-${ownerToken}`;
+        renameSync(lockPath, releasedPath);
+        rmSync(releasedPath, { force: true, recursive: true });
+        released = true;
+      });
     },
   };
 }

--- a/skills/contribute-to-eliza/scripts/live-report.mjs
+++ b/skills/contribute-to-eliza/scripts/live-report.mjs
@@ -6,7 +6,18 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { createHash, randomBytes } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -49,6 +60,10 @@ export class LiveInventoryChangedError extends Error {
     this.name = "LiveInventoryChangedError";
   }
 }
+
+const LIVE_REPORT_LOCK_DIRECTORY = "slop-live-report-locks-v1";
+const LIVE_REPORT_LOCK_OWNER_FILE = "owner.json";
+const LIVE_REPORT_LOCK_ACQUIRE_ATTEMPTS = 8;
 
 const REPOSITORY_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const PLACEHOLDER_RE =
@@ -1316,6 +1331,193 @@ export function createGhCommandBudget(spawn = spawnSync) {
       }
       count += 1;
       return spawn(command, args, options);
+    },
+  };
+}
+
+export class LiveReportLockContentionError extends Error {
+  constructor() {
+    super(
+      "live report lock contention: another report for this GitHub identity is already discovering activity",
+    );
+    this.name = "LiveReportLockContentionError";
+  }
+}
+
+export function readGhAuthenticatedIdentity(spawn = spawnSync) {
+  const result = spawn(
+    "gh",
+    ["api", "--method", "GET", "--jq", "{id: .id, login: .login}", "user"],
+    {
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024,
+      windowsHide: true,
+    },
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const detail =
+      result.stderr.trim().length > 0 ? `: ${result.stderr.trim()}` : "";
+    throw new Error(`gh api failed for authenticated identity${detail}`);
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(result.stdout);
+  } catch (cause) {
+    throw new SyntaxError(
+      "gh api returned malformed JSON for authenticated identity",
+      { cause },
+    );
+  }
+  const identity = asRecord(parsed, "GitHub authenticated identity");
+  const id = asNumberField(identity, "id", "GitHub authenticated identity");
+  const login = asStringField(
+    identity,
+    "login",
+    "GitHub authenticated identity",
+  );
+  if (id <= 0 || login.length === 0) {
+    throw new TypeError("GitHub authenticated identity is invalid");
+  }
+  return { id, login };
+}
+
+function fileSystemErrorCode(error) {
+  return error && typeof error === "object" && "code" in error
+    ? error.code
+    : null;
+}
+
+function readLiveReportLockOwner(lockPath) {
+  try {
+    const owner = asRecord(
+      JSON.parse(
+        readFileSync(join(lockPath, LIVE_REPORT_LOCK_OWNER_FILE), "utf8"),
+      ),
+      "live report lock owner",
+    );
+    const schemaVersion = asNumberField(
+      owner,
+      "schemaVersion",
+      "live report lock owner",
+    );
+    const pid = asNumberField(owner, "pid", "live report lock owner");
+    const ownerToken = asStringField(
+      owner,
+      "ownerToken",
+      "live report lock owner",
+    );
+    if (
+      schemaVersion !== 1 ||
+      pid <= 0 ||
+      !/^[a-f0-9]{32}$/u.test(ownerToken)
+    ) {
+      return null;
+    }
+    return { pid, ownerToken };
+  } catch {
+    // error-policy:J3 A corrupt or incomplete lease cannot claim live ownership.
+    return null;
+  }
+}
+
+function processIsRunning(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (fileSystemErrorCode(error) === "ESRCH") return false;
+    if (fileSystemErrorCode(error) === "EPERM") return true;
+    throw error;
+  }
+}
+
+function lockOwnerIsActive(owner) {
+  return owner !== null && processIsRunning(owner.pid);
+}
+
+function prepareLiveReportLockCandidate(lockPath, ownerToken) {
+  const candidatePath = `${lockPath}.candidate-${process.pid}-${ownerToken}`;
+  mkdirSync(candidatePath, { mode: 0o700 });
+  try {
+    writeFileSync(
+      join(candidatePath, LIVE_REPORT_LOCK_OWNER_FILE),
+      `${JSON.stringify({
+        schemaVersion: 1,
+        pid: process.pid,
+        ownerToken,
+      })}\n`,
+      { flag: "wx", mode: 0o600 },
+    );
+    return candidatePath;
+  } catch (error) {
+    rmSync(candidatePath, { force: true, recursive: true });
+    throw error;
+  }
+}
+
+export function acquireLiveReportLock(identity) {
+  const record = asRecord(identity, "GitHub authenticated identity");
+  const id = asNumberField(record, "id", "GitHub authenticated identity");
+  const login = asStringField(record, "login", "GitHub authenticated identity");
+  if (id <= 0 || login.length === 0) {
+    throw new TypeError("GitHub authenticated identity is invalid");
+  }
+  const root = join(tmpdir(), LIVE_REPORT_LOCK_DIRECTORY);
+  mkdirSync(root, { mode: 0o700, recursive: true });
+  const key = createHash("sha256").update(`github.com:${id}`).digest("hex");
+  const lockPath = join(root, `${key}.lock`);
+  const ownerToken = randomBytes(16).toString("hex");
+  let acquired = false;
+  for (
+    let attempt = 0;
+    attempt < LIVE_REPORT_LOCK_ACQUIRE_ATTEMPTS;
+    attempt += 1
+  ) {
+    const candidatePath = prepareLiveReportLockCandidate(lockPath, ownerToken);
+    try {
+      renameSync(candidatePath, lockPath);
+      acquired = true;
+      break;
+    } catch (error) {
+      rmSync(candidatePath, { force: true, recursive: true });
+      if (!existsSync(lockPath)) {
+        if (fileSystemErrorCode(error) === "ENOENT") continue;
+        throw error;
+      }
+      const currentOwner = readLiveReportLockOwner(lockPath);
+      if (lockOwnerIsActive(currentOwner)) {
+        throw new LiveReportLockContentionError();
+      }
+      const stalePath = `${lockPath}.stale-${process.pid}-${randomBytes(16).toString("hex")}`;
+      try {
+        renameSync(lockPath, stalePath);
+      } catch (renameError) {
+        if (fileSystemErrorCode(renameError) === "ENOENT") continue;
+        throw renameError;
+      }
+      rmSync(stalePath, { force: true, recursive: true });
+    }
+  }
+  if (!acquired) {
+    throw new Error("live report lock changed too often to acquire safely");
+  }
+  let released = false;
+  return {
+    release() {
+      if (released) return;
+      const owner = readLiveReportLockOwner(lockPath);
+      if (
+        owner === null ||
+        owner.pid !== process.pid ||
+        owner.ownerToken !== ownerToken
+      ) {
+        throw new Error("live report lock ownership changed before release");
+      }
+      const releasedPath = `${lockPath}.released-${process.pid}-${ownerToken}`;
+      renameSync(lockPath, releasedPath);
+      rmSync(releasedPath, { force: true, recursive: true });
+      released = true;
     },
   };
 }
@@ -2813,51 +3015,57 @@ export function main(args = process.argv.slice(2)) {
     if (!result.publishable) process.exitCode = 2;
     return;
   }
-  let rateLimits = { preflight: true };
-  const { report } = retryChangedLiveInventory(
-    ({ commandBudget }) => {
-      const boundedRead = (endpoint) => {
-        return readGhPages(endpoint, commandBudget.run);
-      };
-      const openActivity = readGhOpenActivity(
-        options.repo,
-        commandBudget.run,
-        rateLimits,
-      );
-      rateLimits = openActivity.rateLimits;
-      const limits = asRecord(openActivity.rateLimits, "GitHub rate limits");
-      process.stderr.write(
-        `[Slop] GitHub budgets: GraphQL ${limits.graphqlRemaining}/${limits.graphqlLimit} (${limits.graphqlBudgetSource}); REST ${limits.restRemaining}/${limits.restLimit}; Search ${limits.searchRemaining}/${limits.searchLimit}; activity source ${openActivity.source}\n`,
-      );
-      return {
-        report: collectLiveReport(
+  const authenticatedIdentity = readGhAuthenticatedIdentity();
+  const liveReportLock = acquireLiveReportLock(authenticatedIdentity);
+  try {
+    let rateLimits = { preflight: true };
+    const { report } = retryChangedLiveInventory(
+      ({ commandBudget }) => {
+        const boundedRead = (endpoint) => {
+          return readGhPages(endpoint, commandBudget.run);
+        };
+        const openActivity = readGhOpenActivity(
           options.repo,
-          boundedRead,
-          new Date(),
-          ({ phase, current, total }) => {
-            if (current === 0 || current === total || current % 10 === 0) {
-              process.stderr.write(
-                `[Slop] scanning ${phase}: ${current}/${total} (${commandBudget.count} bounded GitHub commands)\n`,
-              );
-            }
-          },
-          openActivity,
-          selectionPolicy.eligibleIssueLabels,
+          commandBudget.run,
+          rateLimits,
+        );
+        rateLimits = openActivity.rateLimits;
+        const limits = asRecord(openActivity.rateLimits, "GitHub rate limits");
+        process.stderr.write(
+          `[Slop] GitHub budgets: GraphQL ${limits.graphqlRemaining}/${limits.graphqlLimit} (${limits.graphqlBudgetSource}); REST ${limits.restRemaining}/${limits.restLimit}; Search ${limits.searchRemaining}/${limits.searchLimit}; activity source ${openActivity.source}\n`,
+        );
+        return {
+          report: collectLiveReport(
+            options.repo,
+            boundedRead,
+            new Date(),
+            ({ phase, current, total }) => {
+              if (current === 0 || current === total || current % 10 === 0) {
+                process.stderr.write(
+                  `[Slop] scanning ${phase}: ${current}/${total} (${commandBudget.count} bounded GitHub commands)\n`,
+                );
+              }
+            },
+            openActivity,
+            selectionPolicy.eligibleIssueLabels,
+          ),
+        };
+      },
+      ({ attempt }) =>
+        process.stderr.write(
+          `[Slop] open-item inventory changed during snapshot attempt ${attempt}; retrying one complete read\n`,
         ),
-      };
-    },
-    ({ attempt }) =>
-      process.stderr.write(
-        `[Slop] open-item inventory changed during snapshot attempt ${attempt}; retrying one complete read\n`,
-      ),
-  );
-  process.stdout.write(
-    options.epochOnly
-      ? `${JSON.stringify(report.selection.reviewEpoch, null, 2)}\n`
-      : options.json
-        ? `${JSON.stringify(report, null, 2)}\n`
-        : renderMarkdown(report),
-  );
+    );
+    process.stdout.write(
+      options.epochOnly
+        ? `${JSON.stringify(report.selection.reviewEpoch, null, 2)}\n`
+        : options.json
+          ? `${JSON.stringify(report, null, 2)}\n`
+          : renderMarkdown(report),
+    );
+  } finally {
+    liveReportLock.release();
+  }
 }
 
 const invokedDirectly =
@@ -2872,7 +3080,12 @@ if (invokedDirectly) {
   } catch (error) {
     // error-policy:J1 The CLI boundary turns a failed read/audit into a non-zero exit.
     const message = error instanceof Error ? error.message : String(error);
-    process.stderr.write(`Slop live report failed: ${message}\n`);
-    process.exitCode = 1;
+    if (error instanceof LiveReportLockContentionError) {
+      process.stderr.write(`Slop live report deferred: ${message}\n`);
+      process.exitCode = 2;
+    } else {
+      process.stderr.write(`Slop live report failed: ${message}\n`);
+      process.exitCode = 1;
+    }
   }
 }

--- a/skills/contribute-to-eliza/scripts/live-report.mjs
+++ b/skills/contribute-to-eliza/scripts/live-report.mjs
@@ -5,20 +5,22 @@
  * adapter; GraphQL uses explicit read-only queries over GitHub's POST endpoint.
  */
 
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { createHash, randomBytes } from "node:crypto";
 import {
   existsSync,
+  lstatSync,
   mkdirSync,
   readFileSync,
+  readdirSync,
   realpathSync,
   renameSync,
   rmSync,
   statSync,
   writeFileSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { platform, userInfo } from "node:os";
+import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 export const MODEL_DISCLOSURE_PREFIX = "AI provider/model:";
@@ -61,9 +63,18 @@ export class LiveInventoryChangedError extends Error {
   }
 }
 
-const LIVE_REPORT_LOCK_DIRECTORY = "slop-live-report-locks-v1";
+const LIVE_REPORT_LOCK_DIRECTORY = "slop-live-report-locks-v2";
 const LIVE_REPORT_LOCK_OWNER_FILE = "owner.json";
+const LIVE_REPORT_LOCK_HEARTBEAT_FILE = "heartbeat.json";
+const LIVE_REPORT_LOCK_COMMAND_DIRECTORY = "commands";
 const LIVE_REPORT_LOCK_ACQUIRE_ATTEMPTS = 8;
+const LIVE_REPORT_HEARTBEAT_INTERVAL_MS = 200;
+const LIVE_REPORT_HEARTBEAT_STALE_MS = 1_000;
+const LIVE_REPORT_ORPHAN_COMMAND_GRACE_MS = 5 * 60 * 1_000;
+const LIVE_REPORT_LOCKED_GH_ARGUMENT = "--slop-internal-locked-gh-v1";
+const LIVE_REPORT_LOCK_HEARTBEAT_ARGUMENT =
+  "--slop-internal-lock-heartbeat-v1";
+const LIVE_REPORT_TOKEN_RE = /^[a-f0-9]{32}$/u;
 
 const REPOSITORY_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const PLACEHOLDER_RE =
@@ -1347,7 +1358,16 @@ export class LiveReportLockContentionError extends Error {
 export function readGhAuthenticatedIdentity(spawn = spawnSync) {
   const result = spawn(
     "gh",
-    ["api", "--method", "GET", "--jq", "{id: .id, login: .login}", "user"],
+    [
+      "api",
+      "--hostname",
+      "github.com",
+      "--method",
+      "GET",
+      "--jq",
+      "{id: .id, login: .login}",
+      "user",
+    ],
     {
       encoding: "utf8",
       maxBuffer: 1024 * 1024,
@@ -1379,7 +1399,7 @@ export function readGhAuthenticatedIdentity(spawn = spawnSync) {
   if (id <= 0 || login.length === 0) {
     throw new TypeError("GitHub authenticated identity is invalid");
   }
-  return { id, login };
+  return { host: "github.com", id, login };
 }
 
 function fileSystemErrorCode(error) {
@@ -1388,63 +1408,166 @@ function fileSystemErrorCode(error) {
     : null;
 }
 
-function readLiveReportLockOwner(lockPath) {
-  try {
-    const owner = asRecord(
-      JSON.parse(
-        readFileSync(join(lockPath, LIVE_REPORT_LOCK_OWNER_FILE), "utf8"),
-      ),
-      "live report lock owner",
-    );
-    const schemaVersion = asNumberField(
-      owner,
-      "schemaVersion",
-      "live report lock owner",
-    );
-    const pid = asNumberField(owner, "pid", "live report lock owner");
-    const ownerToken = asStringField(
-      owner,
-      "ownerToken",
-      "live report lock owner",
-    );
-    if (
-      schemaVersion !== 1 ||
-      pid <= 0 ||
-      !/^[a-f0-9]{32}$/u.test(ownerToken)
-    ) {
-      return null;
-    }
-    return { pid, ownerToken };
-  } catch {
-    // error-policy:J3 A corrupt or incomplete lease cannot claim live ownership.
-    return null;
-  }
+function heartbeatTimestampIsFresh(observedAtMs) {
+  const age = Date.now() - observedAtMs;
+  return age >= -LIVE_REPORT_HEARTBEAT_STALE_MS &&
+    age <= LIVE_REPORT_HEARTBEAT_STALE_MS;
 }
 
-function processIsRunning(pid) {
+export function defaultLiveReportLockRoot() {
+  const uid = typeof process.getuid === "function" ? process.getuid() : null;
+  if (Number.isInteger(uid) && uid >= 0) {
+    return join("/tmp", `${LIVE_REPORT_LOCK_DIRECTORY}-${uid}`);
+  }
+  const identity = userInfo();
+  const key = createHash("sha256")
+    .update(`${identity.username}\0${identity.homedir}`)
+    .digest("hex")
+    .slice(0, 16);
+  return join(identity.homedir, `.${LIVE_REPORT_LOCK_DIRECTORY}-${key}`);
+}
+
+export function ensureLiveReportLockRoot(
+  rootPath = defaultLiveReportLockRoot(),
+) {
   try {
-    process.kill(pid, 0);
-    return true;
+    mkdirSync(rootPath, { mode: 0o700 });
   } catch (error) {
-    if (fileSystemErrorCode(error) === "ESRCH") return false;
-    if (fileSystemErrorCode(error) === "EPERM") return true;
+    if (fileSystemErrorCode(error) !== "EEXIST") throw error;
+  }
+  const stats = lstatSync(rootPath);
+  if (stats.isSymbolicLink() || !stats.isDirectory()) {
+    throw new TypeError("live report lock root must be a real directory");
+  }
+  const uid = typeof process.getuid === "function" ? process.getuid() : null;
+  if (Number.isInteger(uid) && stats.uid !== uid) {
+    throw new TypeError(
+      "live report lock root must belong to the current user",
+    );
+  }
+  if (platform() !== "win32" && (stats.mode & 0o077) !== 0) {
+    throw new TypeError("live report lock root permissions must be 0700");
+  }
+  return rootPath;
+}
+
+function readLiveReportLockOwner(lockPath) {
+  let source;
+  try {
+    source = readFileSync(join(lockPath, LIVE_REPORT_LOCK_OWNER_FILE), "utf8");
+  } catch (error) {
+    if (fileSystemErrorCode(error) === "ENOENT") return null;
     throw error;
   }
+  const owner = asRecord(JSON.parse(source), "live report lock owner");
+  const schemaVersion = asNumberField(
+    owner,
+    "schemaVersion",
+    "live report lock owner",
+  );
+  const processLease = readProcessLease(owner, "live report lock owner");
+  const ownerToken = asStringField(
+    owner,
+    "ownerToken",
+    "live report lock owner",
+  );
+  if (schemaVersion !== 2 || !LIVE_REPORT_TOKEN_RE.test(ownerToken)) {
+    throw new TypeError("live report lock owner is invalid");
+  }
+  return { ...processLease, ownerToken };
 }
 
-function lockOwnerIsActive(owner) {
-  return owner !== null && processIsRunning(owner.pid);
+function liveReportCommandDirectory(lockPath) {
+  return join(lockPath, LIVE_REPORT_LOCK_COMMAND_DIRECTORY);
 }
 
-function prepareLiveReportLockCandidate(lockPath, ownerToken) {
+function readLiveReportCommandLease(path) {
+  const record = asRecord(
+    JSON.parse(readFileSync(path, "utf8")),
+    "live report command lease",
+  );
+  const schemaVersion = asNumberField(
+    record,
+    "schemaVersion",
+    "live report command lease",
+  );
+  const ownerToken = asStringField(
+    record,
+    "ownerToken",
+    "live report command lease",
+  );
+  const startedAtMs = asNumberField(
+    record,
+    "startedAtMs",
+    "live report command lease",
+  );
+  const helper = readProcessLease(record.helper, "live report command helper");
+  const child =
+    record.child === null
+      ? null
+      : readProcessLease(record.child, "live report GitHub child");
+  if (
+    schemaVersion !== 1 ||
+    !LIVE_REPORT_TOKEN_RE.test(ownerToken) ||
+    !Number.isSafeInteger(startedAtMs) ||
+    startedAtMs <= 0
+  ) {
+    throw new TypeError("live report command lease is invalid");
+  }
+  return { child, helper, ownerToken, startedAtMs };
+}
+
+function liveReportCommandIsActive(lease, ownerToken) {
+  if (lease.ownerToken !== ownerToken) {
+    throw new TypeError("live report command lease owner does not match");
+  }
+  if (processLeaseIsActive(lease.helper)) return true;
+  if (lease.child !== null && processLeaseIsActive(lease.child)) return true;
+  return Date.now() - lease.startedAtMs < LIVE_REPORT_ORPHAN_COMMAND_GRACE_MS;
+}
+
+function liveReportHasActiveCommand(lockPath, ownerToken) {
+  const commandDirectory = liveReportCommandDirectory(lockPath);
+  let entries;
+  try {
+    entries = readdirSync(commandDirectory, { withFileTypes: true });
+  } catch (error) {
+    if (fileSystemErrorCode(error) === "ENOENT" && !existsSync(lockPath)) {
+      return false;
+    }
+    throw error;
+  }
+  for (const entry of entries) {
+    if (entry.isSymbolicLink() || (!entry.isFile() && !entry.isDirectory())) {
+      throw new TypeError("live report command directory is invalid");
+    }
+    if (!/^lease-[a-f0-9]{32}\.json$/u.test(entry.name)) continue;
+    const lease = readLiveReportCommandLease(
+      join(commandDirectory, entry.name),
+    );
+    if (liveReportCommandIsActive(lease, ownerToken)) return true;
+  }
+  return false;
+}
+
+function assertLiveReportLockDirectory(lockPath) {
+  const stats = lstatSync(lockPath);
+  if (stats.isSymbolicLink() || !stats.isDirectory()) {
+    throw new TypeError("live report lock must be a real directory");
+  }
+}
+
+function prepareLiveReportLockCandidate(lockPath, ownerToken, processIdentity) {
   const candidatePath = `${lockPath}.candidate-${process.pid}-${ownerToken}`;
   mkdirSync(candidatePath, { mode: 0o700 });
   try {
+    mkdirSync(liveReportCommandDirectory(candidatePath), { mode: 0o700 });
     writeFileSync(
       join(candidatePath, LIVE_REPORT_LOCK_OWNER_FILE),
       `${JSON.stringify({
-        schemaVersion: 1,
+        schemaVersion: 2,
         pid: process.pid,
+        processIdentity,
         ownerToken,
       })}\n`,
       { flag: "wx", mode: 0o600 },
@@ -1456,25 +1579,113 @@ function prepareLiveReportLockCandidate(lockPath, ownerToken) {
   }
 }
 
-export function acquireLiveReportLock(identity) {
+function liveReportLockKey(identity) {
+  return createHash("sha256")
+    .update(`${identity.host}:${identity.id}`)
+    .digest("hex");
+}
+
+function writeLiveReportCommandLease(path, lease, replace = false) {
+  if (!replace) {
+    writeFileSync(path, `${JSON.stringify(lease)}\n`, {
+      flag: "wx",
+      mode: 0o600,
+    });
+    return;
+  }
+  const nextPath = `${path}.next-${process.pid}-${randomBytes(16).toString("hex")}`;
+  try {
+    writeFileSync(nextPath, `${JSON.stringify(lease)}\n`, {
+      flag: "wx",
+      mode: 0o600,
+    });
+    renameSync(nextPath, path);
+  } catch (error) {
+    rmSync(nextPath, { force: true });
+    throw error;
+  }
+}
+
+function spawnLockedGh(lockPath, ownerToken, command, args, options = {}) {
+  if (
+    command !== "gh" ||
+    !Array.isArray(args) ||
+    args.some((argument) => typeof argument !== "string")
+  ) {
+    throw new TypeError("live report lock may execute only a gh argument list");
+  }
+  if (options.encoding !== undefined && options.encoding !== "utf8") {
+    throw new TypeError("live report gh commands require utf8 output");
+  }
+  const maxBuffer = options.maxBuffer ?? 1024 * 1024;
+  if (
+    !Number.isSafeInteger(maxBuffer) ||
+    maxBuffer <= 0 ||
+    maxBuffer > 256 * 1024 * 1024
+  ) {
+    throw new RangeError("live report gh command maxBuffer is invalid");
+  }
+  const commandToken = randomBytes(16).toString("hex");
+  const requestPath = join(
+    liveReportCommandDirectory(lockPath),
+    `request-${commandToken}.json`,
+  );
+  writeFileSync(
+    requestPath,
+    `${JSON.stringify({ args, maxBuffer, ownerToken, schemaVersion: 1 })}\n`,
+    { flag: "wx", mode: 0o600 },
+  );
+  try {
+    return spawnSync(
+      process.execPath,
+      [
+        fileURLToPath(import.meta.url),
+        LIVE_REPORT_LOCKED_GH_ARGUMENT,
+        lockPath,
+        ownerToken,
+        commandToken,
+      ],
+      {
+        encoding: "utf8",
+        env: { ...(options.env ?? process.env), GH_HOST: "github.com" },
+        maxBuffer: Math.min(maxBuffer + 1024 * 1024, 256 * 1024 * 1024),
+        windowsHide: true,
+      },
+    );
+  } finally {
+    rmSync(requestPath, { force: true });
+  }
+}
+
+export function acquireLiveReportLock(identity, options = {}) {
   const record = asRecord(identity, "GitHub authenticated identity");
   const id = asNumberField(record, "id", "GitHub authenticated identity");
   const login = asStringField(record, "login", "GitHub authenticated identity");
-  if (id <= 0 || login.length === 0) {
+  const host = asStringField(record, "host", "GitHub authenticated identity");
+  if (id <= 0 || login.length === 0 || host !== "github.com") {
     throw new TypeError("GitHub authenticated identity is invalid");
   }
-  const root = join(tmpdir(), LIVE_REPORT_LOCK_DIRECTORY);
-  mkdirSync(root, { mode: 0o700, recursive: true });
-  const key = createHash("sha256").update(`github.com:${id}`).digest("hex");
+  const root = ensureLiveReportLockRoot(
+    options.rootPath ?? defaultLiveReportLockRoot(),
+  );
+  const key = liveReportLockKey({ host, id });
   const lockPath = join(root, `${key}.lock`);
   const ownerToken = randomBytes(16).toString("hex");
+  const processIdentity = readLiveReportProcessIdentity(process.pid);
+  if (processIdentity === null) {
+    throw new Error("could not establish the live report process identity");
+  }
   let acquired = false;
   for (
     let attempt = 0;
     attempt < LIVE_REPORT_LOCK_ACQUIRE_ATTEMPTS;
     attempt += 1
   ) {
-    const candidatePath = prepareLiveReportLockCandidate(lockPath, ownerToken);
+    const candidatePath = prepareLiveReportLockCandidate(
+      lockPath,
+      ownerToken,
+      processIdentity,
+    );
     try {
       renameSync(candidatePath, lockPath);
       acquired = true;
@@ -1485,8 +1696,16 @@ export function acquireLiveReportLock(identity) {
         if (fileSystemErrorCode(error) === "ENOENT") continue;
         throw error;
       }
+      assertLiveReportLockDirectory(lockPath);
       const currentOwner = readLiveReportLockOwner(lockPath);
-      if (lockOwnerIsActive(currentOwner)) {
+      if (currentOwner === null) {
+        if (!existsSync(lockPath)) continue;
+        throw new Error("live report lock owner is missing");
+      }
+      if (
+        processLeaseIsActive(currentOwner) ||
+        liveReportHasActiveCommand(lockPath, currentOwner.ownerToken)
+      ) {
         throw new LiveReportLockContentionError();
       }
       const stalePath = `${lockPath}.stale-${process.pid}-${randomBytes(16).toString("hex")}`;
@@ -1504,12 +1723,16 @@ export function acquireLiveReportLock(identity) {
   }
   let released = false;
   return {
+    spawn(command, args, options) {
+      return spawnLockedGh(lockPath, ownerToken, command, args, options);
+    },
     release() {
       if (released) return;
       const owner = readLiveReportLockOwner(lockPath);
       if (
         owner === null ||
         owner.pid !== process.pid ||
+        owner.processIdentity !== processIdentity ||
         owner.ownerToken !== ownerToken
       ) {
         throw new Error("live report lock ownership changed before release");
@@ -1520,6 +1743,173 @@ export function acquireLiveReportLock(identity) {
       released = true;
     },
   };
+}
+
+function readLockedGhRequest(lockPath, ownerToken, commandToken) {
+  if (
+    !LIVE_REPORT_TOKEN_RE.test(ownerToken) ||
+    !LIVE_REPORT_TOKEN_RE.test(commandToken)
+  ) {
+    throw new TypeError("locked GitHub command tokens are invalid");
+  }
+  const root = ensureLiveReportLockRoot();
+  if (
+    dirname(lockPath) !== root ||
+    !/^[a-f0-9]{64}\.lock$/u.test(basename(lockPath))
+  ) {
+    throw new TypeError("locked GitHub command path is invalid");
+  }
+  assertLiveReportLockDirectory(lockPath);
+  const owner = readLiveReportLockOwner(lockPath);
+  if (owner === null || owner.ownerToken !== ownerToken) {
+    throw new Error("live report lock ownership changed before GitHub command");
+  }
+  const requestPath = join(
+    liveReportCommandDirectory(lockPath),
+    `request-${commandToken}.json`,
+  );
+  const request = asRecord(
+    JSON.parse(readFileSync(requestPath, "utf8")),
+    "locked GitHub command request",
+  );
+  const schemaVersion = asNumberField(
+    request,
+    "schemaVersion",
+    "locked GitHub command request",
+  );
+  const requestOwnerToken = asStringField(
+    request,
+    "ownerToken",
+    "locked GitHub command request",
+  );
+  const maxBuffer = asNumberField(
+    request,
+    "maxBuffer",
+    "locked GitHub command request",
+  );
+  if (
+    schemaVersion !== 1 ||
+    requestOwnerToken !== ownerToken ||
+    !Number.isSafeInteger(maxBuffer) ||
+    maxBuffer <= 0 ||
+    maxBuffer > 256 * 1024 * 1024 ||
+    !Array.isArray(request.args) ||
+    request.args.some((argument) => typeof argument !== "string")
+  ) {
+    throw new TypeError("locked GitHub command request is invalid");
+  }
+  return { args: request.args, maxBuffer, requestPath };
+}
+
+function collectBoundedGhChild(child, maxBuffer) {
+  return new Promise((resolvePromise) => {
+    const stdout = [];
+    const stderr = [];
+    let stdoutBytes = 0;
+    let stderrBytes = 0;
+    let overflow = null;
+    let spawnError = null;
+    const collect = (chunks, chunk, stream) => {
+      if (overflow !== null) return;
+      const value = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      if (stream === "stdout") stdoutBytes += value.length;
+      else stderrBytes += value.length;
+      if (stdoutBytes > maxBuffer || stderrBytes > maxBuffer) {
+        overflow = stream;
+        child.kill("SIGTERM");
+        return;
+      }
+      chunks.push(value);
+    };
+    child.stdout.on("data", (chunk) => collect(stdout, chunk, "stdout"));
+    child.stderr.on("data", (chunk) => collect(stderr, chunk, "stderr"));
+    child.once("error", (error) => {
+      spawnError = error;
+    });
+    child.once("close", (status, signal) => {
+      resolvePromise({
+        error: spawnError,
+        overflow,
+        signal,
+        status,
+        stderr: Buffer.concat(stderr),
+        stdout: Buffer.concat(stdout),
+      });
+    });
+  });
+}
+
+function writeProcessDescriptor(descriptor, value) {
+  if (value.length === 0) return;
+  try {
+    writeFileSync(descriptor, value);
+  } catch (error) {
+    if (fileSystemErrorCode(error) !== "EPIPE") throw error;
+  }
+}
+
+async function runLockedGhCommand(lockPath, ownerToken, commandToken) {
+  const request = readLockedGhRequest(lockPath, ownerToken, commandToken);
+  const leasePath = join(
+    liveReportCommandDirectory(lockPath),
+    `lease-${commandToken}.json`,
+  );
+  const helperIdentity = readLiveReportProcessIdentity(process.pid);
+  if (helperIdentity === null) {
+    throw new Error("could not establish the GitHub command helper identity");
+  }
+  const lease = {
+    schemaVersion: 1,
+    ownerToken,
+    startedAtMs: Date.now(),
+    helper: { pid: process.pid, processIdentity: helperIdentity },
+    child: null,
+  };
+  writeLiveReportCommandLease(leasePath, lease);
+  let result;
+  try {
+    const currentOwner = readLiveReportLockOwner(lockPath);
+    if (currentOwner === null || currentOwner.ownerToken !== ownerToken) {
+      throw new Error(
+        "live report lock ownership changed while starting GitHub command",
+      );
+    }
+    const child = spawn("gh", request.args, {
+      env: { ...process.env, GH_HOST: "github.com" },
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+    });
+    const childResult = collectBoundedGhChild(child, request.maxBuffer);
+    if (Number.isInteger(child.pid) && child.pid > 0) {
+      const childIdentity = readLiveReportProcessIdentity(child.pid);
+      if (childIdentity !== null) {
+        writeLiveReportCommandLease(
+          leasePath,
+          {
+            ...lease,
+            child: { pid: child.pid, processIdentity: childIdentity },
+          },
+          true,
+        );
+      }
+    }
+    result = await childResult;
+  } finally {
+    rmSync(leasePath, { force: true });
+    rmSync(request.requestPath, { force: true });
+  }
+  if (result.error) throw result.error;
+  if (result.overflow !== null) {
+    throw new RangeError(
+      `spawn gh ${result.overflow} exceeded the bounded output buffer`,
+    );
+  }
+  writeProcessDescriptor(1, result.stdout);
+  writeProcessDescriptor(2, result.stderr);
+  if (result.status === null) {
+    throw new Error(`gh terminated by ${result.signal ?? "an unknown signal"}`);
+  }
+  process.exitCode = result.status;
 }
 
 function rateResource(value, context) {
@@ -3055,6 +3445,7 @@ export function main(args = process.argv.slice(2)) {
         process.stderr.write(
           `[Slop] open-item inventory changed during snapshot attempt ${attempt}; retrying one complete read\n`,
         ),
+      () => createGhCommandBudget(liveReportLock.spawn),
     );
     process.stdout.write(
       options.epochOnly
@@ -3075,17 +3466,27 @@ const invokedDirectly =
     realpathSync(process.argv[1]);
 
 if (invokedDirectly) {
-  try {
-    main();
-  } catch (error) {
-    // error-policy:J1 The CLI boundary turns a failed read/audit into a non-zero exit.
-    const message = error instanceof Error ? error.message : String(error);
-    if (error instanceof LiveReportLockContentionError) {
-      process.stderr.write(`Slop live report deferred: ${message}\n`);
-      process.exitCode = 2;
-    } else {
-      process.stderr.write(`Slop live report failed: ${message}\n`);
+  const directArguments = process.argv.slice(2);
+  if (directArguments[0] === LIVE_REPORT_LOCKED_GH_ARGUMENT) {
+    runLockedGhCommand(...directArguments.slice(1)).catch((error) => {
+      // error-policy:J1 The internal process boundary fails the owning report.
+      const message = error instanceof Error ? error.message : String(error);
+      process.stderr.write(`Slop locked GitHub command failed: ${message}\n`);
       process.exitCode = 1;
+    });
+  } else {
+    try {
+      main(directArguments);
+    } catch (error) {
+      // error-policy:J1 The CLI boundary turns a failed read/audit into a non-zero exit.
+      const message = error instanceof Error ? error.message : String(error);
+      if (error instanceof LiveReportLockContentionError) {
+        process.stderr.write(`Slop live report deferred: ${message}\n`);
+        process.exitCode = 2;
+      } else {
+        process.stderr.write(`Slop live report failed: ${message}\n`);
+        process.exitCode = 1;
+      }
     }
   }
 }

--- a/skills/contribute-to-eliza/scripts/live-report.mjs
+++ b/skills/contribute-to-eliza/scripts/live-report.mjs
@@ -3,6 +3,7 @@
  * Builds a stable, read-only inventory of open elizaOS issues and pull requests
  * for contribution selection. REST pagination stays behind one GET-only
  * adapter; GraphQL uses explicit read-only queries over GitHub's POST endpoint.
+ * A user-private process lease serializes complete discovery across skill copies.
  */
 
 import { spawn, spawnSync } from "node:child_process";
@@ -11,8 +12,8 @@ import {
   existsSync,
   lstatSync,
   mkdirSync,
-  readFileSync,
   readdirSync,
+  readFileSync,
   realpathSync,
   renameSync,
   rmSync,
@@ -65,15 +66,11 @@ export class LiveInventoryChangedError extends Error {
 
 const LIVE_REPORT_LOCK_DIRECTORY = "slop-live-report-locks-v2";
 const LIVE_REPORT_LOCK_OWNER_FILE = "owner.json";
-const LIVE_REPORT_LOCK_HEARTBEAT_FILE = "heartbeat.json";
 const LIVE_REPORT_LOCK_COMMAND_DIRECTORY = "commands";
 const LIVE_REPORT_LOCK_ACQUIRE_ATTEMPTS = 8;
-const LIVE_REPORT_HEARTBEAT_INTERVAL_MS = 200;
-const LIVE_REPORT_HEARTBEAT_STALE_MS = 1_000;
 const LIVE_REPORT_ORPHAN_COMMAND_GRACE_MS = 5 * 60 * 1_000;
 const LIVE_REPORT_LOCKED_GH_ARGUMENT = "--slop-internal-locked-gh-v1";
-const LIVE_REPORT_LOCK_HEARTBEAT_ARGUMENT =
-  "--slop-internal-lock-heartbeat-v1";
+const LIVE_REPORT_PROCESS_IDENTITY_RE = /^[a-f0-9]{64}$/u;
 const LIVE_REPORT_TOKEN_RE = /^[a-f0-9]{32}$/u;
 
 const REPOSITORY_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
@@ -1408,10 +1405,121 @@ function fileSystemErrorCode(error) {
     : null;
 }
 
-function heartbeatTimestampIsFresh(observedAtMs) {
-  const age = Date.now() - observedAtMs;
-  return age >= -LIVE_REPORT_HEARTBEAT_STALE_MS &&
-    age <= LIVE_REPORT_HEARTBEAT_STALE_MS;
+function assertLiveReportPrivatePath(path, context, kind) {
+  const stats = lstatSync(path);
+  const kindMatches =
+    kind === "directory" ? stats.isDirectory() : stats.isFile();
+  if (stats.isSymbolicLink() || !kindMatches) {
+    throw new TypeError(`${context} must be a real ${kind}`);
+  }
+  const uid = typeof process.getuid === "function" ? process.getuid() : null;
+  if (Number.isInteger(uid) && stats.uid !== uid) {
+    throw new TypeError(`${context} must belong to the current user`);
+  }
+  if (platform() !== "win32" && (stats.mode & 0o077) !== 0) {
+    throw new TypeError(`${context} permissions must exclude group and others`);
+  }
+  return stats;
+}
+
+function processIsRunning(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (fileSystemErrorCode(error) === "ESRCH") return false;
+    if (fileSystemErrorCode(error) === "EPERM") return true;
+    throw error;
+  }
+}
+
+function hashProcessIdentity(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+export function readLiveReportProcessIdentity(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    throw new TypeError("live report process ID must be a positive integer");
+  }
+  if (!processIsRunning(pid)) return null;
+  const operatingSystem = platform();
+  if (operatingSystem === "linux") {
+    let source;
+    try {
+      source = readFileSync(`/proc/${pid}/stat`, "utf8");
+    } catch (error) {
+      if (fileSystemErrorCode(error) === "ENOENT") return null;
+      throw error;
+    }
+    const commandEnd = source.lastIndexOf(")");
+    const fields = source
+      .slice(commandEnd + 2)
+      .trim()
+      .split(/\s+/u);
+    const startTime = fields[19];
+    if (commandEnd < 1 || !/^\d+$/u.test(startTime ?? "")) {
+      throw new TypeError("Linux returned an invalid process birth identity");
+    }
+    return hashProcessIdentity(`linux:${startTime}`);
+  }
+  if (
+    operatingSystem === "darwin" ||
+    operatingSystem === "freebsd" ||
+    operatingSystem === "openbsd"
+  ) {
+    const result = spawnSync(
+      existsSync("/bin/ps") ? "/bin/ps" : "ps",
+      ["-o", "lstart=", "-p", String(pid)],
+      { encoding: "utf8", maxBuffer: 64 * 1024, windowsHide: true },
+    );
+    if (result.error) throw result.error;
+    if (result.status !== 0 || result.stdout.trim() === "") {
+      if (!processIsRunning(pid)) return null;
+      throw new Error("could not read the process birth identity from ps");
+    }
+    return hashProcessIdentity(`${operatingSystem}:${result.stdout.trim()}`);
+  }
+  if (operatingSystem === "win32") {
+    const result = spawnSync(
+      "powershell.exe",
+      [
+        "-NoLogo",
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        `(Get-Process -Id ${pid} -ErrorAction Stop).StartTime.ToUniversalTime().Ticks`,
+      ],
+      { encoding: "utf8", maxBuffer: 64 * 1024, windowsHide: true },
+    );
+    if (result.error) throw result.error;
+    if (result.status !== 0 || !/^\d+$/u.test(result.stdout.trim())) {
+      if (!processIsRunning(pid)) return null;
+      throw new Error("could not read the Windows process birth identity");
+    }
+    return hashProcessIdentity(`win32:${result.stdout.trim()}`);
+  }
+  throw new Error(
+    `live report locking does not support process identity on ${operatingSystem}`,
+  );
+}
+
+function readProcessLease(value, context) {
+  const record = asRecord(value, context);
+  const pid = asNumberField(record, "pid", context);
+  const processIdentity = asStringField(record, "processIdentity", context);
+  if (
+    !Number.isInteger(pid) ||
+    pid <= 0 ||
+    !LIVE_REPORT_PROCESS_IDENTITY_RE.test(processIdentity)
+  ) {
+    throw new TypeError(`${context} is invalid`);
+  }
+  return { pid, processIdentity };
+}
+
+function processLeaseIsActive(lease) {
+  const currentIdentity = readLiveReportProcessIdentity(lease.pid);
+  return currentIdentity !== null && currentIdentity === lease.processIdentity;
 }
 
 export function defaultLiveReportLockRoot() {
@@ -1435,25 +1543,18 @@ export function ensureLiveReportLockRoot(
   } catch (error) {
     if (fileSystemErrorCode(error) !== "EEXIST") throw error;
   }
-  const stats = lstatSync(rootPath);
-  if (stats.isSymbolicLink() || !stats.isDirectory()) {
-    throw new TypeError("live report lock root must be a real directory");
-  }
-  const uid = typeof process.getuid === "function" ? process.getuid() : null;
-  if (Number.isInteger(uid) && stats.uid !== uid) {
-    throw new TypeError(
-      "live report lock root must belong to the current user",
-    );
-  }
-  if (platform() !== "win32" && (stats.mode & 0o077) !== 0) {
-    throw new TypeError("live report lock root permissions must be 0700");
-  }
+  assertLiveReportPrivatePath(rootPath, "live report lock root", "directory");
   return rootPath;
 }
 
 function readLiveReportLockOwner(lockPath) {
   let source;
   try {
+    assertLiveReportPrivatePath(
+      join(lockPath, LIVE_REPORT_LOCK_OWNER_FILE),
+      "live report lock owner",
+      "file",
+    );
     source = readFileSync(join(lockPath, LIVE_REPORT_LOCK_OWNER_FILE), "utf8");
   } catch (error) {
     if (fileSystemErrorCode(error) === "ENOENT") return null;
@@ -1482,6 +1583,7 @@ function liveReportCommandDirectory(lockPath) {
 }
 
 function readLiveReportCommandLease(path) {
+  assertLiveReportPrivatePath(path, "live report command lease", "file");
   const record = asRecord(
     JSON.parse(readFileSync(path, "utf8")),
     "live report command lease",
@@ -1530,6 +1632,11 @@ function liveReportHasActiveCommand(lockPath, ownerToken) {
   const commandDirectory = liveReportCommandDirectory(lockPath);
   let entries;
   try {
+    assertLiveReportPrivatePath(
+      commandDirectory,
+      "live report command directory",
+      "directory",
+    );
     entries = readdirSync(commandDirectory, { withFileTypes: true });
   } catch (error) {
     if (fileSystemErrorCode(error) === "ENOENT" && !existsSync(lockPath)) {
@@ -1538,7 +1645,7 @@ function liveReportHasActiveCommand(lockPath, ownerToken) {
     throw error;
   }
   for (const entry of entries) {
-    if (entry.isSymbolicLink() || (!entry.isFile() && !entry.isDirectory())) {
+    if (!entry.isFile()) {
       throw new TypeError("live report command directory is invalid");
     }
     if (!/^lease-[a-f0-9]{32}\.json$/u.test(entry.name)) continue;
@@ -1551,10 +1658,7 @@ function liveReportHasActiveCommand(lockPath, ownerToken) {
 }
 
 function assertLiveReportLockDirectory(lockPath) {
-  const stats = lstatSync(lockPath);
-  if (stats.isSymbolicLink() || !stats.isDirectory()) {
-    throw new TypeError("live report lock must be a real directory");
-  }
+  assertLiveReportPrivatePath(lockPath, "live report lock", "directory");
 }
 
 function prepareLiveReportLockCandidate(lockPath, ownerToken, processIdentity) {
@@ -1626,6 +1730,11 @@ function spawnLockedGh(lockPath, ownerToken, command, args, options = {}) {
     throw new RangeError("live report gh command maxBuffer is invalid");
   }
   const commandToken = randomBytes(16).toString("hex");
+  assertLiveReportPrivatePath(
+    liveReportCommandDirectory(lockPath),
+    "live report command directory",
+    "directory",
+  );
   const requestPath = join(
     liveReportCommandDirectory(lockPath),
     `request-${commandToken}.json`,
@@ -1752,7 +1861,7 @@ function readLockedGhRequest(lockPath, ownerToken, commandToken) {
   ) {
     throw new TypeError("locked GitHub command tokens are invalid");
   }
-  const root = ensureLiveReportLockRoot();
+  const root = ensureLiveReportLockRoot(dirname(lockPath));
   if (
     dirname(lockPath) !== root ||
     !/^[a-f0-9]{64}\.lock$/u.test(basename(lockPath))
@@ -1767,6 +1876,11 @@ function readLockedGhRequest(lockPath, ownerToken, commandToken) {
   const requestPath = join(
     liveReportCommandDirectory(lockPath),
     `request-${commandToken}.json`,
+  );
+  assertLiveReportPrivatePath(
+    requestPath,
+    "locked GitHub command request",
+    "file",
   );
   const request = asRecord(
     JSON.parse(readFileSync(requestPath, "utf8")),

--- a/skills/contribute-to-eliza/scripts/live-report.mjs
+++ b/skills/contribute-to-eliza/scripts/live-report.mjs
@@ -1625,7 +1625,12 @@ function liveReportCommandIsActive(lease, ownerToken) {
   }
   if (processLeaseIsActive(lease.helper)) return true;
   if (lease.child !== null && processLeaseIsActive(lease.child)) return true;
-  return Date.now() - lease.startedAtMs < LIVE_REPORT_ORPHAN_COMMAND_GRACE_MS;
+  // Only an unpublished child needs a grace period. A recorded birth identity
+  // proves a known child is gone, so recovery need not wait for that period.
+  return (
+    lease.child === null &&
+    Date.now() - lease.startedAtMs < LIVE_REPORT_ORPHAN_COMMAND_GRACE_MS
+  );
 }
 
 function liveReportHasActiveCommand(lockPath, ownerToken) {
@@ -1852,6 +1857,10 @@ export function acquireLiveReportLock(identity, options = {}) {
         ) {
           throw new Error("live report lock ownership changed before release");
         }
+        // An interrupted helper can return before its GitHub child exits. Keep
+        // the owner and command leases so a replacement scan still sees it;
+        // normal stale-owner recovery can reclaim the lock after the child exits.
+        if (liveReportHasActiveCommand(lockPath, ownerToken)) return;
         const releasedPath = `${lockPath}.released-${process.pid}-${ownerToken}`;
         renameSync(lockPath, releasedPath);
         rmSync(releasedPath, { force: true, recursive: true });

--- a/skills/contribute-to-heir-elements-sdk/scripts/live-report.mjs
+++ b/skills/contribute-to-heir-elements-sdk/scripts/live-report.mjs
@@ -16,6 +16,7 @@ import {
   readFileSync,
   realpathSync,
   renameSync,
+  rmdirSync,
   rmSync,
   statSync,
   writeFileSync,
@@ -67,7 +68,6 @@ export class LiveInventoryChangedError extends Error {
 const LIVE_REPORT_LOCK_DIRECTORY = "slop-live-report-locks-v2";
 const LIVE_REPORT_LOCK_OWNER_FILE = "owner.json";
 const LIVE_REPORT_LOCK_COMMAND_DIRECTORY = "commands";
-const LIVE_REPORT_LOCK_ACQUIRE_ATTEMPTS = 8;
 const LIVE_REPORT_ORPHAN_COMMAND_GRACE_MS = 5 * 60 * 1_000;
 const LIVE_REPORT_LOCKED_GH_ARGUMENT = "--slop-internal-locked-gh-v1";
 const LIVE_REPORT_PROCESS_IDENTITY_RE = /^[a-f0-9]{64}$/u;
@@ -1344,10 +1344,10 @@ export function createGhCommandBudget(spawn = spawnSync) {
 }
 
 export class LiveReportLockContentionError extends Error {
-  constructor() {
-    super(
-      "live report lock contention: another report for this GitHub identity is already discovering activity",
-    );
+  constructor(
+    message = "live report lock contention: another report for this GitHub identity is already discovering activity",
+  ) {
+    super(message);
     this.name = "LiveReportLockContentionError";
   }
 }
@@ -1661,6 +1661,27 @@ function assertLiveReportLockDirectory(lockPath) {
   assertLiveReportPrivatePath(lockPath, "live report lock", "directory");
 }
 
+function withLiveReportLockTransition(lockPath, operation) {
+  const transitionPath = `${lockPath}.transition`;
+  // Every lock-path mutation participates in this atomic mkdir guard. Never
+  // reclaim the guard: checking a token or dead PID before renaming it would
+  // recreate the same ABA race that this guard prevents for the report lock.
+  // A crash here requires manual recovery after all local reports are stopped.
+  try {
+    mkdirSync(transitionPath, { mode: 0o700 });
+  } catch (error) {
+    if (fileSystemErrorCode(error) !== "EEXIST") throw error;
+    throw new LiveReportLockContentionError(
+      `live report lock contention: transition guard exists at ${transitionPath}; retry after the other report finishes. If it persists, stop all local reports before manually removing this guard`,
+    );
+  }
+  try {
+    return operation();
+  } finally {
+    rmdirSync(transitionPath);
+  }
+}
+
 function prepareLiveReportLockCandidate(lockPath, ownerToken, processIdentity) {
   const candidatePath = `${lockPath}.candidate-${process.pid}-${ownerToken}`;
   mkdirSync(candidatePath, { mode: 0o700 });
@@ -1784,31 +1805,20 @@ export function acquireLiveReportLock(identity, options = {}) {
   if (processIdentity === null) {
     throw new Error("could not establish the live report process identity");
   }
-  let acquired = false;
-  for (
-    let attempt = 0;
-    attempt < LIVE_REPORT_LOCK_ACQUIRE_ATTEMPTS;
-    attempt += 1
-  ) {
+  withLiveReportLockTransition(lockPath, () => {
     const candidatePath = prepareLiveReportLockCandidate(
       lockPath,
       ownerToken,
       processIdentity,
     );
     try {
-      renameSync(candidatePath, lockPath);
-      acquired = true;
-      break;
-    } catch (error) {
-      rmSync(candidatePath, { force: true, recursive: true });
       if (!existsSync(lockPath)) {
-        if (fileSystemErrorCode(error) === "ENOENT") continue;
-        throw error;
+        renameSync(candidatePath, lockPath);
+        return;
       }
       assertLiveReportLockDirectory(lockPath);
       const currentOwner = readLiveReportLockOwner(lockPath);
       if (currentOwner === null) {
-        if (!existsSync(lockPath)) continue;
         throw new Error("live report lock owner is missing");
       }
       if (
@@ -1818,18 +1828,13 @@ export function acquireLiveReportLock(identity, options = {}) {
         throw new LiveReportLockContentionError();
       }
       const stalePath = `${lockPath}.stale-${process.pid}-${randomBytes(16).toString("hex")}`;
-      try {
-        renameSync(lockPath, stalePath);
-      } catch (renameError) {
-        if (fileSystemErrorCode(renameError) === "ENOENT") continue;
-        throw renameError;
-      }
+      renameSync(lockPath, stalePath);
+      renameSync(candidatePath, lockPath);
       rmSync(stalePath, { force: true, recursive: true });
+    } finally {
+      rmSync(candidatePath, { force: true, recursive: true });
     }
-  }
-  if (!acquired) {
-    throw new Error("live report lock changed too often to acquire safely");
-  }
+  });
   let released = false;
   return {
     spawn(command, args, options) {
@@ -1837,19 +1842,21 @@ export function acquireLiveReportLock(identity, options = {}) {
     },
     release() {
       if (released) return;
-      const owner = readLiveReportLockOwner(lockPath);
-      if (
-        owner === null ||
-        owner.pid !== process.pid ||
-        owner.processIdentity !== processIdentity ||
-        owner.ownerToken !== ownerToken
-      ) {
-        throw new Error("live report lock ownership changed before release");
-      }
-      const releasedPath = `${lockPath}.released-${process.pid}-${ownerToken}`;
-      renameSync(lockPath, releasedPath);
-      rmSync(releasedPath, { force: true, recursive: true });
-      released = true;
+      withLiveReportLockTransition(lockPath, () => {
+        const owner = readLiveReportLockOwner(lockPath);
+        if (
+          owner === null ||
+          owner.pid !== process.pid ||
+          owner.processIdentity !== processIdentity ||
+          owner.ownerToken !== ownerToken
+        ) {
+          throw new Error("live report lock ownership changed before release");
+        }
+        const releasedPath = `${lockPath}.released-${process.pid}-${ownerToken}`;
+        renameSync(lockPath, releasedPath);
+        rmSync(releasedPath, { force: true, recursive: true });
+        released = true;
+      });
     },
   };
 }

--- a/skills/contribute-to-heir-elements-sdk/scripts/live-report.mjs
+++ b/skills/contribute-to-heir-elements-sdk/scripts/live-report.mjs
@@ -6,7 +6,18 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { createHash, randomBytes } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -49,6 +60,10 @@ export class LiveInventoryChangedError extends Error {
     this.name = "LiveInventoryChangedError";
   }
 }
+
+const LIVE_REPORT_LOCK_DIRECTORY = "slop-live-report-locks-v1";
+const LIVE_REPORT_LOCK_OWNER_FILE = "owner.json";
+const LIVE_REPORT_LOCK_ACQUIRE_ATTEMPTS = 8;
 
 const REPOSITORY_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const PLACEHOLDER_RE =
@@ -1316,6 +1331,193 @@ export function createGhCommandBudget(spawn = spawnSync) {
       }
       count += 1;
       return spawn(command, args, options);
+    },
+  };
+}
+
+export class LiveReportLockContentionError extends Error {
+  constructor() {
+    super(
+      "live report lock contention: another report for this GitHub identity is already discovering activity",
+    );
+    this.name = "LiveReportLockContentionError";
+  }
+}
+
+export function readGhAuthenticatedIdentity(spawn = spawnSync) {
+  const result = spawn(
+    "gh",
+    ["api", "--method", "GET", "--jq", "{id: .id, login: .login}", "user"],
+    {
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024,
+      windowsHide: true,
+    },
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const detail =
+      result.stderr.trim().length > 0 ? `: ${result.stderr.trim()}` : "";
+    throw new Error(`gh api failed for authenticated identity${detail}`);
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(result.stdout);
+  } catch (cause) {
+    throw new SyntaxError(
+      "gh api returned malformed JSON for authenticated identity",
+      { cause },
+    );
+  }
+  const identity = asRecord(parsed, "GitHub authenticated identity");
+  const id = asNumberField(identity, "id", "GitHub authenticated identity");
+  const login = asStringField(
+    identity,
+    "login",
+    "GitHub authenticated identity",
+  );
+  if (id <= 0 || login.length === 0) {
+    throw new TypeError("GitHub authenticated identity is invalid");
+  }
+  return { id, login };
+}
+
+function fileSystemErrorCode(error) {
+  return error && typeof error === "object" && "code" in error
+    ? error.code
+    : null;
+}
+
+function readLiveReportLockOwner(lockPath) {
+  try {
+    const owner = asRecord(
+      JSON.parse(
+        readFileSync(join(lockPath, LIVE_REPORT_LOCK_OWNER_FILE), "utf8"),
+      ),
+      "live report lock owner",
+    );
+    const schemaVersion = asNumberField(
+      owner,
+      "schemaVersion",
+      "live report lock owner",
+    );
+    const pid = asNumberField(owner, "pid", "live report lock owner");
+    const ownerToken = asStringField(
+      owner,
+      "ownerToken",
+      "live report lock owner",
+    );
+    if (
+      schemaVersion !== 1 ||
+      pid <= 0 ||
+      !/^[a-f0-9]{32}$/u.test(ownerToken)
+    ) {
+      return null;
+    }
+    return { pid, ownerToken };
+  } catch {
+    // error-policy:J3 A corrupt or incomplete lease cannot claim live ownership.
+    return null;
+  }
+}
+
+function processIsRunning(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (fileSystemErrorCode(error) === "ESRCH") return false;
+    if (fileSystemErrorCode(error) === "EPERM") return true;
+    throw error;
+  }
+}
+
+function lockOwnerIsActive(owner) {
+  return owner !== null && processIsRunning(owner.pid);
+}
+
+function prepareLiveReportLockCandidate(lockPath, ownerToken) {
+  const candidatePath = `${lockPath}.candidate-${process.pid}-${ownerToken}`;
+  mkdirSync(candidatePath, { mode: 0o700 });
+  try {
+    writeFileSync(
+      join(candidatePath, LIVE_REPORT_LOCK_OWNER_FILE),
+      `${JSON.stringify({
+        schemaVersion: 1,
+        pid: process.pid,
+        ownerToken,
+      })}\n`,
+      { flag: "wx", mode: 0o600 },
+    );
+    return candidatePath;
+  } catch (error) {
+    rmSync(candidatePath, { force: true, recursive: true });
+    throw error;
+  }
+}
+
+export function acquireLiveReportLock(identity) {
+  const record = asRecord(identity, "GitHub authenticated identity");
+  const id = asNumberField(record, "id", "GitHub authenticated identity");
+  const login = asStringField(record, "login", "GitHub authenticated identity");
+  if (id <= 0 || login.length === 0) {
+    throw new TypeError("GitHub authenticated identity is invalid");
+  }
+  const root = join(tmpdir(), LIVE_REPORT_LOCK_DIRECTORY);
+  mkdirSync(root, { mode: 0o700, recursive: true });
+  const key = createHash("sha256").update(`github.com:${id}`).digest("hex");
+  const lockPath = join(root, `${key}.lock`);
+  const ownerToken = randomBytes(16).toString("hex");
+  let acquired = false;
+  for (
+    let attempt = 0;
+    attempt < LIVE_REPORT_LOCK_ACQUIRE_ATTEMPTS;
+    attempt += 1
+  ) {
+    const candidatePath = prepareLiveReportLockCandidate(lockPath, ownerToken);
+    try {
+      renameSync(candidatePath, lockPath);
+      acquired = true;
+      break;
+    } catch (error) {
+      rmSync(candidatePath, { force: true, recursive: true });
+      if (!existsSync(lockPath)) {
+        if (fileSystemErrorCode(error) === "ENOENT") continue;
+        throw error;
+      }
+      const currentOwner = readLiveReportLockOwner(lockPath);
+      if (lockOwnerIsActive(currentOwner)) {
+        throw new LiveReportLockContentionError();
+      }
+      const stalePath = `${lockPath}.stale-${process.pid}-${randomBytes(16).toString("hex")}`;
+      try {
+        renameSync(lockPath, stalePath);
+      } catch (renameError) {
+        if (fileSystemErrorCode(renameError) === "ENOENT") continue;
+        throw renameError;
+      }
+      rmSync(stalePath, { force: true, recursive: true });
+    }
+  }
+  if (!acquired) {
+    throw new Error("live report lock changed too often to acquire safely");
+  }
+  let released = false;
+  return {
+    release() {
+      if (released) return;
+      const owner = readLiveReportLockOwner(lockPath);
+      if (
+        owner === null ||
+        owner.pid !== process.pid ||
+        owner.ownerToken !== ownerToken
+      ) {
+        throw new Error("live report lock ownership changed before release");
+      }
+      const releasedPath = `${lockPath}.released-${process.pid}-${ownerToken}`;
+      renameSync(lockPath, releasedPath);
+      rmSync(releasedPath, { force: true, recursive: true });
+      released = true;
     },
   };
 }
@@ -2813,51 +3015,57 @@ export function main(args = process.argv.slice(2)) {
     if (!result.publishable) process.exitCode = 2;
     return;
   }
-  let rateLimits = { preflight: true };
-  const { report } = retryChangedLiveInventory(
-    ({ commandBudget }) => {
-      const boundedRead = (endpoint) => {
-        return readGhPages(endpoint, commandBudget.run);
-      };
-      const openActivity = readGhOpenActivity(
-        options.repo,
-        commandBudget.run,
-        rateLimits,
-      );
-      rateLimits = openActivity.rateLimits;
-      const limits = asRecord(openActivity.rateLimits, "GitHub rate limits");
-      process.stderr.write(
-        `[Slop] GitHub budgets: GraphQL ${limits.graphqlRemaining}/${limits.graphqlLimit} (${limits.graphqlBudgetSource}); REST ${limits.restRemaining}/${limits.restLimit}; Search ${limits.searchRemaining}/${limits.searchLimit}; activity source ${openActivity.source}\n`,
-      );
-      return {
-        report: collectLiveReport(
+  const authenticatedIdentity = readGhAuthenticatedIdentity();
+  const liveReportLock = acquireLiveReportLock(authenticatedIdentity);
+  try {
+    let rateLimits = { preflight: true };
+    const { report } = retryChangedLiveInventory(
+      ({ commandBudget }) => {
+        const boundedRead = (endpoint) => {
+          return readGhPages(endpoint, commandBudget.run);
+        };
+        const openActivity = readGhOpenActivity(
           options.repo,
-          boundedRead,
-          new Date(),
-          ({ phase, current, total }) => {
-            if (current === 0 || current === total || current % 10 === 0) {
-              process.stderr.write(
-                `[Slop] scanning ${phase}: ${current}/${total} (${commandBudget.count} bounded GitHub commands)\n`,
-              );
-            }
-          },
-          openActivity,
-          selectionPolicy.eligibleIssueLabels,
+          commandBudget.run,
+          rateLimits,
+        );
+        rateLimits = openActivity.rateLimits;
+        const limits = asRecord(openActivity.rateLimits, "GitHub rate limits");
+        process.stderr.write(
+          `[Slop] GitHub budgets: GraphQL ${limits.graphqlRemaining}/${limits.graphqlLimit} (${limits.graphqlBudgetSource}); REST ${limits.restRemaining}/${limits.restLimit}; Search ${limits.searchRemaining}/${limits.searchLimit}; activity source ${openActivity.source}\n`,
+        );
+        return {
+          report: collectLiveReport(
+            options.repo,
+            boundedRead,
+            new Date(),
+            ({ phase, current, total }) => {
+              if (current === 0 || current === total || current % 10 === 0) {
+                process.stderr.write(
+                  `[Slop] scanning ${phase}: ${current}/${total} (${commandBudget.count} bounded GitHub commands)\n`,
+                );
+              }
+            },
+            openActivity,
+            selectionPolicy.eligibleIssueLabels,
+          ),
+        };
+      },
+      ({ attempt }) =>
+        process.stderr.write(
+          `[Slop] open-item inventory changed during snapshot attempt ${attempt}; retrying one complete read\n`,
         ),
-      };
-    },
-    ({ attempt }) =>
-      process.stderr.write(
-        `[Slop] open-item inventory changed during snapshot attempt ${attempt}; retrying one complete read\n`,
-      ),
-  );
-  process.stdout.write(
-    options.epochOnly
-      ? `${JSON.stringify(report.selection.reviewEpoch, null, 2)}\n`
-      : options.json
-        ? `${JSON.stringify(report, null, 2)}\n`
-        : renderMarkdown(report),
-  );
+    );
+    process.stdout.write(
+      options.epochOnly
+        ? `${JSON.stringify(report.selection.reviewEpoch, null, 2)}\n`
+        : options.json
+          ? `${JSON.stringify(report, null, 2)}\n`
+          : renderMarkdown(report),
+    );
+  } finally {
+    liveReportLock.release();
+  }
 }
 
 const invokedDirectly =
@@ -2872,7 +3080,12 @@ if (invokedDirectly) {
   } catch (error) {
     // error-policy:J1 The CLI boundary turns a failed read/audit into a non-zero exit.
     const message = error instanceof Error ? error.message : String(error);
-    process.stderr.write(`Slop live report failed: ${message}\n`);
-    process.exitCode = 1;
+    if (error instanceof LiveReportLockContentionError) {
+      process.stderr.write(`Slop live report deferred: ${message}\n`);
+      process.exitCode = 2;
+    } else {
+      process.stderr.write(`Slop live report failed: ${message}\n`);
+      process.exitCode = 1;
+    }
   }
 }

--- a/skills/contribute-to-heir-elements-sdk/scripts/live-report.mjs
+++ b/skills/contribute-to-heir-elements-sdk/scripts/live-report.mjs
@@ -5,20 +5,22 @@
  * adapter; GraphQL uses explicit read-only queries over GitHub's POST endpoint.
  */
 
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { createHash, randomBytes } from "node:crypto";
 import {
   existsSync,
+  lstatSync,
   mkdirSync,
   readFileSync,
+  readdirSync,
   realpathSync,
   renameSync,
   rmSync,
   statSync,
   writeFileSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { platform, userInfo } from "node:os";
+import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 export const MODEL_DISCLOSURE_PREFIX = "AI provider/model:";
@@ -61,9 +63,18 @@ export class LiveInventoryChangedError extends Error {
   }
 }
 
-const LIVE_REPORT_LOCK_DIRECTORY = "slop-live-report-locks-v1";
+const LIVE_REPORT_LOCK_DIRECTORY = "slop-live-report-locks-v2";
 const LIVE_REPORT_LOCK_OWNER_FILE = "owner.json";
+const LIVE_REPORT_LOCK_HEARTBEAT_FILE = "heartbeat.json";
+const LIVE_REPORT_LOCK_COMMAND_DIRECTORY = "commands";
 const LIVE_REPORT_LOCK_ACQUIRE_ATTEMPTS = 8;
+const LIVE_REPORT_HEARTBEAT_INTERVAL_MS = 200;
+const LIVE_REPORT_HEARTBEAT_STALE_MS = 1_000;
+const LIVE_REPORT_ORPHAN_COMMAND_GRACE_MS = 5 * 60 * 1_000;
+const LIVE_REPORT_LOCKED_GH_ARGUMENT = "--slop-internal-locked-gh-v1";
+const LIVE_REPORT_LOCK_HEARTBEAT_ARGUMENT =
+  "--slop-internal-lock-heartbeat-v1";
+const LIVE_REPORT_TOKEN_RE = /^[a-f0-9]{32}$/u;
 
 const REPOSITORY_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const PLACEHOLDER_RE =
@@ -1347,7 +1358,16 @@ export class LiveReportLockContentionError extends Error {
 export function readGhAuthenticatedIdentity(spawn = spawnSync) {
   const result = spawn(
     "gh",
-    ["api", "--method", "GET", "--jq", "{id: .id, login: .login}", "user"],
+    [
+      "api",
+      "--hostname",
+      "github.com",
+      "--method",
+      "GET",
+      "--jq",
+      "{id: .id, login: .login}",
+      "user",
+    ],
     {
       encoding: "utf8",
       maxBuffer: 1024 * 1024,
@@ -1379,7 +1399,7 @@ export function readGhAuthenticatedIdentity(spawn = spawnSync) {
   if (id <= 0 || login.length === 0) {
     throw new TypeError("GitHub authenticated identity is invalid");
   }
-  return { id, login };
+  return { host: "github.com", id, login };
 }
 
 function fileSystemErrorCode(error) {
@@ -1388,63 +1408,166 @@ function fileSystemErrorCode(error) {
     : null;
 }
 
-function readLiveReportLockOwner(lockPath) {
-  try {
-    const owner = asRecord(
-      JSON.parse(
-        readFileSync(join(lockPath, LIVE_REPORT_LOCK_OWNER_FILE), "utf8"),
-      ),
-      "live report lock owner",
-    );
-    const schemaVersion = asNumberField(
-      owner,
-      "schemaVersion",
-      "live report lock owner",
-    );
-    const pid = asNumberField(owner, "pid", "live report lock owner");
-    const ownerToken = asStringField(
-      owner,
-      "ownerToken",
-      "live report lock owner",
-    );
-    if (
-      schemaVersion !== 1 ||
-      pid <= 0 ||
-      !/^[a-f0-9]{32}$/u.test(ownerToken)
-    ) {
-      return null;
-    }
-    return { pid, ownerToken };
-  } catch {
-    // error-policy:J3 A corrupt or incomplete lease cannot claim live ownership.
-    return null;
-  }
+function heartbeatTimestampIsFresh(observedAtMs) {
+  const age = Date.now() - observedAtMs;
+  return age >= -LIVE_REPORT_HEARTBEAT_STALE_MS &&
+    age <= LIVE_REPORT_HEARTBEAT_STALE_MS;
 }
 
-function processIsRunning(pid) {
+export function defaultLiveReportLockRoot() {
+  const uid = typeof process.getuid === "function" ? process.getuid() : null;
+  if (Number.isInteger(uid) && uid >= 0) {
+    return join("/tmp", `${LIVE_REPORT_LOCK_DIRECTORY}-${uid}`);
+  }
+  const identity = userInfo();
+  const key = createHash("sha256")
+    .update(`${identity.username}\0${identity.homedir}`)
+    .digest("hex")
+    .slice(0, 16);
+  return join(identity.homedir, `.${LIVE_REPORT_LOCK_DIRECTORY}-${key}`);
+}
+
+export function ensureLiveReportLockRoot(
+  rootPath = defaultLiveReportLockRoot(),
+) {
   try {
-    process.kill(pid, 0);
-    return true;
+    mkdirSync(rootPath, { mode: 0o700 });
   } catch (error) {
-    if (fileSystemErrorCode(error) === "ESRCH") return false;
-    if (fileSystemErrorCode(error) === "EPERM") return true;
+    if (fileSystemErrorCode(error) !== "EEXIST") throw error;
+  }
+  const stats = lstatSync(rootPath);
+  if (stats.isSymbolicLink() || !stats.isDirectory()) {
+    throw new TypeError("live report lock root must be a real directory");
+  }
+  const uid = typeof process.getuid === "function" ? process.getuid() : null;
+  if (Number.isInteger(uid) && stats.uid !== uid) {
+    throw new TypeError(
+      "live report lock root must belong to the current user",
+    );
+  }
+  if (platform() !== "win32" && (stats.mode & 0o077) !== 0) {
+    throw new TypeError("live report lock root permissions must be 0700");
+  }
+  return rootPath;
+}
+
+function readLiveReportLockOwner(lockPath) {
+  let source;
+  try {
+    source = readFileSync(join(lockPath, LIVE_REPORT_LOCK_OWNER_FILE), "utf8");
+  } catch (error) {
+    if (fileSystemErrorCode(error) === "ENOENT") return null;
     throw error;
   }
+  const owner = asRecord(JSON.parse(source), "live report lock owner");
+  const schemaVersion = asNumberField(
+    owner,
+    "schemaVersion",
+    "live report lock owner",
+  );
+  const processLease = readProcessLease(owner, "live report lock owner");
+  const ownerToken = asStringField(
+    owner,
+    "ownerToken",
+    "live report lock owner",
+  );
+  if (schemaVersion !== 2 || !LIVE_REPORT_TOKEN_RE.test(ownerToken)) {
+    throw new TypeError("live report lock owner is invalid");
+  }
+  return { ...processLease, ownerToken };
 }
 
-function lockOwnerIsActive(owner) {
-  return owner !== null && processIsRunning(owner.pid);
+function liveReportCommandDirectory(lockPath) {
+  return join(lockPath, LIVE_REPORT_LOCK_COMMAND_DIRECTORY);
 }
 
-function prepareLiveReportLockCandidate(lockPath, ownerToken) {
+function readLiveReportCommandLease(path) {
+  const record = asRecord(
+    JSON.parse(readFileSync(path, "utf8")),
+    "live report command lease",
+  );
+  const schemaVersion = asNumberField(
+    record,
+    "schemaVersion",
+    "live report command lease",
+  );
+  const ownerToken = asStringField(
+    record,
+    "ownerToken",
+    "live report command lease",
+  );
+  const startedAtMs = asNumberField(
+    record,
+    "startedAtMs",
+    "live report command lease",
+  );
+  const helper = readProcessLease(record.helper, "live report command helper");
+  const child =
+    record.child === null
+      ? null
+      : readProcessLease(record.child, "live report GitHub child");
+  if (
+    schemaVersion !== 1 ||
+    !LIVE_REPORT_TOKEN_RE.test(ownerToken) ||
+    !Number.isSafeInteger(startedAtMs) ||
+    startedAtMs <= 0
+  ) {
+    throw new TypeError("live report command lease is invalid");
+  }
+  return { child, helper, ownerToken, startedAtMs };
+}
+
+function liveReportCommandIsActive(lease, ownerToken) {
+  if (lease.ownerToken !== ownerToken) {
+    throw new TypeError("live report command lease owner does not match");
+  }
+  if (processLeaseIsActive(lease.helper)) return true;
+  if (lease.child !== null && processLeaseIsActive(lease.child)) return true;
+  return Date.now() - lease.startedAtMs < LIVE_REPORT_ORPHAN_COMMAND_GRACE_MS;
+}
+
+function liveReportHasActiveCommand(lockPath, ownerToken) {
+  const commandDirectory = liveReportCommandDirectory(lockPath);
+  let entries;
+  try {
+    entries = readdirSync(commandDirectory, { withFileTypes: true });
+  } catch (error) {
+    if (fileSystemErrorCode(error) === "ENOENT" && !existsSync(lockPath)) {
+      return false;
+    }
+    throw error;
+  }
+  for (const entry of entries) {
+    if (entry.isSymbolicLink() || (!entry.isFile() && !entry.isDirectory())) {
+      throw new TypeError("live report command directory is invalid");
+    }
+    if (!/^lease-[a-f0-9]{32}\.json$/u.test(entry.name)) continue;
+    const lease = readLiveReportCommandLease(
+      join(commandDirectory, entry.name),
+    );
+    if (liveReportCommandIsActive(lease, ownerToken)) return true;
+  }
+  return false;
+}
+
+function assertLiveReportLockDirectory(lockPath) {
+  const stats = lstatSync(lockPath);
+  if (stats.isSymbolicLink() || !stats.isDirectory()) {
+    throw new TypeError("live report lock must be a real directory");
+  }
+}
+
+function prepareLiveReportLockCandidate(lockPath, ownerToken, processIdentity) {
   const candidatePath = `${lockPath}.candidate-${process.pid}-${ownerToken}`;
   mkdirSync(candidatePath, { mode: 0o700 });
   try {
+    mkdirSync(liveReportCommandDirectory(candidatePath), { mode: 0o700 });
     writeFileSync(
       join(candidatePath, LIVE_REPORT_LOCK_OWNER_FILE),
       `${JSON.stringify({
-        schemaVersion: 1,
+        schemaVersion: 2,
         pid: process.pid,
+        processIdentity,
         ownerToken,
       })}\n`,
       { flag: "wx", mode: 0o600 },
@@ -1456,25 +1579,113 @@ function prepareLiveReportLockCandidate(lockPath, ownerToken) {
   }
 }
 
-export function acquireLiveReportLock(identity) {
+function liveReportLockKey(identity) {
+  return createHash("sha256")
+    .update(`${identity.host}:${identity.id}`)
+    .digest("hex");
+}
+
+function writeLiveReportCommandLease(path, lease, replace = false) {
+  if (!replace) {
+    writeFileSync(path, `${JSON.stringify(lease)}\n`, {
+      flag: "wx",
+      mode: 0o600,
+    });
+    return;
+  }
+  const nextPath = `${path}.next-${process.pid}-${randomBytes(16).toString("hex")}`;
+  try {
+    writeFileSync(nextPath, `${JSON.stringify(lease)}\n`, {
+      flag: "wx",
+      mode: 0o600,
+    });
+    renameSync(nextPath, path);
+  } catch (error) {
+    rmSync(nextPath, { force: true });
+    throw error;
+  }
+}
+
+function spawnLockedGh(lockPath, ownerToken, command, args, options = {}) {
+  if (
+    command !== "gh" ||
+    !Array.isArray(args) ||
+    args.some((argument) => typeof argument !== "string")
+  ) {
+    throw new TypeError("live report lock may execute only a gh argument list");
+  }
+  if (options.encoding !== undefined && options.encoding !== "utf8") {
+    throw new TypeError("live report gh commands require utf8 output");
+  }
+  const maxBuffer = options.maxBuffer ?? 1024 * 1024;
+  if (
+    !Number.isSafeInteger(maxBuffer) ||
+    maxBuffer <= 0 ||
+    maxBuffer > 256 * 1024 * 1024
+  ) {
+    throw new RangeError("live report gh command maxBuffer is invalid");
+  }
+  const commandToken = randomBytes(16).toString("hex");
+  const requestPath = join(
+    liveReportCommandDirectory(lockPath),
+    `request-${commandToken}.json`,
+  );
+  writeFileSync(
+    requestPath,
+    `${JSON.stringify({ args, maxBuffer, ownerToken, schemaVersion: 1 })}\n`,
+    { flag: "wx", mode: 0o600 },
+  );
+  try {
+    return spawnSync(
+      process.execPath,
+      [
+        fileURLToPath(import.meta.url),
+        LIVE_REPORT_LOCKED_GH_ARGUMENT,
+        lockPath,
+        ownerToken,
+        commandToken,
+      ],
+      {
+        encoding: "utf8",
+        env: { ...(options.env ?? process.env), GH_HOST: "github.com" },
+        maxBuffer: Math.min(maxBuffer + 1024 * 1024, 256 * 1024 * 1024),
+        windowsHide: true,
+      },
+    );
+  } finally {
+    rmSync(requestPath, { force: true });
+  }
+}
+
+export function acquireLiveReportLock(identity, options = {}) {
   const record = asRecord(identity, "GitHub authenticated identity");
   const id = asNumberField(record, "id", "GitHub authenticated identity");
   const login = asStringField(record, "login", "GitHub authenticated identity");
-  if (id <= 0 || login.length === 0) {
+  const host = asStringField(record, "host", "GitHub authenticated identity");
+  if (id <= 0 || login.length === 0 || host !== "github.com") {
     throw new TypeError("GitHub authenticated identity is invalid");
   }
-  const root = join(tmpdir(), LIVE_REPORT_LOCK_DIRECTORY);
-  mkdirSync(root, { mode: 0o700, recursive: true });
-  const key = createHash("sha256").update(`github.com:${id}`).digest("hex");
+  const root = ensureLiveReportLockRoot(
+    options.rootPath ?? defaultLiveReportLockRoot(),
+  );
+  const key = liveReportLockKey({ host, id });
   const lockPath = join(root, `${key}.lock`);
   const ownerToken = randomBytes(16).toString("hex");
+  const processIdentity = readLiveReportProcessIdentity(process.pid);
+  if (processIdentity === null) {
+    throw new Error("could not establish the live report process identity");
+  }
   let acquired = false;
   for (
     let attempt = 0;
     attempt < LIVE_REPORT_LOCK_ACQUIRE_ATTEMPTS;
     attempt += 1
   ) {
-    const candidatePath = prepareLiveReportLockCandidate(lockPath, ownerToken);
+    const candidatePath = prepareLiveReportLockCandidate(
+      lockPath,
+      ownerToken,
+      processIdentity,
+    );
     try {
       renameSync(candidatePath, lockPath);
       acquired = true;
@@ -1485,8 +1696,16 @@ export function acquireLiveReportLock(identity) {
         if (fileSystemErrorCode(error) === "ENOENT") continue;
         throw error;
       }
+      assertLiveReportLockDirectory(lockPath);
       const currentOwner = readLiveReportLockOwner(lockPath);
-      if (lockOwnerIsActive(currentOwner)) {
+      if (currentOwner === null) {
+        if (!existsSync(lockPath)) continue;
+        throw new Error("live report lock owner is missing");
+      }
+      if (
+        processLeaseIsActive(currentOwner) ||
+        liveReportHasActiveCommand(lockPath, currentOwner.ownerToken)
+      ) {
         throw new LiveReportLockContentionError();
       }
       const stalePath = `${lockPath}.stale-${process.pid}-${randomBytes(16).toString("hex")}`;
@@ -1504,12 +1723,16 @@ export function acquireLiveReportLock(identity) {
   }
   let released = false;
   return {
+    spawn(command, args, options) {
+      return spawnLockedGh(lockPath, ownerToken, command, args, options);
+    },
     release() {
       if (released) return;
       const owner = readLiveReportLockOwner(lockPath);
       if (
         owner === null ||
         owner.pid !== process.pid ||
+        owner.processIdentity !== processIdentity ||
         owner.ownerToken !== ownerToken
       ) {
         throw new Error("live report lock ownership changed before release");
@@ -1520,6 +1743,173 @@ export function acquireLiveReportLock(identity) {
       released = true;
     },
   };
+}
+
+function readLockedGhRequest(lockPath, ownerToken, commandToken) {
+  if (
+    !LIVE_REPORT_TOKEN_RE.test(ownerToken) ||
+    !LIVE_REPORT_TOKEN_RE.test(commandToken)
+  ) {
+    throw new TypeError("locked GitHub command tokens are invalid");
+  }
+  const root = ensureLiveReportLockRoot();
+  if (
+    dirname(lockPath) !== root ||
+    !/^[a-f0-9]{64}\.lock$/u.test(basename(lockPath))
+  ) {
+    throw new TypeError("locked GitHub command path is invalid");
+  }
+  assertLiveReportLockDirectory(lockPath);
+  const owner = readLiveReportLockOwner(lockPath);
+  if (owner === null || owner.ownerToken !== ownerToken) {
+    throw new Error("live report lock ownership changed before GitHub command");
+  }
+  const requestPath = join(
+    liveReportCommandDirectory(lockPath),
+    `request-${commandToken}.json`,
+  );
+  const request = asRecord(
+    JSON.parse(readFileSync(requestPath, "utf8")),
+    "locked GitHub command request",
+  );
+  const schemaVersion = asNumberField(
+    request,
+    "schemaVersion",
+    "locked GitHub command request",
+  );
+  const requestOwnerToken = asStringField(
+    request,
+    "ownerToken",
+    "locked GitHub command request",
+  );
+  const maxBuffer = asNumberField(
+    request,
+    "maxBuffer",
+    "locked GitHub command request",
+  );
+  if (
+    schemaVersion !== 1 ||
+    requestOwnerToken !== ownerToken ||
+    !Number.isSafeInteger(maxBuffer) ||
+    maxBuffer <= 0 ||
+    maxBuffer > 256 * 1024 * 1024 ||
+    !Array.isArray(request.args) ||
+    request.args.some((argument) => typeof argument !== "string")
+  ) {
+    throw new TypeError("locked GitHub command request is invalid");
+  }
+  return { args: request.args, maxBuffer, requestPath };
+}
+
+function collectBoundedGhChild(child, maxBuffer) {
+  return new Promise((resolvePromise) => {
+    const stdout = [];
+    const stderr = [];
+    let stdoutBytes = 0;
+    let stderrBytes = 0;
+    let overflow = null;
+    let spawnError = null;
+    const collect = (chunks, chunk, stream) => {
+      if (overflow !== null) return;
+      const value = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      if (stream === "stdout") stdoutBytes += value.length;
+      else stderrBytes += value.length;
+      if (stdoutBytes > maxBuffer || stderrBytes > maxBuffer) {
+        overflow = stream;
+        child.kill("SIGTERM");
+        return;
+      }
+      chunks.push(value);
+    };
+    child.stdout.on("data", (chunk) => collect(stdout, chunk, "stdout"));
+    child.stderr.on("data", (chunk) => collect(stderr, chunk, "stderr"));
+    child.once("error", (error) => {
+      spawnError = error;
+    });
+    child.once("close", (status, signal) => {
+      resolvePromise({
+        error: spawnError,
+        overflow,
+        signal,
+        status,
+        stderr: Buffer.concat(stderr),
+        stdout: Buffer.concat(stdout),
+      });
+    });
+  });
+}
+
+function writeProcessDescriptor(descriptor, value) {
+  if (value.length === 0) return;
+  try {
+    writeFileSync(descriptor, value);
+  } catch (error) {
+    if (fileSystemErrorCode(error) !== "EPIPE") throw error;
+  }
+}
+
+async function runLockedGhCommand(lockPath, ownerToken, commandToken) {
+  const request = readLockedGhRequest(lockPath, ownerToken, commandToken);
+  const leasePath = join(
+    liveReportCommandDirectory(lockPath),
+    `lease-${commandToken}.json`,
+  );
+  const helperIdentity = readLiveReportProcessIdentity(process.pid);
+  if (helperIdentity === null) {
+    throw new Error("could not establish the GitHub command helper identity");
+  }
+  const lease = {
+    schemaVersion: 1,
+    ownerToken,
+    startedAtMs: Date.now(),
+    helper: { pid: process.pid, processIdentity: helperIdentity },
+    child: null,
+  };
+  writeLiveReportCommandLease(leasePath, lease);
+  let result;
+  try {
+    const currentOwner = readLiveReportLockOwner(lockPath);
+    if (currentOwner === null || currentOwner.ownerToken !== ownerToken) {
+      throw new Error(
+        "live report lock ownership changed while starting GitHub command",
+      );
+    }
+    const child = spawn("gh", request.args, {
+      env: { ...process.env, GH_HOST: "github.com" },
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+    });
+    const childResult = collectBoundedGhChild(child, request.maxBuffer);
+    if (Number.isInteger(child.pid) && child.pid > 0) {
+      const childIdentity = readLiveReportProcessIdentity(child.pid);
+      if (childIdentity !== null) {
+        writeLiveReportCommandLease(
+          leasePath,
+          {
+            ...lease,
+            child: { pid: child.pid, processIdentity: childIdentity },
+          },
+          true,
+        );
+      }
+    }
+    result = await childResult;
+  } finally {
+    rmSync(leasePath, { force: true });
+    rmSync(request.requestPath, { force: true });
+  }
+  if (result.error) throw result.error;
+  if (result.overflow !== null) {
+    throw new RangeError(
+      `spawn gh ${result.overflow} exceeded the bounded output buffer`,
+    );
+  }
+  writeProcessDescriptor(1, result.stdout);
+  writeProcessDescriptor(2, result.stderr);
+  if (result.status === null) {
+    throw new Error(`gh terminated by ${result.signal ?? "an unknown signal"}`);
+  }
+  process.exitCode = result.status;
 }
 
 function rateResource(value, context) {
@@ -3055,6 +3445,7 @@ export function main(args = process.argv.slice(2)) {
         process.stderr.write(
           `[Slop] open-item inventory changed during snapshot attempt ${attempt}; retrying one complete read\n`,
         ),
+      () => createGhCommandBudget(liveReportLock.spawn),
     );
     process.stdout.write(
       options.epochOnly
@@ -3075,17 +3466,27 @@ const invokedDirectly =
     realpathSync(process.argv[1]);
 
 if (invokedDirectly) {
-  try {
-    main();
-  } catch (error) {
-    // error-policy:J1 The CLI boundary turns a failed read/audit into a non-zero exit.
-    const message = error instanceof Error ? error.message : String(error);
-    if (error instanceof LiveReportLockContentionError) {
-      process.stderr.write(`Slop live report deferred: ${message}\n`);
-      process.exitCode = 2;
-    } else {
-      process.stderr.write(`Slop live report failed: ${message}\n`);
+  const directArguments = process.argv.slice(2);
+  if (directArguments[0] === LIVE_REPORT_LOCKED_GH_ARGUMENT) {
+    runLockedGhCommand(...directArguments.slice(1)).catch((error) => {
+      // error-policy:J1 The internal process boundary fails the owning report.
+      const message = error instanceof Error ? error.message : String(error);
+      process.stderr.write(`Slop locked GitHub command failed: ${message}\n`);
       process.exitCode = 1;
+    });
+  } else {
+    try {
+      main(directArguments);
+    } catch (error) {
+      // error-policy:J1 The CLI boundary turns a failed read/audit into a non-zero exit.
+      const message = error instanceof Error ? error.message : String(error);
+      if (error instanceof LiveReportLockContentionError) {
+        process.stderr.write(`Slop live report deferred: ${message}\n`);
+        process.exitCode = 2;
+      } else {
+        process.stderr.write(`Slop live report failed: ${message}\n`);
+        process.exitCode = 1;
+      }
     }
   }
 }

--- a/skills/contribute-to-heir-elements-sdk/scripts/live-report.mjs
+++ b/skills/contribute-to-heir-elements-sdk/scripts/live-report.mjs
@@ -3,6 +3,7 @@
  * Builds a stable, read-only inventory of open elizaOS issues and pull requests
  * for contribution selection. REST pagination stays behind one GET-only
  * adapter; GraphQL uses explicit read-only queries over GitHub's POST endpoint.
+ * A user-private process lease serializes complete discovery across skill copies.
  */
 
 import { spawn, spawnSync } from "node:child_process";
@@ -11,8 +12,8 @@ import {
   existsSync,
   lstatSync,
   mkdirSync,
-  readFileSync,
   readdirSync,
+  readFileSync,
   realpathSync,
   renameSync,
   rmSync,
@@ -65,15 +66,11 @@ export class LiveInventoryChangedError extends Error {
 
 const LIVE_REPORT_LOCK_DIRECTORY = "slop-live-report-locks-v2";
 const LIVE_REPORT_LOCK_OWNER_FILE = "owner.json";
-const LIVE_REPORT_LOCK_HEARTBEAT_FILE = "heartbeat.json";
 const LIVE_REPORT_LOCK_COMMAND_DIRECTORY = "commands";
 const LIVE_REPORT_LOCK_ACQUIRE_ATTEMPTS = 8;
-const LIVE_REPORT_HEARTBEAT_INTERVAL_MS = 200;
-const LIVE_REPORT_HEARTBEAT_STALE_MS = 1_000;
 const LIVE_REPORT_ORPHAN_COMMAND_GRACE_MS = 5 * 60 * 1_000;
 const LIVE_REPORT_LOCKED_GH_ARGUMENT = "--slop-internal-locked-gh-v1";
-const LIVE_REPORT_LOCK_HEARTBEAT_ARGUMENT =
-  "--slop-internal-lock-heartbeat-v1";
+const LIVE_REPORT_PROCESS_IDENTITY_RE = /^[a-f0-9]{64}$/u;
 const LIVE_REPORT_TOKEN_RE = /^[a-f0-9]{32}$/u;
 
 const REPOSITORY_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
@@ -1408,10 +1405,121 @@ function fileSystemErrorCode(error) {
     : null;
 }
 
-function heartbeatTimestampIsFresh(observedAtMs) {
-  const age = Date.now() - observedAtMs;
-  return age >= -LIVE_REPORT_HEARTBEAT_STALE_MS &&
-    age <= LIVE_REPORT_HEARTBEAT_STALE_MS;
+function assertLiveReportPrivatePath(path, context, kind) {
+  const stats = lstatSync(path);
+  const kindMatches =
+    kind === "directory" ? stats.isDirectory() : stats.isFile();
+  if (stats.isSymbolicLink() || !kindMatches) {
+    throw new TypeError(`${context} must be a real ${kind}`);
+  }
+  const uid = typeof process.getuid === "function" ? process.getuid() : null;
+  if (Number.isInteger(uid) && stats.uid !== uid) {
+    throw new TypeError(`${context} must belong to the current user`);
+  }
+  if (platform() !== "win32" && (stats.mode & 0o077) !== 0) {
+    throw new TypeError(`${context} permissions must exclude group and others`);
+  }
+  return stats;
+}
+
+function processIsRunning(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (fileSystemErrorCode(error) === "ESRCH") return false;
+    if (fileSystemErrorCode(error) === "EPERM") return true;
+    throw error;
+  }
+}
+
+function hashProcessIdentity(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+export function readLiveReportProcessIdentity(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    throw new TypeError("live report process ID must be a positive integer");
+  }
+  if (!processIsRunning(pid)) return null;
+  const operatingSystem = platform();
+  if (operatingSystem === "linux") {
+    let source;
+    try {
+      source = readFileSync(`/proc/${pid}/stat`, "utf8");
+    } catch (error) {
+      if (fileSystemErrorCode(error) === "ENOENT") return null;
+      throw error;
+    }
+    const commandEnd = source.lastIndexOf(")");
+    const fields = source
+      .slice(commandEnd + 2)
+      .trim()
+      .split(/\s+/u);
+    const startTime = fields[19];
+    if (commandEnd < 1 || !/^\d+$/u.test(startTime ?? "")) {
+      throw new TypeError("Linux returned an invalid process birth identity");
+    }
+    return hashProcessIdentity(`linux:${startTime}`);
+  }
+  if (
+    operatingSystem === "darwin" ||
+    operatingSystem === "freebsd" ||
+    operatingSystem === "openbsd"
+  ) {
+    const result = spawnSync(
+      existsSync("/bin/ps") ? "/bin/ps" : "ps",
+      ["-o", "lstart=", "-p", String(pid)],
+      { encoding: "utf8", maxBuffer: 64 * 1024, windowsHide: true },
+    );
+    if (result.error) throw result.error;
+    if (result.status !== 0 || result.stdout.trim() === "") {
+      if (!processIsRunning(pid)) return null;
+      throw new Error("could not read the process birth identity from ps");
+    }
+    return hashProcessIdentity(`${operatingSystem}:${result.stdout.trim()}`);
+  }
+  if (operatingSystem === "win32") {
+    const result = spawnSync(
+      "powershell.exe",
+      [
+        "-NoLogo",
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        `(Get-Process -Id ${pid} -ErrorAction Stop).StartTime.ToUniversalTime().Ticks`,
+      ],
+      { encoding: "utf8", maxBuffer: 64 * 1024, windowsHide: true },
+    );
+    if (result.error) throw result.error;
+    if (result.status !== 0 || !/^\d+$/u.test(result.stdout.trim())) {
+      if (!processIsRunning(pid)) return null;
+      throw new Error("could not read the Windows process birth identity");
+    }
+    return hashProcessIdentity(`win32:${result.stdout.trim()}`);
+  }
+  throw new Error(
+    `live report locking does not support process identity on ${operatingSystem}`,
+  );
+}
+
+function readProcessLease(value, context) {
+  const record = asRecord(value, context);
+  const pid = asNumberField(record, "pid", context);
+  const processIdentity = asStringField(record, "processIdentity", context);
+  if (
+    !Number.isInteger(pid) ||
+    pid <= 0 ||
+    !LIVE_REPORT_PROCESS_IDENTITY_RE.test(processIdentity)
+  ) {
+    throw new TypeError(`${context} is invalid`);
+  }
+  return { pid, processIdentity };
+}
+
+function processLeaseIsActive(lease) {
+  const currentIdentity = readLiveReportProcessIdentity(lease.pid);
+  return currentIdentity !== null && currentIdentity === lease.processIdentity;
 }
 
 export function defaultLiveReportLockRoot() {
@@ -1435,25 +1543,18 @@ export function ensureLiveReportLockRoot(
   } catch (error) {
     if (fileSystemErrorCode(error) !== "EEXIST") throw error;
   }
-  const stats = lstatSync(rootPath);
-  if (stats.isSymbolicLink() || !stats.isDirectory()) {
-    throw new TypeError("live report lock root must be a real directory");
-  }
-  const uid = typeof process.getuid === "function" ? process.getuid() : null;
-  if (Number.isInteger(uid) && stats.uid !== uid) {
-    throw new TypeError(
-      "live report lock root must belong to the current user",
-    );
-  }
-  if (platform() !== "win32" && (stats.mode & 0o077) !== 0) {
-    throw new TypeError("live report lock root permissions must be 0700");
-  }
+  assertLiveReportPrivatePath(rootPath, "live report lock root", "directory");
   return rootPath;
 }
 
 function readLiveReportLockOwner(lockPath) {
   let source;
   try {
+    assertLiveReportPrivatePath(
+      join(lockPath, LIVE_REPORT_LOCK_OWNER_FILE),
+      "live report lock owner",
+      "file",
+    );
     source = readFileSync(join(lockPath, LIVE_REPORT_LOCK_OWNER_FILE), "utf8");
   } catch (error) {
     if (fileSystemErrorCode(error) === "ENOENT") return null;
@@ -1482,6 +1583,7 @@ function liveReportCommandDirectory(lockPath) {
 }
 
 function readLiveReportCommandLease(path) {
+  assertLiveReportPrivatePath(path, "live report command lease", "file");
   const record = asRecord(
     JSON.parse(readFileSync(path, "utf8")),
     "live report command lease",
@@ -1530,6 +1632,11 @@ function liveReportHasActiveCommand(lockPath, ownerToken) {
   const commandDirectory = liveReportCommandDirectory(lockPath);
   let entries;
   try {
+    assertLiveReportPrivatePath(
+      commandDirectory,
+      "live report command directory",
+      "directory",
+    );
     entries = readdirSync(commandDirectory, { withFileTypes: true });
   } catch (error) {
     if (fileSystemErrorCode(error) === "ENOENT" && !existsSync(lockPath)) {
@@ -1538,7 +1645,7 @@ function liveReportHasActiveCommand(lockPath, ownerToken) {
     throw error;
   }
   for (const entry of entries) {
-    if (entry.isSymbolicLink() || (!entry.isFile() && !entry.isDirectory())) {
+    if (!entry.isFile()) {
       throw new TypeError("live report command directory is invalid");
     }
     if (!/^lease-[a-f0-9]{32}\.json$/u.test(entry.name)) continue;
@@ -1551,10 +1658,7 @@ function liveReportHasActiveCommand(lockPath, ownerToken) {
 }
 
 function assertLiveReportLockDirectory(lockPath) {
-  const stats = lstatSync(lockPath);
-  if (stats.isSymbolicLink() || !stats.isDirectory()) {
-    throw new TypeError("live report lock must be a real directory");
-  }
+  assertLiveReportPrivatePath(lockPath, "live report lock", "directory");
 }
 
 function prepareLiveReportLockCandidate(lockPath, ownerToken, processIdentity) {
@@ -1626,6 +1730,11 @@ function spawnLockedGh(lockPath, ownerToken, command, args, options = {}) {
     throw new RangeError("live report gh command maxBuffer is invalid");
   }
   const commandToken = randomBytes(16).toString("hex");
+  assertLiveReportPrivatePath(
+    liveReportCommandDirectory(lockPath),
+    "live report command directory",
+    "directory",
+  );
   const requestPath = join(
     liveReportCommandDirectory(lockPath),
     `request-${commandToken}.json`,
@@ -1752,7 +1861,7 @@ function readLockedGhRequest(lockPath, ownerToken, commandToken) {
   ) {
     throw new TypeError("locked GitHub command tokens are invalid");
   }
-  const root = ensureLiveReportLockRoot();
+  const root = ensureLiveReportLockRoot(dirname(lockPath));
   if (
     dirname(lockPath) !== root ||
     !/^[a-f0-9]{64}\.lock$/u.test(basename(lockPath))
@@ -1767,6 +1876,11 @@ function readLockedGhRequest(lockPath, ownerToken, commandToken) {
   const requestPath = join(
     liveReportCommandDirectory(lockPath),
     `request-${commandToken}.json`,
+  );
+  assertLiveReportPrivatePath(
+    requestPath,
+    "locked GitHub command request",
+    "file",
   );
   const request = asRecord(
     JSON.parse(readFileSync(requestPath, "utf8")),

--- a/skills/contribute-to-heir-elements-sdk/scripts/live-report.mjs
+++ b/skills/contribute-to-heir-elements-sdk/scripts/live-report.mjs
@@ -1625,7 +1625,12 @@ function liveReportCommandIsActive(lease, ownerToken) {
   }
   if (processLeaseIsActive(lease.helper)) return true;
   if (lease.child !== null && processLeaseIsActive(lease.child)) return true;
-  return Date.now() - lease.startedAtMs < LIVE_REPORT_ORPHAN_COMMAND_GRACE_MS;
+  // Only an unpublished child needs a grace period. A recorded birth identity
+  // proves a known child is gone, so recovery need not wait for that period.
+  return (
+    lease.child === null &&
+    Date.now() - lease.startedAtMs < LIVE_REPORT_ORPHAN_COMMAND_GRACE_MS
+  );
 }
 
 function liveReportHasActiveCommand(lockPath, ownerToken) {
@@ -1852,6 +1857,10 @@ export function acquireLiveReportLock(identity, options = {}) {
         ) {
           throw new Error("live report lock ownership changed before release");
         }
+        // An interrupted helper can return before its GitHub child exits. Keep
+        // the owner and command leases so a replacement scan still sees it;
+        // normal stale-owner recovery can reclaim the lock after the child exits.
+        if (liveReportHasActiveCommand(lockPath, ownerToken)) return;
         const releasedPath = `${lockPath}.released-${process.pid}-${ownerToken}`;
         renameSync(lockPath, releasedPath);
         rmSync(releasedPath, { force: true, recursive: true });


### PR DESCRIPTION
Closes #329. Supersedes #359 and the scan-lock portion of #372.

This integrates the reviewed large-queue retry behavior with a per-GitHub-identity process lock, secure lock roots, stale-owner recovery, fresh command budgets per changed-inventory retry, and helper/child leases that cannot be released while a surviving GitHub child is still active. The four contributor implementations remain byte-identical.

The process-heavy skill fixtures now run serially; their parallel Bun execution could kill another fixture's child and produce a false repository-origin failure.

Exact-head validation at 92eb51cdeeaedd2966b1eb9801665023055e33dc:
- `bun run verify` — passed (756 Vitest tests, 124 skill tests, production build)
- focused contributor-skill suite — passed (61 tests)
- deterministic helper SIGKILL/reacquisition regression — passed
- diff check and canonical four-file equality — passed

Browser evidence: N/A — no UI behavior changed.