### PR TITLE
Allow unattended data-only refreshes of approved releases

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -218,15 +218,18 @@ jobs:
       (github.event_name == 'schedule' && github.ref == 'refs/heads/develop') ||
       (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/develop')
     needs: quality
+    permissions:
+      contents: read
+      actions: read
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     concurrency:
-      # Cloudflare Pages publishes atomically; newest trusted develop wins and
-      # replaces an obsolete run that is still waiting for environment review.
+      # Serialize publication without letting a schedule cancel a code release
+      # awaiting approval. Live-source equivalence rejects obsolete releases.
       group: slop-production
-      cancel-in-progress: true
+      cancel-in-progress: false
     environment:
-      name: eliza-army-production
+      name: ${{ github.event_name == 'schedule' && 'slop-data-refresh' || 'eliza-army-production' }}
       url: https://slop.cash
     steps:
       - name: Checkout exact deployment tooling
@@ -311,6 +314,30 @@ jobs:
       - name: Verify downloaded Pages bundle
         run: node scripts/dist-manifest.mjs verify-local dist
 
+      - name: Require already released source and data-only artifact changes
+        if: github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # The first successful run for a SHA must be an approved push/manual
+          # release. Later successful schedules preserve that exact code and
+          # renew the baseline artifact so quiet branches outlive retention.
+          approved_run="$(gh run list --repo "$GITHUB_REPOSITORY" \
+            --workflow deploy.yml --branch develop --commit "$GITHUB_SHA" \
+            --status success --limit 100 --json databaseId,event,headSha \
+            --jq '[.[] | select(.event == "push" or .event == "workflow_dispatch" or .event == "schedule")][0].databaseId // empty')"
+          if ! [[ "$approved_run" =~ ^[0-9]+$ ]]; then
+            echo "::error::This source revision has no successful production release; a code release must be approved first."
+            exit 1
+          fi
+          approved_bundle="$RUNNER_TEMP/slop-approved-$approved_run"
+          mkdir "$approved_bundle"
+          gh run download "$approved_run" --repo "$GITHUB_REPOSITORY" \
+            --name "slop-pages-$approved_run" --dir "$approved_bundle"
+          node scripts/dist-manifest.mjs verify-local "$approved_bundle"
+          node scripts/check-data-refresh-bundle.mjs "$approved_bundle" dist
+
       - name: Require live release-input equivalence
         run: |
           set -euo pipefail
@@ -339,7 +366,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ "$HAS_TOKEN" != "true" ] || [ "$HAS_ACCOUNT" != "true" ]; then
-            echo "::error::The eliza-army-production environment requires CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID."
+            echo "::error::The selected release environment requires CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID."
             exit 1
           fi
 
@@ -431,6 +458,8 @@ jobs:
             exit 1
           fi
 
+          # Scheduled publication never mutates identity, D1, or cleanup schedules.
+          if [ "$GITHUB_EVENT_NAME" != "schedule" ]; then
           # Restore only absent cleanup triggers; reject nonempty provisioning drift.
           bun scripts/verify-identity-schedules.mjs --restore-missing
 
@@ -736,6 +765,8 @@ jobs:
           }
           NODE
 
+          fi
+
           live_develop="$(
             git -C "$GITHUB_WORKSPACE" ls-remote --exit-code --refs \
               https://github.com/SlopDotCash/slopdotcash.git refs/heads/develop |
@@ -1023,6 +1054,7 @@ jobs:
           exit 1
 
       - name: Require public identity OAuth app
+        if: github.event_name != 'schedule'
         env:
           GITHUB_CLIENT_ID: ${{ steps.pages-deploy.outputs.github_client_id }}
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,6 +215,12 @@ designated reviewer, and disallows administrator bypass. Repository rules
 require a pull request, resolved threads, and non-fast-forward history with no
 bypass actors.
 
+Scheduled data-only refreshes use the separate develop-only `slop-data-refresh`
+environment, with its own scoped Cloudflare secrets and no reviewer gate. They
+require a prior successful release of the exact source SHA and a byte-identical
+bundle except the explicit generated data allowlist. They never mutate identity,
+D1, or cleanup schedules. Push and manual code releases retain production approval.
+
 Push, schedule, and manual releases use the exact checked-out `develop` SHA.
 The workflow installs lockfile-pinned Wrangler without lifecycle scripts,
 deploys the verified build selected by `wrangler.toml`, and waits for a new,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,6 +215,12 @@ designated reviewer, and disallows administrator bypass. Repository rules
 require a pull request, resolved threads, and non-fast-forward history with no
 bypass actors.
 
+Scheduled data-only refreshes use the separate develop-only `slop-data-refresh`
+environment, with its own scoped Cloudflare secrets and no reviewer gate. They
+require a prior successful release of the exact source SHA and a byte-identical
+bundle except the explicit generated data allowlist. They never mutate identity,
+D1, or cleanup schedules. Push and manual code releases retain production approval.
+
 Push, schedule, and manual releases use the exact checked-out `develop` SHA.
 The workflow installs lockfile-pinned Wrangler without lifecycle scripts,
 deploys the verified build selected by `wrangler.toml`, and waits for a new,

--- a/backend/trace/PRIVATE_INTAKE_RECOVERY.md
+++ b/backend/trace/PRIVATE_INTAKE_RECOVERY.md
@@ -17,16 +17,22 @@ or let automation approve its own deployment.
 2. Confirm `Skill, data, build, and browser checks` succeeded for the current
    `develop` SHA. Do not approve a run from a pull request, fork, tag, stale SHA,
    or a run whose quality job failed.
-3. A designated `eliza-army-production` reviewer inspects and approves the
-   waiting `Deploy trusted production bundle` job.
+3. For push/manual code releases, a designated `eliza-army-production` reviewer
+   inspects and approves the waiting `Deploy trusted production bundle` job.
+   Scheduled data-only refreshes use `slop-data-refresh` without human approval,
+   but require an already-released exact SHA and unchanged non-data bundle bytes.
 4. Wait for that exact run to finish successfully. A merge, successful quality
    job, or environment approval alone is not deployment evidence.
 5. Run the verification sequence below and record the workflow run URL, tested
    SHA, `verifiedAt`, and verification time on the operations issue.
 
-The scheduled deployment runs every six hours. The hourly freshness watch
-fails when fewer than nine hours remain, so at least one reviewed scheduled
-run is available inside the renewal window before expiry.
+The scheduled deployment runs every six hours. The separate develop-only
+`slop-data-refresh` environment needs its own `CLOUDFLARE_API_TOKEN` and
+`CLOUDFLARE_ACCOUNT_ID`; do not move code-release secrets out of their protected
+environment. Schedules skip identity, database and cleanup mutations. The hourly
+freshness watch fails when fewer than nine hours remain. If the baseline artifact
+has expired after a prolonged outage, approve a fresh code release to reestablish
+the baseline; never bypass the data-only comparison.
 
 ## Designated reviewer unavailable
 

--- a/scripts/check-data-refresh-bundle.mjs
+++ b/scripts/check-data-refresh-bundle.mjs
@@ -12,6 +12,31 @@ const refreshPaths = new Set([
   "data/cycles/index.json",
 ]);
 
+function isSkillManifest(path) {
+  return (
+    path === "skill-manifest.json" ||
+    /^projects\/[a-z0-9-]+\/(?:review-)?skill-manifest\.json$/u.test(path)
+  );
+}
+
+async function stableSkillManifest(root, path) {
+  const manifest = JSON.parse(await readFile(join(root, path), "utf8"));
+  if (
+    !manifest ||
+    Array.isArray(manifest) ||
+    typeof manifest !== "object" ||
+    typeof manifest.generatedAt !== "string" ||
+    !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(
+      manifest.generatedAt,
+    ) ||
+    !Number.isFinite(Date.parse(manifest.generatedAt))
+  ) {
+    throw new Error(`Invalid skill manifest timestamp: ${path}`);
+  }
+  delete manifest.generatedAt;
+  return JSON.stringify(manifest);
+}
+
 async function inventory(root) {
   const files = new Map();
   let directories = 0;
@@ -61,6 +86,14 @@ export async function assertDataOnlyRefresh(approvedRoot, candidateRoot) {
   const changed = [];
   for (const [path, hash] of candidate) {
     if (approved.get(path) === hash) continue;
+    if (
+      isSkillManifest(path) &&
+      (await stableSkillManifest(approvedRoot, path)) ===
+        (await stableSkillManifest(candidateRoot, path))
+    ) {
+      changed.push(path);
+      continue;
+    }
     if (!refreshPaths.has(path))
       throw new Error(`Scheduled refresh changes non-data file: ${path}`);
     changed.push(path);

--- a/scripts/check-data-refresh-bundle.mjs
+++ b/scripts/check-data-refresh-bundle.mjs
@@ -1,0 +1,85 @@
+/** A scheduled refresh may change data, never application or Pages controls. */
+import { createHash } from "node:crypto";
+import { lstat, readdir, readFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const refreshPaths = new Set([
+  "deployment-manifest.json",
+  "data/leaderboard.json",
+  "data/private-intake-attestation.json",
+  "data/funding.json",
+  "data/cycles/index.json",
+]);
+
+async function inventory(root) {
+  const files = new Map();
+  let directories = 0;
+  let total = 0;
+  async function visit(path, relative) {
+    const stat = await lstat(path);
+    if (stat.isSymbolicLink())
+      throw new Error("Refresh bundles cannot contain symlinks");
+    if (stat.isDirectory()) {
+      if (++directories > 128) throw new Error("Too many bundle directories");
+      for (const name of (await readdir(path)).sort()) {
+        await visit(join(path, name), relative ? `${relative}/${name}` : name);
+      }
+    } else if (stat.isFile()) {
+      total += stat.size;
+      if (
+        files.size >= 256 ||
+        stat.size > 25 * 1024 * 1024 ||
+        total > 128 * 1024 * 1024
+      ) {
+        throw new Error("Refresh bundle exceeds inventory limits");
+      }
+      files.set(
+        relative,
+        createHash("sha256")
+          .update(await readFile(path))
+          .digest("hex"),
+      );
+    } else throw new Error("Refresh bundle contains a non-file entry");
+  }
+  await visit(root, "");
+  if (!files.has("index.html") || !files.has("deployment-manifest.json")) {
+    throw new Error("Refresh bundle is incomplete");
+  }
+  return files;
+}
+
+export async function assertDataOnlyRefresh(approvedRoot, candidateRoot) {
+  const approved = await inventory(approvedRoot);
+  const candidate = await inventory(candidateRoot);
+  if (
+    JSON.stringify([...approved.keys()]) !==
+    JSON.stringify([...candidate.keys()])
+  ) {
+    throw new Error("Scheduled refresh cannot add or remove bundle files");
+  }
+  const changed = [];
+  for (const [path, hash] of candidate) {
+    if (approved.get(path) === hash) continue;
+    if (!refreshPaths.has(path))
+      throw new Error(`Scheduled refresh changes non-data file: ${path}`);
+    changed.push(path);
+  }
+  return changed;
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+) {
+  if (process.argv.length !== 4)
+    throw new Error("Usage: check-data-refresh-bundle.mjs APPROVED CANDIDATE");
+  console.log(
+    JSON.stringify({
+      changedDataFiles: await assertDataOnlyRefresh(
+        process.argv[2],
+        process.argv[3],
+      ),
+    }),
+  );
+}

--- a/scripts/check-data-refresh-bundle.test.mjs
+++ b/scripts/check-data-refresh-bundle.test.mjs
@@ -27,6 +27,53 @@ async function fixture() {
   return [join(root, "approved"), join(root, "candidate")];
 }
 describe("scheduled data-only bundle boundary", () => {
+  for (const path of [
+    "skill-manifest.json",
+    "projects/example/skill-manifest.json",
+    "projects/example/review-skill-manifest.json",
+  ]) {
+    it(`allows only generatedAt in ${path}`, async () => {
+      const [approved, candidate] = await fixture();
+      for (const root of [approved, candidate]) {
+        await mkdir(join(root, "projects/example"), { recursive: true });
+        await writeFile(
+          join(root, path),
+          JSON.stringify({
+            generatedAt: "2026-09-06T00:00:00.000Z",
+            source: { sha256: "original" },
+          }),
+        );
+      }
+      await writeFile(
+        join(candidate, path),
+        JSON.stringify({
+          generatedAt: "2026-09-06T06:00:00.000Z",
+          source: { sha256: "original" },
+        }),
+      );
+      expect(await assertDataOnlyRefresh(approved, candidate)).toEqual([path]);
+      await writeFile(
+        join(candidate, path),
+        JSON.stringify({
+          generatedAt: "2026-09-06T06:00:00.000Z",
+          source: { sha256: "substituted" },
+        }),
+      );
+      await expect(assertDataOnlyRefresh(approved, candidate)).rejects.toThrow(
+        "non-data file",
+      );
+      await writeFile(
+        join(candidate, path),
+        JSON.stringify({
+          generatedAt: "invalid",
+          source: { sha256: "original" },
+        }),
+      );
+      await expect(assertDataOnlyRefresh(approved, candidate)).rejects.toThrow(
+        "timestamp",
+      );
+    });
+  }
   it("accepts identical bundles and explicit data changes", async () => {
     const [approved, candidate] = await fixture();
     expect(await assertDataOnlyRefresh(approved, candidate)).toEqual([]);

--- a/scripts/check-data-refresh-bundle.test.mjs
+++ b/scripts/check-data-refresh-bundle.test.mjs
@@ -1,0 +1,68 @@
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { assertDataOnlyRefresh } from "./check-data-refresh-bundle.mjs";
+
+const roots = [];
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+async function fixture() {
+  const root = await mkdtemp(join(tmpdir(), "slop-refresh-test-"));
+  roots.push(root);
+  for (const dir of ["approved", "candidate"]) {
+    await mkdir(join(root, dir, "data"), { recursive: true });
+    for (const file of [
+      "index.html",
+      "deployment-manifest.json",
+      "_headers",
+      "data/leaderboard.json",
+    ]) {
+      await writeFile(join(root, dir, file), "original");
+    }
+  }
+  return [join(root, "approved"), join(root, "candidate")];
+}
+describe("scheduled data-only bundle boundary", () => {
+  it("accepts identical bundles and explicit data changes", async () => {
+    const [approved, candidate] = await fixture();
+    expect(await assertDataOnlyRefresh(approved, candidate)).toEqual([]);
+    await writeFile(join(candidate, "data/leaderboard.json"), "fresh");
+    expect(await assertDataOnlyRefresh(approved, candidate)).toEqual([
+      "data/leaderboard.json",
+    ]);
+  });
+  for (const file of ["index.html", "_headers"]) {
+    it(`rejects changed ${file}`, async () => {
+      const [approved, candidate] = await fixture();
+      await writeFile(join(candidate, file), "changed code or policy");
+      await expect(assertDataOnlyRefresh(approved, candidate)).rejects.toThrow(
+        "non-data file",
+      );
+    });
+  }
+  it("rejects added files even under data", async () => {
+    const [approved, candidate] = await fixture();
+    await writeFile(join(candidate, "data/code.js"), "code");
+    await expect(assertDataOnlyRefresh(approved, candidate)).rejects.toThrow(
+      "add or remove",
+    );
+  });
+  it("rejects removed files", async () => {
+    const [approved, candidate] = await fixture();
+    await rm(join(candidate, "_headers"));
+    await expect(assertDataOnlyRefresh(approved, candidate)).rejects.toThrow(
+      "add or remove",
+    );
+  });
+  it("rejects symlinks", async () => {
+    const [approved, candidate] = await fixture();
+    await symlink(join(approved, "index.html"), join(candidate, "linked"));
+    await expect(assertDataOnlyRefresh(approved, candidate)).rejects.toThrow(
+      "symlinks",
+    );
+  });
+});

--- a/scripts/deployment-contract.test.mjs
+++ b/scripts/deployment-contract.test.mjs
@@ -411,8 +411,34 @@ describe("slop.cash deployment contract", () => {
       'if [ "$GITHUB_REF" != "refs/heads/develop" ]; then',
     );
     expect(deployJob).toContain("group: slop-production");
-    expect(deployJob).toContain("cancel-in-progress: true");
-    expect(deployJob).toContain("name: eliza-army-production");
+    expect(deployJob).toContain("cancel-in-progress: false");
+    expect(deployJob).toContain(
+      `name: ${"$"}{{ github.event_name == 'schedule' && 'slop-data-refresh' || 'eliza-army-production' }}`,
+    );
+  });
+
+  it("limits unattended refreshes to released source and data-only bundles", () => {
+    expect(deployJob).toContain('--branch develop --commit "$GITHUB_SHA"');
+    expect(deployJob).toContain("--status success");
+    expect(deployJob).toContain("node scripts/check-data-refresh-bundle.mjs");
+    const check = deployJob.indexOf(
+      "node scripts/check-data-refresh-bundle.mjs",
+    );
+    expect(check).toBeLessThan(
+      deployJob.indexOf("- name: Require scoped Cloudflare credentials"),
+    );
+    const guard = deployJob.indexOf(
+      'if [ "$GITHUB_EVENT_NAME" != "schedule" ]; then',
+    );
+    expect(guard).toBeGreaterThan(0);
+    expect(guard).toBeLessThan(
+      deployJob.indexOf(
+        "bun scripts/verify-identity-schedules.mjs --restore-missing",
+      ),
+    );
+    expect(deployJob).toContain(
+      "- name: Require public identity OAuth app\n        if: github.event_name != 'schedule'",
+    );
   });
 
   it("keeps pull-request data checks live without exposing repository tokens", () => {


### PR DESCRIPTION
## Scope
Implements the user-approved separation for #302: scheduled data refreshes use a develop-only environment without required reviewers; push and manual code releases retain eliza-army-production approval.

Schedules require a successful production run of the exact source SHA and compare complete artifacts, including Pages control files. Only the explicit generated data allowlist can change; additions, removals, symlinks and application/control changes fail closed. Successful schedules renew the comparison baseline. Identity, D1 and cleanup mutations are skipped. Shared publication concurrency no longer cancels an awaiting code release.

## Validation
- 51 focused tests passed.
- Workflow YAML and all 33 shell steps parsed successfully.
- Real release artifact self-comparison passed; baseline lookup selected successful exact-SHA run 34022599547.
- Full local verify is running; hosted checks and exact-head browser verification pending.

## Activation boundary
The slop-data-refresh environment exists with develop-only branch policy and no reviewer gate. It still needs its separately provisioned CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID. Existing production secrets and reviewer protections are unchanged. Do not close #302 until real scheduled publication and quiet-period freshness are verified.