### PR TITLE
Fix project card spacing and remove funding labels

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -776,11 +776,6 @@ function ProjectCard({ project }: { project: ProjectDefinition }) {
       </div>
       <div className="project-card-content">
         <p className="project-summary">{project.description}</p>
-        <span className={`funding-kind funding-kind-${project.reward.kind}`}>
-          {project.reward.kind === "monthly-pool"
-            ? "Monthly contributor pool"
-            : "External sponsor prize"}
-        </span>
         <p className="project-bounty">
           <strong>{amount}</strong>
           {project.reward.kind === "monthly-pool" ? <span>/mo</span> : null}

--- a/src/styles.css
+++ b/src/styles.css
@@ -934,7 +934,7 @@ p {
   min-width: 0;
   grid-template-columns: minmax(0, 1fr);
   grid-template-rows: auto 1fr;
-  gap: 32px;
+  gap: 24px;
   padding: 28px;
   border: 1px solid var(--line);
   border-radius: var(--radius);
@@ -1057,8 +1057,12 @@ p {
 .project-card-content {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
-  align-items: end;
-  gap: 40px;
+  align-items: center;
+  gap: 24px 40px;
+}
+
+.project-card-content > small {
+  grid-column: 1 / -1;
 }
 
 .project-summary {
@@ -2662,7 +2666,7 @@ small {
 
   .project-card-content {
     grid-template-columns: minmax(0, 1fr);
-    gap: 32px;
+    gap: 24px;
   }
 
   .project-bounty {

--- a/tests/app.test.tsx
+++ b/tests/app.test.tsx
@@ -630,8 +630,8 @@ describe("discovery", () => {
     if (!deltaCard) throw new Error("Delta Star project card is missing");
     expect(within(deltaCard).getByText("$1,000,000")).toBeInTheDocument();
     expect(
-      within(deltaCard).getByText("External sponsor prize"),
-    ).toBeInTheDocument();
+      within(deltaCard).queryByText("External sponsor prize"),
+    ).not.toBeInTheDocument();
     expect(
       within(deltaCard).getByText(/dedicated Proximity Prize repository/u),
     ).toBeInTheDocument();

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -241,7 +241,7 @@ test("discovers both reward models and a score-ranked global ledger", async ({
   ).toBeVisible();
   await expect(
     deltaCard.getByText("External sponsor prize", { exact: true }),
-  ).toBeVisible();
+  ).toHaveCount(0);
   await expect(
     deltaCard.getByText(/Advance machine-checked Reed–Solomon/u),
   ).toBeVisible();


### PR DESCRIPTION
Removes the monthly contributor pool and external sponsor prize labels from project cards. The extra grid item pushed reward amounts onto a second row; descriptions and amounts now align in one desktop row, with tighter spacing on smaller screens.

Validation: typecheck and focused discovery test passed; browser checks at 1440, 819, and 375 pixels confirmed removed labels, desktop alignment, and no horizontal overflow. Existing assertions updated for the label removal.
