### PR TITLE
fix: restore missing identity cleanup schedule in protected releases

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -422,6 +422,9 @@ jobs:
             exit 1
           fi
 
+          # Restore only absent cleanup triggers; reject nonempty provisioning drift.
+          bun scripts/verify-identity-schedules.mjs --restore-missing
+
           identity_secrets="$RUNNER_TEMP/slop-identity-secrets.json"
           ./node_modules/.bin/wrangler secret list \
             --config workers/identity/wrangler.toml > "$identity_secrets"
@@ -560,6 +563,8 @@ jobs:
             throw new TypeError("identity Worker deployment is not bound to the tested commit");
           }
           NODE
+
+          bun scripts/verify-identity-schedules.mjs
 
           identity_rate_probe_started_at="$(date +%s)"
           if ! [[ "$identity_rate_probe_started_at" =~ ^[0-9]{10}$ ]]; then

--- a/scripts/verify-identity-schedules.mjs
+++ b/scripts/verify-identity-schedules.mjs
@@ -1,0 +1,150 @@
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+export function validateIdentitySchedules(response, expected) {
+  if (
+    !Array.isArray(expected) ||
+    expected.length !== 1 ||
+    typeof expected[0] !== "string" ||
+    expected[0].trim() === ""
+  ) {
+    throw new Error("Identity configuration must declare one cleanup schedule");
+  }
+  if (
+    response?.success !== true ||
+    !Array.isArray(response.result) ||
+    response.result.length !== expected.length ||
+    response.result.some((entry, index) => entry?.cron !== expected[index])
+  ) {
+    throw new Error(
+      "Identity cleanup schedule differs from canonical configuration",
+    );
+  }
+}
+
+export async function verifyIdentitySchedules({
+  configuration,
+  accountId,
+  token,
+  fetchImpl = fetch,
+  restoreMissing = false,
+}) {
+  if (
+    !/^[a-f0-9]{32}$/u.test(accountId ?? "") ||
+    typeof token !== "string" ||
+    token.trim() === "" ||
+    typeof configuration?.name !== "string" ||
+    !/^[a-z0-9-]+$/u.test(configuration.name)
+  ) {
+    throw new Error("Identity schedule verification configuration is invalid");
+  }
+  // Reject malformed canonical configuration before making an authenticated request.
+  validateIdentitySchedules(
+    {
+      success: true,
+      result: configuration.triggers?.crons?.map((cron) => ({ cron })),
+    },
+    configuration.triggers?.crons,
+  );
+  let response;
+  try {
+    response = await fetchImpl(
+      `https://api.cloudflare.com/client/v4/accounts/${accountId}/workers/scripts/${configuration.name}/schedules`,
+      {
+        method: "GET",
+        headers: { Authorization: `Bearer ${token}` },
+        redirect: "error",
+        signal: AbortSignal.timeout(20_000),
+      },
+    );
+  } catch {
+    // error-policy:J2 never retain request errors that could contain credentials.
+    throw new Error("Identity schedule readback request failed");
+  }
+  if (!response.ok)
+    throw new Error("Identity schedule readback was not successful");
+  let body;
+  try {
+    body = await response.json();
+  } catch {
+    // error-policy:J2 API bodies are untrusted and must not appear in release logs.
+    throw new Error("Identity schedule readback was not valid JSON");
+  }
+  if (
+    restoreMissing &&
+    body?.success === true &&
+    Array.isArray(body.result) &&
+    body.result.length === 0
+  ) {
+    let restored;
+    try {
+      restored = await fetchImpl(
+        `https://api.cloudflare.com/client/v4/accounts/${accountId}/workers/scripts/${configuration.name}/schedules`,
+        {
+          method: "PUT",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(
+            configuration.triggers.crons.map((cron) => ({ cron })),
+          ),
+          redirect: "error",
+          signal: AbortSignal.timeout(20_000),
+        },
+      );
+      if (!restored.ok || (await restored.json())?.success !== true) {
+        throw new Error("unsuccessful restoration");
+      }
+    } catch {
+      // error-policy:J2 never retain authenticated request or response details.
+      throw new Error("Identity cleanup schedule restoration failed");
+    }
+    // Do not trust a successful write response as configuration readback evidence.
+    return verifyIdentitySchedules({
+      configuration,
+      accountId,
+      token,
+      fetchImpl,
+    });
+  }
+  validateIdentitySchedules(body, configuration.triggers.crons);
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  try {
+    const restoreMissing = process.argv[2] === "--restore-missing";
+    if (
+      process.argv.length > (restoreMissing ? 3 : 2) ||
+      (restoreMissing &&
+        (process.env.GITHUB_ACTIONS !== "true" ||
+          process.env.GITHUB_REF !== "refs/heads/develop"))
+    ) {
+      throw new Error(
+        "Schedule restoration requires the protected develop workflow",
+      );
+    }
+    const configuration = Bun.TOML.parse(
+      readFileSync(
+        new URL("../workers/identity/wrangler.toml", import.meta.url),
+        "utf8",
+      ),
+    );
+    await verifyIdentitySchedules({
+      configuration,
+      accountId: process.env.CLOUDFLARE_ACCOUNT_ID,
+      token: process.env.CLOUDFLARE_API_TOKEN,
+      restoreMissing,
+    });
+    console.log("Identity cleanup schedule matches canonical configuration.");
+  } catch {
+    // error-policy:J2 print no API response, configuration, or authentication material.
+    console.error(
+      "Identity cleanup schedule verification failed; inspect the authorized trigger configuration.",
+    );
+    process.exitCode = 1;
+  }
+}

--- a/scripts/verify-identity-schedules.mjs
+++ b/scripts/verify-identity-schedules.mjs
@@ -12,9 +12,11 @@ export function validateIdentitySchedules(response, expected) {
   }
   if (
     response?.success !== true ||
-    !Array.isArray(response.result) ||
-    response.result.length !== expected.length ||
-    response.result.some((entry, index) => entry?.cron !== expected[index])
+    !Array.isArray(response.result?.schedules) ||
+    response.result.schedules.length !== expected.length ||
+    response.result.schedules.some(
+      (entry, index) => entry?.cron !== expected[index],
+    )
   ) {
     throw new Error(
       "Identity cleanup schedule differs from canonical configuration",
@@ -42,7 +44,9 @@ export async function verifyIdentitySchedules({
   validateIdentitySchedules(
     {
       success: true,
-      result: configuration.triggers?.crons?.map((cron) => ({ cron })),
+      result: {
+        schedules: configuration.triggers?.crons?.map((cron) => ({ cron })),
+      },
     },
     configuration.triggers?.crons,
   );
@@ -73,8 +77,8 @@ export async function verifyIdentitySchedules({
   if (
     restoreMissing &&
     body?.success === true &&
-    Array.isArray(body.result) &&
-    body.result.length === 0
+    Array.isArray(body.result?.schedules) &&
+    body.result.schedules.length === 0
   ) {
     let restored;
     try {

--- a/scripts/verify-identity-schedules.test.mjs
+++ b/scripts/verify-identity-schedules.test.mjs
@@ -8,7 +8,7 @@ import {
 } from "./verify-identity-schedules.mjs";
 
 const cron = "17 * * * *";
-const valid = { success: true, result: [{ cron }] };
+const valid = { success: true, result: { schedules: [{ cron }] } };
 const options = {
   configuration: { name: "slop-identity", triggers: { crons: [cron] } },
   accountId: "a".repeat(32),
@@ -21,7 +21,7 @@ describe("identity cleanup schedule readback", () => {
       .fn()
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ success: true, result: [] }),
+        json: async () => ({ success: true, result: { schedules: [] } }),
       })
       .mockResolvedValueOnce({
         ok: true,
@@ -55,8 +55,8 @@ describe("identity cleanup schedule readback", () => {
     expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
   it.each([
-    { success: false, result: [] },
-    { success: true, result: [{ cron: "0 * * * *" }] },
+    { success: false, result: { schedules: [] } },
+    { success: true, result: { schedules: [{ cron: "0 * * * *" }] } },
   ])(
     "never overwrites nonempty drift or an unsuccessful read %#",
     async (body) => {
@@ -78,7 +78,7 @@ describe("identity cleanup schedule readback", () => {
       .fn()
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ success: true, result: [] }),
+        json: async () => ({ success: true, result: { schedules: [] } }),
       })
       .mockRejectedValueOnce(new Error(options.token));
     await expect(
@@ -88,7 +88,7 @@ describe("identity cleanup schedule readback", () => {
   it("rejects a still-missing schedule after a successful write without retrying writes", async () => {
     const fetchImpl = vi.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({ success: true, result: [] }),
+      json: async () => ({ success: true, result: { schedules: [] } }),
     });
     await expect(
       verifyIdentitySchedules({ ...options, fetchImpl, restoreMissing: true }),
@@ -102,19 +102,19 @@ describe("identity cleanup schedule readback", () => {
   it("accepts the exact canonical schedule with API metadata", () => {
     expect(() =>
       validateIdentitySchedules(
-        { ...valid, result: [{ cron, created_on: "ignored" }] },
+        { ...valid, result: { schedules: [{ cron, created_on: "ignored" }] } },
         [cron],
       ),
     ).not.toThrow();
   });
   it.each([
     null,
-    { success: false, result: [{ cron }] },
-    { success: true, result: [] },
-    { success: true, result: [{ cron: "18 * * * *" }] },
-    { success: true, result: [{ cron }, { cron }] },
-    { success: true, result: [null] },
-    { success: true, result: { schedules: [{ cron }] } },
+    { success: false, result: { schedules: [{ cron }] } },
+    { success: true, result: { schedules: [] } },
+    { success: true, result: { schedules: [{ cron: "18 * * * *" }] } },
+    { success: true, result: { schedules: [{ cron }, { cron }] } },
+    { success: true, result: { schedules: [null] } },
+    { success: true, result: [{ cron }] },
   ])(
     "rejects missing, changed, extra, or malformed schedules %#",
     (response) => {

--- a/scripts/verify-identity-schedules.test.mjs
+++ b/scripts/verify-identity-schedules.test.mjs
@@ -1,0 +1,211 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it, vi } from "vitest";
+import {
+  validateIdentitySchedules,
+  verifyIdentitySchedules,
+} from "./verify-identity-schedules.mjs";
+
+const cron = "17 * * * *";
+const valid = { success: true, result: [{ cron }] };
+const options = {
+  configuration: { name: "slop-identity", triggers: { crons: [cron] } },
+  accountId: "a".repeat(32),
+  token: "test-only-secret",
+};
+
+describe("identity cleanup schedule readback", () => {
+  it("restores only an empty schedule and independently reads it back", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true, result: [] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true }),
+      })
+      .mockResolvedValueOnce({ ok: true, json: async () => valid });
+    await verifyIdentitySchedules({
+      ...options,
+      fetchImpl,
+      restoreMissing: true,
+    });
+    expect(fetchImpl.mock.calls.map((call) => call[1].method)).toEqual([
+      "GET",
+      "PUT",
+      "GET",
+    ]);
+    expect(fetchImpl.mock.calls[1][1]).toMatchObject({
+      body: JSON.stringify([{ cron }]),
+      redirect: "error",
+    });
+  });
+  it("never modifies a valid existing schedule", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => valid });
+    await verifyIdentitySchedules({
+      ...options,
+      fetchImpl,
+      restoreMissing: true,
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+  it.each([
+    { success: false, result: [] },
+    { success: true, result: [{ cron: "0 * * * *" }] },
+  ])(
+    "never overwrites nonempty drift or an unsuccessful read %#",
+    async (body) => {
+      const fetchImpl = vi
+        .fn()
+        .mockResolvedValue({ ok: true, json: async () => body });
+      await expect(
+        verifyIdentitySchedules({
+          ...options,
+          fetchImpl,
+          restoreMissing: true,
+        }),
+      ).rejects.toThrow();
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+    },
+  );
+  it("rejects failed restoration without leaking response details", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true, result: [] }),
+      })
+      .mockRejectedValueOnce(new Error(options.token));
+    await expect(
+      verifyIdentitySchedules({ ...options, fetchImpl, restoreMissing: true }),
+    ).rejects.toThrow(/^Identity cleanup schedule restoration failed$/u);
+  });
+  it("rejects a still-missing schedule after a successful write without retrying writes", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true, result: [] }),
+    });
+    await expect(
+      verifyIdentitySchedules({ ...options, fetchImpl, restoreMissing: true }),
+    ).rejects.toThrow("differs");
+    expect(fetchImpl.mock.calls.map((call) => call[1].method)).toEqual([
+      "GET",
+      "PUT",
+      "GET",
+    ]);
+  });
+  it("accepts the exact canonical schedule with API metadata", () => {
+    expect(() =>
+      validateIdentitySchedules(
+        { ...valid, result: [{ cron, created_on: "ignored" }] },
+        [cron],
+      ),
+    ).not.toThrow();
+  });
+  it.each([
+    null,
+    { success: false, result: [{ cron }] },
+    { success: true, result: [] },
+    { success: true, result: [{ cron: "18 * * * *" }] },
+    { success: true, result: [{ cron }, { cron }] },
+    { success: true, result: [null] },
+    { success: true, result: { schedules: [{ cron }] } },
+  ])(
+    "rejects missing, changed, extra, or malformed schedules %#",
+    (response) => {
+      expect(() => validateIdentitySchedules(response, [cron])).toThrow();
+    },
+  );
+  it.each([undefined, [], [""], [cron, cron]])(
+    "rejects invalid canonical configuration %#",
+    (expected) => {
+      expect(() => validateIdentitySchedules(valid, expected)).toThrow();
+    },
+  );
+  it("uses only a bounded non-redirecting GET against the configured Worker", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => valid });
+    await verifyIdentitySchedules({ ...options, fetchImpl });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(fetchImpl).toHaveBeenCalledWith(
+      `https://api.cloudflare.com/client/v4/accounts/${options.accountId}/workers/scripts/slop-identity/schedules`,
+      expect.objectContaining({
+        method: "GET",
+        redirect: "error",
+        signal: expect.any(AbortSignal),
+        headers: { Authorization: `Bearer ${options.token}` },
+      }),
+    );
+  });
+  it("does not echo sensitive fetch errors", async () => {
+    await expect(
+      verifyIdentitySchedules({
+        ...options,
+        fetchImpl: async () => {
+          throw new Error(options.token);
+        },
+      }),
+    ).rejects.toThrow(/^Identity schedule readback request failed$/u);
+  });
+  it("does not parse or echo unsuccessful API responses", async () => {
+    const json = vi.fn();
+    await expect(
+      verifyIdentitySchedules({
+        ...options,
+        fetchImpl: async () => ({ ok: false, json }),
+      }),
+    ).rejects.toThrow("not successful");
+    expect(json).not.toHaveBeenCalled();
+  });
+  it("sanitizes JSON errors", async () => {
+    await expect(
+      verifyIdentitySchedules({
+        ...options,
+        fetchImpl: async () => ({
+          ok: true,
+          json: async () => {
+            throw new Error(options.token);
+          },
+        }),
+      }),
+    ).rejects.toThrow(/^Identity schedule readback was not valid JSON$/u);
+  });
+  it.each([
+    { accountId: "../other" },
+    { token: "" },
+    { configuration: { name: "../other", triggers: { crons: [cron] } } },
+    { configuration: { name: "slop-identity", triggers: { crons: [] } } },
+  ])(
+    "rejects invalid inputs without sending credentials %#",
+    async (override) => {
+      const fetchImpl = vi.fn();
+      await expect(
+        verifyIdentitySchedules({ ...options, ...override, fetchImpl }),
+      ).rejects.toThrow();
+      expect(fetchImpl).not.toHaveBeenCalled();
+    },
+  );
+  it("checks before deployment mutation and again after identity activation", () => {
+    const workflow = readFileSync(
+      resolve(
+        dirname(fileURLToPath(import.meta.url)),
+        "../.github/workflows/deploy.yml",
+      ),
+      "utf8",
+    );
+    const command = "bun scripts/verify-identity-schedules.mjs";
+    expect(workflow.split(command)).toHaveLength(3);
+    expect(workflow.indexOf(command)).toBeLessThan(
+      workflow.indexOf("./node_modules/.bin/wrangler d1 migrations apply"),
+    );
+    expect(workflow.lastIndexOf(command)).toBeGreaterThan(
+      workflow.indexOf("./node_modules/.bin/wrangler versions deploy"),
+    );
+  });
+});

--- a/workers/identity/README.md
+++ b/workers/identity/README.md
@@ -161,6 +161,17 @@ the protected workflow's `wrangler versions upload` followed by
 requesting zone-level Workers Routes authority or rewriting the established
 domain.
 
+The protected release verifies the live cleanup schedule against this Worker's
+canonical configuration before code/database deployment and after version activation.
+If the live schedule list is entirely empty, the release restores only the canonical
+cleanup schedule and independently reads it back. Additional or changed nonempty
+triggers fail closed without modification. Version activation itself does not
+repair trigger drift. The repair never modifies domains or broadens credentials;
+claim the deployment lever on the tracking issue before other trigger changes. Never enable
+invocation logs or publish OAuth capabilities to diagnose cleanup. A matching
+schedule is configuration evidence only; separately verify a scheduled execution
+removes expired metadata while preserving live flows and permanent trace objects.
+
 Before enabling clients, verify the custom domain's DNS and TLS separately and
 prove rate limiting, assertion replay, and CSRF rejection in production. The
 Workers Rate Limiting bindings are the fast approximate edge shield at a


### PR DESCRIPTION
## Summary

- Addresses the confirmed missing production cleanup Cron Trigger tracked in #388. The protected develop release restores only an entirely absent canonical schedule, then reads it back independently.
- Existing nonempty schedule drift fails closed. No domain, DNS, secret, logging, environment, or branch-protection changes; no local production deployment.
- Adds post-activation readback because Worker version deployment preserves triggers rather than reconciling them.
- Validates the Cloudflare `result.schedules` envelope used by pinned Wrangler, with bounded, non-redirecting requests and sanitized failure output.

## Validation

Exact head and final full verification/browser evidence will be attached before merge. 27 focused schedule regressions cover missing/extra/changed/malformed schedules, no-write paths, empty-only restoration, failed restoration, independent readback, request shape, and credential-safe errors.

UI/screenshots/accessibility changes: N/A - release tooling only; the existing browser suite is being rerun for regression coverage.
Production restoration/scheduled cleanup proof: pending the protected release and an actual hourly execution. This PR does not close #388 or claim production is fixed.
Hosted Actions are not a merge gate at the user's explicit direction; local validation remains required.
