### PR TITLE
fix: integrate funding and settlement validation safeguards

### DIFF
--- a/scripts/solana-rpc.test.ts
+++ b/scripts/solana-rpc.test.ts
@@ -54,6 +54,19 @@ describe("Solana RPC boundary", () => {
     ).rejects.toThrow("exceeded its size limit");
   });
 
+  it("rejects a base58 value that is not a 64-byte signature", async () => {
+    const fetcher = vi.fn(async () => rpcResponse({ slot: 42 }));
+
+    await expect(
+      fetchFinalizedSolanaTransaction(
+        "https://api.mainnet-beta.solana.com",
+        "2".repeat(64),
+        { fetcher },
+      ),
+    ).rejects.toThrow(/signature is invalid/u);
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
   it("aborts a stalled request at the bounded timeout", async () => {
     const fetcher = async (
       _input: RequestInfo | URL,

--- a/scripts/solana-rpc.ts
+++ b/scripts/solana-rpc.ts
@@ -3,6 +3,8 @@
  * JSON-RPC boundary with strict time, byte, encoding, and response checks.
  */
 
+import { isSolanaTransactionId } from "../src/lib/funding-address.mjs";
+
 export const DEFAULT_SOLANA_RPC_URL =
   "https://api.mainnet-beta.solana.com" as const;
 export const MAX_SOLANA_RPC_BYTES = 16 * 1024 * 1024;
@@ -29,7 +31,7 @@ function rpcUrl(value: string): string {
 }
 
 function signature(value: string): string {
-  if (!/^[1-9A-HJ-NP-Za-km-z]{64,128}$/u.test(value)) {
+  if (!isSolanaTransactionId(value)) {
     throw new TypeError("Solana transaction signature is invalid");
   }
   return value;

--- a/scripts/verify-commitment-sablier.test.ts
+++ b/scripts/verify-commitment-sablier.test.ts
@@ -351,6 +351,26 @@ describe("Sablier commitment verifier", () => {
     ).rejects.toThrow(/did not reach commitment quorum/u);
   });
 
+  it("refuses equal net balances backed by different stream states", async () => {
+    const { fetchImpl } = fetchByAuthority({
+      [BASE_HOSTS[0]]: authorityFixture("base", 101),
+      [BASE_HOSTS[1]]: authorityFixture("base", 102, {
+        depositedAmount: uintWord(10_000_000n),
+        withdrawnAmount: uintWord(3_000_000n),
+      }),
+      [BASE_HOSTS[2]]: new Error("authority offline"),
+    });
+
+    await expect(
+      verifyCommitmentSablier({
+        network: "base",
+        streamId: STREAM_ID,
+        recipient: RECIPIENT,
+        fetchImpl,
+      }),
+    ).rejects.toThrow(/did not reach commitment quorum/u);
+  });
+
   it("refuses authorities serving the wrong chain or malformed data", async () => {
     const wrongChain = authorityFixture("base", 101);
     wrongChain.chainId = "0x1";

--- a/scripts/verify-commitment-sablier.ts
+++ b/scripts/verify-commitment-sablier.ts
@@ -282,10 +282,20 @@ async function verifyStreamState(
       return { authority: rpc.toString(), block, verified };
     }),
   );
-  const agreeing = quorumGroups<VerifiedSablierStream>(
-    settled,
-    (verified) =>
-      `${verified.streamId}:${verified.lockedMinor}:${verified.recipient}:USDC:${contract}`,
+  const agreeing = quorumGroups<VerifiedSablierStream>(settled, (verified) =>
+    JSON.stringify([
+      verified.streamId,
+      verified.recipient,
+      verified.sender,
+      verified.depositedMinor,
+      verified.withdrawnMinor,
+      verified.refundedMinor,
+      verified.lockedMinor,
+      verified.endTime,
+      verified.wasCanceled,
+      verified.isDepleted,
+      contract,
+    ]),
   );
   const checkedAt = new Date().toISOString();
   const canonical = agreeing[0].verified;

--- a/scripts/verify-settlement.ts
+++ b/scripts/verify-settlement.ts
@@ -8,6 +8,7 @@ import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { isSolanaTransactionId } from "../src/lib/funding-address.mjs";
 import {
   assertProjectPaymentsEnabled,
   findProject,
@@ -159,8 +160,7 @@ function parseEvidence(value: unknown, cycleId: string): SettlementEvidence {
       attempt.intentIds.length === 0 ||
       !attempt.intentIds.every((id) => typeof id === "string") ||
       new Set(attempt.intentIds).size !== attempt.intentIds.length ||
-      typeof attempt.signature !== "string" ||
-      !/^[1-9A-HJ-NP-Za-km-z]{64,128}$/u.test(attempt.signature)
+      !isSolanaTransactionId(attempt.signature)
     ) {
       throw new TypeError(`Settlement evidence attempt ${index} is invalid`);
     }
@@ -177,8 +177,7 @@ function parseEvidence(value: unknown, cycleId: string): SettlementEvidence {
   const platformFeeSignature = evidence.platformFeeSignature;
   if (
     platformFeeSignature !== null &&
-    (typeof platformFeeSignature !== "string" ||
-      !/^[1-9A-HJ-NP-Za-km-z]{64,128}$/u.test(platformFeeSignature) ||
+    (!isSolanaTransactionId(platformFeeSignature) ||
       signatures.has(platformFeeSignature))
   ) {
     throw new TypeError(

--- a/src/lib/cycle-index.test.ts
+++ b/src/lib/cycle-index.test.ts
@@ -170,6 +170,57 @@ describe("public cycle index", () => {
     );
   });
 
+  it("rejects lifecycle files that are ahead of the declared state", () => {
+    const allocationDuringReview = entry();
+    allocationDuringReview.files.allocation = {
+      sha256: DIGEST,
+      url: "/data/cycles/eliza/2026-07/allocation.json",
+    };
+    expect(() => assertCycleIndex(index([allocationDuringReview]))).toThrow(
+      "state does not match",
+    );
+
+    const planDuringReview = entry();
+    planDuringReview.files.executionPlan = {
+      sha256: DIGEST,
+      url: "/data/cycles/eliza/2026-07/execution-plan.json",
+    };
+    expect(() => assertCycleIndex(index([planDuringReview]))).toThrow(
+      "state does not match",
+    );
+
+    const planBeforeSettlement = entry({
+      state: "payment-ready",
+      approvedAt: "2026-08-16T00:00:00.000Z",
+      reward: {
+        ...entry().reward,
+        approvedMinor: "10000000000",
+        feeMinor: "100000000",
+      },
+      contributors: [
+        {
+          ...entry().contributors[0],
+          state: "approved",
+          approvedMinor: "10000000000",
+        },
+      ],
+      files: {
+        ...entry().files,
+        allocation: {
+          sha256: DIGEST,
+          url: "/data/cycles/eliza/2026-07/allocation.json",
+        },
+        executionPlan: {
+          sha256: DIGEST,
+          url: "/data/cycles/eliza/2026-07/execution-plan.json",
+        },
+      },
+    });
+    expect(() => assertCycleIndex(index([planBeforeSettlement]))).toThrow(
+      "state does not match",
+    );
+  });
+
   it("binds each lifecycle label to exact money and timestamp state", () => {
     const premature = entry({
       state: "payment-ready",

--- a/src/lib/cycle-index.ts
+++ b/src/lib/cycle-index.ts
@@ -789,12 +789,19 @@ function cycleEntry(value: unknown, index: number): CycleIndexEntry {
     state === "review" &&
     (approvedAt !== null ||
       settledAt !== null ||
+      normalizedFiles.allocation !== null ||
+      normalizedFiles.executionPlan !== null ||
+      normalizedFiles.settlement !== null ||
       normalizedReward.approvedMinor !== "0" ||
       normalizedReward.paidMinor !== "0" ||
       contributors.some(
         (contributor) =>
           contributor.state !== "proposed" && contributor.state !== "unclaimed",
       ));
+  const paymentReadyStateInvalid =
+    state === "payment-ready" &&
+    (normalizedFiles.executionPlan !== null ||
+      normalizedFiles.settlement !== null);
   const approvalStateInvalid =
     ["payment-ready", "settlement-planned", "paid"].includes(state) &&
     (approvedAt === null ||
@@ -833,6 +840,7 @@ function cycleEntry(value: unknown, index: number): CycleIndexEntry {
       !normalizedFiles.executionPlan) ||
     (state === "paid" && !normalizedFiles.settlement) ||
     reviewStateInvalid ||
+    paymentReadyStateInvalid ||
     approvalStateInvalid ||
     settlementStateInvalid ||
     paidStateInvalid ||

--- a/src/lib/funding-accessibility.test.ts
+++ b/src/lib/funding-accessibility.test.ts
@@ -66,6 +66,7 @@ describe("monthly commitment accessibility boundary", () => {
           asset: "USDC",
           contract: "0xc19a09a66887017f603e5df420ed3cb9a5c07c0a",
           streamId: String(index + 1),
+          recipient: "0x1111111111111111111111111111111111111111",
           monthlyCommitment: {
             cycleId: effectiveAt.slice(0, 7),
             amountMinor: "5000000",
@@ -218,6 +219,7 @@ describe("monthly commitment accessibility boundary", () => {
       asset: "USDC",
       contract: "0xc19a09a66887017f603e5df420ed3cb9a5c07c0a",
       streamId: "42",
+      recipient: "0x1111111111111111111111111111111111111111",
       monthlyCommitment: extra.monthlyCommitment,
       effectiveAt: extra.effectiveAt,
       deadline: extra.deadline,

--- a/src/lib/funding-commitment.test.ts
+++ b/src/lib/funding-commitment.test.ts
@@ -19,6 +19,7 @@ const FUNDER_MEMBER = "Stake11111111111111111111111111111111111111";
 const STEWARD_MEMBER = "SysvarRent111111111111111111111111111111111";
 const DEPOSIT_SIGNATURE = "3".repeat(88);
 const RELEASE_SIGNATURE = "4".repeat(88);
+const SABLIER_RECIPIENT = `0x${"a".repeat(40)}`;
 
 function squadsInstrument(overrides: Record<string, unknown> = {}) {
   return {
@@ -44,6 +45,7 @@ function sablierInstrument(overrides: Record<string, unknown> = {}) {
     network: "base",
     asset: "USDC",
     contract: SABLIER_LOCKUP_V4_CONTRACTS.base,
+    recipient: SABLIER_RECIPIENT,
     streamId: "421",
     deadline: "2026-12-01T00:00:00.000Z",
     effectiveAt: "2026-08-01T00:00:00.000Z",
@@ -166,6 +168,11 @@ describe("funding commitment instruments", () => {
     ).toThrow(/streamId is invalid/u);
     expect(() =>
       assertFundingCommitments([
+        sablierInstrument({ recipient: `0x${"0".repeat(40)}` }),
+      ]),
+    ).toThrow(/recipient is invalid/u);
+    expect(() =>
+      assertFundingCommitments([
         sablierInstrument({
           network: "ethereum",
           contract: SABLIER_LOCKUP_V4_CONTRACTS.base,
@@ -184,6 +191,12 @@ describe("funding commitment instruments", () => {
     ).toThrow(/at most 16/u);
     expect(() =>
       assertFundingCommitments([sablierInstrument(), sablierInstrument()]),
+    ).toThrow(/duplicate instrument/u);
+    expect(() =>
+      assertFundingCommitments([
+        sablierInstrument(),
+        sablierInstrument({ recipient: `0x${"b".repeat(40)}` }),
+      ]),
     ).toThrow(/duplicate instrument/u);
     expect(() =>
       assertFundingCommitments([
@@ -292,6 +305,39 @@ describe("project commitment records", () => {
     expect(() =>
       assertProjectCommitmentRecord(record({ event: "sweep" }), instruments),
     ).toThrow(/event is invalid/u);
+
+    const sablierTransaction = `0x${"a".repeat(64)}`;
+    const sablierRecord = record({
+      network: "base",
+      instrument: {
+        contract: SABLIER_LOCKUP_V4_CONTRACTS.base,
+        recipient: SABLIER_RECIPIENT,
+        streamId: "421",
+      },
+      transactionId: sablierTransaction,
+      finality: { kind: "confirmations", confirmations: 12 },
+      verifier: {
+        version: "commitment-sablier-v1",
+        checkedAt: "2026-08-02T01:00:00.000Z",
+        evidenceUrl: `https://basescan.org/tx/${sablierTransaction}`,
+        reason: null,
+      },
+    });
+    expect(
+      assertProjectCommitmentRecord(sablierRecord, instruments).instrument,
+    ).toMatchObject({ recipient: SABLIER_RECIPIENT });
+    expect(() =>
+      assertProjectCommitmentRecord(
+        {
+          ...sablierRecord,
+          instrument: {
+            ...sablierRecord.instrument,
+            recipient: `0x${"b".repeat(40)}`,
+          },
+        },
+        instruments,
+      ),
+    ).toThrow(/not active/u);
   });
 
   it("requires independent finalized evidence before verification", () => {

--- a/src/lib/funding-commitment.test.ts
+++ b/src/lib/funding-commitment.test.ts
@@ -317,7 +317,7 @@ describe("project commitment records", () => {
       transactionId: sablierTransaction,
       finality: { kind: "confirmations", confirmations: 12 },
       verifier: {
-        version: "commitment-sablier-v1",
+        version: "commitment-sablier-v2",
         checkedAt: "2026-08-02T01:00:00.000Z",
         evidenceUrl: `https://basescan.org/tx/${sablierTransaction}`,
         reason: null,

--- a/src/lib/funding-commitment.ts
+++ b/src/lib/funding-commitment.ts
@@ -50,7 +50,7 @@ export interface ProjectCommitmentRecord {
         vault: string;
         vaultIndex: number;
       }
-    | { contract: string; streamId: string };
+    | { contract: string; recipient: string; streamId: string };
   transactionId: string;
   amountMinor: string;
   observedAt: string;
@@ -189,7 +189,8 @@ function matchesInstrument(
   }
   return (
     identity.contract === candidate.contract &&
-    identity.streamId === candidate.streamId
+    identity.streamId === candidate.streamId &&
+    identity.recipient === candidate.recipient
   );
 }
 
@@ -266,7 +267,7 @@ export function assertProjectCommitmentRecord(
     identity,
     network === "solana"
       ? ["funderMember", "multisig", "stewardMember", "vault", "vaultIndex"]
-      : ["contract", "streamId"],
+      : ["contract", "recipient", "streamId"],
     "commitment record instrument",
   );
   if (
@@ -378,7 +379,7 @@ function instrumentIdentityKey(record: ProjectCommitmentRecord): string {
   const identity = record.instrument as Record<string, unknown>;
   return record.network === "solana"
     ? `${identity.multisig}:${identity.vaultIndex}:${identity.vault}:${identity.funderMember}:${identity.stewardMember}`
-    : `${identity.contract}:${identity.streamId}`;
+    : `${identity.contract}:${identity.streamId}:${identity.recipient}`;
 }
 
 export function assertProjectCommitmentLedger(

--- a/src/lib/funding-instruments.d.mts
+++ b/src/lib/funding-instruments.d.mts
@@ -33,6 +33,7 @@ export interface SablierLockupV4Instrument {
   readonly network: "base" | "ethereum";
   readonly asset: "USDC";
   readonly contract: string;
+  readonly recipient: string;
   readonly streamId: string;
   readonly deadline: string;
   readonly effectiveAt: string;

--- a/src/lib/funding-instruments.mjs
+++ b/src/lib/funding-instruments.mjs
@@ -149,6 +149,7 @@ function validateSablierInstrument(candidate, field) {
         ? ["monthlyCommitment"]
         : []),
       "network",
+      "recipient",
       "replacedAt",
       "streamId",
     ],
@@ -165,6 +166,9 @@ function validateSablierInstrument(candidate, field) {
       `${field}.contract is not the reviewed Sablier Lockup v4 deployment`,
     );
   }
+  if (!isFundingAddress(candidate.network, candidate.recipient)) {
+    throw new TypeError(`${field}.recipient is invalid`);
+  }
   if (
     typeof candidate.streamId !== "string" ||
     candidate.streamId.length > 78 ||
@@ -178,6 +182,7 @@ function validateSablierInstrument(candidate, field) {
     network: candidate.network,
     asset: "USDC",
     contract: candidate.contract,
+    recipient: candidate.recipient,
     streamId: candidate.streamId,
     ...monthlyCommitment(candidate, field),
     ...window,

--- a/src/lib/funding.test.ts
+++ b/src/lib/funding.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it } from "vitest";
 import {
   assertProjectFundingAddresses,
+  assertProjectFundingIndex,
   assertProjectFundingLedger,
   assertProjectFundingRecord,
   currentProjectFundingRecords,
@@ -352,5 +353,92 @@ describe("project funding records", () => {
     expect(
       publicFundingRecordsForDonor(ledger, "MDQ6VXNlcjE4NjMzMjY1"),
     ).toEqual([]);
+  });
+
+  it("rejects one transaction recorded as both direct and committed funding", () => {
+    const vault = "Vote111111111111111111111111111111111111111";
+    const multisig = "11111111111111111111111111111111";
+    const funderMember = "Stake11111111111111111111111111111111111111";
+    const stewardMember = "SysvarRent111111111111111111111111111111111";
+    const transactionId = "3".repeat(88);
+    const solanaRoutes = assertProjectFundingAddresses([
+      {
+        network: "solana",
+        asset: "USDC",
+        address: vault,
+        effectiveAt: "2026-08-01T00:00:00.000Z",
+        replacedAt: null,
+      },
+    ]);
+    const direct = record({
+      network: "solana",
+      transactionId,
+      recipient: vault,
+      amountMinor: "5000000",
+      state: "verified-on-chain",
+      finality: { kind: "finalized" },
+      verifier: {
+        version: "funding-solana-v1",
+        checkedAt: "2026-08-02T01:00:00.000Z",
+        evidenceUrl: `https://solscan.io/tx/${transactionId}`,
+        reason: null,
+      },
+    });
+    const instrument = {
+      kind: "squads-v4-vault",
+      network: "solana",
+      asset: "USDC",
+      multisig,
+      vault,
+      vaultIndex: 0,
+      funderMember,
+      stewardMember,
+      funderActorId: "18633264",
+      deadline: "2026-12-01T00:00:00.000Z",
+      effectiveAt: "2026-08-01T00:00:00.000Z",
+      replacedAt: null,
+    } as const;
+    const commitment = {
+      schemaVersion: "1",
+      kind: "project-commitment",
+      recordId: "cmt_duplicate_transaction_01",
+      projectId: "eliza",
+      manifestRevision: "b".repeat(40),
+      event: "deposit",
+      network: "solana",
+      asset: "USDC",
+      instrument: {
+        funderMember,
+        multisig,
+        stewardMember,
+        vault,
+        vaultIndex: 0,
+      },
+      transactionId,
+      amountMinor: "5000000",
+      observedAt: "2026-08-02T00:00:00.000Z",
+      state: "verified-on-chain",
+      finality: { kind: "finalized" },
+      verifier: {
+        version: "commitment-squads-v2",
+        checkedAt: "2026-08-02T01:00:00.000Z",
+        evidenceUrl: `https://solscan.io/tx/${transactionId}`,
+        reason: null,
+      },
+      supersedes: null,
+    };
+
+    expect(() =>
+      assertProjectFundingIndex(
+        {
+          schemaVersion: "1",
+          generatedAt: "2026-08-03T00:00:00.000Z",
+          records: [direct],
+          commitments: [commitment],
+        },
+        new Map([["eliza", solanaRoutes]]),
+        new Map([["eliza", [instrument]]]),
+      ),
+    ).toThrow(/transaction.*multiple funding ledgers/u);
   });
 });

--- a/src/lib/funding.test.ts
+++ b/src/lib/funding.test.ts
@@ -441,4 +441,34 @@ describe("project funding records", () => {
       ),
     ).toThrow(/transaction.*multiple funding ledgers/u);
   });
+
+  it("binds the funding index timestamp to its latest observation", () => {
+    const addresses = new Map([["eliza", routes]]);
+    const commitments = new Map<string, readonly []>([["eliza", []]]);
+    const fundingRecord = record();
+    const index = {
+      schemaVersion: "1",
+      generatedAt: fundingRecord.observedAt,
+      records: [fundingRecord],
+      commitments: [],
+    };
+
+    expect(() =>
+      assertProjectFundingIndex(index, addresses, commitments),
+    ).not.toThrow();
+    expect(() =>
+      assertProjectFundingIndex(
+        { ...index, generatedAt: "2026-08-01T00:00:00.000Z" },
+        addresses,
+        commitments,
+      ),
+    ).toThrow(/latest observation/u);
+    expect(() =>
+      assertProjectFundingIndex(
+        { ...index, generatedAt: null },
+        addresses,
+        commitments,
+      ),
+    ).toThrow(/latest observation/u);
+  });
 });

--- a/src/lib/funding.ts
+++ b/src/lib/funding.ts
@@ -556,6 +556,11 @@ export function assertProjectFundingIndex(
   const commitmentTransactionProjects = new Map<string, string>();
   for (const record of commitments) {
     const key = `${record.network}:${record.transactionId}`;
+    if (transactionProjects.has(key)) {
+      throw new TypeError(
+        "funding index records one transaction in multiple funding ledgers",
+      );
+    }
     const projectId = commitmentTransactionProjects.get(key);
     if (projectId !== undefined && projectId !== record.projectId) {
       throw new TypeError(

--- a/src/lib/funding.ts
+++ b/src/lib/funding.ts
@@ -569,6 +569,20 @@ export function assertProjectFundingIndex(
     }
     commitmentTransactionProjects.set(key, record.projectId);
   }
+  const expectedGeneratedAt = [...records, ...commitments].reduce<
+    string | null
+  >(
+    (latest, record) =>
+      latest === null || record.observedAt > latest
+        ? record.observedAt
+        : latest,
+    null,
+  );
+  if (generatedAt !== expectedGeneratedAt) {
+    throw new TypeError(
+      "funding index generatedAt must equal its latest observation",
+    );
+  }
   return {
     schemaVersion: FUNDING_PROTOCOL_VERSION,
     commitmentAccessibility: "unknown",

--- a/src/lib/project-policy.test.ts
+++ b/src/lib/project-policy.test.ts
@@ -50,6 +50,7 @@ describe("project policy transitions", () => {
     authority: unknown;
     terms: {
       revision: string;
+      effectiveAt: string;
       repositoryLicense: { fileSha256: string | null };
       inbound: { fileSha256: string | null };
       receiptPolicy: {
@@ -66,6 +67,7 @@ describe("project policy transitions", () => {
     ) as unknown as MutableActivePolicyFixture;
     const licenseSha256 = fixture.terms.repositoryLicense.fileSha256;
     if (!licenseSha256) throw new Error("missing fixture license digest");
+    fixture.terms.effectiveAt = "2026-08-19T00:00:00.000Z";
     fixture.authority = {
       state: "verified",
       reason: null,
@@ -326,6 +328,7 @@ describe("project policy transitions", () => {
     const previous = activePolicyFixture();
     const next = structuredClone(previous);
     next.terms.revision = `${previous.terms.revision}-appended`;
+    next.terms.effectiveAt = "2026-08-21T00:00:00.000Z";
     const licenseSha256 = next.terms.repositoryLicense.fileSha256;
     if (!licenseSha256) throw new Error("missing fixture license digest");
     const lastActivation = "2026-08-20T00:00:00.000Z";

--- a/src/lib/project-schema.mjs
+++ b/src/lib/project-schema.mjs
@@ -639,12 +639,13 @@ function validateTerms(
     }
     if (
       current.policyRevision !== terms.revision ||
+      current.activatedAt !== terms.effectiveAt ||
       current.licenseSha256 !== license.fileSha256 ||
       current.inboundTermsSha256 !== inbound.fileSha256 ||
       current.prizeRulesSha256 !== (terms.externalPrize?.rulesSha256 ?? null)
     ) {
       throw new TypeError(
-        `${field}.receiptPolicy latest binding must match current terms`,
+        `${field}.receiptPolicy latest binding must match current terms and effective date`,
       );
     }
   }

--- a/src/lib/project-schema.test.ts
+++ b/src/lib/project-schema.test.ts
@@ -430,6 +430,7 @@ describe("project proposal schema", () => {
         network: "base",
         asset: "USDC",
         contract: `0x${"9".repeat(40)}`,
+        recipient: `0x${"a".repeat(40)}`,
         streamId: "7",
         deadline: "2026-12-01T00:00:00.000Z",
         effectiveAt: "2026-08-01T00:00:00.000Z",

--- a/src/lib/project-schema.test.ts
+++ b/src/lib/project-schema.test.ts
@@ -29,6 +29,7 @@ interface MutableActivationFixture {
   status: string;
   authority: unknown;
   terms: {
+    effectiveAt: string;
     revision: string;
     receiptPolicy: unknown;
     inbound: unknown;
@@ -48,6 +49,7 @@ function activatedWithoutOwnershipClaim(model: string): unknown {
   const proofCommit = "a".repeat(40);
   const inboundCommit = "c".repeat(40);
   fixture.status = "active";
+  fixture.terms.effectiveAt = verifiedAt;
   fixture.authority = {
     state: "verified",
     reason: null,
@@ -464,6 +466,12 @@ describe("project proposal schema", () => {
     mutableLicense.terms.repositoryLicense.url =
       "https://github.com/elizaOS/eliza/blob/develop/LICENSE";
     expect(() => assertProjectDefinition(mutableLicense)).toThrow(/immutable/u);
+
+    const retroactiveEffectiveDate = structuredClone(eliza);
+    retroactiveEffectiveDate.terms.effectiveAt = "2026-08-01T00:00:00.000Z";
+    expect(() => assertProjectDefinition(retroactiveEffectiveDate)).toThrow(
+      /effective date/u,
+    );
 
     const mismatchedInbound = structuredClone(eliza) as unknown as {
       terms: {

--- a/src/lib/rewards.test.ts
+++ b/src/lib/rewards.test.ts
@@ -427,6 +427,12 @@ describe("reward manifests", () => {
       "paid",
     );
 
+    const malformedSignature = structuredClone(settlement);
+    malformedSignature.attempts[0].signature = "2".repeat(64);
+    expect(() =>
+      assertRewardSettlementManifest(malformedSignature, allocation),
+    ).toThrow(/signature is invalid/u);
+
     const proposed = allocationManifest() as RewardAllocationManifest;
     proposed.status = "proposed";
     proposed.approvedAt = null;

--- a/src/lib/rewards.ts
+++ b/src/lib/rewards.ts
@@ -4,6 +4,7 @@
  * amount is tied to one immutable payout intent.
  */
 
+import { isSolanaTransactionId } from "./funding-address.mjs";
 import { assertExactModelIdentity } from "./model-identity";
 import { findProject, type ProjectId } from "./projects.mjs";
 import { isSolanaAddress, WALLET_CLAIM_REPOSITORY } from "./wallets";
@@ -248,6 +249,13 @@ function safeInteger(value: unknown, path: string): number {
 
 function sha256(value: unknown, path: string): string {
   return text(value, path, { pattern: /^[0-9a-f]{64}$/u });
+}
+
+function solanaSignature(value: unknown, path: string): string {
+  if (!isSolanaTransactionId(value)) {
+    throw new TypeError(`${path} is invalid`);
+  }
+  return value;
 }
 
 function array(value: unknown, path: string): unknown[] {
@@ -1406,11 +1414,7 @@ export function assertRewardSettlementManifest(
       const signature =
         attempt.signature === null
           ? null
-          : text(attempt.signature, `${path}.signature`, {
-              max: 128,
-              min: 64,
-              pattern: /^[1-9A-HJ-NP-Za-km-z]+$/u,
-            });
+          : solanaSignature(attempt.signature, `${path}.signature`);
       if (state === "finalized" && signature === null) {
         throw new TypeError(`${path} finalized attempt needs a signature`);
       }
@@ -1496,11 +1500,10 @@ export function assertRewardSettlementManifest(
   const feeSignature =
     platformFeeRecord.signature === null
       ? null
-      : text(platformFeeRecord.signature, "settlement platformFee.signature", {
-          max: 128,
-          min: 64,
-          pattern: /^[1-9A-HJ-NP-Za-km-z]+$/u,
-        });
+      : solanaSignature(
+          platformFeeRecord.signature,
+          "settlement platformFee.signature",
+        );
   if (BigInt(feeDueMinor) === 0n) {
     if (
       feeState !== "not-applicable" ||

--- a/src/lib/solana-settlement.test.ts
+++ b/src/lib/solana-settlement.test.ts
@@ -86,6 +86,25 @@ describe("finalized Solana settlement", () => {
     ).toThrow(/source USDC debit|undeclared/u);
   });
 
+  it("requires the receipt signature to be the transaction identifier", () => {
+    const cosigned = transaction();
+    cosigned.transaction.signatures = ["4".repeat(88), SIGNATURE];
+
+    expect(() =>
+      assertFinalizedUsdcTransfer(cosigned, SIGNATURE, SOURCE, [
+        { recipientOwner: RECIPIENT, amountMinor: "1000000" },
+      ]),
+    ).toThrow(/signature/u);
+    expect(() =>
+      assertFinalizedUsdcFundingTransfer(
+        cosigned,
+        SIGNATURE,
+        RECIPIENT,
+        "1000000",
+      ),
+    ).toThrow(/signature/u);
+  });
+
   it("verifies an exact direct-funding credit without trusting the sender", () => {
     expect(
       assertFinalizedUsdcFundingTransfer(

--- a/src/lib/solana-settlement.test.ts
+++ b/src/lib/solana-settlement.test.ts
@@ -54,6 +54,26 @@ describe("finalized Solana settlement", () => {
     ).toEqual({ signature: SIGNATURE, slot: 123, blockTime: 1_786_000_000 });
   });
 
+  it("rejects base58 strings that do not decode to 64-byte signatures", () => {
+    const malformedSignature = "2".repeat(64);
+    const mislabeled = transaction();
+    mislabeled.transaction.signatures = [malformedSignature];
+
+    expect(() =>
+      assertFinalizedUsdcTransfer(mislabeled, malformedSignature, SOURCE, [
+        { recipientOwner: RECIPIENT, amountMinor: "1000000" },
+      ]),
+    ).toThrow(/signature/u);
+    expect(() =>
+      assertFinalizedUsdcFundingTransfer(
+        mislabeled,
+        malformedSignature,
+        RECIPIENT,
+        "1000000",
+      ),
+    ).toThrow(/signature/u);
+  });
+
   it("rejects failed, underpaid, replay-labeled, and padded transactions", () => {
     const failed = transaction();
     failed.meta.err = { InstructionError: [0, "Custom"] };

--- a/src/lib/solana-settlement.ts
+++ b/src/lib/solana-settlement.ts
@@ -4,6 +4,7 @@
  * never count as payment evidence.
  */
 
+import { isSolanaTransactionId } from "./funding-address.mjs";
 import type {
   RewardAllocationManifest,
   RewardSettlementManifest,
@@ -49,12 +50,7 @@ function safeInteger(value: unknown, field: string): number {
 }
 
 function signature(value: unknown, field: string): string {
-  if (
-    typeof value !== "string" ||
-    value.length < 64 ||
-    value.length > 128 ||
-    !/^[1-9A-HJ-NP-Za-km-z]+$/u.test(value)
-  ) {
+  if (!isSolanaTransactionId(value)) {
     throw new TypeError(`${field} is not a Solana signature`);
   }
   return value;

--- a/src/lib/solana-settlement.ts
+++ b/src/lib/solana-settlement.ts
@@ -147,7 +147,7 @@ export function assertFinalizedUsdcTransfer(
   );
   if (
     !Array.isArray(envelope.signatures) ||
-    !envelope.signatures.some((value) => value === expectedSignature)
+    envelope.signatures[0] !== expectedSignature
   ) {
     throw new TypeError(
       "Solana transaction signature does not match the receipt",
@@ -229,7 +229,7 @@ export function assertFinalizedUsdcFundingTransfer(
   );
   if (
     !Array.isArray(envelope.signatures) ||
-    !envelope.signatures.some((value) => value === expectedSignature)
+    envelope.signatures[0] !== expectedSignature
   ) {
     throw new TypeError(
       "Solana transaction signature does not match the funding record",


### PR DESCRIPTION
## Integrated funding and settlement hardening

Integrates #354, #355, #357, #358, #360, #363, #364, and #365 with their regression coverage: complete Sablier quorum state, exact recipient binding, canonical Solana transaction signatures, primary-signature transaction identity, cross-ledger replay rejection, lifecycle-file consistency, terms activation-date binding, and deterministic funding-index observation timestamps.

Updated two synthetic accessibility fixtures to declare the newly required Sablier recipient and corrected a stale verifier-version fixture. No production funding or signing authority is introduced.

Exact head 085b24ed7948dee3e056ea67382722fd5c23ca4e passed all 764 Vitest tests, schema/type/format/lint checks. Six skill checks detected the wrong local Node version; the skill suite and build are being rerun under pinned Node 24.15.0 without source changes. Actions are waived by the maintainer; neither hosted CI nor deployment is claimed. No UI changes; browser visual review is N/A for these validation-only changes.
