### PR TITLE
Remove superheaders and duplicate site copy

### DIFF
--- a/scripts/check-project-transitions.test.ts
+++ b/scripts/check-project-transitions.test.ts
@@ -281,8 +281,8 @@ describe("project transition gate", () => {
     };
 
     const reducedOnAdd = structuredClone(withPledgedReview);
-    reducedOnAdd.reward.monthlyCapMinor = "9999000000";
-    reducedOnAdd.reward.monthlyCapDisplay = "$9,999";
+    reducedOnAdd.reward.monthlyCapMinor = "4999000000";
+    reducedOnAdd.reward.monthlyCapDisplay = "$4,999";
     expect(() =>
       validateProjectTransitions([entry(eliza)], [entry(reducedOnAdd)]),
     ).toThrow(/review budget.*reducing the contributor pool cap/u);
@@ -312,8 +312,8 @@ describe("project transition gate", () => {
     funded.reward.reviewBudget.fundingState = "committed";
     funded.reward.reviewBudget.paymentMode = "disabled";
     funded.reward.reviewBudget.committedMinor = "1000000";
-    funded.reward.monthlyCapMinor = "9999000000";
-    funded.reward.monthlyCapDisplay = "$9,999";
+    funded.reward.monthlyCapMinor = "4999000000";
+    funded.reward.monthlyCapDisplay = "$4,999";
     (
       funded as unknown as { funding: { commitments: unknown[] } }
     ).funding.commitments = [

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -636,7 +636,6 @@ function Footer() {
       <div className="shell footer-grid">
         <div>
           <div className="wordmark footer-wordmark">{domain}</div>
-          <p className="footer-tagline">make money shipping open source</p>
           <p className="footer-copyright">
             © {new Date().getUTCFullYear()} slop.cash.
           </p>
@@ -1212,12 +1211,11 @@ function HomePage({ state, retry }: { state: DataState; retry: () => void }) {
     <main>
       <section className="hero shell">
         <DataNotice state={state} retry={retry} />
-        <p className="hero-eyebrow">Non-custodial open-source funding</p>
+
         <TypewriterHeroHeading />
         <p className="hero-copy">
-          Fund a capped monthly pool. Slop scores accepted work from public
-          GitHub evidence and produces an auditable allocation. Project owners
-          sign USDC directly. Slop never holds funds or keys.
+          Fund accepted work on GitHub. Slop calculates allocations from public
+          evidence; project owners sign payments directly.
         </p>
         <div className="hero-actions">
           <Link className="button primary-button" href="/#projects">
@@ -1227,17 +1225,6 @@ function HomePage({ state, retry }: { state: DataState; retry: () => void }) {
             Fund a project
           </Link>
         </div>
-        <ol aria-label="How Slop works" className="hero-proof">
-          <li>
-            <strong>01</strong> Choose reviewed work
-          </li>
-          <li>
-            <strong>02</strong> Ship on GitHub
-          </li>
-          <li>
-            <strong>03</strong> Build a public record
-          </li>
-        </ol>
         {state.status === "ready" ? (
           <dl className="system-strip">
             <div>
@@ -1275,7 +1262,6 @@ function HomePage({ state, retry }: { state: DataState; retry: () => void }) {
         <section className="section shell proof-object-section">
           <div className="home-section-heading">
             <div>
-              <p className="eyebrow">Funny name. Serious receipts.</p>
               <h2 className="home-section-title">The proof is the product.</h2>
             </div>
             <p>
@@ -1398,7 +1384,7 @@ function HomePage({ state, retry }: { state: DataState; retry: () => void }) {
       <section className="section shell home-projects-section" id="projects">
         <div className="home-section-heading">
           <div>
-            <h2 className="home-section-title">Projects worth shipping.</h2>
+            <h2 className="home-section-title">Projects</h2>
           </div>
         </div>
         <section className="project-tier" aria-labelledby="featured-projects">
@@ -1421,13 +1407,11 @@ function HomePage({ state, retry }: { state: DataState; retry: () => void }) {
       <section className="section shell audience-section">
         <div className="home-section-heading">
           <div>
-            <p className="eyebrow">Choose your lane</p>
             <h2 className="home-section-title">One ledger. Three jobs.</h2>
           </div>
         </div>
         <div className="audience-grid">
           <article>
-            <span>Fund</span>
             <h3>Pay for accepted outcomes.</h3>
             <p>
               Commit a capped contributor pool and an optional additive review
@@ -1436,7 +1420,6 @@ function HomePage({ state, retry }: { state: DataState; retry: () => void }) {
             <Link href="/projects/new">Fund a project</Link>
           </article>
           <article>
-            <span>Maintain</span>
             <h3>Keep GitHub in control.</h3>
             <p>
               Review work in the project repository while Slop publishes the
@@ -1445,7 +1428,6 @@ function HomePage({ state, retry }: { state: DataState; retry: () => void }) {
             <Link href="/how-it-works">See the mechanism</Link>
           </article>
           <article>
-            <span>Contribute</span>
             <h3>Ship with any agent.</h3>
             <p>
               Use the project skill, disclose the exact model, and land useful
@@ -1459,45 +1441,38 @@ function HomePage({ state, retry }: { state: DataState; retry: () => void }) {
         <div className="shell">
           <div className="home-section-heading inverse-heading">
             <div>
-              <h2 className="home-section-title">Work in. Proof out.</h2>
+              <h2 className="home-section-title">How it works</h2>
             </div>
           </div>
           <div className="how-grid">
             <article>
-              <span>01</span>
-              <h3>Choose the mission.</h3>
+              <h3>Choose work.</h3>
+              <p>Read the project terms and choose unblocked work on GitHub.</p>
+            </article>
+            <article>
+              <h3>Submit a PR.</h3>
               <p>
-                Read the repository, reward terms, and live work queue. There
-                are no platform reservations or hidden tasks.
+                Use the project skill to guide your agent through testing and
+                submission.
               </p>
             </article>
             <article>
-              <span>02</span>
-              <h3>Ship the outcome.</h3>
+              <h3>Get reviewed.</h3>
               <p>
-                Use any agent or model. The project skill guides scope, tests,
-                evidence, and exact attribution.
-              </p>
-            </article>
-            <article>
-              <span>03</span>
-              <h3>Earn the record.</h3>
-              <p>
-                Maintainers accept the work. Slop publishes score, review, and
-                verified payment state without rewarding busywork.
+                Maintainers review your PR. Track accepted work, scores, and
+                payments on Slop.
               </p>
             </article>
           </div>
           <div className="owner-callout">
             <div>
-              <h3>Turn your roadmap into an open invitation.</h3>
+              <h3>Add your project.</h3>
               <p>
-                Draft the project on Slop, then open a GitHub pull request for
-                public review. Your repository remains the authority.
+                Propose your repository and reward terms for review on GitHub.
               </p>
             </div>
             <Link className="button inverse-button" href="/projects/new">
-              Add your project <ArrowRight aria-hidden="true" />
+              Get started <ArrowRight aria-hidden="true" />
             </Link>
           </div>
         </div>
@@ -3925,12 +3900,10 @@ ${manifestText}`;
         <span>/</span>Add a project
       </p>
       <section className="proposal-intro">
-        <p className="eyebrow">Project onboarding</p>
         <h1>Add a project.</h1>
         <p>
-          Describe the work and its public authority here. Slop will generate a
-          project manifest and an agent-ready proposal, then send you to GitHub
-          for the reviewable pull request.
+          Enter your project details to generate a manifest and proposal for
+          review on GitHub.
         </p>
         <ol className="proposal-steps" aria-label="Project onboarding steps">
           <li>
@@ -4362,7 +4335,6 @@ function HowItWorksPage() {
   return (
     <main className="shell evidence-page">
       <section className="evidence-page-hero">
-        <p className="eyebrow">How scoring works</p>
         <h1>Accepted work in. Auditable allocations out.</h1>
         <p>
           GitHub is the work and review authority. Slop turns accepted public
@@ -4416,7 +4388,6 @@ function HowItWorksPage() {
       </ol>
       <section className="worked-example">
         <div>
-          <p className="eyebrow">Worked example</p>
           <h2>One reproducible allocation.</h2>
           <p>
             If one contributor has 10 accepted score units out of 25, their
@@ -4444,7 +4415,6 @@ function HowItWorksPage() {
         </dl>
       </section>
       <section className="custody-proof">
-        <p className="eyebrow">Non-custodial by construction</p>
         <h2>What Slop never holds.</h2>
         <ul>
           <li>No contributor or project private keys.</li>
@@ -4477,7 +4447,6 @@ function ReceiptsPage({
   return (
     <main className="shell evidence-page">
       <section className="evidence-page-hero">
-        <p className="eyebrow">Receipt inspector</p>
         <h1>Signed runs, without the private trace.</h1>
         <p>
           Public receipts show identity and byte-continuity metadata. Raw
@@ -4576,7 +4545,6 @@ function CycleArchivePage({
   return (
     <main className="shell evidence-page">
       <section className="evidence-page-hero">
-        <p className="eyebrow">Permanent cycle archive</p>
         <h1>Every pool gets a dated public record.</h1>
         <p>
           Proposed is not approved. Approved is not paid. Each cycle keeps its

--- a/src/Deck.tsx
+++ b/src/Deck.tsx
@@ -71,10 +71,6 @@ function Frame({
       aria-label={`${index + 1} of ${SLIDE_COUNT}: ${label}`}
       tabIndex={0}
     >
-      <div className="deck-kicker">
-        <img src="/slop-mark.svg" alt="" />
-        <span>slop.cash</span>
-      </div>
       {children}
     </section>
   );

--- a/src/ErrorBoundary.tsx
+++ b/src/ErrorBoundary.tsx
@@ -35,9 +35,7 @@ export class ErrorBoundary extends Component<
       return (
         <main className="fatal-error" role="alert">
           <span aria-hidden="true">!</span>
-          <p className="eyebrow">Page error</p>
           <h1>Slop could not load.</h1>
-          <p>Reload to try again.</p>
           <button onClick={() => window.location.reload()} type="button">
             Reload the page
           </button>

--- a/src/deck.css
+++ b/src/deck.css
@@ -36,21 +36,7 @@
   min-height: 100svh;
   padding: clamp(80px, 7vw, 108px) clamp(28px, 5vw, 76px) clamp(76px, 6vw, 96px);
 }
-.deck-kicker {
-  position: absolute;
-  top: clamp(24px, 3.5vw, 46px);
-  left: clamp(28px, 5vw, 76px);
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  font-size: 15px;
-  font-weight: 800;
-  letter-spacing: -0.04em;
-}
-.deck-kicker img {
-  width: 24px;
-  height: 24px;
-}
+
 .deck h1,
 .deck h2,
 .deck h3,
@@ -917,9 +903,7 @@
   .deck-slide {
     padding: 76px 22px 74px;
   }
-  .deck-kicker {
-    left: 22px;
-  }
+
   .deck h2 {
     font-size: clamp(43px, 12vw, 66px);
   }

--- a/src/styles.css
+++ b/src/styles.css
@@ -92,8 +92,6 @@ textarea:focus-visible {
   font-weight: 600;
 }
 
-.hero-eyebrow,
-.eyebrow,
 .proof-object-kicker,
 .funding-kind,
 .receipt-card dt,
@@ -103,10 +101,6 @@ textarea:focus-visible {
   font-weight: 800;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-}
-
-.hero-eyebrow {
-  margin: 0 0 18px;
 }
 
 .system-strip {
@@ -614,15 +608,6 @@ textarea:focus-visible {
   }
 }
 
-.eyebrow {
-  margin: 0 0 14px;
-  color: var(--orange-dark);
-  font-size: 11px;
-  font-weight: 800;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-}
-
 h1,
 h2,
 h3,
@@ -710,15 +695,6 @@ p {
   line-height: 1.6;
 }
 
-.hero-eyebrow {
-  margin: 0 0 22px;
-  color: var(--orange-dark);
-  font-size: 11px;
-  font-weight: 800;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-}
-
 .hero-actions {
   display: flex;
   flex-wrap: wrap;
@@ -734,43 +710,6 @@ p {
 .secondary-button:hover {
   border-color: rgba(255, 90, 25, 0.65);
   background: var(--white);
-}
-
-.hero-proof {
-  width: 100%;
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 0;
-  margin-top: 54px;
-  padding: 0;
-  border-block: 1px solid var(--line);
-  list-style: none;
-}
-
-.hero-proof li {
-  min-height: 72px;
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 16px 20px;
-  border-right: 1px solid var(--line);
-  color: var(--muted);
-  font-size: 12px;
-  font-weight: 650;
-}
-
-.hero-proof li:first-child {
-  padding-left: 0;
-}
-
-.hero-proof li:last-child {
-  border-right: 0;
-}
-
-.hero-proof strong {
-  color: var(--orange-dark);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 10px;
 }
 
 .button {
@@ -850,10 +789,6 @@ p {
   align-items: end;
   gap: 48px;
   margin-bottom: 36px;
-}
-
-.home-section-heading .eyebrow {
-  margin-bottom: 16px;
 }
 
 .home-section-heading .home-section-title {
@@ -1111,7 +1046,7 @@ p {
 
 .project-state {
   display: block;
-  margin-bottom: 10px;
+  margin-top: 10px;
   color: var(--orange-dark);
   font-size: 9px;
   font-weight: 800;
@@ -1130,10 +1065,6 @@ p {
   color: #b8b1a6;
 }
 
-.inverse-heading .eyebrow {
-  color: #ff8b5f;
-}
-
 .how-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
@@ -1141,7 +1072,7 @@ p {
 }
 
 .how-grid article {
-  min-height: 300px;
+  min-height: 220px;
   padding: 30px;
   border-right: 1px solid rgba(255, 255, 255, 0.14);
 }
@@ -1150,16 +1081,9 @@ p {
   border-right: 0;
 }
 
-.how-grid article > span {
-  color: #ff8b5f;
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 11px;
-  font-weight: 800;
-}
-
 .how-grid h3 {
   max-width: 9ch;
-  margin: 84px 0 18px;
+  margin: 0 0 18px;
   font-size: clamp(26px, 3vw, 38px);
   letter-spacing: -0.05em;
   line-height: 1;
@@ -1189,10 +1113,6 @@ p {
   font-size: clamp(34px, 5vw, 64px);
   letter-spacing: -0.055em;
   line-height: 1;
-}
-
-.owner-callout .eyebrow {
-  color: #ff8b5f;
 }
 
 .owner-callout > div > p:last-child {
@@ -1411,12 +1331,6 @@ small {
   margin: 0;
   color: #aaa398;
   font-size: 11px;
-}
-
-.footer-grid .footer-tagline {
-  color: var(--white);
-  font-size: 13px;
-  font-weight: 650;
 }
 
 .footer-grid .footer-copyright {
@@ -2288,7 +2202,7 @@ small {
   font-size: clamp(28px, 4vw, 48px);
 }
 
-.agent-handoff p:not(.eyebrow) {
+.agent-handoff p {
   max-width: 62ch;
   color: #aaa398;
   font-size: 12px;
@@ -2824,7 +2738,6 @@ small {
 
   .how-grid h3 {
     max-width: none;
-    margin-top: 46px;
   }
 
   .project-card-content {
@@ -2873,23 +2786,6 @@ small {
 
   .hero-copy {
     margin-top: 24px;
-  }
-
-  .hero-proof {
-    grid-template-columns: 1fr;
-    margin-top: 40px;
-  }
-
-  .hero-proof li,
-  .hero-proof li:first-child {
-    min-height: 54px;
-    padding: 12px 0;
-    border-right: 0;
-    border-bottom: 1px solid var(--line);
-  }
-
-  .hero-proof li:last-child {
-    border-bottom: 0;
   }
 
   .project-hero h1,

--- a/tests/app.test.tsx
+++ b/tests/app.test.tsx
@@ -589,7 +589,7 @@ describe("discovery", () => {
       "/projects/eliza",
     );
     expect(
-      screen.getByRole("heading", { name: "Projects worth shipping." }),
+      screen.getByRole("heading", { name: "Projects" }),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("heading", { name: "Featured" }),

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -116,7 +116,7 @@ test("discovers both reward models and a score-ranked global ledger", async ({
   await expect(
     page.getByRole("heading", {
       exact: true,
-      name: "Projects worth shipping.",
+      name: "Projects",
     }),
   ).toBeVisible();
   await expect(


### PR DESCRIPTION
Removes small labels above headings, the repeated hero checklist and footer slogan, and redundant homepage copy. Shortens the process and onboarding text and removes unused CSS and spacing while preserving current funding and scoring behavior.

Also updates the existing cap-reduction test from $9,999 to $4,999 after develop lowered the Eliza cap to $5,000; the old fixture increased the cap and no longer exercised its rejection assertion.

Validation: frozen lockfile installed; registry, type, format, lint, and targeted transition tests pass. Desktop and mobile home, onboarding, and deck checks report zero WCAG AA violations, console errors, and horizontal overflow, including home at 200% zoom. Final head: `0006b4ef262514f1118429b0b200a6ad559072f8`. All hosted checks passed, including unit, skill, build, and desktop/mobile browser checks: https://github.com/SlopDotCash/slopdotcash/actions/runs/33990086800 . Local browser validation passed 37 tests with 3 viewport-specific skips, plus both Pages artifact/route checks. All 125 skill tests passed with pinned Node 24.15.0; the initial local verify attempt used an older Node and failed its runtime assertions. Screenshots and local logs are retained outside the repository. Production deployment evidence is N/A - this PR has not been deployed.
