### PR TITLE
Remove homepage proof section and show monthly amounts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -753,15 +753,26 @@ function TypewriterHeroHeading() {
   );
 }
 
+function monthlyPoolCapLabel(reward: ProjectDefinition["reward"]): string {
+  const minor = BigInt(reward.monthlyCapMinor);
+  if (minor % 1_000_000n !== 0n) return reward.monthlyCapDisplay;
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    notation: "compact",
+    maximumFractionDigits: 2,
+  })
+    .format(minor / 1_000_000n)
+    .replace(/K$/u, "k");
+}
+
 function ProjectCard({ project }: { project: ProjectDefinition }) {
   const unfunded =
     project.reward.kind === "monthly-pool" &&
     monthlyPoolUnfunded(project.reward);
   const amount =
     project.reward.kind === "monthly-pool"
-      ? unfunded
-        ? "Unfunded"
-        : "Accessibility unknown"
+      ? monthlyPoolCapLabel(project.reward)
       : (project.reward.externalOpportunity?.advertisedAmountDisplay ??
         "External");
   return (
@@ -782,11 +793,7 @@ function ProjectCard({ project }: { project: ProjectDefinition }) {
         <p className="project-bounty">
           <strong>{amount}</strong>
           <span>
-            {project.reward.kind === "monthly-pool"
-              ? unfunded
-                ? `target ${project.reward.monthlyCapDisplay} / month`
-                : `${formatMicroUsdc(project.reward.committedMinor)} committed`
-              : "external prize"}
+            {project.reward.kind === "monthly-pool" ? "/ mo" : "external prize"}
           </span>
         </p>
         <small className="project-money-state">
@@ -796,10 +803,6 @@ function ProjectCard({ project }: { project: ProjectDefinition }) {
               : "Committed balance · accessibility unknown · payments disabled"
             : "External sponsor controls eligibility and payment"}
         </small>
-        {project.reward.kind === "monthly-pool" &&
-        allocationFundingMinor(project.reward) === 0n ? (
-          <small>Unfunded trial · score recording remains open</small>
-        ) : null}
         {project.reward.reviewBudget ? (
           <small className="project-review-budget">
             + {reviewBudgetLabel(project.reward.reviewBudget)}
@@ -1192,18 +1195,6 @@ function HomePage({ state, retry }: { state: DataState; retry: () => void }) {
   const communityProjects = promotedProjects.filter(
     (project) => project.listingTier === "community",
   );
-  const latestReceipt =
-    state.status === "ready"
-      ? (state.snapshot.attributions.find((entry) => entry.run !== null)?.run ??
-        null)
-      : null;
-  const latestCycle =
-    state.status === "ready"
-      ? [...state.cycleIndex.cycles].sort(
-          (left, right) =>
-            Date.parse(right.generatedAt) - Date.parse(left.generatedAt),
-        )[0]
-      : undefined;
   const paidMinor =
     state.status === "ready"
       ? state.cycleIndex.cycles.reduce(
@@ -1261,129 +1252,6 @@ function HomePage({ state, retry }: { state: DataState; retry: () => void }) {
           </dl>
         ) : null}
       </section>
-
-      {state.status === "ready" ? (
-        <section className="section shell proof-object-section">
-          <div className="home-section-heading">
-            <div>
-              <h2 className="home-section-title">The proof is the product.</h2>
-            </div>
-            <p>
-              Every number names its source, state, and authority. Private trace
-              bodies stay private; only safe receipt metadata is public.
-            </p>
-          </div>
-          <div className="proof-object-grid">
-            <article className="proof-object">
-              <span className="proof-object-kicker">Receipt</span>
-              {latestReceipt ? (
-                <>
-                  <strong>{latestReceipt.runId}</strong>
-                  <dl>
-                    <div>
-                      <dt>Model</dt>
-                      <dd>
-                        {latestReceipt.provider}/{latestReceipt.model}
-                      </dd>
-                    </div>
-                    <div>
-                      <dt>Client</dt>
-                      <dd>{latestReceipt.client}</dd>
-                    </div>
-                    <div>
-                      <dt>Trace</dt>
-                      <dd>
-                        {latestReceipt.traceUpload
-                          ? "digest verified"
-                          : "unavailable"}
-                      </dd>
-                    </div>
-                  </dl>
-                </>
-              ) : (
-                <p>No publishable signed receipt in this snapshot.</p>
-              )}
-              <Link href="/receipts">
-                Inspect receipts <ArrowRight aria-hidden="true" />
-              </Link>
-            </article>
-            <article className="proof-object">
-              <span className="proof-object-kicker">Pool</span>
-              <strong>
-                {featuredProjects[0] &&
-                !monthlyPoolUnfunded(featuredProjects[0].reward)
-                  ? "Accessibility unknown"
-                  : "Unfunded"}
-              </strong>
-              <dl>
-                <div>
-                  <dt>Target</dt>
-                  <dd>
-                    {featuredProjects[0]?.reward.monthlyCapDisplay ?? "$0"}{" "}
-                    monthly cap
-                  </dd>
-                </div>
-                <div>
-                  <dt>Funding</dt>
-                  <dd>
-                    {featuredProjects[0]?.reward.fundingState === "committed"
-                      ? "Committed · accessibility unknown"
-                      : "Uncommitted"}
-                  </dd>
-                </div>
-                <div>
-                  <dt>Payment</dt>
-                  <dd>
-                    {featuredProjects[0]?.reward.paymentMode === "enabled"
-                      ? "Enabled"
-                      : "Disabled"}
-                  </dd>
-                </div>
-              </dl>
-              <Link href="/#projects">
-                Compare pools <ArrowRight aria-hidden="true" />
-              </Link>
-            </article>
-            <article className="proof-object">
-              <span className="proof-object-kicker">Cycle</span>
-              <strong>
-                {latestCycle
-                  ? `${latestCycle.projectId} · ${latestCycle.cycleId}`
-                  : "No closed cycle"}
-              </strong>
-              <dl>
-                <div>
-                  <dt>State</dt>
-                  <dd>
-                    {latestCycle
-                      ? cycleStateLabel(latestCycle.state)
-                      : "Unavailable"}
-                  </dd>
-                </div>
-                <div>
-                  <dt>Suggested</dt>
-                  <dd>
-                    {latestCycle
-                      ? formatMicroUsdc(latestCycle.reward.suggestedMinor)
-                      : "$0"}
-                  </dd>
-                </div>
-                <div>
-                  <dt>Paid</dt>
-                  <dd>
-                    {latestCycle
-                      ? formatMicroUsdc(latestCycle.reward.paidMinor)
-                      : "$0"}
-                  </dd>
-                </div>
-              </dl>
-              <Link href="/cycles">
-                Open archive <ArrowRight aria-hidden="true" />
-              </Link>
-            </article>
-          </div>
-        </section>
-      ) : null}
 
       <section className="section shell home-projects-section" id="projects">
         <div className="home-section-heading">
@@ -2443,9 +2311,7 @@ function ProjectPage({
                   }
                 >
                   {project.reward.kind === "monthly-pool"
-                    ? monthlyPoolUnfunded(project.reward)
-                      ? "Unfunded"
-                      : "Accessibility unknown"
+                    ? `${monthlyPoolCapLabel(project.reward)} / mo`
                     : project.reward.externalOpportunity
                         ?.advertisedAmountDisplay}
                 </strong>

--- a/src/styles.css
+++ b/src/styles.css
@@ -92,7 +92,6 @@ textarea:focus-visible {
   font-weight: 600;
 }
 
-.proof-object-kicker,
 .funding-kind,
 .receipt-card dt,
 .cycle-archive-card dt {
@@ -127,7 +126,6 @@ textarea:focus-visible {
 }
 
 .system-strip dt,
-.proof-object dt,
 .equation-card dt {
   color: var(--muted);
   font-size: 11px;
@@ -135,7 +133,6 @@ textarea:focus-visible {
 }
 
 .system-strip dd,
-.proof-object dd,
 .equation-card dd,
 .receipt-card dd,
 .cycle-archive-card dd {
@@ -144,24 +141,12 @@ textarea:focus-visible {
   font-variant-numeric: tabular-nums;
 }
 
-.proof-object-section {
-  padding-top: 22px;
-}
-
-.proof-object-section .home-section-heading > p {
-  max-width: 58ch;
-  color: var(--muted);
-  line-height: 1.6;
-}
-
-.proof-object-grid,
 .audience-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 18px;
 }
 
-.proof-object,
 .audience-grid article,
 .receipt-card,
 .cycle-archive-card,
@@ -171,27 +156,6 @@ textarea:focus-visible {
   background: var(--white);
 }
 
-.proof-object {
-  min-height: 340px;
-  display: flex;
-  flex-direction: column;
-  padding: 28px;
-}
-
-.proof-object > strong {
-  margin-top: 20px;
-  overflow-wrap: anywhere;
-  font-family: var(--brand-font-data);
-  font-size: clamp(18px, 2vw, 25px);
-}
-
-.proof-object dl {
-  display: grid;
-  gap: 13px;
-  margin: 28px 0;
-}
-
-.proof-object dl div,
 .receipt-card dl div,
 .cycle-archive-card dl div,
 .equation-card div {
@@ -203,7 +167,6 @@ textarea:focus-visible {
   border-bottom: 1px solid var(--line);
 }
 
-.proof-object > a,
 .audience-grid a,
 .cycle-archive-card > a {
   display: inline-flex;
@@ -215,7 +178,6 @@ textarea:focus-visible {
   font-weight: 700;
 }
 
-.proof-object > a svg,
 .cycle-archive-card > a svg {
   width: 15px;
 }
@@ -442,7 +404,6 @@ textarea:focus-visible {
 }
 
 @media (max-width: 900px) {
-  .proof-object-grid,
   .audience-grid,
   .mechanism-flow {
     grid-template-columns: 1fr 1fr;
@@ -459,7 +420,6 @@ textarea:focus-visible {
 
 @media (max-width: 680px) {
   .system-strip,
-  .proof-object-grid,
   .audience-grid,
   .mechanism-flow,
   .worked-example,
@@ -480,7 +440,6 @@ textarea:focus-visible {
     border-bottom: 0;
   }
 
-  .proof-object,
   .audience-grid article,
   .mechanism-flow li {
     min-height: 0;

--- a/tests/app.test.tsx
+++ b/tests/app.test.tsx
@@ -608,11 +608,16 @@ describe("discovery", () => {
       .closest("a");
     expect(elizaCard).not.toBeNull();
     if (!elizaCard) throw new Error("Eliza project card is missing");
-    expect(within(elizaCard).getByText("Unfunded")).toBeInTheDocument();
+    expect(within(elizaCard).queryByText(/Unfunded/u)).not.toBeInTheDocument();
+    expect(within(elizaCard).getByText("$5k")).toBeInTheDocument();
+    expect(within(elizaCard).getByText("/ mo")).toBeInTheDocument();
     expect(
-      within(elizaCard).getByText("target $5,000 / month"),
+      within(elizaCard).getByText("Target cap · no funding committed"),
     ).toBeInTheDocument();
-    expect(within(elizaCard).queryByText("$5,000")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("The proof is the product."),
+    ).not.toBeInTheDocument();
+    expect(document.querySelector(".proof-object-section")).toBeNull();
     expect(
       within(elizaCard).getByText(/Build and verify the elizaOS framework/u),
     ).toBeInTheDocument();
@@ -866,7 +871,7 @@ describe("project routes", () => {
         .getByText("MONTHLY POOL")
         .closest("aside")
         ?.querySelector(".reward-amount-monthly"),
-    ).toHaveTextContent("Unfunded");
+    ).toHaveTextContent("$5k / mo");
     expect(
       screen.getByText(/Target \$5,000 per month\. No funding is committed/u),
     ).toBeInTheDocument();

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -229,10 +229,8 @@ test("discovers both reward models and a score-ranked global ledger", async ({
     page.getByRole("heading", { exact: true, name: "Delta Star" }),
   ).toBeVisible();
   const elizaCard = page.locator('a.project-card[href="/projects/eliza"]');
-  await expect(elizaCard.getByText("Unfunded", { exact: true })).toBeVisible();
-  await expect(
-    elizaCard.getByText("target $5,000 / month", { exact: true }),
-  ).toBeVisible();
+  await expect(elizaCard.getByText("Unfunded", { exact: true })).toHaveCount(0);
+  await expect(elizaCard.getByText("$5k", { exact: true })).toBeVisible();
   await expect(elizaCard.getByText("$5,000", { exact: true })).toHaveCount(0);
   await expect(
     elizaCard.getByText(/Build and verify the elizaOS framework/u),


### PR DESCRIPTION
## Changes
- Remove the entire The proof is the product section and its unused data selection/styles.
- Show manifest-derived compact monthly amounts ($5k / mo for Eliza) instead of the prominent Unfunded label on project cards and project pages.
- Remove the duplicate Unfunded trial line from homepage cards; preserve separate factual funding details and all funding/payment state logic.
- Add regression assertions for the removed section and updated amounts.

## Validation
Typecheck and 63 app tests passed. Full exact-head verification and desktop/mobile visual/accessibility review are underway. No funding configuration or payment authority changes.