### PR TITLE
Authenticate reviewed signer access reports without payment authority

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,7 @@
       "devDependencies": {
         "@axe-core/playwright": "^4.11.1",
         "@biomejs/biome": "2.5.6",
+        "@noble/curves": "2.4.0",
         "@playwright/test": "^1.61.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -226,6 +227,10 @@
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.2.2", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3", "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3" } }, "sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw=="],
+
+    "@noble/curves": ["@noble/curves@2.4.0", "", { "dependencies": { "@noble/hashes": "2.4.0" } }, "sha512-P4/62zrgfH33CneE3Dn4WhJVA22YUU0eR51wKIan4NVRvwsA0YnPTwWGpNbpuacSujmSFLvyzpyuR30+fbq2Ew=="],
+
+    "@noble/hashes": ["@noble/hashes@2.4.0", "", {}, "sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.142.0", "", {}, "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ=="],
 

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "react-dom": "19.2.7"
   },
   "devDependencies": {
+    "@noble/curves": "2.4.0",
     "@axe-core/playwright": "^4.11.1",
     "@biomejs/biome": "2.5.6",
     "@playwright/test": "^1.61.0",

--- a/protocol/signer-access-attestations.md
+++ b/protocol/signer-access-attestations.md
@@ -1,0 +1,91 @@
+# Signer access attestations
+
+This is the read-only authentication component of #333. It verifies an exact
+report against an already reviewed monthly Squads instrument. It does not
+publish a commitment as accessible, activate payments, merge evidence into the
+funding ledger, change an allocation, or authorize a transaction. Those remain
+blocked until the append-only lifecycle integration described below is reviewed.
+
+## Authority and evidence
+
+`scripts/verify-signer-access.ts` implements `slop-signer-access:v1`. The
+attesters are the instrument's numeric `funderActorId` and its independently
+reviewed `stewardGithub.actorId` plus immutable node ID, not a display login,
+commit author email, model judgment, or project owner substituted for a signer.
+Each role binds its exact reviewed Solana member key. The manifest revision must
+already be an ancestor of the operator's fetched `origin/develop`; proposed
+head manifests do not establish authority. Fetch current GitHub before use.
+
+Reports bind project, manifest SHA, monthly cycle, complete instrument identity,
+role, actor ID, member key, capability, canonical UTC report time, expiry,
+bounded public reason, member signature, source repository, and source commit.
+The CLI accepts only a bounded regular canonical JSON file; duplicate keys,
+extra fields, malformed timestamps, future reports, and altered authority fail.
+
+Both report types require a publicly readable GitHub commit whose verified
+signature belongs to the reviewed actor. The exact commit message is returned
+by `signerAccessCommitMessage`. It binds all report fields except its own commit
+SHA, which cannot be included recursively. GitHub's verified-signature state,
+immutable signer identity, exact commit ID, and complete message must agree.
+The GitHub signing credential is separate from the Squads member key.
+
+- `lost-access` requires a public reason, `expiresAt: null`, and
+  `memberSignature: null`. Authentication does not require the key that was lost.
+- `can-sign` additionally requires an Ed25519 signature by the reviewed member
+  over the exact UTF-8 bytes returned by `signerCapabilityMessage`. This message
+  is domain-separated from transactions and expressly denies payment authority.
+  It excludes only its own detached signature and the source commit SHA. The
+  signature is canonical padded base64. Positive reports have a maximum
+  24-hour lifetime; verification of a historical report is not a claim that
+  its capability is still current.
+
+Member proofs use lockfile-pinned Noble Curves strict verification
+(`zip215: false`), not permissive consensus verification. A regression covers
+identity-point forgeries accepted by Node's native verifier. See the library's
+[strict verification contract](https://github.com/paulmillr/noble-curves/tree/2.4.0#consensus-friendliness-vs-e-voting).
+Production code imports verification only. Tests generate disposable synthetic
+keys; no production key or signer identity is created by this implementation.
+
+## Operator use
+
+The signer uses an external client to obtain the canonical message, optionally
+sign the capability message with their existing member key, then create the
+GitHub-signed commit with the exact report message. Only the final public report
+and public proof are supplied to Slop. Never include private keys, seed phrases,
+credentials, private wallet metadata, or private repository contents.
+
+After fetching trusted `develop`, run from the repository root:
+
+```bash
+bun install --frozen-lockfile --ignore-scripts
+bun scripts/verify-signer-access.ts <reviewed-manifest-sha> <report.json>
+```
+
+The command performs read-only Git/GitHub queries and signature verification.
+Its output says `paymentAuthorized: false`. A positive result authenticates one
+signer's historical report, not both signers, current on-chain configuration,
+instrument balance, legal ownership, or a transferable payment approval.
+
+## Lifecycle integration still required before activation
+
+Reports must enter a complete append-only, trusted-base-validated ledger before
+they can drive public state. An omitted loss report must never be replaced by a
+caller-selected pair of positive reports. Loss by either signer is terminal for
+that instrument; later capability reports cannot silently undo it. Positive
+accessibility requires both unexpired member proofs plus independently verified
+instrument configuration and backing. Expiry returns positive evidence to
+unknown, never silently extends it.
+
+Loss must publish the exact reason and instrument/cycle identity and block new
+settlement plans for that funding basis. Proposed rows may be held through an
+explicit reviewed transition. Approved, scheduled, partially settled, and paid
+history must stay immutable: an append-only hold overlay must reconcile exact
+remaining principal and prevent both an old intent and a successor cycle from
+paying it. Only eligible shared-pool principal carries, exactly once; review
+budget does not carry. The successor monthly cycle requires a fresh instrument.
+
+Until those gates, complete public readback, and settlement/carry regressions
+are in place, the existing `unknown` accessibility and disabled-payment policy
+remain unchanged. #333 is not closed by authentication alone. There is no
+unilateral recovery, refund, key rotation, signing, broadcasting, or money
+movement in this component.

--- a/scripts/verify-signer-access.test.ts
+++ b/scripts/verify-signer-access.test.ts
@@ -1,0 +1,226 @@
+import { generateKeyPairSync, sign } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import eliza from "../projects/eliza/project.json";
+import { assertProjectDefinition } from "../src/lib/project-schema.mjs";
+import {
+  assertSignerAccessReport,
+  type SignerAccessReport,
+  signerAccessCommitMessage,
+  signerCapabilityMessage,
+  squadsAccessInstrumentId,
+  verifySignerAccess,
+} from "./verify-signer-access";
+
+function base58(bytes: Uint8Array): string {
+  const alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+  let number = BigInt(`0x${Buffer.from(bytes).toString("hex")}`);
+  let result = "";
+  while (number > 0n) {
+    result = alphabet[Number(number % 58n)] + result;
+    number /= 58n;
+  }
+  let leading = 0;
+  while (leading < bytes.length && bytes[leading] === 0) leading++;
+  return "1".repeat(leading) + result;
+}
+function fixture(role: "funder" | "steward" = "funder") {
+  const keys = generateKeyPairSync("ed25519");
+  const other = generateKeyPairSync("ed25519");
+  const member = base58(
+    keys.publicKey.export({ format: "der", type: "spki" }).subarray(-32),
+  );
+  const otherMember = base58(
+    other.publicKey.export({ format: "der", type: "spki" }).subarray(-32),
+  );
+  const instrument = {
+    kind: "squads-v4-vault" as const,
+    network: "solana" as const,
+    asset: "USDC" as const,
+    multisig: "11111111111111111111111111111111",
+    vault: "Vote111111111111111111111111111111111111111",
+    vaultIndex: 0,
+    funderActorId: "18633264",
+    funderMember: role === "funder" ? member : otherMember,
+    stewardMember: role === "steward" ? member : otherMember,
+    stewardGithub: {
+      actorId: "42",
+      nodeId: "U_fixture_42",
+      login: "independent-fixture",
+    },
+    monthlyCommitment: {
+      cycleId: "2026-09",
+      amountMinor: "5000000",
+      accessibility: "unknown" as const,
+    },
+    effectiveAt: "2026-09-01T00:00:00.000Z",
+    deadline: "2026-10-01T00:00:00.000Z",
+    replacedAt: null,
+  };
+  const project = assertProjectDefinition({
+    ...structuredClone(eliza),
+    reward: {
+      ...eliza.reward,
+      fundingState: "committed",
+      committedMinor: "5000000",
+      paymentMode: "disabled",
+    },
+    funding: { ...eliza.funding, commitments: [instrument] },
+  });
+  const report: SignerAccessReport = {
+    kind: "slop-signer-access",
+    schemaVersion: "1",
+    projectId: project.id,
+    manifestRevision: "a".repeat(40),
+    cycleId: "2026-09",
+    instrumentId: squadsAccessInstrumentId(instrument),
+    actorId: role === "funder" ? "18633264" : "42",
+    role,
+    member,
+    capability: "can-sign",
+    reportedAt: "2026-09-05T20:00:00.000Z",
+    expiresAt: "2026-09-06T20:00:00.000Z",
+    reason: "I can sign with the reviewed member key.",
+    memberSignature: null,
+    sourceRepository: "example/evidence",
+    sourceCommit: "b".repeat(40),
+  };
+  report.memberSignature = sign(
+    null,
+    Buffer.from(signerCapabilityMessage(report)),
+    keys.privateKey,
+  ).toString("base64");
+  const commit = () => ({
+    oid: report.sourceCommit,
+    message: `${signerAccessCommitMessage(report)}\n`,
+    signature: {
+      isValid: true,
+      state: "VALID",
+      signer: {
+        databaseId: Number(report.actorId),
+        id: role === "steward" ? "U_fixture_42" : "U_funder",
+      },
+    },
+  });
+  const input = () => ({
+    report,
+    project,
+    manifestRevision: report.manifestRevision,
+    now: "2026-09-05T20:01:00.000Z",
+    readCommit: async () => commit(),
+  });
+  return { report, project, commit, input };
+}
+
+describe("independently authenticated signer access reports", () => {
+  it.each(["funder", "steward"] as const)(
+    "verifies %s GitHub identity and member proof",
+    async (role) => {
+      const f = fixture(role);
+      expect(await verifySignerAccess(f.input())).toEqual(f.report);
+    },
+  );
+  it.each(["funder", "steward"] as const)(
+    "authenticates %s loss without requiring the lost key",
+    async (role) => {
+      const f = fixture(role);
+      f.report.capability = "lost-access";
+      f.report.memberSignature = null;
+      f.report.expiresAt = null;
+      f.report.reason = "Signing capability was lost.";
+      expect(await verifySignerAccess(f.input())).toEqual(f.report);
+    },
+  );
+  it("does not accept a GitHub signature alone as capability proof", async () => {
+    const f = fixture();
+    f.report.memberSignature = Buffer.alloc(64).toString("base64");
+    await expect(verifySignerAccess(f.input())).rejects.toThrow(
+      "Member capability signature",
+    );
+  });
+  it("rejects forged identity-point signatures accepted by native permissive verification", async () => {
+    const f = fixture();
+    const publicKey = Buffer.alloc(32);
+    publicKey[0] = 1;
+    const signature = Buffer.alloc(64);
+    signature[0] = 1;
+    f.report.member = base58(publicKey);
+    f.report.memberSignature = signature.toString("base64");
+    const rawProject = structuredClone(f.project);
+    const instrument = rawProject.funding.commitments?.[0];
+    if (instrument?.kind !== "squads-v4-vault") throw new Error("fixture");
+    const project = assertProjectDefinition({
+      ...rawProject,
+      funding: {
+        ...rawProject.funding,
+        commitments: [{ ...instrument, funderMember: f.report.member }],
+      },
+    });
+    await expect(verifySignerAccess({ ...f.input(), project })).rejects.toThrow(
+      "Member capability signature",
+    );
+  });
+  it.each(["reason", "reportedAt", "sourceRepository"])(
+    "binds %s into the member proof",
+    async (field) => {
+      const f = fixture();
+      if (field === "reason") f.report.reason = "Changed claim";
+      if (field === "reportedAt")
+        f.report.reportedAt = "2026-09-05T20:00:01.000Z";
+      if (field === "sourceRepository")
+        f.report.sourceRepository = "another/repository";
+      await expect(verifySignerAccess(f.input())).rejects.toThrow(
+        "Member capability signature",
+      );
+    },
+  );
+  it.each([
+    "invalid",
+    "wrong-actor",
+    "wrong-message",
+    "wrong-commit",
+    "wrong-node",
+  ])("rejects GitHub evidence: %s", async (failure) => {
+    const f = fixture("steward");
+    const commit = f.commit();
+    if (failure === "invalid") commit.signature.isValid = false;
+    if (failure === "wrong-actor") commit.signature.signer.databaseId = 99;
+    if (failure === "wrong-message") commit.message += "extra text";
+    if (failure === "wrong-commit") commit.oid = "c".repeat(40);
+    if (failure === "wrong-node") commit.signature.signer.id = "U_other";
+    await expect(
+      verifySignerAccess({ ...f.input(), readCommit: async () => commit }),
+    ).rejects.toThrow("GitHub signature");
+  });
+  it("rejects role substitution and future reports", async () => {
+    const f = fixture();
+    f.report.role = "steward";
+    await expect(verifySignerAccess(f.input())).rejects.toThrow("authority");
+    f.report.role = "funder";
+    await expect(
+      verifySignerAccess({ ...f.input(), now: "2026-09-05T19:00:00.000Z" }),
+    ).rejects.toThrow("time");
+  });
+  it("rejects expanded lifetime, expiring loss, unknown fields and control characters", () => {
+    const f = fixture();
+    for (const change of [
+      { expiresAt: "2026-09-07T20:00:00.000Z" },
+      { capability: "lost-access" },
+      { reason: "unsafe\ncopy" },
+      { arbitrary: true },
+    ])
+      expect(() =>
+        assertSignerAccessReport({ ...f.report, ...change }),
+      ).toThrow();
+  });
+  it("fails closed on unavailable GitHub authority", async () => {
+    const f = fixture();
+    await expect(
+      verifySignerAccess({
+        ...f.input(),
+        readCommit: async () => {
+          throw new Error("unavailable");
+        },
+      }),
+    ).rejects.toThrow("unavailable");
+  });
+});

--- a/scripts/verify-signer-access.ts
+++ b/scripts/verify-signer-access.ts
@@ -1,0 +1,330 @@
+/** Read-only signer attestations. This module never authorizes a payment. */
+import { execFileSync } from "node:child_process";
+import { lstat, readFile } from "node:fs/promises";
+import { ed25519 } from "@noble/curves/ed25519.js";
+import type { SquadsV4VaultInstrument } from "../src/lib/funding-instruments.mjs";
+import { assertProjectDefinition } from "../src/lib/project-schema.mjs";
+import type { ProjectDefinition } from "../src/lib/projects.mjs";
+import { canonicalFundingDecisionBytes } from "./check-funding-record-pr";
+
+export interface SignerAccessReport {
+  kind: "slop-signer-access";
+  schemaVersion: "1";
+  projectId: string;
+  manifestRevision: string;
+  cycleId: string;
+  instrumentId: string;
+  actorId: string;
+  role: "funder" | "steward";
+  member: string;
+  capability: "can-sign" | "lost-access";
+  reportedAt: string;
+  expiresAt: string | null;
+  reason: string;
+  memberSignature: string | null;
+  sourceRepository: string;
+  sourceCommit: string;
+}
+
+const SHA = /^[a-f0-9]{40}$/u;
+const BASE58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+const DAY_MS = 24 * 60 * 60 * 1000;
+const KEYS = [
+  "kind",
+  "schemaVersion",
+  "projectId",
+  "manifestRevision",
+  "cycleId",
+  "instrumentId",
+  "actorId",
+  "role",
+  "member",
+  "capability",
+  "reportedAt",
+  "expiresAt",
+  "reason",
+  "memberSignature",
+  "sourceRepository",
+  "sourceCommit",
+]
+  .sort()
+  .join(",");
+
+function object(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value))
+    throw new TypeError("Signer evidence must be an object");
+  return value as Record<string, unknown>;
+}
+function timestamp(value: unknown): number {
+  if (
+    typeof value !== "string" ||
+    !Number.isFinite(Date.parse(value)) ||
+    new Date(value).toISOString() !== value
+  )
+    throw new TypeError("Signer evidence requires canonical UTC timestamps");
+  return Date.parse(value);
+}
+
+export function squadsAccessInstrumentId(
+  instrument: SquadsV4VaultInstrument,
+): string {
+  return `squads-v4-vault:solana:${instrument.multisig}:${instrument.vaultIndex}:${instrument.vault}`;
+}
+
+export function assertSignerAccessReport(value: unknown): SignerAccessReport {
+  const report = object(value);
+  if (
+    Object.keys(report).sort().join(",") !== KEYS ||
+    report.kind !== "slop-signer-access" ||
+    report.schemaVersion !== "1" ||
+    typeof report.projectId !== "string" ||
+    !/^[a-z0-9][a-z0-9-]{0,47}$/u.test(report.projectId) ||
+    typeof report.manifestRevision !== "string" ||
+    !SHA.test(report.manifestRevision) ||
+    typeof report.sourceCommit !== "string" ||
+    !SHA.test(report.sourceCommit) ||
+    typeof report.sourceRepository !== "string" ||
+    !/^[A-Za-z0-9_.-]{1,100}\/[A-Za-z0-9_.-]{1,100}$/u.test(
+      report.sourceRepository,
+    ) ||
+    typeof report.cycleId !== "string" ||
+    !/^\d{4}-(?:0[1-9]|1[0-2])$/u.test(report.cycleId) ||
+    typeof report.instrumentId !== "string" ||
+    report.instrumentId.length > 200 ||
+    typeof report.actorId !== "string" ||
+    !/^[1-9]\d{0,19}$/u.test(report.actorId) ||
+    (report.role !== "funder" && report.role !== "steward") ||
+    typeof report.member !== "string" ||
+    !/^[1-9A-HJ-NP-Za-km-z]{32,44}$/u.test(report.member) ||
+    (report.capability !== "can-sign" && report.capability !== "lost-access") ||
+    typeof report.reason !== "string" ||
+    report.reason.trim() !== report.reason ||
+    report.reason.length < 1 ||
+    report.reason.length > 500 ||
+    [...report.reason].some(
+      (character) =>
+        character.charCodeAt(0) < 32 || character.charCodeAt(0) === 127,
+    )
+  )
+    throw new TypeError("Invalid signer access report");
+  const reportedAt = timestamp(report.reportedAt);
+  if (report.capability === "lost-access") {
+    if (report.expiresAt !== null || report.memberSignature !== null)
+      throw new TypeError(
+        "Loss reports require neither the lost key nor an expiry",
+      );
+  } else {
+    const expiresAt = timestamp(report.expiresAt);
+    if (
+      expiresAt <= reportedAt ||
+      expiresAt - reportedAt > DAY_MS ||
+      typeof report.memberSignature !== "string" ||
+      !/^[A-Za-z0-9+/]{86}==$/u.test(report.memberSignature) ||
+      Buffer.from(report.memberSignature, "base64").toString("base64") !==
+        report.memberSignature
+    )
+      throw new TypeError(
+        "Capability requires a canonical Ed25519 signature and at most 24-hour validity",
+      );
+  }
+  return { ...report } as unknown as SignerAccessReport;
+}
+
+/** Domain-separated message; not a transaction and not payment authorization. */
+export function signerCapabilityMessage(report: SignerAccessReport): string {
+  const {
+    memberSignature: _signature,
+    sourceCommit: _commit,
+    ...claims
+  } = report;
+  return `Slop signer capability only; no payment authorization.\n${canonicalFundingDecisionBytes(claims)}`;
+}
+export function signerAccessCommitMessage(report: SignerAccessReport): string {
+  const { sourceCommit: _commit, ...claims } = report;
+  return `slop-signer-access:v1\n${canonicalFundingDecisionBytes(claims)}`.trimEnd();
+}
+
+function memberPublicKey(member: string) {
+  let number = 0n;
+  for (const character of member) {
+    const digit = BASE58.indexOf(character);
+    if (digit < 0) throw new TypeError("Invalid member public key");
+    number = number * 58n + BigInt(digit);
+  }
+  const bytes: number[] = [];
+  while (number > 0n) {
+    bytes.unshift(Number(number & 255n));
+    number >>= 8n;
+  }
+  const leading = member.match(/^1*/u)?.[0].length ?? 0;
+  const raw = Buffer.concat([Buffer.alloc(leading), Buffer.from(bytes)]);
+  if (raw.length !== 32) throw new TypeError("Member key must be 32 bytes");
+  return Uint8Array.from(raw);
+}
+
+export async function readSignerCommit(
+  repository: string,
+  commit: string,
+): Promise<unknown> {
+  const [owner, name] = repository.split("/");
+  const output = execFileSync(
+    "gh",
+    [
+      "api",
+      "graphql",
+      "-f",
+      "query=query($owner:String!,$name:String!,$oid:String!){repository(owner:$owner,name:$name){isPrivate object(expression:$oid){... on Commit{oid message signature{isValid state signer{id databaseId}}}}}}",
+      "-f",
+      `owner=${owner}`,
+      "-f",
+      `name=${name}`,
+      "-f",
+      `oid=${commit}`,
+    ],
+    { encoding: "utf8", timeout: 30_000, maxBuffer: 128 * 1024 },
+  );
+  const envelope = JSON.parse(output);
+  if (envelope.errors || envelope.data?.repository?.isPrivate !== false)
+    throw new TypeError("Public GitHub signer lookup failed");
+  return envelope.data?.repository?.object;
+}
+
+/** Caller supplies a reviewed immutable manifest, never a proposed head manifest. */
+export async function verifySignerAccess(input: {
+  report: unknown;
+  project: ProjectDefinition;
+  manifestRevision: string;
+  now: string;
+  readCommit?: typeof readSignerCommit;
+}): Promise<SignerAccessReport> {
+  const report = assertSignerAccessReport(input.report);
+  const now = timestamp(input.now);
+  if (
+    report.projectId !== input.project.id ||
+    report.manifestRevision !== input.manifestRevision ||
+    timestamp(report.reportedAt) > now
+  )
+    throw new TypeError(
+      "Signer report does not bind the reviewed manifest or time",
+    );
+  const matches = (input.project.funding.commitments ?? []).filter(
+    (instrument): instrument is SquadsV4VaultInstrument =>
+      instrument.kind === "squads-v4-vault" &&
+      squadsAccessInstrumentId(instrument) === report.instrumentId,
+  );
+  const instrument = matches[0];
+  if (
+    matches.length !== 1 ||
+    !instrument.monthlyCommitment ||
+    !instrument.stewardGithub ||
+    instrument.monthlyCommitment.cycleId !== report.cycleId ||
+    instrument.funderActorId === instrument.stewardGithub.actorId ||
+    timestamp(report.reportedAt) < timestamp(instrument.effectiveAt)
+  )
+    throw new TypeError(
+      "Report requires the exact reviewed monthly Squads instrument",
+    );
+  const actorId =
+    report.role === "funder"
+      ? instrument.funderActorId
+      : instrument.stewardGithub.actorId;
+  const member =
+    report.role === "funder"
+      ? instrument.funderMember
+      : instrument.stewardMember;
+  if (report.actorId !== actorId || report.member !== member)
+    throw new TypeError(
+      "Signer identity or member key differs from reviewed authority",
+    );
+  const commit = object(
+    await (input.readCommit ?? readSignerCommit)(
+      report.sourceRepository,
+      report.sourceCommit,
+    ),
+  );
+  const signature = object(commit.signature);
+  const signer = object(signature.signer);
+  if (
+    commit.oid !== report.sourceCommit ||
+    signature.isValid !== true ||
+    signature.state !== "VALID" ||
+    String(signer.databaseId) !== actorId ||
+    (report.role === "steward" &&
+      signer.id !== instrument.stewardGithub.nodeId) ||
+    typeof commit.message !== "string" ||
+    commit.message.replace(/\n$/u, "") !== signerAccessCommitMessage(report)
+  )
+    throw new TypeError(
+      "GitHub signature does not bind the exact signer report",
+    );
+  if (
+    report.capability === "can-sign" &&
+    !ed25519.verify(
+      Uint8Array.from(Buffer.from(report.memberSignature ?? "", "base64")),
+      new TextEncoder().encode(signerCapabilityMessage(report)),
+      memberPublicKey(member),
+      { zip215: false },
+    )
+  )
+    throw new TypeError("Member capability signature is invalid");
+  return report;
+}
+
+if (import.meta.main) {
+  const [revision, path, ...extra] = process.argv.slice(2);
+  if (!revision || !SHA.test(revision) || !path || extra.length)
+    throw new TypeError(
+      "Usage: verify-signer-access.ts <reviewed-manifest-sha> <report.json>",
+    );
+  const stats = await lstat(path);
+  if (
+    !stats.isFile() ||
+    stats.isSymbolicLink() ||
+    stats.size <= 0 ||
+    stats.size > 16 * 1024
+  )
+    throw new TypeError("Report must be a bounded regular file");
+  const bytes = await readFile(path);
+  const report = assertSignerAccessReport(
+    JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(bytes)),
+  );
+  if (!bytes.equals(Buffer.from(canonicalFundingDecisionBytes(report))))
+    throw new TypeError("Report must be canonical JSON with no duplicate keys");
+  execFileSync(
+    "git",
+    [
+      "--no-replace-objects",
+      "merge-base",
+      "--is-ancestor",
+      revision,
+      "origin/develop",
+    ],
+    { stdio: "ignore" },
+  );
+  const manifestPath = `projects/${report.projectId}/project.json`;
+  const mode = execFileSync(
+    "git",
+    ["--no-replace-objects", "ls-tree", revision, "--", manifestPath],
+    { encoding: "utf8" },
+  );
+  if (!mode.startsWith("100644 blob "))
+    throw new TypeError("Manifest must be a regular reviewed file");
+  const project = assertProjectDefinition(
+    JSON.parse(
+      execFileSync(
+        "git",
+        ["--no-replace-objects", "show", `${revision}:${manifestPath}`],
+        { encoding: "utf8", maxBuffer: 1024 * 1024 },
+      ),
+    ),
+  );
+  await verifySignerAccess({
+    report,
+    project,
+    manifestRevision: revision,
+    now: new Date().toISOString(),
+  });
+  process.stdout.write(
+    `${JSON.stringify({ verifiedSignerReport: true, sourceCommit: report.sourceCommit, capability: report.capability, paymentAuthorized: false })}\n`,
+  );
+}


### PR DESCRIPTION
Refs #333. Implements the approved attester choice: the reviewed funder actor and independent steward actor/node ID, bound to the exact monthly Squads instrument and member keys. Loss reports require a verified GitHub signature without the lost wallet key; positive reports also require a strict domain-separated Ed25519 member proof with at most 24-hour validity. Includes an identity-point forgery regression that permissive native verification accepts. Uses pinned Noble Curves 2.4.0; dependency audit passes. CLI is read-only and explicitly reports paymentAuthorized=false. 17 focused tests pass; full verification and browser evidence are in progress. This is the authentication component, NOT payment activation or a claim that #333 is finished. Public append-only report ingestion, visible loss/hold overlay, exact-once carry and settlement fencing remain required and are documented; existing unknown accessibility and disabled-payment policy stay unchanged.