### PR TITLE
fix: bind settlement sources to frozen funding instruments

### DIFF
--- a/cycles/README.md
+++ b/cycles/README.md
@@ -208,3 +208,12 @@ bun run cycles:verify
 
 No command reads a private key or signs a transaction. Keep seed phrases and
 private keys out of Git, issues, CI, skills, prompts, and local telemetry.
+
+For an allocation with a frozen funding basis, a Solana execution plan must
+use that exact Squads vault as `sourceOwner`. The same check applies when
+reading a stored plan; another valid wallet is not a substitute. A pledged or
+Sablier/EVM basis cannot produce a Solana plan without a separately reviewed
+funding transition. Historical allocations predating the funding-basis schema
+retain their existing validation; this does not migrate or rewrite records.
+Source binding does not prove current backing, signing capability, transaction
+retirement, or safe carry, and does not enable payments.

--- a/protocol/signer-access-attestations.md
+++ b/protocol/signer-access-attestations.md
@@ -103,9 +103,12 @@ remaining principal and prevent both an old intent and a successor cycle from
 paying it. Only eligible shared-pool principal carries, exactly once; review
 budget does not carry. The successor monthly cycle requires a fresh instrument.
 
-The current unsigned execution-plan schema does not bind `sourceOwner` to the
-frozen funding instrument or record a signed transaction's lifetime, nonce, or
-Squads proposal retirement. Consequently an issued or partially settled plan
+New funding-basis Solana plans bind `sourceOwner` to the exact frozen Squads
+vault, including when revalidating a stored plan. A Sablier/EVM or unfunded basis
+cannot supply an arbitrary Solana source. Historical pre-basis plans retain
+their original validation. The unsigned execution-plan schema still does not
+record a signed transaction's lifetime, nonce, or Squads proposal retirement.
+Consequently an issued or partially settled plan
 cannot become carry merely because a signer reports loss or time passes.
 [Solana durable nonces](https://solana.com/developers/cookbook/transactions/confirmation)
 can outlive ordinary blockhash expiration. A reviewed retirement/reconciliation

--- a/scripts/unsafe-destination-hold.test.ts
+++ b/scripts/unsafe-destination-hold.test.ts
@@ -33,7 +33,7 @@ function createRewardCycleProposal(
     ...input,
     fundingBasis: input.fundingBasis ?? {
       cycleId: input.cycleId,
-      instrumentId: `sablier-lockup-v4:base:0x${"1".repeat(40)}:1`,
+      instrumentId: `squads-v4-vault:solana:${UNSAFE}:0:${FUNDING_SOURCE}`,
       fundingState: "committed",
       committedMinor: "10000000000",
       monthlyCapMinor: "10000000000",
@@ -46,6 +46,7 @@ const REPORTED = "2026-08-03T00:00:00.000Z";
 const VERIFIED = "2026-08-03T01:00:00.000Z";
 const UNSAFE = "11111111111111111111111111111111";
 const SAFE = "Vote111111111111111111111111111111111111111";
+const FUNDING_SOURCE = "Stake11111111111111111111111111111111111111";
 
 function wallet(
   actor = "U_fixture",
@@ -505,7 +506,7 @@ describe("authenticated unsafe destination holds", () => {
       allocation: approved,
       allocationSha256: "d".repeat(64),
       createdAt: held.review.endsAt,
-      sourceOwner: "Stake11111111111111111111111111111111111111",
+      sourceOwner: FUNDING_SOURCE,
       feeRecipient: "SysvarRent111111111111111111111111111111111",
     });
     expect(

--- a/src/lib/settlement-plan.test.ts
+++ b/src/lib/settlement-plan.test.ts
@@ -11,6 +11,7 @@ import {
 
 const RECIPIENT = "11111111111111111111111111111111";
 const SOURCE = "Vote111111111111111111111111111111111111111";
+const OTHER_SOURCE = "SysvarRent111111111111111111111111111111111";
 const FEE = "Stake11111111111111111111111111111111111111";
 const COMMIT = "a".repeat(40);
 
@@ -68,6 +69,62 @@ function approvedAllocation() {
 }
 
 describe("settlement execution plans", () => {
+  function fundedAllocation(instrumentId: string) {
+    const allocation = approvedAllocation();
+    return assertRewardAllocationManifest({
+      ...allocation,
+      fundingBasis: {
+        cycleId: allocation.cycleId,
+        fundingState: "committed",
+        committedMinor: allocation.capMinor,
+        monthlyCapMinor: allocation.capMinor,
+        instrumentId,
+      },
+    });
+  }
+
+  it("binds creation and readback to the frozen Squads vault, not any valid wallet", () => {
+    const allocation = fundedAllocation(
+      `squads-v4-vault:solana:${RECIPIENT}:0:${SOURCE}`,
+    );
+    const input = {
+      allocation,
+      allocationSha256: "c".repeat(64),
+      createdAt: "2026-08-15T00:01:00.000Z",
+      feeRecipient: FEE,
+      sourceOwner: SOURCE,
+    };
+    const plan = createSettlementExecutionPlan(input);
+    expect(assertSettlementExecutionPlan(plan, allocation)).toEqual(plan);
+    expect(() =>
+      createSettlementExecutionPlan({ ...input, sourceOwner: OTHER_SOURCE }),
+    ).toThrow(/source owner must match the frozen funding vault/u);
+    expect(() =>
+      assertSettlementExecutionPlan(
+        { ...plan, sourceOwner: OTHER_SOURCE },
+        allocation,
+      ),
+    ).toThrow(/source owner must match the frozen funding vault/u);
+  });
+
+  it.each(["base", "ethereum"])(
+    "does not invent a Solana source for a %s stream",
+    (network) => {
+      const allocation = fundedAllocation(
+        `sablier-lockup-v4:${network}:0x${"a".repeat(40)}:1`,
+      );
+      expect(() =>
+        createSettlementExecutionPlan({
+          allocation,
+          allocationSha256: "c".repeat(64),
+          createdAt: "2026-08-15T00:01:00.000Z",
+          feeRecipient: FEE,
+          sourceOwner: SOURCE,
+        }),
+      ).toThrow(/requires a frozen Solana Squads funding instrument/u);
+    },
+  );
+
   it("includes exact contributor principal and the fee on top", () => {
     const allocation = approvedAllocation();
     const plan = createSettlementExecutionPlan({

--- a/src/lib/settlement-plan.ts
+++ b/src/lib/settlement-plan.ts
@@ -128,6 +128,22 @@ export function createSettlementExecutionPlan(input: {
     throw new TypeError("Settlement allocation digest is invalid");
   }
   const sourceOwner = address(input.sourceOwner, "sourceOwner");
+  if (allocation.fundingBasis) {
+    // The allocation validator has already checked the complete identity syntax.
+    // A caller-supplied wallet cannot substitute for the frozen funding source.
+    const instrumentId = allocation.fundingBasis.instrumentId;
+    if (!instrumentId?.startsWith("squads-v4-vault:solana:")) {
+      throw new TypeError(
+        "Settlement requires a frozen Solana Squads funding instrument",
+      );
+    }
+    const vault = instrumentId.split(":")[4];
+    if (sourceOwner !== vault) {
+      throw new TypeError(
+        "Settlement source owner must match the frozen funding vault",
+      );
+    }
+  }
   const approved = allocation.allocations.filter(
     (row) => row.state === "approved",
   );


### PR DESCRIPTION
Refs #333. The shared settlement constructor and stored-plan validator previously accepted a caller-chosen Solana source independently of the frozen funding instrument. Require the exact frozen Squads vault, and refuse an unfunded or Sablier/EVM basis as authority for an arbitrary Solana source. Preserve historical allocations predating the funding-basis schema; no committed cycle artifacts are rewritten. Three new regressions fail before the fix and pass after it; the focused plan/exact-cycle suite passes 11 tests. Source tampering is rejected during both creation and readback. No signing, transaction retirement, carry, or payment activation is added. Full exact-head verification and hosted browser checks pending; draft until evidence is complete.