### PR TITLE
fix(ingestion): narrow the GraphQL page when GitHub cannot build it

### DIFF
--- a/scripts/generate-leaderboard.test.ts
+++ b/scripts/generate-leaderboard.test.ts
@@ -26,6 +26,7 @@ import {
   estimateFirstPageDetailCost,
   estimateReviewFirstPageDetailCost,
   GitHubGraphqlClient,
+  GRAPHQL_PAGE_SIZE,
   type GraphqlExecutor,
   generateLeaderboardFromGitHub,
   LEADERBOARD_QUERY_DOCUMENTS,
@@ -882,6 +883,96 @@ describe("GitHub GraphQL boundary", () => {
     expect(client.getRateLimit().consumedDuringRun).toBe(1);
   });
 
+  // Reproduces the 2026-09-06 outage: GitHub Search 502s while building a
+  // 100-node page of `repo:SlopDotCash/proximityprize is:pr is:merged` but
+  // serves the same slice at 50, so identical retries could never recover.
+  it("narrows the requested page until GitHub can build it", async () => {
+    const requestedPageSizes: unknown[] = [];
+    const fetcher = async (
+      _input: RequestInfo | URL,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      const { pageSize } = JSON.parse(String(init?.body ?? "{}")).variables;
+      requestedPageSizes.push(pageSize);
+      if (pageSize > 50) {
+        return new Response(
+          "<html><head><title>502 Bad Gateway</title></head></html>",
+          { status: 502, headers: { "Content-Type": "text/html" } },
+        );
+      }
+      return successResponse();
+    };
+    const client = new GitHubGraphqlClient("secret-token", fetcher, {
+      retryBaseDelayMs: 0,
+    });
+
+    await expect(
+      client.execute("query Search($pageSize: Int!) { search { id } }", {
+        searchQuery: "repo:owner/name is:pr is:merged",
+        after: null,
+        pageSize: GRAPHQL_PAGE_SIZE,
+      }),
+    ).resolves.toMatchObject({ viewer: { login: "eliza" } });
+    expect(requestedPageSizes).toEqual([100, 50]);
+  });
+
+  it("reports the exhausted attempt count and final page size", async () => {
+    const requestedPageSizes: unknown[] = [];
+    const fetcher = async (
+      _input: RequestInfo | URL,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      const { variables } = JSON.parse(String(init?.body ?? "{}"));
+      requestedPageSizes.push(variables.pageSize);
+      return new Response("<html>bad gateway</html>", {
+        status: 502,
+        headers: { "Content-Type": "text/html" },
+      });
+    };
+    const client = new GitHubGraphqlClient("secret-token", fetcher, {
+      retryBaseDelayMs: 0,
+    });
+
+    await expect(
+      client.execute("query Search($pageSize: Int!) { search { id } }", {
+        after: null,
+        pageSize: GRAPHQL_PAGE_SIZE,
+      }),
+    ).rejects.toThrow(
+      "GitHub GraphQL HTTP 502 returned a non-JSON response (5/5; text/html; page size 6)",
+    );
+    expect(requestedPageSizes).toEqual([100, 50, 25, 12, 6]);
+  });
+
+  it("retries an unpaginated query without inventing a page size", async () => {
+    const bodies: string[] = [];
+    let attempts = 0;
+    const fetcher = async (
+      _input: RequestInfo | URL,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      attempts += 1;
+      bodies.push(String(init?.body ?? ""));
+      if (attempts === 1) {
+        return new Response("<html>bad gateway</html>", {
+          status: 502,
+          headers: { "Content-Type": "text/html" },
+        });
+      }
+      return successResponse();
+    };
+    const client = new GitHubGraphqlClient("secret-token", fetcher, {
+      retryBaseDelayMs: 0,
+    });
+
+    await expect(
+      client.execute("query { viewer { login } }", { owner: "elizaOS" }),
+    ).resolves.toMatchObject({ viewer: { login: "eliza" } });
+    expect(JSON.parse(bodies[1] ?? "{}").variables).toEqual({
+      owner: "elizaOS",
+    });
+  });
+
   it("honors GitHub secondary-limit retry guidance before returning data", async () => {
     let attempts = 0;
     const fetcher = async () => {
@@ -990,7 +1081,7 @@ describe("GitHub GraphQL boundary", () => {
     });
 
     await expect(client.execute("query { viewer { login } }")).rejects.toThrow(
-      "GitHub GraphQL HTTP 200 returned a non-JSON response (text/html)",
+      "GitHub GraphQL HTTP 200 returned a non-JSON response (1/5; text/html)",
     );
     expect(attempts).toBe(1);
     expect(client.getRequestCount()).toBe(1);
@@ -1010,7 +1101,7 @@ describe("GitHub GraphQL boundary", () => {
     });
 
     await expect(client.execute("query { viewer { login } }")).rejects.toThrow(
-      "GitHub GraphQL HTTP 401 returned a non-JSON response (application/json)",
+      "GitHub GraphQL HTTP 401 returned a non-JSON response (1/5; application/json)",
     );
     expect(attempts).toBe(1);
     expect(client.getRequestCount()).toBe(1);

--- a/scripts/generate-leaderboard.ts
+++ b/scripts/generate-leaderboard.ts
@@ -52,6 +52,7 @@ import { verifyRunReceiptSignature } from "./run-receipt-crypto";
 export const SEARCH_SAFE_RESULT_LIMIT = 950;
 export const MINIMUM_SEARCH_SLICE_MS = 60_000;
 export const GRAPHQL_PAGE_SIZE = 100;
+export const MINIMUM_GRAPHQL_PAGE_SIZE = 1;
 export const DETAIL_BATCH_SIZE = 25;
 export const REVIEW_DETAIL_BATCH_SIZE = 100;
 export const MAX_TRANSIENT_ATTEMPTS = 3;
@@ -1320,6 +1321,29 @@ async function readGraphqlResponseBody(response: Response): Promise<string> {
   return body;
 }
 
+// A 502/503/504 on a paginated read is usually GitHub timing out while it
+// builds the requested page, not a transient edge fault: repeating the
+// identical page reliably repeats the timeout. Halving `pageSize` keeps the
+// opaque `after` cursor valid, because a smaller `first` returns fewer nodes
+// from the same position, so callers page more times over an unchanged result
+// set and every reported total stays comparable.
+function narrowedPageSize(
+  variables: GraphqlVariables,
+): GraphqlVariables | null {
+  const current = variables.pageSize;
+  if (typeof current !== "number" || !Number.isInteger(current)) return null;
+  if (current <= MINIMUM_GRAPHQL_PAGE_SIZE) return null;
+  return {
+    ...variables,
+    pageSize: Math.max(MINIMUM_GRAPHQL_PAGE_SIZE, Math.floor(current / 2)),
+  };
+}
+
+function describePageSize(variables: GraphqlVariables): string {
+  const current = variables.pageSize;
+  return typeof current === "number" ? `; page size ${current}` : "";
+}
+
 export class GitHubGraphqlClient implements GraphqlExecutor {
   readonly #token: string;
   readonly #fetch: FetchLike;
@@ -1414,6 +1438,7 @@ export class GitHubGraphqlClient implements GraphqlExecutor {
     let response: Response | null = null;
     let payload: unknown;
     let parsedResponse = false;
+    let activeVariables = variables;
     for (
       let attempt = 1;
       attempt <= MAX_GRAPHQL_REQUEST_ATTEMPTS;
@@ -1436,7 +1461,7 @@ export class GitHubGraphqlClient implements GraphqlExecutor {
             "User-Agent": "eliza-computer-leaderboard",
             "X-GitHub-Api-Version": "2022-11-28",
           },
-          body: JSON.stringify({ query: document, variables }),
+          body: JSON.stringify({ query: document, variables: activeVariables }),
           signal: controller.signal,
         });
         responseBody = await readGraphqlResponseBody(response);
@@ -1461,6 +1486,10 @@ export class GitHubGraphqlClient implements GraphqlExecutor {
       }
       const retryableStatus = [502, 503, 504].includes(response.status);
       if (retryableStatus && attempt < MAX_GRAPHQL_REQUEST_ATTEMPTS) {
+        // error-policy:J2 Retrying the identical page cannot clear a
+        // server-side page-build timeout, so narrow the request before backing
+        // off. Requests without a page size retry unchanged.
+        activeVariables = narrowedPageSize(activeVariables) ?? activeVariables;
         await retryDelay(this.#retryBaseDelayMs * 2 ** (attempt - 1));
         continue;
       }
@@ -1493,7 +1522,7 @@ export class GitHubGraphqlClient implements GraphqlExecutor {
         throw new Error(
           retryableMalformedJson
             ? `GitHub GraphQL HTTP ${response.status} returned malformed JSON (${attempt}/${MAX_GRAPHQL_REQUEST_ATTEMPTS}; ${contentType ?? "unknown content type"})`
-            : `GitHub GraphQL HTTP ${response.status} returned a non-JSON response (${contentType ?? "unknown content type"})`,
+            : `GitHub GraphQL HTTP ${response.status} returned a non-JSON response (${attempt}/${MAX_GRAPHQL_REQUEST_ATTEMPTS}; ${contentType ?? "unknown content type"}${describePageSize(activeVariables)})`,
           { cause },
         );
       }


### PR DESCRIPTION
Closes #414.

## The change

On a 502/503/504, halve `pageSize` before backing off instead of repeating the
identical request. The opaque `after` cursor stays valid because a smaller
`first` returns fewer nodes from the same position, so callers page more times
over an unchanged result set. `issueCount` and `totalCount` are independent of
page size, so the existing coherence checks in `collectSearchReferences`
(`page.totalCount !== expectedCount` and the final
`deduped.length !== expectedCount`) still hold. Requests that carry no
`pageSize` retry unchanged, and exhausting the attempts still fails closed.

Second, smaller change: a terminal non-JSON response now names the attempt
count and the final page size. The old message said only
`HTTP 502 returned a non-JSON response (text/html)`, which is why this cost a
full instrumented re-run to locate rather than a log read.

## Why not just lower GRAPHQL_PAGE_SIZE

A fixed smaller constant would not have fixed it. In the verifying run, page 1
of that query succeeded at 50 while page 2 still returned 502 at 50 and needed
25, then the remainder succeeded at 100. Per-page cost tracks the size of the
PR bodies that land in each page, so the usable ceiling moves within a single
query and has to adapt.

## Evidence

A complete `leaderboard:generate` against live GitHub at this branch head, run
unattended, now finishes:

```text
[slop.cash] wrote public/data/leaderboard.json
(118 leaders, 9453 score events, 601 GraphQL requests, 3928/5000 points remaining)
```

The narrowing sequence in that run, from the same `fetch` instrumentation used
to diagnose the bug:

```text
[req 126] pageSize 100 -> 502 in 10461ms
[req 127] pageSize  50 -> 200 in  6943ms   50 nodes, cursor -> 50
[req 128] pageSize 100 -> 502 in 10775ms   next page
[req 129] pageSize  50 -> 502 in 10392ms   a fixed 50 would have failed here
[req 130] pageSize  25 -> 200 in  7751ms   25 nodes, cursor -> 75
[req 131] pageSize 100 -> 200 in  5693ms   final 23 nodes
```

Tests: three new cases in `scripts/generate-leaderboard.test.ts` covering the
reproduced boundary (narrows until the page builds), the fail-closed report
(exhausted attempt count and final page size), and the guard that an
unpaginated query retries with its variables untouched.

Gate at head:

- `typecheck`, `format:check`, `lint:check`: clean, no warnings in touched files
- `test`: 996 vitest across 86 files, plus 129 skill-tests across 7 files, all passing
- `build`: succeeds, 1844 modules
- `test:e2e`: `N/A - ingestion script change with no UI surface`
- `audit:dependencies`: fails identically on clean `develop` with my changes
  stashed (vitest GHSA-82fw-gwwq-j7x9, sharp GHSA-rgj7-g3m4-5g8c), so
  `bun run verify` cannot currently pass end to end on any branch. Untouched by
  this change, and worth its own issue if it is not already known.

Note that PR CI will not exercise this fix: the `Generate live contribution
data` step is gated on `github.event_name != 'pull_request'`, so a PR loads the
deployed ledger instead of ingesting. The live run above is the evidence.

## Known limits, deliberately not addressed

- Page size resets to `GRAPHQL_PAGE_SIZE` on each `execute()` call, so this
  repository pays one wasted ~10s 502 per page. Making the reduction sticky per
  document would remove that at the cost of client state. Happy to add it if
  you want it, but it seemed like scope beyond the demonstrated boundary.
- Detail queries batch by `ids` rather than a cursor page, so they cannot
  narrow this way. No such failure is observed today.

AI provider/model: anthropic / claude-opus-5
Client / agent tooling: Claude Code
Contribution skill revision: N/A - direct platform pull request, not a skill-mediated contribution
Attribution status: self-reported
— [claude-code-wbaxterh]
