### PR TITLE
fix: retry transient final review census churn within existing budgets

### DIFF
--- a/scripts/generate-leaderboard.ts
+++ b/scripts/generate-leaderboard.ts
@@ -281,6 +281,7 @@ export interface GeneratorDependencies {
     options?: GenerateOptions,
   ) => Promise<LeaderboardSnapshot>;
   write: (snapshot: LeaderboardSnapshot, outputPath: string) => Promise<void>;
+  onCensusRetry?: () => void;
 }
 
 const ACTOR_FRAGMENT = `
@@ -2726,12 +2727,19 @@ export async function planMergedPullRequestHydration(
   return { detailEligibleIds, hydratedIds, reviewCounts };
 }
 
+/** Only final census churn may restart a complete, unpublished collection. */
+export class ReviewCensusChangedError extends Error {
+  override readonly name = "ReviewCensusChangedError";
+}
+
 export function assertReviewCensusStable(
   before: ReadonlyMap<string, ReviewCensusEntry>,
   after: ReadonlyMap<string, ReviewCensusEntry>,
 ): void {
   if (before.size !== after.size) {
-    throw new Error("Review census changed identity before snapshot assembly");
+    throw new ReviewCensusChangedError(
+      "Review census changed identity before snapshot assembly",
+    );
   }
   for (const [id, entry] of before) {
     const current = after.get(id);
@@ -2740,7 +2748,7 @@ export function assertReviewCensusStable(
       current.reviewCount !== entry.reviewCount ||
       current.updatedAt !== entry.updatedAt
     ) {
-      throw new Error(
+      throw new ReviewCensusChangedError(
         `Review census changed for ${id} before snapshot assembly`,
       );
     }
@@ -3607,15 +3615,32 @@ export async function runGenerator(
     createClient: (token) => new GitHubGraphqlClient(token),
     generate: generateLeaderboardFromGitHub,
     write: writeLeaderboardAtomically,
+    onCensusRetry: () => {
+      process.stderr.write(
+        "[slop.cash] final review census changed; recollecting once with the existing GraphQL budget\n",
+      );
+    },
   },
   options: GenerateOptions = {},
 ): Promise<LeaderboardSnapshot> {
   const token = await dependencies.getToken();
   const client = dependencies.createClient(token);
-  const snapshot = await dependencies.generate(client, {
+  const generationOptions = {
     ...options,
     evidenceToken: options.evidenceToken ?? token,
-  });
+  };
+  let snapshot: LeaderboardSnapshot;
+  try {
+    snapshot = await dependencies.generate(client, generationOptions);
+  } catch (error) {
+    // error-policy:J2 recover only classified census churn, once, with no budget reset.
+    if (!(error instanceof ReviewCensusChangedError)) throw error;
+    dependencies.onCensusRetry?.();
+    // Recollect every source; never reuse a partially assembled first attempt.
+    // The same client retains consumed cost, request counts, reserve and reset state.
+    snapshot = await dependencies.generate(client, generationOptions);
+  }
+  // Publication is outside the retry boundary: a write failure never regenerates.
   await dependencies.write(snapshot, outputPath);
   return snapshot;
 }

--- a/scripts/generator-census-retry.test.ts
+++ b/scripts/generator-census-retry.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it, vi } from "vitest";
+import { snapshotFixture } from "../tests/fixtures";
+import {
+  assertReviewCensusStable,
+  GitHubGraphqlClient,
+  ReviewCensusChangedError,
+  runGenerator,
+} from "./generate-leaderboard";
+
+function setup(cost = 10, maximum = 4_000) {
+  let requests = 0;
+  const client = new GitHubGraphqlClient(
+    "test-token",
+    async () => {
+      requests++;
+      return Response.json({
+        data: {
+          rateLimit: {
+            cost,
+            limit: 5_000,
+            remaining: 5_000 - requests * cost,
+            resetAt: "2099-01-01T00:00:00.000Z",
+          },
+        },
+      });
+    },
+    { maxGenerationCost: maximum },
+  );
+  return {
+    client,
+    getToken: vi.fn(async () => "test-token"),
+    createClient: vi.fn(() => client),
+    onCensusRetry: vi.fn(),
+    write: vi.fn(async () => undefined),
+  };
+}
+
+describe("complete collection retry after final review census churn", () => {
+  it("classifies only actual final census inconsistency", () => {
+    const before = new Map([
+      ["PR_test", { reviewCount: 1, updatedAt: "before" }],
+    ]);
+    expect(() => assertReviewCensusStable(before, before)).not.toThrow();
+    expect(() => assertReviewCensusStable(before, new Map())).toThrow(
+      ReviewCensusChangedError,
+    );
+    expect(() =>
+      assertReviewCensusStable(
+        before,
+        new Map([["PR_test", { reviewCount: 2, updatedAt: "after" }]]),
+      ),
+    ).toThrow(ReviewCensusChangedError);
+  });
+
+  it("recollects once on the same client and writes only the coherent result", async () => {
+    const f = setup();
+    const snapshot = snapshotFixture();
+    const options = { now: new Date("2026-07-30T00:00:00.000Z") };
+    const generate = vi.fn(async (client, receivedOptions) => {
+      expect(client).toBe(f.client);
+      expect(receivedOptions.now).toBe(options.now);
+      expect(receivedOptions.evidenceToken).toBe("test-token");
+      expect(f.write).not.toHaveBeenCalled();
+      await client.execute("query { rateLimit { cost } }");
+      if (generate.mock.calls.length === 1)
+        throw new ReviewCensusChangedError("churn");
+      expect(client.getRequestCount()).toBe(2);
+      expect(client.getRateLimit().consumedDuringRun).toBe(20);
+      return snapshot;
+    });
+    await expect(
+      runGenerator("/unused/output.json", { ...f, generate }, options),
+    ).resolves.toBe(snapshot);
+    expect(f.createClient).toHaveBeenCalledTimes(1);
+    expect(f.getToken).toHaveBeenCalledTimes(1);
+    expect(generate).toHaveBeenCalledTimes(2);
+    expect(f.onCensusRetry).toHaveBeenCalledTimes(1);
+    expect(f.write).toHaveBeenCalledExactlyOnceWith(
+      snapshot,
+      "/unused/output.json",
+    );
+  });
+
+  it("fails closed on repeated churn after exactly two attempts", async () => {
+    const f = setup();
+    const generate = vi.fn(async () => {
+      throw new ReviewCensusChangedError("still changing");
+    });
+    await expect(runGenerator("/unused", { ...f, generate })).rejects.toThrow(
+      "still changing",
+    );
+    expect(generate).toHaveBeenCalledTimes(2);
+    expect(f.write).not.toHaveBeenCalled();
+  });
+
+  it("does not reset the safety budget when recollecting", async () => {
+    const f = setup(600, 1_000);
+    const generate = vi.fn(async (client) => {
+      await client.execute("query { rateLimit { cost } }");
+      throw new ReviewCensusChangedError("changed");
+    });
+    await expect(runGenerator("/unused", { ...f, generate })).rejects.toThrow(
+      "safety budget exceeded",
+    );
+    expect(generate).toHaveBeenCalledTimes(2);
+    expect(f.client.getRateLimit().consumedDuringRun).toBe(1_200);
+    expect(f.createClient).toHaveBeenCalledTimes(1);
+    expect(f.write).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "schema invalid",
+    "permission denied",
+    "Review census changed for forged-message",
+  ])("never classifies errors by text: %s", async (message) => {
+    const f = setup();
+    const generate = vi.fn(async () => {
+      throw new Error(message);
+    });
+    await expect(runGenerator("/unused", { ...f, generate })).rejects.toThrow(
+      message,
+    );
+    expect(generate).toHaveBeenCalledTimes(1);
+    expect(f.write).not.toHaveBeenCalled();
+  });
+
+  it("does not retry publication even if a writer throws the typed error", async () => {
+    const f = setup();
+    const generate = vi.fn(async () => snapshotFixture());
+    f.write.mockImplementation(async () => {
+      throw new ReviewCensusChangedError("write failed");
+    });
+    await expect(runGenerator("/unused", { ...f, generate })).rejects.toThrow(
+      "write failed",
+    );
+    expect(generate).toHaveBeenCalledTimes(1);
+    expect(f.write).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Refs #302. The scheduled refresh on 2026-09-06 (run 34012416120) failed at its final review census after live GitHub changed during collection.

## Change

- Classify only final review-census inconsistency with a dedicated error type.
- Retry one complete collection, not a partial snapshot or patched census.
- Reuse the same GraphQL client, preserving request counts, consumed cost, reserves, and reset state; do not increase the configured budget.
- Preserve explicit historical cutoff options and atomic publication. Repeated churn and every other failure remain terminal; writer failures are never retried.
- Emit a static retry diagnostic without tokens or source contents.

## Exact-head validation

Head: `4dd5ea62b5b95f9c5efa2b8ce8b28b0b405be9ad`; base: `1a442080d9d898811918bbbedfa0cffe110521eb`.

- Local `bun run verify`: exit 0 with pinned Node 24.15.0; 965 unit tests across 82 files, 125 skill tests, registry/schema/typecheck/lint/format/build checks passed.
- [Hosted exact-head verification](https://github.com/SlopDotCash/slopdotcash/actions/runs/34013745783): success; 965 unit tests, 125 skill tests, 37 desktop/mobile browser tests and 2 Pages tests passed; 3 intentional duplicate-browser skips.
- All three trusted transition/funding gates passed.
- New regressions cover exact retry bound, no partial writes, real-client cumulative budget enforcement, stable explicit cutoff, same token/client, error-type rather than error-text matching, and write failures outside the retry boundary.

No UI changes: visual redesign review N/A. No deployment environment or approval behavior changes. This does not close #302: successful scheduled publication and quiet-period freshness still need operational proof. No production deployment or live retry success is claimed.
