### PR TITLE
fix(funding): preserve monthly instrument history beyond sixteen cycles

### DIFF
--- a/funding/README.md
+++ b/funding/README.md
@@ -232,23 +232,16 @@ reference may remain in current history but cannot back a current commitment.
 New monthly references cannot be used to relabel old records or move balances
 between months. Existing approved and paid allocation rows are unchanged.
 
+The complete monthly instrument history stays in the reviewed manifest without
+a lifetime entry-count ceiling. The trusted transition reader still limits each
+manifest to 1 MiB, including the immutable base. Duplicate identities, overlapping
+active windows, historical rewrites, and deletion remain invalid. Tests cover
+the sixteenth-to-seventeenth-month transition and a 1,200-month history.
+New cycle funding bases bind their exact month and instrument identity. Moving
+history to separate archive files would require a reviewed reference-preserving
+protocol; an archive marker alone never authorizes deleting instrument evidence.
+
 ### Still unresolved: authenticated loss and immutable lifecycle overlay
-
-The current schema also has an executable archival blocker: sixteen distinct
-monthly instruments fit the bounded manifest, but a seventeenth cannot be added.
-Deleting an old entry would violate the immutable prefix and make current public
-ledger validation lose its instrument reference. This draft intentionally does
-not increase the limit or permit deletion. It is not ready for ongoing monthly
-operation until a reviewed archive protocol exists.
-
-That protocol needs an append-only archive record binding the exact instrument,
-monthly period and amount to immutable reviewed manifest bytes, plus verifiable
-lifecycle references proving no open proposal, approved unpaid intent, or carry
-still depends on it. Existing commitment transaction records do not contain that
-complete monthly binding, and cycle records do not identify their backing
-instrument. Resolving those missing references is a schema decision; an archive
-marker alone cannot authorize removal. Historical readers must resolve archived
-instruments while active backing calculations continue to exclude them.
 
 Issue #333 remains open. Loss of either key in the reviewed no-config-authority
 2-of-2 can strand funds; no unilateral recovery, auto-refund, or new recovery

--- a/scripts/check-project-transitions.test.ts
+++ b/scripts/check-project-transitions.test.ts
@@ -13,6 +13,18 @@ function entry(value: { id: string }): [string, string] {
 }
 
 describe("project transition gate", () => {
+  it("bounds manifest bytes on both sides without a lifetime instrument count", () => {
+    const oversized: [string, string] = [
+      "projects/eliza/project.json",
+      `${JSON.stringify(eliza)}${" ".repeat(1024 * 1024)}`,
+    ];
+    expect(() =>
+      validateProjectTransitions([entry(eliza)], [oversized]),
+    ).toThrow(/manifest byte limit/u);
+    expect(() =>
+      validateProjectTransitions([oversized], [entry(eliza)]),
+    ).toThrow(/manifest byte limit/u);
+  });
   it("freezes legacy proposal caps independently of later project caps", () => {
     const path = "cycles/eliza/2026-07/proposal.json";
     const proposal = {

--- a/src/lib/funding-accessibility.test.ts
+++ b/src/lib/funding-accessibility.test.ts
@@ -52,7 +52,7 @@ function fixture() {
 }
 
 describe("monthly commitment accessibility boundary", () => {
-  it("demonstrates the unresolved seventeenth-month archival ceiling without deleting history", () => {
+  it("retains append-only monthly history beyond the seventeenth month", () => {
     const withMonths = (count: number) => {
       const project = fixture();
       const commitments = Array.from({ length: count }, (_, index) => {
@@ -84,9 +84,29 @@ describe("monthly commitment accessibility boundary", () => {
     expect(assertProjectDefinition(sixteen).funding.commitments).toHaveLength(
       16,
     );
-    expect(() => assertProjectDefinition(seventeen)).toThrow(/at most 16/u);
-    expect(() => assertProjectPolicyTransition(sixteen, seventeen)).toThrow(
-      /at most 16/u,
+    const originalBytes = JSON.stringify(seventeen);
+    expect(assertProjectDefinition(seventeen).funding.commitments).toHaveLength(
+      17,
+    );
+    expect(() =>
+      assertProjectPolicyTransition(sixteen, seventeen),
+    ).not.toThrow();
+    expect(JSON.stringify(seventeen)).toBe(originalBytes);
+    expect(
+      assertProjectDefinition(withMonths(1200)).funding.commitments,
+    ).toHaveLength(1200);
+
+    const rewritten = structuredClone(seventeen);
+    rewritten.funding.commitments[0].recipient =
+      "0x2222222222222222222222222222222222222222";
+    expect(() => assertProjectPolicyTransition(sixteen, rewritten)).toThrow(
+      /historical commitment.*immutable/u,
+    );
+
+    const overlapping = structuredClone(seventeen);
+    overlapping.funding.commitments[0].replacedAt = null;
+    expect(() => assertProjectDefinition(overlapping)).toThrow(
+      /overlapping active instruments/u,
     );
   });
   it("requires append-only monthly history and refuses relabeling an old instrument", () => {

--- a/src/lib/funding-commitment.test.ts
+++ b/src/lib/funding-commitment.test.ts
@@ -181,14 +181,14 @@ describe("funding commitment instruments", () => {
     ).toThrow(/reviewed Sablier Lockup v4 deployment/u);
   });
 
-  it("bounds counts and rejects duplicate or overlapping instruments", () => {
+  it("rejects duplicate or overlapping instruments regardless of history length", () => {
     expect(() =>
       assertFundingCommitments(
         Array.from({ length: 17 }, (_, index) =>
           sablierInstrument({ streamId: `${index + 1}` }),
         ),
       ),
-    ).toThrow(/at most 16/u);
+    ).toThrow(/overlapping active instruments/u);
     expect(() =>
       assertFundingCommitments([sablierInstrument(), sablierInstrument()]),
     ).toThrow(/duplicate instrument/u);

--- a/src/lib/funding-commitment.ts
+++ b/src/lib/funding-commitment.ts
@@ -21,7 +21,6 @@ export type {
 export {
   assertFundingCommitments,
   hasActiveFundingCommitment,
-  MAX_FUNDING_COMMITMENTS,
   SABLIER_LOCKUP_V4_CONTRACTS,
 } from "./funding-instruments.mjs";
 

--- a/src/lib/funding-instruments.d.mts
+++ b/src/lib/funding-instruments.d.mts
@@ -44,8 +44,6 @@ export type FundingCommitmentInstrument =
   | SquadsV4VaultInstrument
   | SablierLockupV4Instrument;
 
-export declare const MAX_FUNDING_COMMITMENTS: 16;
-
 export declare const SABLIER_LOCKUP_V4_CONTRACTS: {
   readonly base: "0xc19a09a66887017f603e5df420ed3cb9a5c07c0a";
   readonly ethereum: "0x93b37bd5b6b278373217333ac30d7e74c85fbdcb";

--- a/src/lib/funding-instruments.mjs
+++ b/src/lib/funding-instruments.mjs
@@ -7,8 +7,6 @@
 
 import { isFundingAddress } from "./funding-address.mjs";
 
-export const MAX_FUNDING_COMMITMENTS = 16;
-
 /** Sablier Lockup v4 deployments; the only accepted EVM stream contracts. */
 export const SABLIER_LOCKUP_V4_CONTRACTS = Object.freeze({
   base: "0xc19a09a66887017f603e5df420ed3cb9a5c07c0a",
@@ -362,7 +360,9 @@ function instrumentIdentity(instrument) {
 }
 
 /**
- * Validates the complete bounded commitment-instrument history. Replaced
+ * Validates the complete commitment-instrument history. The trusted manifest
+ * reader bounds input bytes; a lifetime entry cap would eventually require
+ * deleting append-only monthly evidence. Replaced
  * instruments stay listed so historical commitment records remain
  * independently verifiable, while windows for the same network and asset may
  * never overlap.
@@ -371,10 +371,8 @@ export function assertFundingCommitments(
   value,
   field = "project funding commitments",
 ) {
-  if (!Array.isArray(value) || value.length > MAX_FUNDING_COMMITMENTS) {
-    throw new TypeError(
-      `${field} must be an array of at most ${MAX_FUNDING_COMMITMENTS} instruments`,
-    );
+  if (!Array.isArray(value)) {
+    throw new TypeError(`${field} must be an array of instruments`);
   }
   const seenIdentities = new Set();
   const histories = new Map();


### PR DESCRIPTION
## Preserve monthly instrument history

Removes the lifetime 16-instrument ceiling that prevented a seventeenth monthly commitment while immutable-prefix policy forbids deleting earlier instruments. Full history remains in the reviewed manifest; duplicate identities, overlapping active windows, historical rewriting, and deletion still fail closed. The existing trusted reader retains its 1 MiB per-manifest limit on both base and head.

Regressions cover month 16 to 17, 1,200 monthly references, input immutability, historical rewrites, overlapping windows, and oversized base/head manifests. Removes stale documentation claiming cycle records lack an instrument-bound funding basis.

37 focused tests passed. Exact head 592382b1c3ac223de927fde99db3674e1b7bf493 passed full verification (874 tests, 125 skill checks, all static checks and build) and isolated browser/artifact validation (37 viewport plus 2 Pages tests, 3 intentional duplicate reflow skips). Merge 4774a01d36d27fd244e81d21b7a88f0c78df330d has the exact tested tree. Actions remain waived by the maintainer. This addresses the archive-limit portion of #333 only; authenticated capability-loss/accessibility transitions and their settlement-safe carry protocol remain unresolved. No activation, accessibility claim, payment, or deployment is introduced.
