### PR TITLE
feat: publish authenticated signer history and block new plans after loss

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -110,6 +110,15 @@ jobs:
           done
           bun test ./skill-tests
 
+      - name: Authenticate signer history before trusted publication
+        if: github.event_name != 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          bun --no-install scripts/check-signer-access-transitions.ts "$GITHUB_SHA" "$GITHUB_SHA"
+
       - name: Generate live contribution data
         # Pull-request code is untrusted, so this step never explicitly injects
         # a repository-scoped token into it. Trusted develop runs refresh the

--- a/.github/workflows/funding-records.yml
+++ b/.github/workflows/funding-records.yml
@@ -59,3 +59,17 @@ jobs:
           path: ${{ runner.temp }}/funding-record-decision.json
           if-no-files-found: error
           retention-days: 30
+
+      - name: Install only trusted lockfile dependencies for signer verification
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      - name: Authenticate complete append-only signer history
+        env:
+          GH_TOKEN: ${{ github.token }}
+          FUNDING_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          FUNDING_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$FUNDING_BASE_SHA"
+          bun --no-install scripts/check-signer-access-transitions.ts \
+            "$FUNDING_BASE_SHA" "$FUNDING_HEAD_SHA"

--- a/protocol/signer-access-attestations.md
+++ b/protocol/signer-access-attestations.md
@@ -103,6 +103,17 @@ remaining principal and prevent both an old intent and a successor cycle from
 paying it. Only eligible shared-pool principal carries, exactly once; review
 budget does not carry. The successor monthly cycle requires a fresh instrument.
 
+The current unsigned execution-plan schema does not bind `sourceOwner` to the
+frozen funding instrument or record a signed transaction's lifetime, nonce, or
+Squads proposal retirement. Consequently an issued or partially settled plan
+cannot become carry merely because a signer reports loss or time passes.
+[Solana durable nonces](https://solana.com/developers/cookbook/transactions/confirmation)
+can outlive ordinary blockhash expiration. A reviewed retirement/reconciliation
+protocol must establish the exact remaining principal and prevent execution
+through both old and successor intents before this carry path can open. No
+such retirement proof is implemented here; existing plans and paid history
+remain unchanged and this acceptance gate remains unresolved.
+
 Until those gates, complete public readback, and settlement/carry regressions
 are in place, the existing `unknown` accessibility and disabled-payment policy
 remain unchanged. #333 is not closed by authentication alone. There is no

--- a/protocol/signer-access-attestations.md
+++ b/protocol/signer-access-attestations.md
@@ -68,10 +68,29 @@ instrument balance, legal ownership, or a transferable payment approval.
 
 ## Lifecycle integration still required before activation
 
-Reports must enter a complete append-only, trusted-base-validated ledger before
-they can drive public state. An omitted loss report must never be replaced by a
-caller-selected pair of positive reports. Loss by either signer is terminal for
-that instrument; later capability reports cannot silently undo it. Positive
+Reports are stored as canonical JSON at
+`funding/<project>/signer-access/<sha256-of-canonical-report-bytes>.json`.
+The trusted funding PR gate reads the complete proposed Git tree with
+`scripts/check-signer-access-transitions.ts`, requires every accepted base blob
+to survive unchanged, and authenticates every report against a manifest already
+reviewed in the trusted base history. Symlinks, duplicate source commits,
+noncanonical bytes, and missing GitHub authority fail the whole read. Working
+tree bytes cannot replace committed evidence. `funding:check` performs offline
+structural validation only; it is not proof of signer authentication.
+Trusted publication reauthenticates the committed history. Before preparing a
+new Squads-backed settlement plan, the command fetches current `develop`, reads
+its complete history, and requires both current member proofs. This check uses
+the actual evaluation time, not the caller's plan timestamp. Lost or expired
+capability blocks new plans, but this necessary check does not activate payment,
+prove backing, revoke an existing external signature, or replace settlement
+reconciliation. The immutable hold overlay and carry integration below remain
+required.
+
+The diagnostic reducer accepts only a complete ledger authenticated in-process,
+not a caller-selected pair of positive reports. Loss by either signer is
+terminal for that instrument; later capability reports cannot undo it. Its
+`both-signers-current` result is explicitly not an `accessible` or payable claim.
+At the exact expiry timestamp a positive report ceases to count. Positive
 accessibility requires both unexpired member proofs plus independently verified
 instrument configuration and backing. Expiry returns positive evidence to
 unknown, never silently extends it.

--- a/scripts/check-funding-record-pr.test.ts
+++ b/scripts/check-funding-record-pr.test.ts
@@ -983,7 +983,13 @@ describe("trusted funding-record PR gate", () => {
       'test "$(git rev-parse refs/remotes/origin/slop-funding-head)" = "$FUNDING_HEAD_SHA"',
     );
     expect(workflow).not.toMatch(
-      /contents: write|pull-requests: write|gh pr merge|gh pr review|environment:|bun install|ref:.*head.sha/u,
+      /contents: write|pull-requests: write|gh pr merge|gh pr review|environment:|ref:.*head.sha/u,
+    );
+    expect(workflow.match(/bun install[^\n]*/gu)).toEqual([
+      "bun install --frozen-lockfile --ignore-scripts",
+    ]);
+    expect(workflow).toContain(
+      "bun --no-install scripts/check-signer-access-transitions.ts",
     );
   });
 });

--- a/scripts/check-signer-access-transitions.ts
+++ b/scripts/check-signer-access-transitions.ts
@@ -1,0 +1,25 @@
+/** Invoked only from trusted-base code; proposed trees are data, never code. */
+import { readSignerAccessLedger } from "./signer-access-ledger";
+
+if (import.meta.main) {
+  const [baseSha, headSha, ...extra] = process.argv.slice(2);
+  if (!baseSha || !headSha || extra.length)
+    throw new TypeError(
+      "Usage: check-signer-access-transitions.ts <trusted-base-sha> <head-sha>",
+    );
+  const ledger = await readSignerAccessLedger({
+    root: process.cwd(),
+    baseSha,
+    headSha,
+    now: new Date().toISOString(),
+  });
+  process.stdout.write(
+    `${JSON.stringify({
+      kind: "signer-access-history-check",
+      baseSha,
+      headSha,
+      authenticatedReports: ledger.reports.length,
+      paymentAuthorized: false,
+    })}\n`,
+  );
+}

--- a/scripts/prepare-settlement-plan.ts
+++ b/scripts/prepare-settlement-plan.ts
@@ -13,7 +13,12 @@ import {
   findProject,
   type ProjectId,
 } from "../src/lib/projects.mjs";
+import { assertRewardAllocationManifest } from "../src/lib/rewards";
 import { createSettlementExecutionPlan } from "../src/lib/settlement-plan";
+import {
+  assertSignerCapabilityForSettlement,
+  readCurrentSignerAccessLedger,
+} from "./signer-access-ledger";
 import { validateCycleTransition } from "./sync-cycle-index";
 import { writeNewJsonFile } from "./write-new-file";
 
@@ -115,6 +120,19 @@ export async function prepareSettlementPlan(
     allocation = JSON.parse(source.toString("utf8"));
   } catch (error) {
     throw new TypeError("Allocation is not valid JSON", { cause: error });
+  }
+  const reviewedAllocation = assertRewardAllocationManifest(allocation);
+  if (
+    reviewedAllocation.fundingBasis?.instrumentId?.startsWith(
+      "squads-v4-vault:",
+    )
+  ) {
+    const ledger = await readCurrentSignerAccessLedger(REPOSITORY_ROOT);
+    assertSignerCapabilityForSettlement(
+      ledger,
+      reviewedAllocation,
+      new Date().toISOString(),
+    );
   }
   const plan = createSettlementExecutionPlan({
     allocation,

--- a/scripts/signer-access-ledger.test.ts
+++ b/scripts/signer-access-ledger.test.ts
@@ -1,0 +1,371 @@
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { ed25519 } from "@noble/curves/ed25519.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import eliza from "../projects/eliza/project.json";
+import { canonicalFundingDecisionBytes } from "./check-funding-record-pr";
+import {
+  assertSignerCapabilityForSettlement,
+  readCurrentSignerAccessLedger,
+  readSignerAccessLedger,
+  signerCapabilityState,
+  signerReportPath,
+} from "./signer-access-ledger";
+import { buildFundingIndex } from "./sync-funding-index";
+import {
+  type SignerAccessReport,
+  signerAccessCommitMessage,
+  signerCapabilityMessage,
+} from "./verify-signer-access";
+
+const roots: string[] = [];
+function base58(bytes: Uint8Array) {
+  let n = BigInt(`0x${Buffer.from(bytes).toString("hex")}`);
+  let encoded = "";
+  while (n) {
+    encoded =
+      "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"[
+        Number(n % 58n)
+      ] + encoded;
+    n /= 58n;
+  }
+  for (const byte of bytes) {
+    if (byte !== 0) break;
+    encoded = `1${encoded}`;
+  }
+  return encoded;
+}
+afterEach(async () => {
+  vi.useRealTimers();
+  await Promise.all(
+    roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+async function fixture() {
+  const root = await mkdtemp(join(tmpdir(), "slop-signer-ledger-test-"));
+  roots.push(root);
+  const git = (...args: string[]) =>
+    execFileSync("git", args, {
+      cwd: root,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+  git("init", "-q");
+  git("config", "user.name", "Synthetic test");
+  git("config", "user.email", "fixture@example.invalid");
+  git("config", "commit.gpgsign", "false");
+  const seeds = {
+    funder: new Uint8Array(32).fill(1),
+    steward: new Uint8Array(32).fill(2),
+  };
+  const member = base58(ed25519.getPublicKey(seeds.funder));
+  const stewardMember = base58(ed25519.getPublicKey(seeds.steward));
+  const vault = "Vote111111111111111111111111111111111111111";
+  const instrument = {
+    kind: "squads-v4-vault",
+    network: "solana",
+    asset: "USDC",
+    multisig: member,
+    vault,
+    vaultIndex: 0,
+    funderActorId: "18633264",
+    funderMember: member,
+    stewardMember,
+    stewardGithub: {
+      actorId: "42",
+      nodeId: "U_fixture_42",
+      login: "independent-fixture",
+    },
+    monthlyCommitment: {
+      cycleId: "2026-09",
+      amountMinor: "5000000",
+      accessibility: "unknown",
+    },
+    effectiveAt: "2026-09-01T00:00:00.000Z",
+    deadline: "2026-10-01T00:00:00.000Z",
+    replacedAt: null,
+  };
+  const write = async (path: string, bytes: string) => {
+    await mkdir(dirname(join(root, path)), { recursive: true });
+    await writeFile(join(root, path), bytes);
+  };
+  await write(
+    "projects/eliza/project.json",
+    JSON.stringify({
+      ...eliza,
+      reward: {
+        ...eliza.reward,
+        fundingState: "committed",
+        committedMinor: "5000000",
+        paymentMode: "disabled",
+      },
+      funding: { ...eliza.funding, commitments: [instrument] },
+    }),
+  );
+  const commit = () => {
+    git("add", "-A");
+    git("commit", "-qm", "fixture");
+    return git("rev-parse", "HEAD");
+  };
+  const baseSha = commit();
+  const report: SignerAccessReport = {
+    kind: "slop-signer-access",
+    schemaVersion: "1",
+    projectId: "eliza",
+    manifestRevision: baseSha,
+    cycleId: "2026-09",
+    instrumentId: `squads-v4-vault:solana:${member}:0:${vault}`,
+    actorId: "18633264",
+    role: "funder",
+    member,
+    capability: "lost-access",
+    reportedAt: "2026-09-05T20:00:00.000Z",
+    expiresAt: null,
+    reason: "Synthetic signer lost access.",
+    memberSignature: null,
+    sourceRepository: "example/evidence",
+    sourceCommit: "b".repeat(40),
+  };
+  const authenticated = new Map<string, SignerAccessReport>();
+  const add = async (value = report) => {
+    authenticated.set(value.sourceCommit, structuredClone(value));
+    await write(signerReportPath(value), canonicalFundingDecisionBytes(value));
+  };
+  const positive = (
+    role: "funder" | "steward",
+    source: string,
+    reportedAt = report.reportedAt,
+  ): SignerAccessReport => {
+    const value: SignerAccessReport = {
+      ...report,
+      reportedAt,
+      role,
+      actorId: role === "funder" ? "18633264" : "42",
+      member: role === "funder" ? member : stewardMember,
+      capability: "can-sign",
+      sourceCommit: source.repeat(40),
+      expiresAt: "2026-09-06T20:00:00.000Z",
+      memberSignature: null,
+    };
+    value.memberSignature = Buffer.from(
+      ed25519.sign(
+        new TextEncoder().encode(signerCapabilityMessage(value)),
+        seeds[role],
+      ),
+    ).toString("base64");
+    return value;
+  };
+  const readCommit = async (_repository: string, source: string) => {
+    const value = authenticated.get(source);
+    if (!value) throw new Error("missing synthetic signature authority");
+    return {
+      oid: value.sourceCommit,
+      message: signerAccessCommitMessage(value),
+      signature: {
+        isValid: true,
+        state: "VALID",
+        signer: { databaseId: Number(value.actorId), id: "U_fixture_42" },
+      },
+    };
+  };
+  const input = () => ({
+    root,
+    baseSha,
+    headSha: git("rev-parse", "HEAD"),
+    now: "2026-09-06T00:00:00.000Z",
+    readCommit,
+  });
+  return { root, git, write, commit, report, add, input, positive };
+}
+
+describe("complete authenticated signer history", () => {
+  it("fetches accepted loss rather than trusting a stale local develop ref", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-09-06T00:00:00.000Z"));
+    const f = await fixture();
+    f.git("branch", "-M", "develop");
+    f.git("remote", "add", "origin", f.root);
+    f.git("update-ref", "refs/remotes/origin/develop", f.input().baseSha);
+    await f.add();
+    const acceptedLoss = f.commit();
+    const ledger = await readCurrentSignerAccessLedger(
+      f.root,
+      f.input().readCommit,
+    );
+    expect(ledger.headSha).toBe(acceptedLoss);
+    expect(
+      signerCapabilityState(ledger, f.report, new Date().toISOString()).state,
+    ).toBe("inaccessible");
+  });
+  it("validates stored reports offline without turning them into funding", async () => {
+    const f = await fixture();
+    await f.add();
+    f.commit();
+    const result = await buildFundingIndex({
+      repositoryRoot: f.root,
+      projects: [eliza],
+    });
+    expect(result.records).toEqual([]);
+    expect(result.commitments).toEqual([]);
+    await f.write(signerReportPath(f.report), JSON.stringify(f.report));
+    await expect(
+      buildFundingIndex({ repositoryRoot: f.root, projects: [eliza] }),
+    ).rejects.toThrow("content-addressed");
+  });
+  it("requires both member proofs and expires at the exact bound", async () => {
+    const f = await fixture();
+    await f.add(f.positive("funder", "c"));
+    f.commit();
+    const one = await readSignerAccessLedger(f.input());
+    expect(signerCapabilityState(one, f.report, f.input().now).state).toBe(
+      "unknown",
+    );
+    const allocation = {
+      ...f.report,
+      fundingBasis: { instrumentId: f.report.instrumentId },
+    };
+    expect(() =>
+      assertSignerCapabilityForSettlement(one, allocation, f.input().now),
+    ).toThrow("unknown");
+    await f.add(f.positive("steward", "d"));
+    f.commit();
+    const both = await readSignerAccessLedger(f.input());
+    expect(
+      signerCapabilityState(both, f.report, "2026-09-06T19:59:59.999Z").state,
+    ).toBe("both-signers-current");
+    expect(
+      signerCapabilityState(both, f.report, "2026-09-06T20:00:00.000Z").state,
+    ).toBe("unknown");
+    expect(() =>
+      assertSignerCapabilityForSettlement(both, allocation, f.input().now),
+    ).not.toThrow();
+    expect(() =>
+      assertSignerCapabilityForSettlement(
+        both,
+        allocation,
+        "2026-09-06T20:00:00.000Z",
+      ),
+    ).toThrow("unknown");
+  });
+
+  it("never lets later positive reports erase a terminal loss", async () => {
+    const f = await fixture();
+    await f.add();
+    const baseSha = f.commit();
+    for (const [role, source] of [
+      ["funder", "c"],
+      ["steward", "d"],
+    ] as const) {
+      const value = f.positive(role, source, "2026-09-05T21:00:00.000Z");
+      // A later signed report still cannot restore this instrument.
+      await f.add(value);
+    }
+    f.commit();
+    const ledger = await readSignerAccessLedger({ ...f.input(), baseSha });
+    expect(signerCapabilityState(ledger, f.report, f.input().now).state).toBe(
+      "inaccessible",
+    );
+  });
+  it("authenticates loss from immutable blobs and ignores dirty working bytes", async () => {
+    const f = await fixture();
+    await f.add();
+    f.commit();
+    await f.write(signerReportPath(f.report), "not a report");
+    const ledger = await readSignerAccessLedger(f.input());
+    const state = signerCapabilityState(ledger, f.report, f.input().now);
+    expect(state.state).toBe("inaccessible");
+    expect(state.losses.map((loss) => loss.reason)).toEqual([f.report.reason]);
+    expect(state.paymentAuthorized).toBe(false);
+    expect(() =>
+      assertSignerCapabilityForSettlement(
+        ledger,
+        { ...f.report, fundingBasis: { instrumentId: f.report.instrumentId } },
+        f.input().now,
+      ),
+    ).toThrow("inaccessible");
+    expect(() =>
+      signerCapabilityState(
+        { ...ledger, reports: [] },
+        f.report,
+        f.input().now,
+      ),
+    ).toThrow("complete authenticated ledger");
+  });
+
+  it.each(["delete", "rewrite"])(
+    "rejects %s of a previously accepted loss",
+    async (change) => {
+      const f = await fixture();
+      await f.add();
+      const baseSha = f.commit();
+      if (change === "delete") f.git("rm", signerReportPath(f.report));
+      else
+        await f.write(
+          signerReportPath(f.report),
+          canonicalFundingDecisionBytes({ ...f.report, reason: "changed" }),
+        );
+      f.commit();
+      await expect(
+        readSignerAccessLedger({ ...f.input(), baseSha }),
+      ).rejects.toThrow("append-only");
+    },
+  );
+
+  it("does not authenticate a report against its own proposed manifest", async () => {
+    const f = await fixture();
+    await f.write("extra.txt", "new revision");
+    f.report.manifestRevision = f.commit();
+    await f.add();
+    f.commit();
+    await expect(readSignerAccessLedger(f.input())).rejects.toThrow();
+  });
+
+  it("fails the whole read on unavailable signature authority", async () => {
+    const f = await fixture();
+    await f.add();
+    f.commit();
+    await expect(
+      readSignerAccessLedger({
+        ...f.input(),
+        readCommit: async () => {
+          throw new Error("offline");
+        },
+      }),
+    ).rejects.toThrow("offline");
+  });
+
+  it.each(["duplicate-key", "wrong-path", "symlink"])(
+    "rejects %s records",
+    async (change) => {
+      const f = await fixture();
+      if (change === "duplicate-key")
+        await f.write(
+          signerReportPath(f.report),
+          canonicalFundingDecisionBytes(f.report).replace(
+            "{",
+            '{"reason":"discarded",',
+          ),
+        );
+      if (change === "wrong-path")
+        await f.write(
+          `funding/eliza/signer-access/${"0".repeat(64)}.json`,
+          canonicalFundingDecisionBytes(f.report),
+        );
+      if (change === "symlink") {
+        const { symlink } = await import("node:fs/promises");
+        await mkdir(join(f.root, "funding/eliza/signer-access"), {
+          recursive: true,
+        });
+        await symlink(
+          "../../../projects/eliza/project.json",
+          join(f.root, signerReportPath(f.report)),
+        );
+      }
+      f.commit();
+      await expect(readSignerAccessLedger(f.input())).rejects.toThrow();
+    },
+  );
+});

--- a/scripts/signer-access-ledger.ts
+++ b/scripts/signer-access-ledger.ts
@@ -1,0 +1,259 @@
+/** Complete immutable Git-tree report history. Never payment authorization. */
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { assertProjectDefinition } from "../src/lib/project-schema.mjs";
+import { canonicalFundingDecisionBytes } from "./check-funding-record-pr";
+import {
+  assertSignerAccessReport,
+  readSignerCommit,
+  type SignerAccessReport,
+  verifySignerAccess,
+} from "./verify-signer-access";
+
+const SHA = /^[a-f0-9]{40}$/u;
+const PATH =
+  /^funding\/([a-z0-9][a-z0-9-]{0,47})\/signer-access\/([a-f0-9]{64})\.json$/u;
+const MAX_BYTES = 16 * 1024;
+const verifiedLedgers = new WeakSet<object>();
+export interface SignerAccessLedger {
+  readonly baseSha: string;
+  readonly headSha: string;
+  readonly reports: readonly SignerAccessReport[];
+}
+
+function git(root: string, args: string[], maxBuffer = 16 * 1024 * 1024) {
+  return execFileSync(
+    "git",
+    ["--no-replace-objects", "--literal-pathspecs", ...args],
+    {
+      cwd: root,
+      timeout: 30_000,
+      maxBuffer,
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+}
+
+function entries(root: string, revision: string, path: string) {
+  const result = new Map<string, string>();
+  for (const line of git(root, ["ls-tree", "-r", "-z", revision, "--", path])
+    .toString("utf8")
+    .split("\0")
+    .filter(Boolean)) {
+    const match = /^100644 blob ([a-f0-9]{40})\t(.+)$/u.exec(line);
+    if (!match) throw new TypeError("Signer ledger requires regular Git blobs");
+    result.set(match[2], match[1]);
+  }
+  return result;
+}
+
+function blob(root: string, oid: string, limit: number) {
+  const size = Number(
+    git(root, ["cat-file", "-s", oid], 1024).toString().trim(),
+  );
+  if (!Number.isSafeInteger(size) || size <= 0 || size > limit)
+    throw new TypeError("Signer ledger blob exceeds its byte limit");
+  return git(root, ["cat-file", "blob", oid], limit);
+}
+
+function json(bytes: Buffer): unknown {
+  return JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(bytes));
+}
+
+export function signerReportPath(report: SignerAccessReport): string {
+  const digest = createHash("sha256")
+    .update(canonicalFundingDecisionBytes(report))
+    .digest("hex");
+  return `funding/${report.projectId}/signer-access/${digest}.json`;
+}
+
+/**
+ * Reads every report from head, preserving every base blob. The caller must
+ * resolve base to current trusted develop; a proposed manifest is not authority.
+ * All reports, including historical loss, are authenticated before returning.
+ */
+export async function readSignerAccessLedger(input: {
+  root: string;
+  baseSha: string;
+  headSha: string;
+  now: string;
+  readCommit?: typeof readSignerCommit;
+}): Promise<SignerAccessLedger> {
+  if (!SHA.test(input.baseSha) || !SHA.test(input.headSha))
+    throw new TypeError("Signer ledger requires immutable Git SHAs");
+  if (
+    !Number.isFinite(Date.parse(input.now)) ||
+    new Date(input.now).toISOString() !== input.now
+  )
+    throw new TypeError("Signer ledger requires canonical current time");
+  git(input.root, [
+    "merge-base",
+    "--is-ancestor",
+    input.baseSha,
+    input.headSha,
+  ]);
+  const history = (revision: string) =>
+    new Map(
+      [...entries(input.root, revision, "funding")].filter(([path]) =>
+        /^funding\/[^/]+\/signer-access(?:\/|$)/u.test(path),
+      ),
+    );
+  const base = history(input.baseSha);
+  const head = history(input.headSha);
+  for (const [path, oid] of base) {
+    if (head.get(path) !== oid)
+      throw new TypeError(
+        "Signer report history is append-only; omission or rewriting is forbidden",
+      );
+  }
+  const reports: SignerAccessReport[] = [];
+  const sources = new Set<string>();
+  for (const [path, oid] of head) {
+    if (!PATH.test(path))
+      throw new TypeError("Noncanonical signer report path");
+    const bytes = blob(input.root, oid, MAX_BYTES);
+    const report = assertSignerAccessReport(json(bytes));
+    if (
+      !bytes.equals(Buffer.from(canonicalFundingDecisionBytes(report))) ||
+      signerReportPath(report) !== path
+    )
+      throw new TypeError(
+        "Signer report bytes and content-addressed path must be canonical",
+      );
+    const source = `${report.sourceRepository.toLowerCase()}@${report.sourceCommit}`;
+    if (sources.has(source))
+      throw new TypeError("Duplicate signer report source");
+    sources.add(source);
+    git(input.root, [
+      "merge-base",
+      "--is-ancestor",
+      report.manifestRevision,
+      input.baseSha,
+    ]);
+    const manifestPath = `projects/${report.projectId}/project.json`;
+    const manifestEntries = entries(
+      input.root,
+      report.manifestRevision,
+      manifestPath,
+    );
+    const manifestOid = manifestEntries.get(manifestPath);
+    if (!manifestOid || manifestEntries.size !== 1)
+      throw new TypeError(
+        "Signer report requires its reviewed project manifest",
+      );
+    const project = assertProjectDefinition(
+      json(blob(input.root, manifestOid, 1024 * 1024)),
+    );
+    reports.push(
+      await verifySignerAccess({
+        report,
+        project,
+        manifestRevision: report.manifestRevision,
+        now: input.now,
+        readCommit: input.readCommit,
+      }),
+    );
+  }
+  const ledger = Object.freeze({
+    baseSha: input.baseSha,
+    headSha: input.headSha,
+    reports: Object.freeze(reports.map((report) => Object.freeze(report))),
+  });
+  verifiedLedgers.add(ledger);
+  return ledger;
+}
+
+/** One necessary settlement check, never sufficient payment authorization. */
+export function assertSignerCapabilityForSettlement(
+  ledger: SignerAccessLedger,
+  allocation: {
+    projectId: string;
+    cycleId: string;
+    fundingBasis?: { instrumentId: string | null };
+  },
+  now: string,
+) {
+  const instrumentId = allocation.fundingBasis?.instrumentId;
+  if (!instrumentId?.startsWith("squads-v4-vault:")) return;
+  const result = signerCapabilityState(
+    ledger,
+    { ...allocation, instrumentId },
+    now,
+  );
+  if (result.state !== "both-signers-current")
+    throw new TypeError(
+      `Settlement blocked by signer capability state: ${result.state}`,
+    );
+}
+
+/** Fetch before evaluating: stale local refs cannot hide an accepted loss. */
+export async function readCurrentSignerAccessLedger(
+  root: string,
+  readCommit: typeof readSignerCommit = readSignerCommit,
+) {
+  git(root, [
+    "fetch",
+    "--no-tags",
+    "origin",
+    "+refs/heads/develop:refs/remotes/origin/develop",
+  ]);
+  const current = git(root, ["rev-parse", "refs/remotes/origin/develop"])
+    .toString()
+    .trim();
+  return readSignerAccessLedger({
+    root,
+    baseSha: current,
+    headSha: current,
+    now: new Date().toISOString(),
+    readCommit,
+  });
+}
+
+/** Diagnostic only: signer capability does not prove backing or payability. */
+export function signerCapabilityState(
+  ledger: SignerAccessLedger,
+  identity: { projectId: string; cycleId: string; instrumentId: string },
+  now: string,
+) {
+  if (!verifiedLedgers.has(ledger))
+    throw new TypeError(
+      "Signer state requires the complete authenticated ledger",
+    );
+  if (!Number.isFinite(Date.parse(now)) || new Date(now).toISOString() !== now)
+    throw new TypeError("Signer state requires canonical current time");
+  const relevant = ledger.reports.filter(
+    (report) =>
+      report.projectId === identity.projectId &&
+      report.cycleId === identity.cycleId &&
+      report.instrumentId === identity.instrumentId,
+  );
+  if (relevant.some((report) => report.reportedAt > now))
+    throw new TypeError("Signer state cannot include future reports");
+  const losses = relevant
+    .filter((report) => report.capability === "lost-access")
+    .sort(
+      (a, b) =>
+        a.reportedAt.localeCompare(b.reportedAt) ||
+        signerReportPath(a).localeCompare(signerReportPath(b)),
+    );
+  if (losses.length)
+    return {
+      state: "inaccessible" as const,
+      losses,
+      paymentAuthorized: false as const,
+    };
+  const current = (["funder", "steward"] as const).every((role) =>
+    relevant.some(
+      (report) =>
+        report.role === role &&
+        report.capability === "can-sign" &&
+        report.expiresAt !== null &&
+        report.expiresAt > now,
+    ),
+  );
+  return {
+    state: current ? ("both-signers-current" as const) : ("unknown" as const),
+    losses,
+    paymentAuthorized: false as const,
+  };
+}

--- a/scripts/sync-funding-index.ts
+++ b/scripts/sync-funding-index.ts
@@ -16,6 +16,12 @@ import {
   assertProjectCommitmentRecord,
 } from "../src/lib/funding-commitment";
 import { PROJECTS } from "../src/lib/projects.mjs";
+import { canonicalFundingDecisionBytes } from "./check-funding-record-pr";
+import { signerReportPath } from "./signer-access-ledger";
+import {
+  assertSignerAccessReport,
+  squadsAccessInstrumentId,
+} from "./verify-signer-access";
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const OUTPUT = join(ROOT, "public", "data", "funding.json");
@@ -234,10 +240,52 @@ export async function buildFundingIndex(
         `funding/${projectId} is not a registered project path`,
       );
     }
+    // Offline structural validation is not signature authentication. The trusted
+    // PR gate authenticates the complete immutable history before acceptance.
+    const signerRoot = join(fundingRoot, projectId, "signer-access");
+    let signerFiles: string[] = [];
+    try {
+      const stat = await lstat(signerRoot);
+      if (!stat.isDirectory() || stat.isSymbolicLink())
+        throw new TypeError("Signer history must be a real directory");
+      signerFiles = await recordFiles(signerRoot, /^[a-f0-9]{64}\.json$/u);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+    for (const file of signerFiles) {
+      const path = join(signerRoot, file);
+      const report = assertSignerAccessReport(
+        await readRecordFile(path, { projectId }),
+      );
+      const bytes = await readFile(path);
+      if (
+        bytes.length > 16 * 1024 ||
+        !bytes.equals(Buffer.from(canonicalFundingDecisionBytes(report))) ||
+        signerReportPath(report) !==
+          `funding/${projectId}/signer-access/${file}`
+      )
+        throw new TypeError(
+          "Signer report bytes or content-addressed path are invalid",
+        );
+      const instruments = fundingCommitmentsAtRevision(
+        projectId,
+        report.manifestRevision,
+        repositoryRoot,
+      );
+      if (
+        !instruments.some(
+          (instrument) =>
+            instrument.kind === "squads-v4-vault" &&
+            squadsAccessInstrumentId(instrument) === report.instrumentId &&
+            instrument.monthlyCommitment?.cycleId === report.cycleId,
+        )
+      )
+        throw new TypeError("Signer report has no exact historical instrument");
+    }
     for (const network of await directories(
       join(fundingRoot, projectId),
       [],
-      [COMMITMENTS_DIRECTORY],
+      [COMMITMENTS_DIRECTORY, "signer-access"],
     )) {
       for (const transactionId of await directories(
         join(fundingRoot, projectId, network),

--- a/scripts/sync-funding-index.ts
+++ b/scripts/sync-funding-index.ts
@@ -16,6 +16,10 @@ import {
   assertProjectCommitmentRecord,
 } from "../src/lib/funding-commitment";
 import { PROJECTS } from "../src/lib/projects.mjs";
+import {
+  type PublicSignerReport,
+  publicSignerReport,
+} from "../src/lib/signer-capability";
 import { canonicalFundingDecisionBytes } from "./check-funding-record-pr";
 import { signerReportPath } from "./signer-access-ledger";
 import {
@@ -233,6 +237,7 @@ export async function buildFundingIndex(
   const fundingRoot = join(repositoryRoot, "funding");
   const records: unknown[] = [];
   const commitments: unknown[] = [];
+  const signerReports: PublicSignerReport[] = [];
   for (const projectId of await directories(fundingRoot, ["README.md"])) {
     const project = projects.find((candidate) => candidate.id === projectId);
     if (!project || project.funding.recordsPath !== `funding/${projectId}`) {
@@ -257,6 +262,7 @@ export async function buildFundingIndex(
       const report = assertSignerAccessReport(
         await readRecordFile(path, { projectId }),
       );
+      signerReports.push(publicSignerReport(report));
       const bytes = await readFile(path);
       if (
         bytes.length > 16 * 1024 ||
@@ -383,7 +389,13 @@ export async function buildFundingIndex(
   );
   const generatedAt = latestObservedAt(
     commitments,
-    latestObservedAt(records, null),
+    latestObservedAt(
+      records,
+      latestObservedAt(
+        signerReports.map((r) => ({ observedAt: r.reportedAt })),
+        null,
+      ),
+    ),
   );
   const index = assertProjectFundingIndex(
     {
@@ -391,6 +403,7 @@ export async function buildFundingIndex(
       generatedAt,
       records,
       commitments,
+      ...(signerReports.length ? { signerReports } : {}),
     },
     addresses,
     instruments,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,6 +73,10 @@ import {
 } from "./lib/projects.mjs";
 import { formatThirds, selectReviewerLeaders } from "./lib/reviewer-leaders";
 import { feeForPrincipal, PLATFORM_FEE_BASIS_POINTS } from "./lib/rewards";
+import {
+  type PublicSignerReport,
+  publicSignerStatus,
+} from "./lib/signer-capability";
 
 const SOURCE_REPOSITORY = "https://github.com/SlopDotCash/slopdotcash";
 const SOCIAL_X = "https://x.com/SlopCash";
@@ -2166,6 +2170,85 @@ function useCurrentWallet(state: DataState, login: string): CurrentWalletState {
   return wallet;
 }
 
+export function SignerReports({
+  reports,
+}: {
+  reports: readonly PublicSignerReport[];
+}) {
+  const [now, setNow] = useState(Date.now);
+  useEffect(() => {
+    const refresh = () => setNow(Date.now());
+    const timer = window.setInterval(refresh, 1000);
+    window.addEventListener("focus", refresh);
+    return () => {
+      window.clearInterval(timer);
+      window.removeEventListener("focus", refresh);
+    };
+  }, []);
+  const groups = new Map<string, PublicSignerReport[]>();
+  for (const report of reports) {
+    const key = `${report.cycleId}:${report.instrumentId}`;
+    const group = groups.get(key) ?? [];
+    group.push(report);
+    groups.set(key, group);
+  }
+  return (
+    <section aria-label="Signer capability reports">
+      <h2>Signer capability</h2>
+      <p>
+        These reports do not prove available balance or authorize payment.
+        Payments remain disabled.
+      </p>
+      {[...groups.entries()].map(([key, group]) => {
+        const state = publicSignerStatus(group, now);
+        return (
+          <article key={key}>
+            <h3>
+              <span aria-live="polite">
+                {group[0].cycleId} ·{" "}
+                {state === "inaccessible"
+                  ? "Inaccessible"
+                  : state === "both-signers-current"
+                    ? "Both signers reported capability"
+                    : "Current capability unknown"}
+              </span>
+            </h3>
+            <p>Instrument: {group[0].instrumentId}</p>
+            <ul>
+              {group.map((report) => (
+                <li key={`${report.sourceRepository}:${report.sourceCommit}`}>
+                  {report.role}:{" "}
+                  {report.capability === "lost-access"
+                    ? "reported lost access"
+                    : report.expiresAt !== null &&
+                        Date.parse(report.expiresAt) <= now
+                      ? "capability report expired"
+                      : "reported signing capability"}
+                  . {report.reason}{" "}
+                  <ExternalLinkAnchor
+                    href={`https://github.com/${report.sourceRepository}/commit/${report.sourceCommit}`}
+                  >
+                    Signed report
+                  </ExternalLinkAnchor>
+                  {report.expiresAt && (
+                    <>
+                      {" "}
+                      · Expires{" "}
+                      <time dateTime={report.expiresAt}>
+                        {report.expiresAt}
+                      </time>
+                    </>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </article>
+        );
+      })}
+    </section>
+  );
+}
+
 function ProjectFundingPage({ project }: { project: ProjectDefinition }) {
   const funding = useFundingIndex();
   const records =
@@ -2195,10 +2278,20 @@ function ProjectFundingPage({ project }: { project: ProjectDefinition }) {
         payment.
       </p>
       <p>
-        Commitment accessibility: unknown. On-chain balance does not establish
-        that both signers can act. No commitment is available payout funding
-        until an authenticated accessibility evidence protocol is reviewed.
+        On-chain balance does not establish signer capability or payout
+        availability. Published signer reports do not activate payments;
+        settlement and funding safeguards must also be satisfied.
       </p>
+      {funding.status === "ready" &&
+        funding.index.signerReports?.some(
+          (r) => r.projectId === project.id,
+        ) && (
+          <SignerReports
+            reports={funding.index.signerReports.filter(
+              (r) => r.projectId === project.id,
+            )}
+          />
+        )}
       {funding.status === "loading" ? (
         <div className="data-notice" role="status">
           <span className="pulse" /> Reading funding records…

--- a/src/lib/funding.ts
+++ b/src/lib/funding.ts
@@ -11,6 +11,10 @@ import {
   type ProjectCommitmentRecord,
 } from "./funding-commitment";
 import type { FundingCommitmentInstrument } from "./funding-instruments.mjs";
+import {
+  assertPublicSignerReport,
+  type PublicSignerReport,
+} from "./signer-capability";
 
 export { isFundingAddress } from "./funding-address.mjs";
 
@@ -62,6 +66,7 @@ export interface ProjectFundingRecord {
 }
 
 export interface ProjectFundingIndex {
+  signerReports?: readonly PublicSignerReport[];
   commitmentAccessibility?: "unknown";
   schemaVersion: typeof FUNDING_PROTOCOL_VERSION;
   generatedAt: string | null;
@@ -480,6 +485,7 @@ export function assertProjectFundingIndex(
       "generatedAt",
       "records",
       "schemaVersion",
+      ...(Object.hasOwn(index, "signerReports") ? ["signerReports"] : []),
       ...(Object.hasOwn(index, "commitmentAccessibility")
         ? ["commitmentAccessibility"]
         : []),
@@ -569,9 +575,30 @@ export function assertProjectFundingIndex(
     }
     commitmentTransactionProjects.set(key, record.projectId);
   }
-  const expectedGeneratedAt = [...records, ...commitments].reduce<
-    string | null
-  >(
+  const signerReports: PublicSignerReport[] = [];
+  if (Object.hasOwn(index, "signerReports")) {
+    if (
+      !Array.isArray(index.signerReports) ||
+      index.signerReports.length > 100_000
+    )
+      throw new TypeError("Signer reports are invalid or unbounded");
+    const sources = new Set<string>();
+    for (const value of index.signerReports) {
+      const report = assertPublicSignerReport(value);
+      const source = `${report.sourceRepository.toLowerCase()}@${report.sourceCommit}`;
+      if (!addressesByProject.has(report.projectId) || sources.has(source))
+        throw new TypeError(
+          "Signer reports require known projects and unique sources",
+        );
+      sources.add(source);
+      signerReports.push(report);
+    }
+  }
+  const expectedGeneratedAt = [
+    ...records,
+    ...commitments,
+    ...signerReports.map((r) => ({ observedAt: r.reportedAt })),
+  ].reduce<string | null>(
     (latest, record) =>
       latest === null || record.observedAt > latest
         ? record.observedAt
@@ -585,6 +612,7 @@ export function assertProjectFundingIndex(
   }
   return {
     schemaVersion: FUNDING_PROTOCOL_VERSION,
+    ...(signerReports.length ? { signerReports } : {}),
     commitmentAccessibility: "unknown",
     generatedAt,
     records,

--- a/src/lib/signer-capability.test.ts
+++ b/src/lib/signer-capability.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertPublicSignerReport,
+  type PublicSignerReport,
+  publicSignerStatus,
+} from "./signer-capability";
+
+const report: PublicSignerReport = {
+  projectId: "eliza",
+  cycleId: "2026-09",
+  instrumentId:
+    "squads-v4-vault:solana:11111111111111111111111111111111:0:Vote111111111111111111111111111111111111111",
+  role: "funder",
+  capability: "can-sign",
+  reportedAt: "2026-09-05T20:00:00.000Z",
+  expiresAt: "2026-09-06T20:00:00.000Z",
+  reason: "Synthetic public report.",
+  sourceRepository: "example/evidence",
+  sourceCommit: "a".repeat(40),
+};
+const at = (value: string) => Date.parse(value);
+describe("public signer capability, never payment availability", () => {
+  it("requires both roles for one instrument and expires at the exact boundary", () => {
+    const both = [
+      report,
+      { ...report, role: "steward" as const, sourceCommit: "b".repeat(40) },
+    ];
+    expect(publicSignerStatus([report], at("2026-09-06T00:00:00.000Z"))).toBe(
+      "unknown",
+    );
+    expect(publicSignerStatus(both, at("2026-09-06T19:59:59.999Z"))).toBe(
+      "both-signers-current",
+    );
+    expect(publicSignerStatus(both, at("2026-09-06T20:00:00.000Z"))).toBe(
+      "unknown",
+    );
+    expect(() =>
+      publicSignerStatus(
+        [report, { ...both[1], cycleId: "2026-10" }],
+        at("2026-09-06T00:00:00.000Z"),
+      ),
+    ).toThrow("one exact monthly instrument");
+  });
+  it("retains a published loss despite later or future positive claims", () => {
+    const loss = assertPublicSignerReport({
+      ...report,
+      capability: "lost-access",
+      expiresAt: null,
+    });
+    const future = {
+      ...report,
+      reportedAt: "2026-09-07T00:00:00.000Z",
+      expiresAt: "2026-09-08T00:00:00.000Z",
+    };
+    expect(
+      publicSignerStatus([future, loss], at("2026-09-06T00:00:00.000Z")),
+    ).toBe("inaccessible");
+    expect(publicSignerStatus([future], at("2026-09-06T00:00:00.000Z"))).toBe(
+      "unknown",
+    );
+  });
+  it("rejects unsafe source links, extended lifetimes, and expiring losses", () => {
+    for (const change of [
+      { sourceRepository: "https://evil.invalid" },
+      { sourceCommit: "main" },
+      { expiresAt: "2026-09-07T20:00:00.000Z" },
+      { capability: "lost-access" },
+      { paymentAuthorized: true },
+    ])
+      expect(() =>
+        assertPublicSignerReport({ ...report, ...change }),
+      ).toThrow();
+  });
+});

--- a/src/lib/signer-capability.test.ts
+++ b/src/lib/signer-capability.test.ts
@@ -62,6 +62,8 @@ describe("public signer capability, never payment availability", () => {
   it("rejects unsafe source links, extended lifetimes, and expiring losses", () => {
     for (const change of [
       { sourceRepository: "https://evil.invalid" },
+      { role: ["funder"] },
+      { capability: ["can-sign"] },
       { sourceCommit: "main" },
       { expiresAt: "2026-09-07T20:00:00.000Z" },
       { capability: "lost-access" },

--- a/src/lib/signer-capability.ts
+++ b/src/lib/signer-capability.ts
@@ -37,8 +37,8 @@ export function assertPublicSignerReport(value: unknown): PublicSignerReport {
     !/^squads-v4-vault:solana:[1-9A-HJ-NP-Za-km-z]{32,44}:(?:0|[1-9][0-9]*):[1-9A-HJ-NP-Za-km-z]{32,44}$/u.test(
       r.instrumentId,
     ) ||
-    !["funder", "steward"].includes(String(r.role)) ||
-    !["can-sign", "lost-access"].includes(String(r.capability)) ||
+    (r.role !== "funder" && r.role !== "steward") ||
+    (r.capability !== "can-sign" && r.capability !== "lost-access") ||
     typeof r.reason !== "string" ||
     r.reason.trim() !== r.reason ||
     r.reason.length < 1 ||

--- a/src/lib/signer-capability.ts
+++ b/src/lib/signer-capability.ts
@@ -1,0 +1,128 @@
+/** Public signer reports are evidence, not backing or payment authorization. */
+export interface PublicSignerReport {
+  projectId: string;
+  cycleId: string;
+  instrumentId: string;
+  role: "funder" | "steward";
+  capability: "can-sign" | "lost-access";
+  reportedAt: string;
+  expiresAt: string | null;
+  reason: string;
+  sourceRepository: string;
+  sourceCommit: string;
+}
+
+function time(value: unknown): number {
+  if (
+    typeof value !== "string" ||
+    !Number.isFinite(Date.parse(value)) ||
+    new Date(value).toISOString() !== value
+  )
+    throw new TypeError("Signer report time must be canonical UTC");
+  return Date.parse(value);
+}
+
+export function assertPublicSignerReport(value: unknown): PublicSignerReport {
+  if (!value || typeof value !== "object" || Array.isArray(value))
+    throw new TypeError("Invalid public signer report");
+  const r = value as Record<string, unknown>;
+  if (
+    Object.keys(r).sort().join(",") !==
+      "capability,cycleId,expiresAt,instrumentId,projectId,reason,reportedAt,role,sourceCommit,sourceRepository" ||
+    typeof r.projectId !== "string" ||
+    !/^[a-z0-9][a-z0-9-]{0,47}$/u.test(r.projectId) ||
+    typeof r.cycleId !== "string" ||
+    !/^\d{4}-(?:0[1-9]|1[0-2])$/u.test(r.cycleId) ||
+    typeof r.instrumentId !== "string" ||
+    !/^squads-v4-vault:solana:[1-9A-HJ-NP-Za-km-z]{32,44}:(?:0|[1-9][0-9]*):[1-9A-HJ-NP-Za-km-z]{32,44}$/u.test(
+      r.instrumentId,
+    ) ||
+    !["funder", "steward"].includes(String(r.role)) ||
+    !["can-sign", "lost-access"].includes(String(r.capability)) ||
+    typeof r.reason !== "string" ||
+    r.reason.trim() !== r.reason ||
+    r.reason.length < 1 ||
+    r.reason.length > 500 ||
+    [...r.reason].some(
+      (character) =>
+        character.charCodeAt(0) < 32 || character.charCodeAt(0) === 127,
+    ) ||
+    typeof r.sourceRepository !== "string" ||
+    !/^[A-Za-z0-9_.-]{1,100}\/[A-Za-z0-9_.-]{1,100}$/u.test(
+      r.sourceRepository,
+    ) ||
+    typeof r.sourceCommit !== "string" ||
+    !/^[a-f0-9]{40}$/u.test(r.sourceCommit)
+  )
+    throw new TypeError("Invalid public signer report");
+  const reported = time(r.reportedAt);
+  if (r.capability === "lost-access") {
+    if (r.expiresAt !== null) throw new TypeError("Loss cannot expire");
+  } else if (
+    time(r.expiresAt) <= reported ||
+    time(r.expiresAt) - reported > 86400000
+  )
+    throw new TypeError("Signer capability lifetime exceeds its bound");
+  return { ...r } as unknown as PublicSignerReport;
+}
+
+export function publicSignerReport(
+  report: PublicSignerReport,
+): PublicSignerReport {
+  const {
+    projectId,
+    cycleId,
+    instrumentId,
+    role,
+    capability,
+    reportedAt,
+    expiresAt,
+    reason,
+    sourceRepository,
+    sourceCommit,
+  } = report;
+  return assertPublicSignerReport({
+    projectId,
+    cycleId,
+    instrumentId,
+    role,
+    capability,
+    reportedAt,
+    expiresAt,
+    reason,
+    sourceRepository,
+    sourceCommit,
+  });
+}
+
+export function publicSignerStatus(
+  reports: readonly PublicSignerReport[],
+  now: number,
+) {
+  if (!Number.isFinite(now))
+    throw new TypeError("Invalid signer evaluation time");
+  if (
+    new Set(reports.map((r) => `${r.projectId}:${r.cycleId}:${r.instrumentId}`))
+      .size > 1
+  )
+    throw new TypeError("Signer status requires one exact monthly instrument");
+  if (
+    reports.some(
+      (r) => r.capability === "lost-access" && Date.parse(r.reportedAt) <= now,
+    )
+  )
+    return "inaccessible" as const;
+  if (reports.some((r) => Date.parse(r.reportedAt) > now))
+    return "unknown" as const;
+  return (["funder", "steward"] as const).every((role) =>
+    reports.some(
+      (r) =>
+        r.role === role &&
+        r.capability === "can-sign" &&
+        r.expiresAt !== null &&
+        Date.parse(r.expiresAt) > now,
+    ),
+  )
+    ? ("both-signers-current" as const)
+    : ("unknown" as const);
+}

--- a/tests/app.test.tsx
+++ b/tests/app.test.tsx
@@ -1750,7 +1750,9 @@ describe("direct project funding", () => {
       screen.getByText(/Funds go directly to the project wallet/u),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/Commitment accessibility: unknown/u),
+      screen.getByText(
+        /On-chain balance does not establish signer capability/u,
+      ),
     ).toBeInTheDocument();
     expect(
       screen.getByText(

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -1134,7 +1134,9 @@ test("keeps primary routes accessible and inside the viewport", async ({
         page.getByRole("heading", { exact: true, name: "Project funding" }),
       ).toBeVisible();
       await expect(
-        page.getByText(/Commitment accessibility: unknown/u),
+        page.getByText(
+          /On-chain balance does not establish signer capability/u,
+        ),
       ).toBeVisible();
     }
     const results = await new AxeBuilder({ page })

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -77,6 +77,95 @@ test.beforeEach(async ({ page }, testInfo) => {
   await page.goto("/", { waitUntil: "networkidle" });
 });
 
+test("shows signer loss and expired capability without payout availability", async ({
+  page,
+}, testInfo) => {
+  const project = PROJECTS.find(
+    (candidate) => candidate.reward.kind === "monthly-pool",
+  );
+  if (!project) throw new Error("Monthly project fixture is unavailable");
+  const reportedAt = new Date(Date.now() - 3600000).toISOString();
+  const expiresAt = new Date(Date.now() - 1800000).toISOString();
+  const report = {
+    projectId: project.id,
+    cycleId: reportedAt.slice(0, 7),
+    instrumentId:
+      "squads-v4-vault:solana:11111111111111111111111111111111:0:Vote111111111111111111111111111111111111111",
+    role: "funder",
+    capability: "lost-access",
+    reportedAt,
+    expiresAt: null,
+    reason: "Synthetic browser fixture: signing capability was lost.",
+    sourceRepository: "example/evidence",
+    sourceCommit: "a".repeat(40),
+  };
+  await page.route("**/data/funding.json", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        schemaVersion: "1",
+        generatedAt: reportedAt,
+        records: [],
+        commitments: [],
+        signerReports: [
+          report,
+          {
+            ...report,
+            role: "steward",
+            capability: "can-sign",
+            expiresAt,
+            sourceCommit: "b".repeat(40),
+          },
+        ],
+      }),
+    }),
+  );
+  await page.goto(`/projects/${project.slug}/funding`, {
+    waitUntil: "networkidle",
+  });
+  const section = page.getByRole("region", {
+    name: "Signer capability reports",
+  });
+  await expect(
+    section.getByRole("heading", { name: /Inaccessible/u }),
+  ).toBeVisible();
+  await expect(section.getByText(/capability report expired/u)).toBeVisible();
+  await expect(section.getByText(/Payments remain disabled/u)).toBeVisible();
+  const source = section.getByRole("link", { name: "Signed report" }).first();
+  await expect(source).toHaveAttribute(
+    "href",
+    `https://github.com/example/evidence/commit/${"a".repeat(40)}`,
+  );
+  await source.focus();
+  await expect(source).toBeFocused();
+  expect(
+    (
+      await new AxeBuilder({ page })
+        .withTags(["wcag2a", "wcag2aa", "wcag21aa"])
+        .analyze()
+    ).violations,
+  ).toEqual([]);
+  expect(
+    await page.evaluate(
+      () => document.documentElement.scrollWidth <= window.innerWidth,
+    ),
+  ).toBe(true);
+  if (testInfo.project.name === "wide-desktop-chromium") {
+    await page.evaluate(() => {
+      document.documentElement.style.fontSize = "200%";
+    });
+    expect(
+      await page.evaluate(
+        () => document.documentElement.scrollWidth <= window.innerWidth,
+      ),
+    ).toBe(true);
+  }
+  await page.screenshot({
+    path: testInfo.outputPath("signer-loss.png"),
+    fullPage: true,
+  });
+});
+
 test("discovers both reward models and a score-ranked global ledger", async ({
   page,
   request,

--- a/tests/signer-reports.test.tsx
+++ b/tests/signer-reports.test.tsx
@@ -1,0 +1,85 @@
+import "@testing-library/jest-dom/vitest";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SignerReports } from "../src/App";
+import type { PublicSignerReport } from "../src/lib/signer-capability";
+
+const report: PublicSignerReport = {
+  projectId: "eliza",
+  cycleId: "2026-09",
+  instrumentId:
+    "squads-v4-vault:solana:11111111111111111111111111111111:0:Vote111111111111111111111111111111111111111",
+  role: "funder",
+  capability: "can-sign",
+  reportedAt: "2026-09-05T20:00:00.000Z",
+  expiresAt: "2026-09-06T20:00:00.000Z",
+  reason: "Synthetic signer evidence.",
+  sourceRepository: "example/evidence",
+  sourceCommit: "a".repeat(40),
+};
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+describe("visible signer history", () => {
+  it("updates an open page when positive capability expires", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-09-06T19:59:59.000Z"));
+    render(
+      <SignerReports
+        reports={[
+          report,
+          { ...report, role: "steward", sourceCommit: "b".repeat(40) },
+        ]}
+      />,
+    );
+    expect(
+      screen.getByRole("heading", {
+        name: /Both signers reported capability/u,
+      }),
+    ).toBeVisible();
+    act(() => vi.advanceTimersByTime(1000));
+    expect(
+      screen.getByRole("heading", { name: /Current capability unknown/u }),
+    ).toBeVisible();
+    expect(screen.getAllByText(/capability report expired/u)).toHaveLength(2);
+    expect(screen.getByText(/Payments remain disabled/u)).toBeVisible();
+  });
+  it("shows loss reason and exact source without borrowing another cycle's proof", () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-09-06T00:00:00.000Z"));
+    render(
+      <SignerReports
+        reports={[
+          {
+            ...report,
+            capability: "lost-access",
+            expiresAt: null,
+            reason: "The reviewed signer lost the key.",
+          },
+          {
+            ...report,
+            cycleId: "2026-10",
+            role: "steward",
+            sourceCommit: "b".repeat(40),
+          },
+        ]}
+      />,
+    );
+    expect(
+      screen.getByRole("heading", { name: "2026-09 · Inaccessible" }),
+    ).toBeVisible();
+    expect(
+      screen.getByRole("heading", {
+        name: "2026-10 · Current capability unknown",
+      }),
+    ).toBeVisible();
+    expect(screen.getByText(/The reviewed signer lost the key/u)).toBeVisible();
+    expect(
+      screen.getAllByRole("link", { name: "Signed report" })[0],
+    ).toHaveAttribute(
+      "href",
+      `https://github.com/example/evidence/commit/${"a".repeat(40)}`,
+    );
+  });
+});

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -23,6 +23,7 @@
     "src/lib/evaluator-awards.ts",
     "src/lib/evm-funding.ts",
     "src/lib/funding.ts",
+    "src/lib/signer-capability.ts",
     "src/lib/funding-commitment.ts",
     "src/lib/sablier-funding.ts",
     "src/lib/squads-funding.ts",


### PR DESCRIPTION
Refs #333; partial implementation, not issue completion.

Adds a complete append-only content-addressed signer report ledger authenticated against reviewed manifests and public GitHub signatures. The trusted funding gate and trusted publication reauthenticate history. Public funding pages distinguish reported loss, unknown/expired capability, and current signer reports without claiming available payout funding. New Squads-backed plans fetch current develop and require both current member proofs; existing payment activation guards remain unchanged.

Already-issued plans, approved/partially paid history, hold overlays, and exact-once carry are NOT changed. The source-wallet/instrument binding and transaction-retirement evidence gaps are documented in protocol/signer-access-attestations.md and on #333. No elapsed-time-only retirement, key custody, signing, broadcasting, or payment activation is introduced.

## Validation

Exact head: `de75520f86f491f3372266ab5c17602e063717e1`, based on `1a442080d9d898811918bbbedfa0cffe110521eb`.

- Final local `bun run verify` passed with pinned Node 24.15.0: 974 unit/integration tests across 84 files, 125 skill tests, all static checks, and the 175-file build.
- Fresh exact-head browser regression passed all 8 affected cases: signer evidence and primary-route accessibility/reflow at four viewport sizes, without retries.
- [Inspected screenshot evidence](https://github.com/SlopDotCash/slopdotcash/pull/397#issuecomment-5557394978) captures the unchanged application source from the preceding head; the only subsequent change updates the stale route-test copy assertion.
- [Full hosted exact-head run](https://github.com/SlopDotCash/slopdotcash/actions/runs/34016191439) passed: 41 viewport browser cases and 2 Pages checks. All required exact-head checks are green; this PR is ready for independent maintainer review.

The screenshots and browser reports use synthetic signer fixtures, not real signer or production availability evidence. Deployment, real signer canaries, retirement proofs, and carry acceptance remain pending.

