### PR TITLE
fix: integrate identity, wallet, and trace persistence safeguards

### DIFF
--- a/backend/trace/cloudflare-persistence.ts
+++ b/backend/trace/cloudflare-persistence.ts
@@ -735,6 +735,7 @@ export class CloudflareTracePersistence implements TracePersistence {
 
   async createWalletClaim(
     claim: WalletClaim,
+    audit: AuditInput,
   ): Promise<PersistenceResult<WalletClaim>> {
     const byDigest = await this.db
       .prepare("SELECT * FROM wallet_claims WHERE record_sha256 = ?")
@@ -748,32 +749,72 @@ export class CloudflareTracePersistence implements TracePersistence {
         return { status: "conflict" };
       }
     }
-    try {
-      await this.db
-        .prepare(
-          `INSERT INTO wallet_claims (
+    const claimInsert = this.db
+      .prepare(
+        `INSERT INTO wallet_claims (
             id, github_user_id, github_login, wallet_address, source,
             issue_repository, issue_number, source_body_sha256, observed_at,
             record_sha256, supersedes_claim_id, created_at
           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(
+        claim.id,
+        claim.githubId,
+        claim.githubLogin,
+        claim.walletAddress,
+        claim.source,
+        claim.issueRepository,
+        claim.issueNumber,
+        claim.sourceBodySha256,
+        claim.observedAt,
+        claim.recordSha256,
+        claim.supersedesClaimId,
+        claim.createdAt,
+      );
+    const auditInsert = this.db
+      .prepare(
+        `INSERT INTO private_audit_events (
+          id, actor_github_id, action, target, request_id, created_at, details_json
+        ) SELECT ?, ?, ?, ?, ?, ?, ?
+          WHERE EXISTS (SELECT 1 FROM wallet_claims WHERE id = ?)`,
+      )
+      .bind(
+        audit.id,
+        audit.actorGithubId,
+        audit.action,
+        audit.target,
+        audit.requestId,
+        audit.createdAt,
+        JSON.stringify(audit.details),
+        claim.id,
+      );
+    try {
+      const results = await this.db.batch([claimInsert, auditInsert]);
+      if (
+        results.length !== 2 ||
+        results.some((result) => !result.success) ||
+        results.some((result) => (result.meta?.changes ?? 0) !== 1)
+      ) {
+        throw new Error("Atomic wallet claim and audit did not both commit");
+      }
+    } catch (error) {
+      const raced = await this.db
+        .prepare("SELECT * FROM wallet_claims WHERE record_sha256 = ?")
+        .bind(claim.recordSha256)
+        .first<WalletClaimRow>();
+      if (raced !== null)
+        return { status: "existing", value: mapWalletClaim(raced) };
+      const competing = await this.db
+        .prepare(
+          claim.supersedesClaimId === null
+            ? `SELECT id FROM wallet_claims
+               WHERE github_user_id = ? AND supersedes_claim_id IS NULL`
+            : "SELECT id FROM wallet_claims WHERE supersedes_claim_id = ?",
         )
-        .bind(
-          claim.id,
-          claim.githubId,
-          claim.githubLogin,
-          claim.walletAddress,
-          claim.source,
-          claim.issueRepository,
-          claim.issueNumber,
-          claim.sourceBodySha256,
-          claim.observedAt,
-          claim.recordSha256,
-          claim.supersedesClaimId,
-          claim.createdAt,
-        )
-        .run();
-    } catch {
-      return { status: "conflict" };
+        .bind(claim.supersedesClaimId ?? claim.githubId)
+        .first<{ id: string }>();
+      if (competing !== null) return { status: "conflict" };
+      throw error;
     }
     return { status: "created", value: claim };
   }

--- a/backend/trace/cloudflare-persistence.ts
+++ b/backend/trace/cloudflare-persistence.ts
@@ -634,8 +634,11 @@ export class CloudflareTracePersistence implements TracePersistence {
     }
   }
 
-  async createReadGrant(input: CreateGrantInput): Promise<void> {
-    await this.db
+  async createReadGrant(
+    input: CreateGrantInput,
+    audit: AuditInput,
+  ): Promise<void> {
+    const grantInsert = this.db
       .prepare(
         `INSERT INTO trace_read_grants (
           token_hash, trace_sha256, operator_github_id, reason, request_id,
@@ -650,8 +653,30 @@ export class CloudflareTracePersistence implements TracePersistence {
         input.requestId,
         input.createdAt,
         input.expiresAt,
+      );
+    const auditInsert = this.db
+      .prepare(
+        `INSERT INTO private_audit_events (
+          id, actor_github_id, action, target, request_id, created_at, details_json
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
       )
-      .run();
+      .bind(
+        audit.id,
+        audit.actorGithubId,
+        audit.action,
+        audit.target,
+        audit.requestId,
+        audit.createdAt,
+        JSON.stringify(audit.details),
+      );
+    const results = await this.db.batch([grantInsert, auditInsert]);
+    if (
+      results.length !== 2 ||
+      results.some((result) => !result.success) ||
+      results.some((result) => (result.meta?.changes ?? 0) !== 1)
+    ) {
+      throw new Error("Atomic trace read grant creation failed");
+    }
   }
 
   async consumeReadGrant(
@@ -659,16 +684,50 @@ export class CloudflareTracePersistence implements TracePersistence {
     traceSha256: string,
     operatorGithubId: string,
     now: string,
+    audit: AuditInput,
   ): Promise<boolean> {
-    const result = await this.db
+    const auditInsert = this.db
+      .prepare(
+        `INSERT INTO private_audit_events (
+          id, actor_github_id, action, target, request_id, created_at, details_json
+        ) SELECT ?, ?, ?, ?, ?, ?, ?
+          WHERE EXISTS (
+            SELECT 1 FROM trace_read_grants
+            WHERE token_hash = ? AND trace_sha256 = ? AND operator_github_id = ?
+              AND consumed_at IS NULL AND expires_at > ?
+          )`,
+      )
+      .bind(
+        audit.id,
+        audit.actorGithubId,
+        audit.action,
+        audit.target,
+        audit.requestId,
+        audit.createdAt,
+        JSON.stringify(audit.details),
+        tokenHash,
+        traceSha256,
+        operatorGithubId,
+        now,
+      );
+    const grantConsume = this.db
       .prepare(
         `UPDATE trace_read_grants SET consumed_at = ?
          WHERE token_hash = ? AND trace_sha256 = ? AND operator_github_id = ?
            AND consumed_at IS NULL AND expires_at > ?`,
       )
-      .bind(now, tokenHash, traceSha256, operatorGithubId, now)
-      .run();
-    return (result.meta?.changes ?? 0) === 1;
+      .bind(now, tokenHash, traceSha256, operatorGithubId, now);
+    const results = await this.db.batch([auditInsert, grantConsume]);
+    if (results.length !== 2 || results.some((result) => !result.success)) {
+      throw new Error("Atomic trace read grant consumption failed");
+    }
+    const auditChanges = results[0].meta?.changes ?? 0;
+    const grantChanges = results[1].meta?.changes ?? 0;
+    if (auditChanges === 0 && grantChanges === 0) return false;
+    if (auditChanges !== 1 || grantChanges !== 1) {
+      throw new Error("Trace read grant and audit state diverged");
+    }
+    return true;
   }
 
   async readTraceBytes(object: TraceObject): Promise<Uint8Array | null> {

--- a/backend/trace/cloudflare-persistence.ts
+++ b/backend/trace/cloudflare-persistence.ts
@@ -499,12 +499,14 @@ export class CloudflareTracePersistence implements TracePersistence {
         : { status: "conflict" };
     }
     try {
-      await this.db
+      const inserted = await this.db
         .prepare(
           `INSERT INTO run_progress_events (
             id, run_id, github_user_id, kind, occurred_at, source,
             github_object_id, github_url, head_sha, created_at, idempotency_key
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          ) SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+            FROM trace_runs
+           WHERE id = ? AND github_user_id = ? AND state != 'finalized'`,
         )
         .bind(
           event.id,
@@ -518,8 +520,13 @@ export class CloudflareTracePersistence implements TracePersistence {
           event.headSha,
           event.createdAt,
           event.idempotencyKey,
+          event.runId,
+          event.githubId,
         )
         .run();
+      if ((inserted.meta?.changes ?? 0) !== 1) {
+        return { status: "conflict" };
+      }
     } catch {
       return { status: "conflict" };
     }

--- a/backend/trace/cloudflare-persistence.ts
+++ b/backend/trace/cloudflare-persistence.ts
@@ -552,8 +552,9 @@ export class CloudflareTracePersistence implements TracePersistence {
         ? { status: "existing", value: mapped }
         : { status: "conflict" };
     }
+    let inserted: D1Result;
     try {
-      await this.db
+      inserted = await this.db
         .prepare(
           `INSERT INTO trace_upload_intents (
             token_hash, run_id, github_user_id, trace_sha256, size_bytes,
@@ -574,6 +575,9 @@ export class CloudflareTracePersistence implements TracePersistence {
         .run();
     } catch {
       return { status: "conflict" };
+    }
+    if (!inserted.success || (inserted.meta?.changes ?? 0) !== 1) {
+      throw new Error("Trace upload intent insertion failed");
     }
     return { status: "created", value: intent };
   }

--- a/backend/trace/contracts.ts
+++ b/backend/trace/contracts.ts
@@ -165,12 +165,13 @@ export interface TracePersistence {
     now: string,
   ): Promise<TraceUploadIntent | null>;
   putTraceBytes(object: TraceObject, bytes: Uint8Array): Promise<void>;
-  createReadGrant(input: CreateGrantInput): Promise<void>;
+  createReadGrant(input: CreateGrantInput, audit: AuditInput): Promise<void>;
   consumeReadGrant(
     tokenHash: string,
     traceSha256: string,
     operatorGithubId: string,
     now: string,
+    audit: AuditInput,
   ): Promise<boolean>;
   readTraceBytes(
     object: TraceObject,

--- a/backend/trace/contracts.ts
+++ b/backend/trace/contracts.ts
@@ -176,8 +176,10 @@ export interface TracePersistence {
     object: TraceObject,
   ): Promise<ReadableStream<Uint8Array> | Uint8Array | null>;
   writeAudit(input: AuditInput): Promise<void>;
+  /** Atomically commits a wallet claim and its required audit event. */
   createWalletClaim(
     claim: WalletClaim,
+    audit: AuditInput,
   ): Promise<PersistenceResult<WalletClaim>>;
   getWalletClaim(claimId: string): Promise<WalletClaim | null>;
   getCurrentWalletClaim(githubId: string): Promise<WalletClaim | null>;

--- a/backend/trace/handler.ts
+++ b/backend/trace/handler.ts
@@ -2,6 +2,7 @@ import { isSolanaAddress } from "../../src/lib/wallets";
 import { signApiToken, verifyApiToken } from "./auth";
 import {
   type ApiRole,
+  type AuditInput,
   type AuthenticatedActor,
   MAX_TRACE_BYTES,
   OPERATOR_GRANT_TTL_SECONDS,
@@ -305,7 +306,19 @@ async function createContributorWalletClaim(
     supersedesClaimId: requestedPredecessor,
     createdAt: observedAt,
   };
-  const result = await deps.persistence.createWalletClaim(claim);
+  const audit: AuditInput = {
+    id: deps.randomId(),
+    actorGithubId: actor.githubId,
+    action: "wallet_claim.created",
+    target: `wallet-claim:${claim.id}`,
+    requestId: deps.randomId(),
+    createdAt: observedAt,
+    details: {
+      recordDigest: claim.recordSha256,
+      supersedesClaimId: claim.supersedesClaimId,
+    },
+  };
+  const result = await deps.persistence.createWalletClaim(claim, audit);
   if (result.status === "conflict") {
     fail(
       409,
@@ -313,18 +326,6 @@ async function createContributorWalletClaim(
       "Wallet claim changed; reload the current claim before submitting",
     );
   }
-  await deps.persistence.writeAudit({
-    id: deps.randomId(),
-    actorGithubId: actor.githubId,
-    action: "wallet_claim.created",
-    target: `wallet-claim:${result.value.id}`,
-    requestId: deps.randomId(),
-    createdAt: observedAt,
-    details: {
-      recordDigest: result.value.recordSha256,
-      supersedesClaimId: result.value.supersedesClaimId,
-    },
-  });
   return json(
     result.status === "created" ? 201 : 200,
     publicWalletClaim(result.value),
@@ -416,24 +417,24 @@ async function createFallbackWalletClaim(
     supersedesClaimId,
     createdAt: deps.now().toISOString(),
   };
-  const result = await deps.persistence.createWalletClaim(claim);
-  if (result.status === "conflict")
-    fail(409, "claim_conflict", "Wallet claim conflicts");
-  await deps.persistence.writeAudit({
+  const audit: AuditInput = {
     id: deps.randomId(),
     actorGithubId: actor.githubId,
     action:
       source === "github_issue"
         ? "wallet_claim.historical_issue_migrated"
         : "wallet_claim.operator_recovery_created",
-    target: `wallet-claim:${result.value.id}`,
+    target: `wallet-claim:${claim.id}`,
     requestId: deps.randomId(),
     createdAt: deps.now().toISOString(),
     details: {
-      githubActorId: result.value.githubId,
-      recordDigest: result.value.recordSha256,
+      githubActorId: claim.githubId,
+      recordDigest: claim.recordSha256,
     },
-  });
+  };
+  const result = await deps.persistence.createWalletClaim(claim, audit);
+  if (result.status === "conflict")
+    fail(409, "claim_conflict", "Wallet claim conflicts");
   return json(
     result.status === "created" ? 201 : 200,
     publicWalletClaim(result.value),

--- a/backend/trace/handler.ts
+++ b/backend/trace/handler.ts
@@ -267,7 +267,10 @@ async function createContributorWalletClaim(
       "Wallet claim changed; reload the current claim before submitting",
     );
   }
-  if (current?.walletAddress === walletAddress) {
+  if (
+    current?.walletAddress === walletAddress &&
+    current.githubLogin.toLowerCase() === actor.githubLogin.toLowerCase()
+  ) {
     return json(200, publicWalletClaim(current));
   }
 

--- a/backend/trace/handler.ts
+++ b/backend/trace/handler.ts
@@ -627,9 +627,10 @@ async function uploadTraceCapability(
     fail(404, "not_found", "Upload capability not found");
   }
   const tokenHash = await sha256Hex(new TextEncoder().encode(capability));
+  const authorizedAt = deps.now().toISOString();
   const intent = await deps.persistence.getUploadIntent(
     tokenHash,
-    deps.now().toISOString(),
+    authorizedAt,
   );
   if (intent === null) {
     fail(
@@ -685,12 +686,11 @@ async function uploadTraceCapability(
       createdAt: deps.now().toISOString(),
     } as const);
   await deps.persistence.putTraceBytes(object, bytes);
-  const intentConsumedAt = deps.now().toISOString();
   const result = await deps.persistence.attachTrace({
     runId: intent.runId,
     githubId: intent.githubId,
     idempotencyKey: tokenHash,
-    intentConsumedAt,
+    intentConsumedAt: authorizedAt,
     object,
   });
   if (result.status === "conflict") {

--- a/backend/trace/handler.ts
+++ b/backend/trace/handler.ts
@@ -355,6 +355,10 @@ async function createFallbackWalletClaim(
     fail(400, "invalid_request", "Invalid Solana address");
   }
   const observedAt = requiredString(body, "observedAt", validIsoTimestamp);
+  const createdAt = deps.now();
+  if (Date.parse(observedAt) > createdAt.getTime()) {
+    fail(400, "invalid_request", "Wallet observation cannot be in the future");
+  }
   const sourceBodySha256 = requiredString(
     body,
     "sourceBodySha256",
@@ -415,7 +419,7 @@ async function createFallbackWalletClaim(
     observedAt,
     recordSha256: await sha256Hex(new TextEncoder().encode(canonicalRecord)),
     supersedesClaimId,
-    createdAt: deps.now().toISOString(),
+    createdAt: createdAt.toISOString(),
   };
   const audit: AuditInput = {
     id: deps.randomId(),
@@ -426,7 +430,7 @@ async function createFallbackWalletClaim(
         : "wallet_claim.operator_recovery_created",
     target: `wallet-claim:${claim.id}`,
     requestId: deps.randomId(),
-    createdAt: deps.now().toISOString(),
+    createdAt: createdAt.toISOString(),
     details: {
       githubActorId: claim.githubId,
       recordDigest: claim.recordSha256,

--- a/backend/trace/handler.ts
+++ b/backend/trace/handler.ts
@@ -47,6 +47,7 @@ export type TraceApiDependencies = {
 type ApiError = Error & { status?: number; code?: string };
 
 export const TRACE_API_CONTRACT_VERSION = "private-trace-v1-opaque-hmac-v1";
+const MAX_EVENT_CLOCK_SKEW_MS = 5 * 60 * 1000;
 
 function fail(status: number, code: string, message: string): never {
   const error: ApiError = new Error(message);
@@ -750,6 +751,10 @@ async function appendEvent(
   const kind = body.kind;
   if (!validEventKind(kind)) fail(400, "invalid_request", "Invalid event kind");
   const occurredAt = requiredString(body, "occurredAt", validIsoTimestamp);
+  const createdAt = deps.now();
+  if (Date.parse(occurredAt) > createdAt.getTime() + MAX_EVENT_CLOCK_SKEW_MS) {
+    fail(400, "invalid_request", "Event time is too far in the future");
+  }
   const source = body.source;
   // GitHub-authoritative events are written only by the webhook processor,
   // never by this contributor endpoint.
@@ -775,7 +780,7 @@ async function appendEvent(
     }),
     headSha: optionalString(body, "headSha", validGitSha),
     idempotencyKey: idempotencyKey(request),
-    createdAt: deps.now().toISOString(),
+    createdAt: createdAt.toISOString(),
   });
   if (result.status === "conflict") {
     fail(409, "idempotency_conflict", "Idempotency key was reused");

--- a/backend/trace/handler.ts
+++ b/backend/trace/handler.ts
@@ -809,24 +809,26 @@ async function createReadGrant(
   const expiresAt = new Date(
     createdAt.getTime() + OPERATOR_GRANT_TTL_SECONDS * 1000,
   );
-  await deps.persistence.createReadGrant({
-    tokenHash,
-    traceSha256: sha256,
-    operatorGithubId: actor.githubId,
-    reason,
-    requestId,
-    createdAt: createdAt.toISOString(),
-    expiresAt: expiresAt.toISOString(),
-  });
-  await deps.persistence.writeAudit({
-    id: deps.randomId(),
-    actorGithubId: actor.githubId,
-    action: "trace.read_grant.created",
-    target: `sha256:${sha256}`,
-    requestId,
-    createdAt: createdAt.toISOString(),
-    details: { reason, expiresAt: expiresAt.toISOString() },
-  });
+  await deps.persistence.createReadGrant(
+    {
+      tokenHash,
+      traceSha256: sha256,
+      operatorGithubId: actor.githubId,
+      reason,
+      requestId,
+      createdAt: createdAt.toISOString(),
+      expiresAt: expiresAt.toISOString(),
+    },
+    {
+      id: deps.randomId(),
+      actorGithubId: actor.githubId,
+      action: "trace.read_grant.created",
+      target: `sha256:${sha256}`,
+      requestId,
+      createdAt: createdAt.toISOString(),
+      details: { reason, expiresAt: expiresAt.toISOString() },
+    },
+  );
   return json(201, {
     grant,
     expiresAt: expiresAt.toISOString(),
@@ -847,29 +849,30 @@ async function readTrace(
     fail(403, "read_grant_required", "A one-time trace read grant is required");
   }
   const tokenHash = await sha256Hex(new TextEncoder().encode(grant));
-  const consumed = await deps.persistence.consumeReadGrant(
-    tokenHash,
-    sha256,
-    actor.githubId,
-    deps.now().toISOString(),
-  );
-  if (!consumed)
-    fail(403, "invalid_read_grant", "Trace read grant is invalid or expired");
   const object = await deps.persistence.getTraceObject(sha256);
   if (object === null) fail(404, "not_found", "Trace not found");
   const bytes = await deps.persistence.readTraceBytes(object);
   if (bytes === null)
     fail(503, "object_unavailable", "Trace object is unavailable");
   const requestId = deps.randomId();
-  await deps.persistence.writeAudit({
-    id: deps.randomId(),
-    actorGithubId: actor.githubId,
-    action: "trace.read_grant.consumed",
-    target: `sha256:${sha256}`,
-    requestId,
-    createdAt: deps.now().toISOString(),
-    details: { sizeBytes: object.sizeBytes },
-  });
+  const consumedAt = deps.now().toISOString();
+  const consumed = await deps.persistence.consumeReadGrant(
+    tokenHash,
+    sha256,
+    actor.githubId,
+    consumedAt,
+    {
+      id: deps.randomId(),
+      actorGithubId: actor.githubId,
+      action: "trace.read_grant.consumed",
+      target: `sha256:${sha256}`,
+      requestId,
+      createdAt: consumedAt,
+      details: { sizeBytes: object.sizeBytes },
+    },
+  );
+  if (!consumed)
+    fail(403, "invalid_read_grant", "Trace read grant is invalid or expired");
   const responseBody =
     bytes instanceof Uint8Array ? bytes.slice().buffer : bytes;
   return new Response(responseBody, {

--- a/backend/trace/validation.ts
+++ b/backend/trace/validation.ts
@@ -78,11 +78,20 @@ export function validEventKind(value: unknown): value is RunEventKind {
 }
 
 export function validIsoTimestamp(value: unknown): value is string {
-  return (
-    typeof value === "string" &&
-    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/u.test(value) &&
-    Number.isFinite(Date.parse(value))
-  );
+  if (
+    typeof value !== "string" ||
+    !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/u.test(value)
+  ) {
+    return false;
+  }
+  const milliseconds = Date.parse(value);
+  if (!Number.isFinite(milliseconds)) return false;
+  const canonical = value.endsWith(".000Z")
+    ? value
+    : value.endsWith("Z") && !value.includes(".")
+      ? `${value.slice(0, -1)}.000Z`
+      : value;
+  return new Date(milliseconds).toISOString() === canonical;
 }
 
 export async function readJsonObject(

--- a/functions/api/v1/cloudflare-persistence.test.ts
+++ b/functions/api/v1/cloudflare-persistence.test.ts
@@ -4,7 +4,11 @@ import {
   type D1Database,
   type R2Bucket,
 } from "../../../backend/trace/cloudflare-persistence";
-import type { TraceObject } from "../../../backend/trace/contracts";
+import type {
+  AuditInput,
+  TraceObject,
+  WalletClaim,
+} from "../../../backend/trace/contracts";
 
 const object: TraceObject = {
   sha256: "eafe895eb8119e6e5d06463590b2ef81b3651c157d5c8e18f1889186c7fd0ac0",
@@ -26,6 +30,69 @@ function body(text: string): ReadableStream<Uint8Array> {
 }
 
 describe("Cloudflare trace object persistence", () => {
+  it("submits wallet claim and audit writes in one atomic D1 batch", async () => {
+    const queries: string[] = [];
+    const db: D1Database = {
+      async batch(statements) {
+        expect(statements).toHaveLength(2);
+        return statements.map(() => ({ success: true, meta: { changes: 1 } }));
+      },
+      prepare(query) {
+        queries.push(query);
+        const statement = {
+          bind() {
+            return statement;
+          },
+          async first<T>() {
+            return null as T;
+          },
+          async run() {
+            throw new Error("wallet writes must use the atomic batch");
+          },
+        };
+        return statement;
+      },
+    };
+    const claim: WalletClaim = {
+      id: "claim-1",
+      githubId: "42",
+      githubLogin: "octocat",
+      walletAddress: "11111111111111111111111111111111",
+      source: "d1_registry",
+      issueRepository: null,
+      issueNumber: null,
+      sourceBodySha256: "b".repeat(64),
+      observedAt: object.createdAt,
+      recordSha256: "c".repeat(64),
+      supersedesClaimId: null,
+      createdAt: object.createdAt,
+    };
+    const audit: AuditInput = {
+      id: "audit-1",
+      actorGithubId: "42",
+      action: "wallet_claim.created",
+      target: "wallet-claim:claim-1",
+      requestId: "request-1",
+      createdAt: object.createdAt,
+      details: { recordDigest: claim.recordSha256 },
+    };
+
+    await expect(
+      new CloudflareTracePersistence(db, {} as R2Bucket).createWalletClaim(
+        claim,
+        audit,
+      ),
+    ).resolves.toEqual({ status: "created", value: claim });
+    expect(
+      queries.some((query) => query.includes("INSERT INTO wallet_claims")),
+    ).toBe(true);
+    expect(
+      queries.some((query) =>
+        query.includes("INSERT INTO private_audit_events"),
+      ),
+    ).toBe(true);
+  });
+
   it("does not disguise a missing atomic-attachment migration as replay", async () => {
     const db: D1Database = {
       batch: async () => {

--- a/functions/api/v1/cloudflare-persistence.test.ts
+++ b/functions/api/v1/cloudflare-persistence.test.ts
@@ -6,8 +6,8 @@ import {
 } from "../../../backend/trace/cloudflare-persistence";
 import type {
   AuditInput,
-  RunProgressEvent,
   CreateGrantInput,
+  RunProgressEvent,
   TraceObject,
   WalletClaim,
 } from "../../../backend/trace/contracts";

--- a/functions/api/v1/cloudflare-persistence.test.ts
+++ b/functions/api/v1/cloudflare-persistence.test.ts
@@ -6,6 +6,7 @@ import {
 } from "../../../backend/trace/cloudflare-persistence";
 import type {
   AuditInput,
+  RunProgressEvent,
   CreateGrantInput,
   TraceObject,
   WalletClaim,
@@ -293,6 +294,46 @@ describe("Cloudflare trace object persistence", () => {
     expect(result.status === "existing" && result.value.expiresAt).toBe(
       "2026-08-15T12:11:00.000Z",
     );
+  });
+
+  it("rejects an event when its run finalized before the atomic insert", async () => {
+    const db: D1Database = {
+      batch: async () => [],
+      prepare(query) {
+        const statement = {
+          bind() {
+            return statement;
+          },
+          async first<_T>() {
+            if (query.includes("FROM run_progress_events")) return null;
+            throw new Error(`Unexpected query: ${query}`);
+          },
+          async run() {
+            expect(query).toMatch(/FROM trace_runs/u);
+            expect(query).toMatch(/state != 'finalized'/u);
+            return { success: true, meta: { changes: 0 } };
+          },
+        };
+        return statement;
+      },
+    };
+    const event: RunProgressEvent & { idempotencyKey: string } = {
+      id: "event-1",
+      runId: "run-1",
+      githubId: "42",
+      kind: "checkpoint",
+      occurredAt: object.createdAt,
+      source: "agent",
+      githubObjectId: null,
+      githubUrl: null,
+      headSha: null,
+      createdAt: object.createdAt,
+      idempotencyKey: "event-key-0001",
+    };
+
+    await expect(
+      new CloudflareTracePersistence(db, {} as R2Bucket).appendEvent(event),
+    ).resolves.toEqual({ status: "conflict" });
   });
 
   it("does not disguise a missing atomic-attachment migration as replay", async () => {

--- a/functions/api/v1/cloudflare-persistence.test.ts
+++ b/functions/api/v1/cloudflare-persistence.test.ts
@@ -191,6 +191,48 @@ describe("Cloudflare trace object persistence", () => {
       ),
     ).toBe(true);
   });
+  it.each([
+    { success: false, meta: { changes: 1 } },
+    { success: true, meta: { changes: 0 } },
+  ])(
+    "does not report an upload intent that D1 did not insert",
+    async (result) => {
+      const db: D1Database = {
+        async batch() {
+          return [];
+        },
+        prepare() {
+          const statement = {
+            bind() {
+              return statement;
+            },
+            async first<T>() {
+              return null as T | null;
+            },
+            async run() {
+              return result;
+            },
+          };
+          return statement;
+        },
+      };
+
+      await expect(
+        new CloudflareTracePersistence(db, {} as R2Bucket).createUploadIntent({
+          tokenHash: "a".repeat(64),
+          runId: "run-1",
+          githubId: "42",
+          sha256: object.sha256,
+          sizeBytes: object.sizeBytes,
+          contentType: object.contentType,
+          idempotencyKey: "intent-key-0001",
+          createdAt: object.createdAt,
+          expiresAt: "2026-08-15T12:05:00.000Z",
+          consumedAt: null,
+        }),
+      ).rejects.toThrow(/upload intent insertion failed/u);
+    },
+  );
 
   it("does not disguise a missing atomic-attachment migration as replay", async () => {
     const db: D1Database = {

--- a/functions/api/v1/cloudflare-persistence.test.ts
+++ b/functions/api/v1/cloudflare-persistence.test.ts
@@ -6,6 +6,7 @@ import {
 } from "../../../backend/trace/cloudflare-persistence";
 import type {
   AuditInput,
+  CreateGrantInput,
   TraceObject,
   WalletClaim,
 } from "../../../backend/trace/contracts";
@@ -30,6 +31,104 @@ function body(text: string): ReadableStream<Uint8Array> {
 }
 
 describe("Cloudflare trace object persistence", () => {
+  it("creates read grants and their audit records in one D1 batch", async () => {
+    const queries: string[] = [];
+    const batches: string[][] = [];
+    const db: D1Database = {
+      async batch(statements) {
+        batches.push(queries.slice(-statements.length));
+        return statements.map(() => ({ success: true, meta: { changes: 1 } }));
+      },
+      prepare(query) {
+        queries.push(query);
+        const statement = {
+          bind() {
+            return statement;
+          },
+          async first<T>() {
+            return null as T | null;
+          },
+          async run() {
+            return { success: true };
+          },
+        };
+        return statement;
+      },
+    };
+    const grant: CreateGrantInput = {
+      tokenHash: "a".repeat(64),
+      traceSha256: object.sha256,
+      operatorGithubId: "99",
+      reason: "investigate payout dispute",
+      requestId: "request-1",
+      createdAt: object.createdAt,
+      expiresAt: "2026-08-15T12:05:00.000Z",
+    };
+    const audit: AuditInput = {
+      id: "audit-1",
+      actorGithubId: "99",
+      action: "trace.read_grant.created",
+      target: `sha256:${object.sha256}`,
+      requestId: grant.requestId,
+      createdAt: grant.createdAt,
+      details: { reason: grant.reason, expiresAt: grant.expiresAt },
+    };
+
+    await new CloudflareTracePersistence(db, {} as R2Bucket).createReadGrant(
+      grant,
+      audit,
+    );
+
+    expect(batches).toHaveLength(1);
+    expect(batches[0]).toHaveLength(2);
+    expect(batches[0][0]).toContain("INSERT INTO trace_read_grants");
+    expect(batches[0][1]).toContain("INSERT INTO private_audit_events");
+  });
+
+  it("fails closed when read-grant consumption and audit results diverge", async () => {
+    const db: D1Database = {
+      async batch() {
+        return [
+          { success: true, meta: { changes: 1 } },
+          { success: true, meta: { changes: 0 } },
+        ];
+      },
+      prepare() {
+        const statement = {
+          bind() {
+            return statement;
+          },
+          async first<T>() {
+            return null as T | null;
+          },
+          async run() {
+            return { success: true };
+          },
+        };
+        return statement;
+      },
+    };
+    const audit: AuditInput = {
+      id: "audit-2",
+      actorGithubId: "99",
+      action: "trace.read_grant.consumed",
+      target: `sha256:${object.sha256}`,
+      requestId: "request-2",
+      createdAt: object.createdAt,
+      details: { sizeBytes: object.sizeBytes },
+    };
+
+    await expect(
+      new CloudflareTracePersistence(db, {} as R2Bucket).consumeReadGrant(
+        "a".repeat(64),
+        object.sha256,
+        "99",
+        object.createdAt,
+        audit,
+      ),
+    ).rejects.toThrow("Trace read grant and audit state diverged");
+  });
+
   it("submits wallet claim and audit writes in one atomic D1 batch", async () => {
     const queries: string[] = [];
     const db: D1Database = {

--- a/functions/api/v1/trace-api.test.ts
+++ b/functions/api/v1/trace-api.test.ts
@@ -44,6 +44,7 @@ class MemoryPersistence implements TracePersistence {
   readonly audits: AuditInput[] = [];
   readonly claims = new Map<string, WalletClaim>();
   failNextPut = false;
+  failNextAudit = false;
 
   async createRun(input: CreateRunInput): Promise<PersistenceResult<TraceRun>> {
     const key = `${input.githubId}:${input.idempotencyKey}`;
@@ -265,11 +266,16 @@ class MemoryPersistence implements TracePersistence {
   }
 
   async writeAudit(input: AuditInput): Promise<void> {
+    if (this.failNextAudit) {
+      this.failNextAudit = false;
+      throw new Error("injected audit failure");
+    }
     this.audits.push(input);
   }
 
   async createWalletClaim(
     claim: WalletClaim,
+    audit: AuditInput,
   ): Promise<PersistenceResult<WalletClaim>> {
     const existing = [...this.claims.values()].find(
       (item) => item.recordSha256 === claim.recordSha256,
@@ -288,7 +294,12 @@ class MemoryPersistence implements TracePersistence {
     ) {
       return { status: "conflict" };
     }
+    if (this.failNextAudit) {
+      this.failNextAudit = false;
+      throw new Error("injected audit failure");
+    }
     this.claims.set(claim.id, claim);
+    this.audits.push(audit);
     return { status: "created", value: claim };
   }
 
@@ -1596,6 +1607,26 @@ describe("private trace API", () => {
       dependencies(),
     );
     expect(response.status).toBe(401);
+  });
+
+  it("does not activate a wallet claim when its required audit write fails", async () => {
+    const store = new MemoryPersistence();
+    const deps = dependencies(store);
+    const contributor = await token("42", "octocat", ["contributor"]);
+    store.failNextAudit = true;
+    const failed = await handleTraceApi(
+      request(
+        "wallet-claims",
+        "POST",
+        contributor,
+        JSON.stringify({ address: "11111111111111111111111111111111" }),
+        { "content-type": "application/json" },
+      ),
+      deps,
+    );
+    expect(failed.status).toBe(500);
+    expect(await store.getCurrentWalletClaim("42")).toBeNull();
+    expect(store.audits).toEqual([]);
   });
 
   it("reports unknown paths as not found instead of demanding authentication", async () => {

--- a/functions/api/v1/trace-api.test.ts
+++ b/functions/api/v1/trace-api.test.ts
@@ -1884,6 +1884,44 @@ describe("private trace API", () => {
     expect(await stale.json()).toMatchObject({ error: "stale_wallet_claim" });
   });
 
+  it("refreshes an unchanged wallet claim after a GitHub login rename", async () => {
+    const deps = dependencies();
+    const originalActor = await token("42", "old-login", ["contributor"]);
+    const original = await handleTraceApi(
+      request(
+        "wallet-claims",
+        "POST",
+        originalActor,
+        JSON.stringify({ address: "11111111111111111111111111111111" }),
+        { "content-type": "application/json" },
+      ),
+      deps,
+    );
+    const originalClaim = (await original.json()) as { claimId: string };
+    const renamedActor = await token("42", "new-login", ["contributor"]);
+
+    const refreshed = await handleTraceApi(
+      request(
+        "wallet-claims",
+        "POST",
+        renamedActor,
+        JSON.stringify({
+          address: "11111111111111111111111111111111",
+          supersedesClaimId: originalClaim.claimId,
+        }),
+        { "content-type": "application/json" },
+      ),
+      deps,
+    );
+
+    expect(refreshed.status).toBe(201);
+    expect(await refreshed.json()).toMatchObject({
+      githubActorId: "42",
+      githubLogin: "new-login",
+      supersedesClaimId: originalClaim.claimId,
+    });
+  });
+
   it("does not let an unauthenticated caller create a wallet claim", async () => {
     const response = await handleTraceApi(
       new Request("https://api.slop.cash/api/v1/wallet-claims", {

--- a/functions/api/v1/trace-api.test.ts
+++ b/functions/api/v1/trace-api.test.ts
@@ -237,8 +237,16 @@ class MemoryPersistence implements TracePersistence {
     this.bytes.set(object.sha256, bytes.slice());
   }
 
-  async createReadGrant(input: CreateGrantInput): Promise<void> {
+  async createReadGrant(
+    input: CreateGrantInput,
+    audit: AuditInput,
+  ): Promise<void> {
+    if (this.failNextAudit) {
+      this.failNextAudit = false;
+      throw new Error("injected audit failure");
+    }
     this.grants.set(input.tokenHash, { ...input, consumed: false });
+    this.audits.push(audit);
   }
 
   async consumeReadGrant(
@@ -246,6 +254,7 @@ class MemoryPersistence implements TracePersistence {
     traceSha256: string,
     operatorGithubId: string,
     now: string,
+    audit: AuditInput,
   ): Promise<boolean> {
     const grant = this.grants.get(tokenHash);
     if (
@@ -257,7 +266,12 @@ class MemoryPersistence implements TracePersistence {
     ) {
       return false;
     }
+    if (this.failNextAudit) {
+      this.failNextAudit = false;
+      throw new Error("injected audit failure");
+    }
     grant.consumed = true;
+    this.audits.push(audit);
     return true;
   }
 
@@ -1459,6 +1473,66 @@ describe("private trace API", () => {
       "trace.read_grant.created",
       "trace.read_grant.consumed",
     ]);
+  });
+
+  it("does not activate or consume a read grant without its audit event", async () => {
+    const store = new MemoryPersistence();
+    const deps = dependencies(store);
+    const contributor = await token("42", "octocat", ["contributor"]);
+    const operator = await token("99", "slop-operator", ["operator"]);
+    const created = await createRun(deps, contributor);
+    const { serverRunId } = (await created.json()) as { serverRunId: string };
+    const bytes = new TextEncoder().encode("audited private trace");
+    const digest = await sha256Hex(bytes);
+    await uploadTrace(
+      deps,
+      contributor,
+      serverRunId,
+      bytes,
+      "upload_trace_key_audit_failure",
+    );
+
+    store.failNextAudit = true;
+    const failedGrant = await handleTraceApi(
+      request(
+        `operator/traces/${digest}/grant`,
+        "POST",
+        operator,
+        JSON.stringify({ reason: "verify atomic grant audit behavior" }),
+        { "content-type": "application/json" },
+      ),
+      deps,
+    );
+    expect(failedGrant.status).toBe(500);
+    expect(store.grants.size).toBe(0);
+
+    const grantResponse = await handleTraceApi(
+      request(
+        `operator/traces/${digest}/grant`,
+        "POST",
+        operator,
+        JSON.stringify({ reason: "verify atomic read audit behavior" }),
+        { "content-type": "application/json" },
+      ),
+      deps,
+    );
+    const { grant } = (await grantResponse.json()) as { grant: string };
+    store.failNextAudit = true;
+    const failedRead = await handleTraceApi(
+      request(`operator/traces/${digest}`, "GET", operator, undefined, {
+        "x-trace-read-grant": grant,
+      }),
+      deps,
+    );
+    expect(failedRead.status).toBe(500);
+    const retriedRead = await handleTraceApi(
+      request(`operator/traces/${digest}`, "GET", operator, undefined, {
+        "x-trace-read-grant": grant,
+      }),
+      deps,
+    );
+    expect(retriedRead.status).toBe(200);
+    expect(await retriedRead.text()).toBe("audited private trace");
   });
 
   it("publishes only immutable wallet claim metadata", async () => {

--- a/functions/api/v1/trace-api.test.ts
+++ b/functions/api/v1/trace-api.test.ts
@@ -1290,6 +1290,39 @@ describe("private trace API", () => {
     });
   });
 
+  it("rejects a progress event beyond the server clock tolerance", async () => {
+    const store = new MemoryPersistence();
+    const deps = dependencies(store);
+    const contributor = await token("42", "octocat", ["contributor"]);
+    const created = await createRun(
+      deps,
+      contributor,
+      "create_future_event_run_key_0001",
+    );
+    const { serverRunId } = (await created.json()) as { serverRunId: string };
+    const response = await handleTraceApi(
+      request(
+        `runs/${serverRunId}/events`,
+        "POST",
+        contributor,
+        JSON.stringify({
+          kind: "run_completed",
+          occurredAt: new Date(NOW.getTime() + 5 * 60_000 + 1).toISOString(),
+          source: "agent",
+        }),
+        {
+          "content-type": "application/json",
+          "idempotency-key": "future_progress_event_key_0001",
+        },
+      ),
+      deps,
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({ error: "invalid_request" });
+    expect(store.events.size).toBe(0);
+  });
+
   it("rejects digest mismatches before retaining an object", async () => {
     const store = new MemoryPersistence();
     const deps = dependencies(store);

--- a/functions/api/v1/trace-api.test.ts
+++ b/functions/api/v1/trace-api.test.ts
@@ -1574,6 +1574,34 @@ describe("private trace API", () => {
     });
   });
 
+  it("rejects an operator wallet observation from the future", async () => {
+    const store = new MemoryPersistence();
+    const deps = dependencies(store);
+    const operator = await token("99", "slop-operator", ["operator"]);
+    const response = await handleTraceApi(
+      request(
+        "operator/wallet-claims",
+        "POST",
+        operator,
+        JSON.stringify({
+          githubActorId: "42",
+          githubLogin: "octocat",
+          address: "11111111111111111111111111111111",
+          observedAt: new Date(NOW.getTime() + 1).toISOString(),
+          sourceBodySha256: "b".repeat(64),
+        }),
+        { "content-type": "application/json" },
+      ),
+      deps,
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      error: "invalid_request",
+    });
+    expect(store.claims.size).toBe(0);
+  });
+
   it("lets a GitHub-authenticated contributor create and supersede one wallet lineage", async () => {
     const deps = dependencies();
     const contributor = await token("42", "octocat", ["contributor"]);

--- a/functions/api/v1/trace-api.test.ts
+++ b/functions/api/v1/trace-api.test.ts
@@ -1508,6 +1508,61 @@ describe("private trace API", () => {
     expect((await handleTraceApi(uploadRequest(), deps)).status).toBe(201);
   });
 
+  it("completes an upload authorized immediately before capability expiry", async () => {
+    const store = new MemoryPersistence();
+    const deps = dependencies(store);
+    const contributor = await token("42", "octocat", ["contributor"]);
+    const created = await createRun(
+      deps,
+      contributor,
+      "create_expiring_upload_run_0001",
+    );
+    const { serverRunId } = (await created.json()) as { serverRunId: string };
+    const bytes = new TextEncoder().encode("authorized before expiry");
+    const digest = await sha256Hex(bytes);
+    const intentResponse = await handleTraceApi(
+      request(
+        `runs/${serverRunId}/trace-intents`,
+        "POST",
+        contributor,
+        JSON.stringify({
+          sha256: digest,
+          sizeBytes: bytes.byteLength,
+          contentType: "text/plain",
+        }),
+        {
+          "content-type": "application/json",
+          "idempotency-key": "expiring_upload_key_0001",
+        },
+      ),
+      deps,
+    );
+    const { uploadUrl } = (await intentResponse.json()) as {
+      uploadUrl: string;
+    };
+    const intent = [...store.intents.values()][0];
+    intent.expiresAt = new Date(NOW.getTime() + 1).toISOString();
+    const times = [
+      NOW,
+      new Date(NOW.getTime() + 2),
+      new Date(NOW.getTime() + 3),
+    ];
+    deps.now = () => new Date(times.shift() ?? times.at(-1) ?? NOW);
+
+    const response = await handleTraceApi(
+      new Request(uploadUrl, {
+        method: "PUT",
+        body: bytes.slice().buffer,
+        headers: { "content-type": "text/plain", digest: `sha-256=${digest}` },
+      }),
+      deps,
+    );
+
+    expect(response.status).toBe(201);
+    expect(store.bytes.has(digest)).toBe(true);
+    expect(store.uploads.size).toBe(1);
+  });
+
   it("atomically permits only one concurrent upload capability consumer", async () => {
     const store = new MemoryPersistence();
     const deps = dependencies(store);

--- a/functions/api/v1/trace-api.test.ts
+++ b/functions/api/v1/trace-api.test.ts
@@ -1323,6 +1323,39 @@ describe("private trace API", () => {
     expect(store.events.size).toBe(0);
   });
 
+  it("rejects impossible calendar dates in progress events", async () => {
+    const deps = dependencies();
+    const contributor = await token("42", "octocat", ["contributor"]);
+    const created = await createRun(
+      deps,
+      contributor,
+      "create_invalid_date_run_key_0001",
+    );
+    const { serverRunId } = (await created.json()) as { serverRunId: string };
+
+    const response = await handleTraceApi(
+      request(
+        `runs/${serverRunId}/events`,
+        "POST",
+        contributor,
+        JSON.stringify({
+          kind: "checkpoint",
+          occurredAt: "2026-02-30T11:59:00.000Z",
+          source: "agent",
+        }),
+        {
+          "content-type": "application/json",
+          "idempotency-key": "invalid_date_event_key_0001",
+        },
+      ),
+      deps,
+    );
+
+    expect(response.status).toBe(400);
+    expect(deps.persistence).toBeInstanceOf(MemoryPersistence);
+    expect((deps.persistence as MemoryPersistence).events.size).toBe(0);
+  });
+
   it("rejects digest mismatches before retaining an object", async () => {
     const store = new MemoryPersistence();
     const deps = dependencies(store);

--- a/skill-tests/project-skills.test.ts
+++ b/skill-tests/project-skills.test.ts
@@ -1119,6 +1119,93 @@ describe("project run usage", () => {
     }
   });
 
+  it("retries one transient trace-upload server failure on the same capability", async () => {
+    const fixtureRoot = mkdtempSync(join(tmpdir(), "slop-trace-upload-retry-"));
+    try {
+      const trajectory = join(fixtureRoot, "trace.ndjson");
+      const contents = '{"event":"complete"}\n';
+      writeFileSync(trajectory, contents);
+      const digest = createHash("sha256").update(contents).digest("hex");
+      const uploadUrl = "https://api.slop.cash/api/v1/trace-uploads/retry-test";
+      let uploadAttempts = 0;
+      const fetchImpl = async (url: RequestInfo | URL) => {
+        const target = String(url);
+        if (target.endsWith("private-request-intake")) {
+          return Response.json({
+            enabled: true,
+            source: "github-public-status",
+            verifiedAt: "2026-08-25T12:00:00.000Z",
+          });
+        }
+        if (target.endsWith("auth/session")) {
+          return Response.json({
+            token: "s".repeat(32),
+            tokenType: "Bearer",
+            expiresAt: "2030-01-01T00:00:00.000Z",
+          });
+        }
+        if (target.endsWith("/runs")) {
+          return Response.json({
+            serverRunId: "srv_retry",
+            clientRunId: "run_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+            state: "awaiting_trace",
+          });
+        }
+        if (target.endsWith("trace-intents")) {
+          return Response.json({
+            serverRunId: "srv_retry",
+            uploadUrl,
+            expiresAt: "2030-01-01T00:00:00.000Z",
+            sha256: digest,
+            sizeBytes: Buffer.byteLength(contents),
+            contentType: "application/x-ndjson",
+          });
+        }
+        if (target === uploadUrl) {
+          uploadAttempts += 1;
+          if (uploadAttempts === 1)
+            return Response.json({ error: "internal_error" }, { status: 500 });
+          return Response.json({
+            serverRunId: "srv_retry",
+            clientRunId: "run_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+            traceObjectId: `sha256:${digest}`,
+            traceSha256: digest,
+            sizeBytes: Buffer.byteLength(contents),
+            state: "trace_uploaded",
+          });
+        }
+        return Response.json({
+          serverRunId: "srv_retry",
+          clientRunId: "run_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+          traceObjectId: `sha256:${digest}`,
+          traceSha256: digest,
+          state: "finalized",
+        });
+      };
+      await uploadPrivateTrace(
+        {
+          runId: "run_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+          projectId: "eliza",
+          repositoryId: "elizaOS/eliza",
+          revision: "a".repeat(40),
+          provider: "openai",
+          model: "gpt-5.6-sol",
+          client: "codex",
+        },
+        trajectory,
+        "1.2.3",
+        {
+          disclosure: () => {},
+          assertionProvider: () => "i".repeat(32),
+          fetchImpl,
+        },
+      );
+      assert.strictEqual(uploadAttempts, 2);
+    } finally {
+      rmSync(fixtureRoot, { force: true, recursive: true });
+    }
+  });
+
   it("reports private intake rate-limit reset before authorization", async () => {
     const fixtureRoot = mkdtempSync(join(tmpdir(), "slop-trace-intake-rate-"));
     try {

--- a/skills/contribute-to-asi/scripts/run-receipt.mjs
+++ b/skills/contribute-to-asi/scripts/run-receipt.mjs
@@ -1223,15 +1223,30 @@ async function boundedResponseText(response, field) {
   }
 }
 
-async function jsonRequest(fetchImpl, url, options, keys, field) {
+async function jsonRequest(
+  fetchImpl,
+  url,
+  options,
+  keys,
+  field,
+  retryServerErrors = 0,
+) {
   let response;
-  try {
-    response = await fetchImpl(url, {
-      ...options,
-      signal: AbortSignal.timeout(30_000),
-    });
-  } catch {
-    fail(`${field} request failed`);
+  for (let attempt = 0; attempt <= retryServerErrors; attempt += 1) {
+    try {
+      response = await fetchImpl(url, {
+        ...options,
+        signal: AbortSignal.timeout(30_000),
+      });
+    } catch {
+      fail(`${field} request failed`);
+    }
+    if (
+      response?.ok ||
+      (response?.status ?? 0) < 500 ||
+      attempt === retryServerErrors
+    )
+      break;
   }
   if (!response?.ok) fail(`${field} request returned HTTP ${response?.status}`);
   const source = await boundedResponseText(response, field);
@@ -1639,6 +1654,7 @@ export async function uploadPrivateTrace(
         "traceSha256",
       ],
       "trace upload",
+      1,
     );
     if (
       uploaded.clientRunId !== state.runId ||

--- a/skills/contribute-to-delta-star/scripts/run-receipt.mjs
+++ b/skills/contribute-to-delta-star/scripts/run-receipt.mjs
@@ -1223,15 +1223,30 @@ async function boundedResponseText(response, field) {
   }
 }
 
-async function jsonRequest(fetchImpl, url, options, keys, field) {
+async function jsonRequest(
+  fetchImpl,
+  url,
+  options,
+  keys,
+  field,
+  retryServerErrors = 0,
+) {
   let response;
-  try {
-    response = await fetchImpl(url, {
-      ...options,
-      signal: AbortSignal.timeout(30_000),
-    });
-  } catch {
-    fail(`${field} request failed`);
+  for (let attempt = 0; attempt <= retryServerErrors; attempt += 1) {
+    try {
+      response = await fetchImpl(url, {
+        ...options,
+        signal: AbortSignal.timeout(30_000),
+      });
+    } catch {
+      fail(`${field} request failed`);
+    }
+    if (
+      response?.ok ||
+      (response?.status ?? 0) < 500 ||
+      attempt === retryServerErrors
+    )
+      break;
   }
   if (!response?.ok) fail(`${field} request returned HTTP ${response?.status}`);
   const source = await boundedResponseText(response, field);
@@ -1639,6 +1654,7 @@ export async function uploadPrivateTrace(
         "traceSha256",
       ],
       "trace upload",
+      1,
     );
     if (
       uploaded.clientRunId !== state.runId ||

--- a/skills/contribute-to-eliza/scripts/run-receipt.mjs
+++ b/skills/contribute-to-eliza/scripts/run-receipt.mjs
@@ -1223,15 +1223,30 @@ async function boundedResponseText(response, field) {
   }
 }
 
-async function jsonRequest(fetchImpl, url, options, keys, field) {
+async function jsonRequest(
+  fetchImpl,
+  url,
+  options,
+  keys,
+  field,
+  retryServerErrors = 0,
+) {
   let response;
-  try {
-    response = await fetchImpl(url, {
-      ...options,
-      signal: AbortSignal.timeout(30_000),
-    });
-  } catch {
-    fail(`${field} request failed`);
+  for (let attempt = 0; attempt <= retryServerErrors; attempt += 1) {
+    try {
+      response = await fetchImpl(url, {
+        ...options,
+        signal: AbortSignal.timeout(30_000),
+      });
+    } catch {
+      fail(`${field} request failed`);
+    }
+    if (
+      response?.ok ||
+      (response?.status ?? 0) < 500 ||
+      attempt === retryServerErrors
+    )
+      break;
   }
   if (!response?.ok) fail(`${field} request returned HTTP ${response?.status}`);
   const source = await boundedResponseText(response, field);
@@ -1639,6 +1654,7 @@ export async function uploadPrivateTrace(
         "traceSha256",
       ],
       "trace upload",
+      1,
     );
     if (
       uploaded.clientRunId !== state.runId ||

--- a/skills/contribute-to-heir-elements-sdk/scripts/run-receipt.mjs
+++ b/skills/contribute-to-heir-elements-sdk/scripts/run-receipt.mjs
@@ -1223,15 +1223,30 @@ async function boundedResponseText(response, field) {
   }
 }
 
-async function jsonRequest(fetchImpl, url, options, keys, field) {
+async function jsonRequest(
+  fetchImpl,
+  url,
+  options,
+  keys,
+  field,
+  retryServerErrors = 0,
+) {
   let response;
-  try {
-    response = await fetchImpl(url, {
-      ...options,
-      signal: AbortSignal.timeout(30_000),
-    });
-  } catch {
-    fail(`${field} request failed`);
+  for (let attempt = 0; attempt <= retryServerErrors; attempt += 1) {
+    try {
+      response = await fetchImpl(url, {
+        ...options,
+        signal: AbortSignal.timeout(30_000),
+      });
+    } catch {
+      fail(`${field} request failed`);
+    }
+    if (
+      response?.ok ||
+      (response?.status ?? 0) < 500 ||
+      attempt === retryServerErrors
+    )
+      break;
   }
   if (!response?.ok) fail(`${field} request returned HTTP ${response?.status}`);
   const source = await boundedResponseText(response, field);
@@ -1639,6 +1654,7 @@ export async function uploadPrivateTrace(
         "traceSha256",
       ],
       "trace upload",
+      1,
     );
     if (
       uploaded.clientRunId !== state.runId ||

--- a/src/lib/solana-settlement.test.ts
+++ b/src/lib/solana-settlement.test.ts
@@ -5,6 +5,7 @@ import { SOLANA_MAINNET_USDC_MINT } from "./settlement-plan";
 import {
   assertFinalizedUsdcFundingTransfer,
   assertFinalizedUsdcTransfer,
+  assertSettlementChronology,
 } from "./solana-settlement";
 
 const SOURCE = "Vote111111111111111111111111111111111111111";
@@ -46,6 +47,14 @@ function transaction() {
 }
 
 describe("finalized Solana settlement", () => {
+  it("rejects a settlement timestamp before its finalized transaction", () => {
+    expect(() =>
+      assertSettlementChronology("2026-08-01T00:00:00.000Z", [
+        { signature: SIGNATURE, slot: 123, blockTime: 1_786_000_000 },
+      ]),
+    ).toThrow(/predates its finalized transaction/u);
+  });
+
   it("accepts only the exact raw USDC debit and credit", () => {
     expect(
       assertFinalizedUsdcTransfer(transaction(), SIGNATURE, SOURCE, [

--- a/src/lib/solana-settlement.ts
+++ b/src/lib/solana-settlement.ts
@@ -34,6 +34,24 @@ export interface VerifiedSolanaTransaction {
 
 export const SOLANA_FUNDING_VERIFIER_VERSION = "funding-solana-v1" as const;
 
+/** Refuses an immutable settlement time earlier than its chain evidence. */
+export function assertSettlementChronology(
+  settledAt: string,
+  transactions: readonly VerifiedSolanaTransaction[],
+): void {
+  const settledAtMs = Date.parse(settledAt);
+  if (!Number.isFinite(settledAtMs)) {
+    throw new TypeError("Settlement time is invalid");
+  }
+  if (
+    transactions.some(
+      (transaction) => transaction.blockTime * 1_000 > settledAtMs,
+    )
+  ) {
+    throw new TypeError("Settlement time predates its finalized transaction");
+  }
+}
+
 function record(value: unknown, field: string): Record<string, unknown> {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     throw new TypeError(`${field} must be an object`);
@@ -361,5 +379,6 @@ export async function verifyRewardSettlementOnchain(input: {
       ),
     );
   }
+  assertSettlementChronology(settlement.settledAt, verified);
   return verified;
 }

--- a/workers/identity/contracts.ts
+++ b/workers/identity/contracts.ts
@@ -56,7 +56,9 @@ export interface IdentityPersistence {
     pollCapabilityHash: string,
     now: string,
   ): Promise<OAuthFlow | null>;
-  createAssertion(assertion: IdentityAssertion): Promise<void>;
+  createAssertion(
+    assertion: IdentityAssertion,
+  ): Promise<IdentityAssertion | null>;
   markAssertionIssued(flowId: string, issuedAt: string): Promise<boolean>;
   consumeAssertion(
     tokenHash: string,

--- a/workers/identity/handler.ts
+++ b/workers/identity/handler.ts
@@ -361,7 +361,7 @@ async function pollFlow(
     deps.assertionSecret,
   );
   const expiresAt = new Date(now.getTime() + ASSERTION_TTL_SECONDS * 1000);
-  await deps.persistence.createAssertion({
+  const storedAssertion = await deps.persistence.createAssertion({
     tokenHash: await sha256Hex(assertion),
     githubActorId: flow.githubActorId,
     githubLogin: flow.githubLogin,
@@ -370,6 +370,19 @@ async function pollFlow(
     expiresAt: expiresAt.toISOString(),
     consumedAt: null,
   });
+  const storedCreatedAt = Date.parse(storedAssertion?.createdAt ?? "");
+  const storedExpiresAt = Date.parse(storedAssertion?.expiresAt ?? "");
+  if (
+    storedAssertion === null ||
+    !Number.isFinite(storedCreatedAt) ||
+    !Number.isFinite(storedExpiresAt) ||
+    new Date(storedCreatedAt).toISOString() !== storedAssertion.createdAt ||
+    new Date(storedExpiresAt).toISOString() !== storedAssertion.expiresAt ||
+    storedCreatedAt > now.getTime() ||
+    storedExpiresAt <= now.getTime()
+  ) {
+    fail(503, "assertion_unavailable", "Could not create identity assertion");
+  }
   const issued = await deps.persistence.markAssertionIssued(
     flow.id,
     now.toISOString(),
@@ -379,7 +392,7 @@ async function pollFlow(
     status: "complete",
     assertion,
     assertionType: "SlopIdentity",
-    expiresAt: expiresAt.toISOString(),
+    expiresAt: storedAssertion.expiresAt,
   });
 }
 

--- a/workers/identity/identity.test.ts
+++ b/workers/identity/identity.test.ts
@@ -19,6 +19,8 @@ const ASSERTION_SECRET = "B".repeat(43);
 class MemoryIdentityPersistence implements IdentityPersistence {
   readonly flows = new Map<string, OAuthFlow>();
   readonly assertions = new Map<string, IdentityAssertion>();
+  failAssertionCreate = false;
+  failAssertionIssueOnce = false;
 
   async createFlow(flow: OAuthFlow): Promise<boolean> {
     if (this.flows.has(flow.id)) return false;
@@ -92,16 +94,32 @@ class MemoryIdentityPersistence implements IdentityPersistence {
       : null;
   }
 
-  async createAssertion(assertion: IdentityAssertion): Promise<void> {
+  async createAssertion(
+    assertion: IdentityAssertion,
+  ): Promise<IdentityAssertion | null> {
+    if (this.failAssertionCreate) return null;
     if (!this.assertions.has(assertion.tokenHash)) {
       this.assertions.set(assertion.tokenHash, { ...assertion });
     }
+    const stored = this.assertions.get(assertion.tokenHash);
+    return stored &&
+      stored.tokenHash === assertion.tokenHash &&
+      stored.githubActorId === assertion.githubActorId &&
+      stored.githubLogin === assertion.githubLogin &&
+      stored.audience === assertion.audience &&
+      stored.consumedAt === null
+      ? { ...stored }
+      : null;
   }
 
   async markAssertionIssued(
     flowId: string,
     issuedAt: string,
   ): Promise<boolean> {
+    if (this.failAssertionIssueOnce) {
+      this.failAssertionIssueOnce = false;
+      throw new Error("simulated post-insert persistence failure");
+    }
     const flow = this.flows.get(flowId);
     if (flow?.status !== "callback_complete") return false;
     this.flows.set(flowId, {
@@ -351,6 +369,59 @@ describe("slop identity worker", () => {
       deps,
     );
     expect(consumeReplay.status).toBe(401);
+  });
+
+  it("does not issue an assertion that persistence refused to create", async () => {
+    const { deps, store } = dependencies();
+    const flow = await start(deps);
+    const { callback } = await authorizeAndCallback(deps, flow);
+    expect(callback.status).toBe(200);
+    store.failAssertionCreate = true;
+
+    const response = await handleIdentityRequest(
+      jsonRequest("identity.slop.cash", "/v1/oauth/poll", {
+        flowId: flow.flowId,
+        pollCapability: flow.pollCapability,
+        audience: IDENTITY_AUDIENCE,
+      }),
+      deps,
+    );
+
+    expect(response.status).toBe(503);
+    expect(store.flows.get(flow.flowId)?.status).toBe("callback_complete");
+    expect(store.assertions.size).toBe(0);
+  });
+
+  it("recovers the original durable assertion after a post-insert failure", async () => {
+    const { deps, store } = dependencies();
+    const flow = await start(deps);
+    const { callback } = await authorizeAndCallback(deps, flow);
+    expect(callback.status).toBe(200);
+    store.failAssertionIssueOnce = true;
+
+    const poll = () =>
+      handleIdentityRequest(
+        jsonRequest("identity.slop.cash", "/v1/oauth/poll", {
+          flowId: flow.flowId,
+          pollCapability: flow.pollCapability,
+          audience: IDENTITY_AUDIENCE,
+        }),
+        deps,
+      );
+    const failed = await poll();
+    expect(failed.status).toBe(500);
+    const [durable] = [...store.assertions.values()];
+    expect(durable).toBeDefined();
+
+    deps.now = () => new Date(NOW.getTime() + 2_000);
+    const recovered = await poll();
+    expect(recovered.status).toBe(200);
+    const completion = (await recovered.json()) as {
+      expiresAt: string;
+    };
+    expect(completion.expiresAt).toBe(durable?.expiresAt);
+    expect(store.assertions.size).toBe(1);
+    expect(store.flows.get(flow.flowId)?.status).toBe("assertion_issued");
   });
 
   it("requires the browser-bound CSRF cookie and consumes callback state once", async () => {

--- a/workers/identity/persistence.test.ts
+++ b/workers/identity/persistence.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { type D1Database, D1IdentityPersistence } from "./persistence";
+
+describe("D1 identity persistence", () => {
+  it("returns a consumed assertion from the same statement that consumes it", async () => {
+    const queries: string[] = [];
+    const db: D1Database = {
+      prepare(query) {
+        queries.push(query);
+        const statement = {
+          bind() {
+            return statement;
+          },
+          async first<T>() {
+            if (!query.includes("UPDATE identity_assertions")) {
+              throw new Error(
+                "identity lookup ran after assertion consumption",
+              );
+            }
+            return {
+              token_hash: "a".repeat(64),
+              github_actor_id: "123456",
+              github_login: "octocat",
+              audience: "private-trace-api",
+              created_at: "2026-08-15T20:00:00.000Z",
+              expires_at: "2026-08-15T20:01:30.000Z",
+              consumed_at: "2026-08-15T20:00:30.000Z",
+            } as T;
+          },
+          async run() {
+            throw new Error("assertion consumption did not return its row");
+          },
+        };
+        return statement;
+      },
+    };
+
+    await expect(
+      new D1IdentityPersistence(db).consumeAssertion(
+        "a".repeat(64),
+        "private-trace-api",
+        "2026-08-15T20:00:30.000Z",
+      ),
+    ).resolves.toMatchObject({
+      githubActorId: "123456",
+      githubLogin: "octocat",
+      consumedAt: "2026-08-15T20:00:30.000Z",
+    });
+    expect(queries).toHaveLength(1);
+  });
+});

--- a/workers/identity/persistence.test.ts
+++ b/workers/identity/persistence.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { OAuthFlow } from "./contracts";
+import type { OAuthFlow, IdentityAssertion } from "./contracts";
 import { type D1Database, D1IdentityPersistence } from "./persistence";
 
 const flow: OAuthFlow = {
@@ -40,7 +40,77 @@ function database(result: {
   };
 }
 
-describe("D1 identity persistence", () => {
+const assertion: IdentityAssertion = {
+  tokenHash: "a".repeat(64),
+  githubActorId: "123456",
+  githubLogin: "octocat",
+  audience: "private-trace-api",
+  createdAt: "2026-08-15T20:00:00.000Z",
+  expiresAt: "2026-08-15T20:01:30.000Z",
+  consumedAt: null,
+};
+
+function assertionDatabase(options: {
+  insertSuccess: boolean;
+  stored: boolean;
+}): D1Database {
+  return {
+    prepare(query) {
+      const statement = {
+        bind() {
+          return statement;
+        },
+        async first<T>() {
+          return options.stored && query.startsWith("SELECT")
+            ? ({
+                token_hash: assertion.tokenHash,
+                github_actor_id: assertion.githubActorId,
+                github_login: assertion.githubLogin,
+                audience: assertion.audience,
+                created_at: assertion.createdAt,
+                expires_at: assertion.expiresAt,
+                consumed_at: null,
+              } as T)
+            : null;
+        },
+        async run() {
+          return { success: options.insertSuccess };
+        },
+      };
+      return statement;
+    },
+  };
+}
+
+describe("D1 identity persistence", () => {  it.each([
+    { insertSuccess: false, stored: false },
+    { insertSuccess: true, stored: false },
+  ])("does not confirm an assertion absent from D1", async (options) => {
+    await expect(
+      new D1IdentityPersistence(assertionDatabase(options)).createAssertion(assertion),
+    ).resolves.toBeNull();
+  });
+
+  it("confirms the exact durable assertion", async () => {
+    await expect(
+      new D1IdentityPersistence(
+        assertionDatabase({ insertSuccess: true, stored: true }),
+      ).createAssertion(assertion),
+    ).resolves.toEqual(assertion);
+  });
+
+  it("returns the original assertion when a later retry finds its token", async () => {
+    const retry = {
+      ...assertion,
+      createdAt: "2026-08-15T20:00:02.000Z",
+      expiresAt: "2026-08-15T20:01:32.000Z",
+    };
+    await expect(
+      new D1IdentityPersistence(
+        assertionDatabase({ insertSuccess: true, stored: true }),
+      ).createAssertion(retry),
+    ).resolves.toEqual(assertion);
+  });
   it("returns a consumed assertion from the same statement that consumes it", async () => {
     const queries: string[] = [];
     const db: D1Database = {

--- a/workers/identity/persistence.test.ts
+++ b/workers/identity/persistence.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { OAuthFlow, IdentityAssertion } from "./contracts";
+import type { IdentityAssertion, OAuthFlow } from "./contracts";
 import { type D1Database, D1IdentityPersistence } from "./persistence";
 
 const flow: OAuthFlow = {

--- a/workers/identity/persistence.test.ts
+++ b/workers/identity/persistence.test.ts
@@ -1,5 +1,44 @@
 import { describe, expect, it } from "vitest";
+import type { OAuthFlow } from "./contracts";
 import { type D1Database, D1IdentityPersistence } from "./persistence";
+
+const flow: OAuthFlow = {
+  id: "flow_abcdefghijklmnopqrst",
+  stateHash: "a".repeat(64),
+  pollCapabilityHash: "b".repeat(64),
+  encryptedPkceVerifier: "ciphertext",
+  pkceIv: "initialization-vector",
+  audience: "private-trace-api",
+  status: "pending",
+  githubActorId: null,
+  githubLogin: null,
+  createdAt: "2026-08-15T20:00:00.000Z",
+  expiresAt: "2026-08-15T20:05:00.000Z",
+  callbackCompletedAt: null,
+  assertionIssuedAt: null,
+};
+
+function database(result: {
+  success: boolean;
+  meta?: { changes?: number };
+}): D1Database {
+  return {
+    prepare() {
+      const statement = {
+        bind() {
+          return statement;
+        },
+        async first<T>() {
+          return null as T | null;
+        },
+        async run() {
+          return result;
+        },
+      };
+      return statement;
+    },
+  };
+}
 
 describe("D1 identity persistence", () => {
   it("returns a consumed assertion from the same statement that consumes it", async () => {
@@ -47,5 +86,13 @@ describe("D1 identity persistence", () => {
       consumedAt: "2026-08-15T20:00:30.000Z",
     });
     expect(queries).toHaveLength(1);
+  });
+  it.each([
+    { success: false, meta: { changes: 1 } },
+    { success: true, meta: { changes: 0 } },
+  ])("does not report an OAuth flow that D1 did not insert", async (result) => {
+    await expect(
+      new D1IdentityPersistence(database(result)).createFlow(flow),
+    ).resolves.toBe(false);
   });
 });

--- a/workers/identity/persistence.test.ts
+++ b/workers/identity/persistence.test.ts
@@ -82,12 +82,15 @@ function assertionDatabase(options: {
   };
 }
 
-describe("D1 identity persistence", () => {  it.each([
+describe("D1 identity persistence", () => {
+  it.each([
     { insertSuccess: false, stored: false },
     { insertSuccess: true, stored: false },
   ])("does not confirm an assertion absent from D1", async (options) => {
     await expect(
-      new D1IdentityPersistence(assertionDatabase(options)).createAssertion(assertion),
+      new D1IdentityPersistence(assertionDatabase(options)).createAssertion(
+        assertion,
+      ),
     ).resolves.toBeNull();
   });
 

--- a/workers/identity/persistence.ts
+++ b/workers/identity/persistence.ts
@@ -212,17 +212,13 @@ export class D1IdentityPersistence implements IdentityPersistence {
     audience: string,
     now: string,
   ): Promise<IdentityAssertion | null> {
-    const result = await this.db
+    const row = await this.db
       .prepare(
         `UPDATE identity_assertions SET consumed_at = ?
-         WHERE token_hash = ? AND audience = ? AND consumed_at IS NULL AND expires_at > ?`,
+         WHERE token_hash = ? AND audience = ? AND consumed_at IS NULL AND expires_at > ?
+         RETURNING *`,
       )
       .bind(now, tokenHash, audience, now)
-      .run();
-    if ((result.meta?.changes ?? 0) !== 1) return null;
-    const row = await this.db
-      .prepare("SELECT * FROM identity_assertions WHERE token_hash = ?")
-      .bind(tokenHash)
       .first<AssertionRow>();
     return row === null ? null : mapAssertion(row);
   }

--- a/workers/identity/persistence.ts
+++ b/workers/identity/persistence.ts
@@ -173,8 +173,10 @@ export class D1IdentityPersistence implements IdentityPersistence {
     return row === null ? null : mapFlow(row);
   }
 
-  async createAssertion(assertion: IdentityAssertion): Promise<void> {
-    await this.db
+  async createAssertion(
+    assertion: IdentityAssertion,
+  ): Promise<IdentityAssertion | null> {
+    const result = await this.db
       .prepare(
         `INSERT INTO identity_assertions (
           token_hash, github_actor_id, github_login, audience, created_at,
@@ -190,6 +192,22 @@ export class D1IdentityPersistence implements IdentityPersistence {
         assertion.expiresAt,
       )
       .run();
+    if (!result.success) return null;
+    const row = await this.db
+      .prepare("SELECT * FROM identity_assertions WHERE token_hash = ?")
+      .bind(assertion.tokenHash)
+      .first<AssertionRow>();
+    if (
+      row !== null &&
+      row.token_hash === assertion.tokenHash &&
+      row.github_actor_id === assertion.githubActorId &&
+      row.github_login === assertion.githubLogin &&
+      row.audience === assertion.audience &&
+      row.consumed_at === null
+    ) {
+      return mapAssertion(row);
+    }
+    return null;
   }
 
   async markAssertionIssued(

--- a/workers/identity/persistence.ts
+++ b/workers/identity/persistence.ts
@@ -76,7 +76,7 @@ export class D1IdentityPersistence implements IdentityPersistence {
 
   async createFlow(flow: OAuthFlow): Promise<boolean> {
     try {
-      await this.db
+      const result = await this.db
         .prepare(
           `INSERT INTO identity_oauth_flows (
             id, state_hash, poll_capability_hash, encrypted_pkce_verifier,
@@ -96,7 +96,7 @@ export class D1IdentityPersistence implements IdentityPersistence {
           flow.expiresAt,
         )
         .run();
-      return true;
+      return result.success && (result.meta?.changes ?? 0) === 1;
     } catch {
       return false;
     }


### PR DESCRIPTION
## Integrated persistence fixes

Resolves overlapping changes from #340, #343, #344, #345, #346, #347, #348, #349, #350, #351, #352, #356, #361, and #362, preserving the merged #341/#342 upload recovery behavior.

Wallet and private read-grant writes commit with their audits; identity assertions are durably confirmed and atomically consumed; timestamps and finalized-run event races fail closed; uploads use their authorization time consistently; renamed GitHub identities retain wallet lineage. The receipt client retries one transient upload server failure.

Validation: 68 focused identity/trace tests passed before the bounded client retry integration. Independent review and an external local SQLite harness passed real migration/transaction rollback, one-time-use, expired-intent renewal, upload expiry, finalized event, and wallet audit semantics. Full exact-head validation is running after import-format cleanup. Live D1/production execution is not claimed. No UI change; visual/browser UI review is N/A. Actions are waived by the maintainer, not represented as passing.

Closes #353 after all included upload-recovery tests pass and this integration merges.
