### PR TITLE
fix(funding): accept increasing confirmation evidence

### DIFF
--- a/scripts/check-funding-record-pr.test.ts
+++ b/scripts/check-funding-record-pr.test.ts
@@ -542,28 +542,35 @@ describe("trusted funding-record PR gate", () => {
     }
   });
 
-  it("rejects a fresh confirmation count different from the submitted finality", async () => {
-    const repo = fixture();
-    try {
-      const record = {
-        ...repo.record("bitcoin"),
-        finality: { kind: "confirmations" as const, confirmations: 10 },
-      };
-      const headSha = repo.proposal([record]);
-      const result = await checkFundingRecordPr({
-        repositoryRoot: repo.root,
-        baseSha: repo.baseSha,
-        headSha,
-        pullRequestNumber: 368,
-        fetchImpl: chainFetcher("bitcoin").fetchImpl,
-      });
-      expect(result.decision).toBe("verification-failed");
-      expect(result.reason).toMatch(/finality/u);
-      expect(result.records[0].verifierOutputSha256).toMatch(/^[a-f0-9]{64}$/u);
-    } finally {
-      repo.cleanup();
-    }
-  });
+  it.each([10, 11, 12])(
+    "accepts only nondecreasing fresh confirmations for submitted count %i",
+    async (confirmations) => {
+      const repo = fixture();
+      try {
+        const record = {
+          ...repo.record("bitcoin"),
+          finality: { kind: "confirmations" as const, confirmations },
+        };
+        const headSha = repo.proposal([record]);
+        const result = await checkFundingRecordPr({
+          repositoryRoot: repo.root,
+          baseSha: repo.baseSha,
+          headSha,
+          pullRequestNumber: 368,
+          fetchImpl: chainFetcher("bitcoin").fetchImpl,
+        });
+        expect(result.decision).toBe(
+          confirmations <= 11 ? "verified-records" : "verification-failed",
+        );
+        if (confirmations > 11) expect(result.reason).toMatch(/finality/u);
+        expect(result.records[0].verifierOutputSha256).toMatch(
+          /^[a-f0-9]{64}$/u,
+        );
+      } finally {
+        repo.cleanup();
+      }
+    },
+  );
 
   for (const kind of [
     "manifest",

--- a/scripts/check-funding-record-pr.ts
+++ b/scripts/check-funding-record-pr.ts
@@ -416,8 +416,13 @@ export async function checkFundingRecordPr(input: {
         output.verifier.reason !== null ||
         Date.parse(output.verifier.checkedAt) <
           Date.parse(record.verifier.checkedAt) ||
-        canonicalFundingDecisionBytes(output.finality) !==
-          canonicalFundingDecisionBytes(record.finality)
+        !(
+          canonicalFundingDecisionBytes(output.finality) ===
+            canonicalFundingDecisionBytes(record.finality) ||
+          (output.finality.kind === "confirmations" &&
+            record.finality.kind === "confirmations" &&
+            output.finality.confirmations >= record.finality.confirmations)
+        )
       )
         throw new TypeError(
           "fresh verifier output does not exactly match the record identity, version, or finality",


### PR DESCRIPTION
## Funding verifier confirmation monotonicity

Fresh evidence with more confirmations must not reject a previously verified funding record solely because time has advanced. Accept equal or increased confirmation counts while preserving finality kind, exact transfer identity, amount, verifier version, observation chronology, and all existing schema/finality thresholds. Reject a fresh count below the submitted count.

50 funding-gate tests passed, including equal/increased/decreased confirmation coverage. Full local verification is running. Actions are waived by the maintainer. No signing, payment, automatic merge authority, or deployment is introduced; this addresses one correctness blocker under #368, not its complete unattended-merge acceptance.
