### PR TITLE
Simplify homepage cards, spacing, and footer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -638,7 +638,7 @@ function Footer() {
   return (
     <footer className="site-footer">
       <div className="shell footer-grid">
-        <div>
+        <div className="footer-brand-row">
           <div className="wordmark footer-wordmark">{domain}</div>
           <p className="footer-copyright">
             © {new Date().getUTCFullYear()} slop.cash.
@@ -661,11 +661,6 @@ function Footer() {
             Telegram
           </ExternalLinkAnchor>
         </div>
-        <p className="footer-fine">
-          Projections are estimates, not wages or guarantees. Project owners
-          approve rewards; public manifests and Solana settlement signatures are
-          the record.
-        </p>
       </div>
     </footer>
   );
@@ -673,11 +668,7 @@ function Footer() {
 
 function DataNotice({ state, retry }: { state: DataState; retry: () => void }) {
   if (state.status === "loading") {
-    return (
-      <div className="data-notice" role="status">
-        <span className="pulse" /> Reading the public GitHub ledger…
-      </div>
-    );
+    return null;
   }
   if (state.status === "error") {
     return (
@@ -792,17 +783,13 @@ function ProjectCard({ project }: { project: ProjectDefinition }) {
         </span>
         <p className="project-bounty">
           <strong>{amount}</strong>
-          <span>
-            {project.reward.kind === "monthly-pool" ? "/ mo" : "external prize"}
-          </span>
+          {project.reward.kind === "monthly-pool" ? <span>/mo</span> : null}
         </p>
-        <small className="project-money-state">
-          {project.reward.kind === "monthly-pool"
-            ? unfunded
-              ? "Target cap · no funding committed"
-              : "Committed balance · accessibility unknown · payments disabled"
-            : "External sponsor controls eligibility and payment"}
-        </small>
+        {project.reward.kind === "monthly-pool" && !unfunded ? (
+          <small className="project-money-state">
+            Committed balance · accessibility unknown · payments disabled
+          </small>
+        ) : null}
         {project.reward.reviewBudget ? (
           <small className="project-review-budget">
             + {reviewBudgetLabel(project.reward.reviewBudget)}
@@ -1195,13 +1182,6 @@ function HomePage({ state, retry }: { state: DataState; retry: () => void }) {
   const communityProjects = promotedProjects.filter(
     (project) => project.listingTier === "community",
   );
-  const paidMinor =
-    state.status === "ready"
-      ? state.cycleIndex.cycles.reduce(
-          (total, cycle) => total + BigInt(cycle.reward.paidMinor),
-          0n,
-        )
-      : 0n;
   return (
     <main>
       <section className="hero shell">
@@ -1220,37 +1200,6 @@ function HomePage({ state, retry }: { state: DataState; retry: () => void }) {
             Fund a project
           </Link>
         </div>
-        {state.status === "ready" ? (
-          <dl className="system-strip">
-            <div>
-              <dt>Accepted events</dt>
-              <dd>{state.snapshot.ledger.length}</dd>
-            </div>
-            <div>
-              <dt>Signed receipts</dt>
-              <dd>
-                {
-                  state.snapshot.attributions.filter((entry) => entry.run)
-                    .length
-                }
-              </dd>
-            </div>
-            <div>
-              <dt>Project pools</dt>
-              <dd>
-                {
-                  PROJECTS.filter(
-                    (project) => project.reward.kind === "monthly-pool",
-                  ).length
-                }
-              </dd>
-            </div>
-            <div>
-              <dt>Verified paid</dt>
-              <dd>{formatMicroUsdc(paidMinor.toString())}</dd>
-            </div>
-          </dl>
-        ) : null}
       </section>
 
       <section className="section shell home-projects-section" id="projects">
@@ -1277,11 +1226,6 @@ function HomePage({ state, retry }: { state: DataState; retry: () => void }) {
         </section>
       </section>
       <section className="section shell audience-section">
-        <div className="home-section-heading">
-          <div>
-            <h2 className="home-section-title">One ledger. Three jobs.</h2>
-          </div>
-        </div>
         <div className="audience-grid">
           <article>
             <h3>Pay for accepted outcomes.</h3>
@@ -1339,9 +1283,6 @@ function HomePage({ state, retry }: { state: DataState; retry: () => void }) {
           <div className="owner-callout">
             <div>
               <h3>Add your project.</h3>
-              <p>
-                Propose your repository and reward terms for review on GitHub.
-              </p>
             </div>
             <Link className="button inverse-button" href="/projects/new">
               Get started <ArrowRight aria-hidden="true" />

--- a/src/styles.css
+++ b/src/styles.css
@@ -102,37 +102,12 @@ textarea:focus-visible {
   text-transform: uppercase;
 }
 
-.system-strip {
-  width: 100%;
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  margin: 42px 0 0;
-  padding: 0;
-  border-top: 1px solid var(--line);
-  border-bottom: 1px solid var(--line);
-}
-
-.system-strip div {
-  padding: 18px 20px 18px 0;
-  border-right: 1px solid var(--line);
-}
-
-.system-strip div + div {
-  padding-left: 20px;
-}
-
-.system-strip div:last-child {
-  border-right: 0;
-}
-
-.system-strip dt,
 .equation-card dt {
   color: var(--muted);
   font-size: 11px;
   font-weight: 600;
 }
 
-.system-strip dd,
 .equation-card dd,
 .receipt-card dd,
 .cycle-archive-card dd {
@@ -419,7 +394,6 @@ textarea:focus-visible {
 }
 
 @media (max-width: 680px) {
-  .system-strip,
   .audience-grid,
   .mechanism-flow,
   .worked-example,
@@ -427,17 +401,6 @@ textarea:focus-visible {
   .cycle-archive-list,
   .custody-proof ul {
     grid-template-columns: 1fr;
-  }
-
-  .system-strip div,
-  .system-strip div + div {
-    padding: 14px 0;
-    border-right: 0;
-    border-bottom: 1px solid var(--line);
-  }
-
-  .system-strip div:last-child {
-    border-bottom: 0;
   }
 
   .audience-grid article,
@@ -727,7 +690,7 @@ p {
 }
 
 .home-projects-section {
-  padding-block: 92px 96px;
+  padding-block: 0 96px;
 }
 
 .home-leaderboard-section {
@@ -1108,9 +1071,9 @@ p {
 
 .project-bounty {
   display: flex;
-  align-items: flex-end;
-  flex-direction: column;
-  gap: 4px;
+  align-items: baseline;
+  justify-content: flex-end;
+  gap: 8px;
   margin: 0;
   text-align: right;
 }
@@ -1138,7 +1101,6 @@ small {
   color: var(--muted);
   font-size: 13px;
   font-weight: 700;
-  text-transform: uppercase;
 }
 
 .leader-table {
@@ -1278,12 +1240,19 @@ small {
 
 .footer-grid {
   display: grid;
-  grid-template-columns: 1fr auto;
+  grid-template-columns: 1fr;
   gap: 28px;
 }
 
+.footer-brand-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+}
+
 .footer-wordmark {
-  margin-bottom: 13px;
+  margin: 0;
 }
 
 .footer-grid p {
@@ -1293,7 +1262,7 @@ small {
 }
 
 .footer-grid .footer-copyright {
-  margin-top: 6px;
+  text-align: right;
 }
 
 .footer-links {
@@ -1302,14 +1271,6 @@ small {
   gap: 24px;
   font-size: 12px;
   font-weight: 600;
-}
-
-.footer-fine {
-  grid-column: 1 / -1;
-  max-width: 720px;
-  padding-top: 20px;
-  border-top: 1px solid rgba(255, 255, 255, 0.1);
-  line-height: 1.6;
 }
 
 .route-main {
@@ -2705,7 +2666,7 @@ small {
   }
 
   .project-bounty {
-    align-items: flex-start;
+    justify-content: flex-start;
     text-align: left;
   }
 }
@@ -2761,7 +2722,7 @@ small {
   }
 
   .home-projects-section {
-    padding-block: 64px;
+    padding-block: 0 64px;
   }
 
   .home-section-heading {
@@ -2940,10 +2901,6 @@ small {
   .footer-links {
     flex-direction: column;
     gap: 12px;
-  }
-
-  .footer-fine {
-    grid-column: auto;
   }
 
   .breadcrumb {

--- a/tests/app.test.tsx
+++ b/tests/app.test.tsx
@@ -455,9 +455,9 @@ describe("discovery", () => {
     );
     render(<App />);
 
-    expect(screen.getByRole("status")).toHaveTextContent(
-      "Reading the public GitHub ledger",
-    );
+    expect(
+      screen.queryByText("Reading the public GitHub ledger…"),
+    ).not.toBeInTheDocument();
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
     expect(screen.queryByText(/No accepted outcomes/u)).not.toBeInTheDocument();
   });

--- a/tests/app.test.tsx
+++ b/tests/app.test.tsx
@@ -610,10 +610,10 @@ describe("discovery", () => {
     if (!elizaCard) throw new Error("Eliza project card is missing");
     expect(within(elizaCard).queryByText(/Unfunded/u)).not.toBeInTheDocument();
     expect(within(elizaCard).getByText("$5k")).toBeInTheDocument();
-    expect(within(elizaCard).getByText("/ mo")).toBeInTheDocument();
+    expect(within(elizaCard).getByText("/mo")).toBeInTheDocument();
     expect(
-      within(elizaCard).getByText("Target cap · no funding committed"),
-    ).toBeInTheDocument();
+      within(elizaCard).queryByText("Target cap · no funding committed"),
+    ).not.toBeInTheDocument();
     expect(
       screen.queryByText("The proof is the product."),
     ).not.toBeInTheDocument();
@@ -629,7 +629,9 @@ describe("discovery", () => {
     expect(deltaCard).not.toBeNull();
     if (!deltaCard) throw new Error("Delta Star project card is missing");
     expect(within(deltaCard).getByText("$1,000,000")).toBeInTheDocument();
-    expect(within(deltaCard).getByText("external prize")).toBeInTheDocument();
+    expect(
+      within(deltaCard).getByText("External sponsor prize"),
+    ).toBeInTheDocument();
     expect(
       within(deltaCard).getByText(/dedicated Proximity Prize repository/u),
     ).toBeInTheDocument();

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -240,7 +240,7 @@ test("discovers both reward models and a score-ranked global ledger", async ({
     deltaCard.getByText("$1,000,000", { exact: true }),
   ).toBeVisible();
   await expect(
-    deltaCard.getByText("external prize", { exact: true }),
+    deltaCard.getByText("External sponsor prize", { exact: true }),
   ).toBeVisible();
   await expect(
     deltaCard.getByText(/Advance machine-checked Reed–Solomon/u),


### PR DESCRIPTION
Removes the homepage ledger loading message and statistics strip, redundant card notes, the audience slogan, and footer fine print. Monthly prices keep /mo on the same line, Projects has less top spacing, and copyright sits beside the footer logo.

Updates existing assertions for the requested copy removals. Desktop, tablet, and mobile layout checks passed locally; full verification is running.
