### PR TITLE
fix(installer): honor GH_TOKEN for GitHub verification and explain rate limits

### DIFF
--- a/scripts/render-install-guide.mjs
+++ b/scripts/render-install-guide.mjs
@@ -46,6 +46,10 @@ Install or update the complete skill archive. The authenticated installer
 accepts the current \`develop\` revision, a byte-identical authorized ancestor,
 or an explicitly labeled same-repository release candidate. It independently
 compares packaged bytes with immutable GitHub source before atomic activation.
+Verification uses GitHub's anonymous API budget, which is shared by every
+process behind your public IP. Export \`GH_TOKEN\` or \`GITHUB_TOKEN\` to use
+your own authenticated budget instead; the token is sent only to
+\`api.github.com\` and is never stored.
 
 \`\`\`bash
 ${createInstallCommand(artifactOrigin, skillsRoot, {

--- a/src/lib/install-command.test.ts
+++ b/src/lib/install-command.test.ts
@@ -9,6 +9,7 @@ import {
   existsSync,
   mkdirSync,
   mkdtempSync,
+  readdirSync,
   readFileSync,
   readlinkSync,
   rmSync,
@@ -1539,6 +1540,300 @@ time.sleep(60)
       );
     } finally {
       server.kill();
+    }
+  });
+
+  const headerLoggingServerScript = `
+    const http = require("node:http");
+    const fs = require("node:fs");
+    const path = require("node:path");
+    const [kind, source, logPath, forbidPattern, redirectTarget] =
+      process.argv.slice(1);
+    const responses =
+      kind === "json" ? JSON.parse(fs.readFileSync(source, "utf8")) : null;
+    const server = http.createServer((request, response) => {
+      fs.appendFileSync(
+        logPath,
+        request.url + "\\t" + (request.headers.authorization || "-") + "\\n",
+      );
+      if (redirectTarget && request.url.includes("/git/ref/")) {
+        response.statusCode = 302;
+        response.setHeader("location", redirectTarget + request.url);
+        response.end();
+        return;
+      }
+      if (forbidPattern && request.url.includes(forbidPattern)) {
+        response.statusCode = 403;
+        response.setHeader("x-ratelimit-limit", "60");
+        response.setHeader("x-ratelimit-remaining", "0");
+        response.setHeader("x-ratelimit-reset", "1800000000");
+        response.setHeader("content-type", "application/json");
+        response.end(JSON.stringify({ message: "API rate limit exceeded" }));
+        return;
+      }
+      if (responses) {
+        if (!(request.url in responses)) {
+          response.statusCode = 404;
+          response.end("{}");
+          return;
+        }
+        response.setHeader("content-type", "application/json");
+        response.end(JSON.stringify(responses[request.url]));
+        return;
+      }
+      const file = path.join(source, decodeURIComponent(request.url));
+      if (!file.startsWith(source) || !fs.existsSync(file)) {
+        response.statusCode = 404;
+        response.end();
+        return;
+      }
+      response.end(fs.readFileSync(file));
+    });
+    server.listen(0, "127.0.0.1", () => {
+      console.log("PORT " + server.address().port);
+    });
+  `;
+
+  async function startHeaderLoggingServer(options: {
+    kind: "json" | "static";
+    source: string;
+    requestLog: string;
+    forbidPattern?: string;
+    redirectTarget?: string;
+  }): Promise<{ port: number; kill: () => void }> {
+    writeFileSync(options.requestLog, "");
+    const child = spawn(
+      process.execPath,
+      [
+        "-e",
+        headerLoggingServerScript,
+        options.kind,
+        options.source,
+        options.requestLog,
+        options.forbidPattern ?? "",
+        options.redirectTarget ?? "",
+      ],
+      { stdio: ["ignore", "pipe", "inherit"] },
+    );
+    const port = await new Promise<number>((resolvePort, rejectPort) => {
+      let buffered = "";
+      child.stdout.on("data", (chunk: Buffer) => {
+        buffered += chunk.toString("utf8");
+        const match = buffered.match(/PORT (\d+)/u);
+        if (match) resolvePort(Number(match[1]));
+      });
+      child.once("exit", () =>
+        rejectPort(new Error("header-logging server exited before listening")),
+      );
+    });
+    return { port, kill: () => child.kill("SIGKILL") };
+  }
+
+  function loggedRequests(logPath: string): Array<[string, string]> {
+    return readFileSync(logPath, "utf8")
+      .split("\n")
+      .filter((line) => line.length > 0)
+      .map((line) => {
+        const [url, authorization] = line.split("\t");
+        return [url ?? "", authorization ?? ""];
+      });
+  }
+
+  function freshInstallFixture(root: string) {
+    const installRoot = join(root, "install");
+    const filesA = baseFiles("revision-a");
+    const artifactA = writeArtifact(root, revisionA, filesA);
+    const authority = configureAuthority(root, {
+      developHead: revisionA,
+      revisions: { [revisionA]: { files: filesA } },
+    });
+    return {
+      artifactA,
+      installRoot,
+      apiResponses: join(fileURLToPath(authority.apiOrigin), "responses.json"),
+      rawRoot: fileURLToPath(authority.rawOrigin),
+    };
+  }
+
+  function listFilesRecursively(directory: string): string[] {
+    const found: string[] = [];
+    const pending = [directory];
+    while (pending.length > 0) {
+      const current = pending.pop();
+      if (!current) break;
+      for (const entry of readdirSync(current, { withFileTypes: true })) {
+        const path = join(current, entry.name);
+        if (entry.isSymbolicLink()) continue;
+        if (entry.isDirectory()) pending.push(path);
+        else found.push(path);
+      }
+    }
+    return found;
+  }
+
+  it("sends a configured GitHub token only to the API authority and never persists it", async () => {
+    const root = freshRoot("token-scope");
+    const { artifactA, installRoot, apiResponses, rawRoot } =
+      freshInstallFixture(root);
+    const api = await startHeaderLoggingServer({
+      kind: "json",
+      source: apiResponses,
+      requestLog: join(root, "api.log"),
+    });
+    const raw = await startHeaderLoggingServer({
+      kind: "static",
+      source: rawRoot,
+      requestLog: join(root, "raw.log"),
+    });
+    try {
+      const install = run(
+        loopbackCommand(artifactA, api.port, `http://127.0.0.1:${raw.port}`),
+        installRoot,
+        { GH_TOKEN: " ghp_scoped_token ", GITHUB_TOKEN: "ghp_fallback_token" },
+      );
+      expect(install.status, install.stderr).toBe(0);
+      expect(currentLink(installRoot)).toBe(
+        `.contribute-to-eliza-versions/${revisionA}`,
+      );
+      const apiRequests = loggedRequests(join(root, "api.log"));
+      expect(apiRequests.length).toBeGreaterThan(0);
+      for (const [, authorization] of apiRequests) {
+        expect(authorization).toBe("Bearer ghp_scoped_token");
+      }
+      const rawRequests = loggedRequests(join(root, "raw.log"));
+      expect(rawRequests.length).toBeGreaterThan(0);
+      for (const [, authorization] of rawRequests) {
+        expect(authorization).toBe("-");
+      }
+      for (const file of listFilesRecursively(
+        join(installRoot, "codex", "skills"),
+      )) {
+        expect(readFileSync(file, "utf8")).not.toContain("ghp_");
+      }
+    } finally {
+      api.kill();
+      raw.kill();
+    }
+  });
+
+  it("falls back to GITHUB_TOKEN and rejects a token that cannot be sent as a header", async () => {
+    const root = freshRoot("token-fallback");
+    const { artifactA, installRoot, apiResponses, rawRoot } =
+      freshInstallFixture(root);
+    const api = await startHeaderLoggingServer({
+      kind: "json",
+      source: apiResponses,
+      requestLog: join(root, "api.log"),
+    });
+    try {
+      const install = run(
+        loopbackCommand(artifactA, api.port, pathToFileURL(rawRoot).href),
+        installRoot,
+        { GH_TOKEN: "   ", GITHUB_TOKEN: "ghp_fallback_token" },
+      );
+      expect(install.status, install.stderr).toBe(0);
+      for (const [, authorization] of loggedRequests(join(root, "api.log"))) {
+        expect(authorization).toBe("Bearer ghp_fallback_token");
+      }
+      const malformed = run(
+        loopbackCommand(artifactA, api.port, pathToFileURL(rawRoot).href),
+        installRoot,
+        { GH_TOKEN: "ghp_bad\ntoken", GITHUB_TOKEN: "" },
+      );
+      expect(malformed.status).not.toBe(0);
+      expect(malformed.stderr).toContain(
+        "GH_TOKEN contains characters that cannot be sent in an Authorization header",
+      );
+    } finally {
+      api.kill();
+    }
+  });
+
+  it("names an exhausted GitHub rate limit, its reset time, and the token remedy without retrying", async () => {
+    const root = freshRoot("rate-limit");
+    const { artifactA, installRoot, apiResponses, rawRoot } =
+      freshInstallFixture(root);
+    const api = await startHeaderLoggingServer({
+      kind: "json",
+      source: apiResponses,
+      requestLog: join(root, "api.log"),
+      forbidPattern: "/git/ref/heads/develop",
+    });
+    try {
+      const anonymous = run(
+        loopbackCommand(artifactA, api.port, pathToFileURL(rawRoot).href),
+        installRoot,
+        { GH_TOKEN: "", GITHUB_TOKEN: "" },
+      );
+      expect(anonymous.status).not.toBe(0);
+      expect(anonymous.stderr).toContain(
+        "GitHub API rate limit exhausted (anonymous budget, 60 requests per hour)",
+      );
+      expect(anonymous.stderr).toContain(
+        "shared by every process behind this public IP",
+      );
+      expect(anonymous.stderr).toContain("resets at 2027-01-15T08:00:00Z");
+      expect(anonymous.stderr).toContain("set GH_TOKEN or GITHUB_TOKEN");
+      expect(
+        existsSync(join(installRoot, "codex", "skills", "contribute-to-eliza")),
+      ).toBe(false);
+      expect(
+        loggedRequests(join(root, "api.log")).filter(([url]) =>
+          url.includes("/git/ref/heads/develop"),
+        ),
+      ).toHaveLength(1);
+
+      const authenticated = run(
+        loopbackCommand(artifactA, api.port, pathToFileURL(rawRoot).href),
+        installRoot,
+        { GH_TOKEN: "ghp_scoped_token", GITHUB_TOKEN: "" },
+      );
+      expect(authenticated.status).not.toBe(0);
+      expect(authenticated.stderr).toContain(
+        "GitHub API rate limit exhausted (authenticated budget, 60 requests per hour)",
+      );
+      expect(authenticated.stderr).not.toContain(
+        "set GH_TOKEN or GITHUB_TOKEN",
+      );
+    } finally {
+      api.kill();
+    }
+  });
+
+  it("refuses a cross-origin API redirect before forwarding any header", async () => {
+    const root = freshRoot("redirect-guard");
+    const { artifactA, installRoot, apiResponses, rawRoot } =
+      freshInstallFixture(root);
+    const decoyRoot = join(root, "decoy");
+    mkdirSync(decoyRoot, { recursive: true });
+    const decoy = await startHeaderLoggingServer({
+      kind: "static",
+      source: decoyRoot,
+      requestLog: join(root, "decoy.log"),
+    });
+    const api = await startHeaderLoggingServer({
+      kind: "json",
+      source: apiResponses,
+      requestLog: join(root, "api.log"),
+      redirectTarget: `http://127.0.0.1:${decoy.port}`,
+    });
+    try {
+      const install = run(
+        loopbackCommand(artifactA, api.port, pathToFileURL(rawRoot).href),
+        installRoot,
+        { GH_TOKEN: "ghp_scoped_token", GITHUB_TOKEN: "" },
+      );
+      expect(install.status).not.toBe(0);
+      expect(install.stderr).toContain(
+        "authenticated request redirected to another authority",
+      );
+      expect(loggedRequests(join(root, "decoy.log"))).toHaveLength(0);
+      expect(
+        existsSync(join(installRoot, "codex", "skills", "contribute-to-eliza")),
+      ).toBe(false);
+    } finally {
+      api.kill();
+      decoy.kill();
     }
   });
 });

--- a/src/lib/install-command.ts
+++ b/src/lib/install-command.ts
@@ -180,6 +180,27 @@ local_signature = 0x04034B50
 api_fixture = None
 
 
+def configured_github_token():
+    # Optional. Moves GitHub API verification from the anonymous core budget,
+    # which every process behind one public IP shares, to the caller's own
+    # authenticated budget. The token is sent only to the GitHub API authority,
+    # never to raw or artifact origins, and is never written to disk.
+    for name in ("GH_TOKEN", "GITHUB_TOKEN"):
+        value = os.environ.get(name)
+        if value is None:
+            continue
+        value = value.strip()
+        if not value:
+            continue
+        if not re.fullmatch(r"[\\x21-\\x7e]+", value):
+            raise ValueError(f"{name} contains characters that cannot be sent in an Authorization header")
+        return value
+    return None
+
+
+github_token = configured_github_token()
+
+
 def require_sha(value, context):
     if not isinstance(value, str) or not sha_pattern.fullmatch(value):
         raise ValueError(f"{context} is not a full lowercase commit SHA")
@@ -220,18 +241,59 @@ class RetryableDownloadError(Exception):
         self.reason = reason
 
 
-def fetch_bytes_once(url, limit, expected_origin):
-    request = urllib.request.Request(
-        url,
-        headers={
-            "Accept": "application/vnd.github+json",
-            "User-Agent": "slop-skill-installer/1",
-            "X-GitHub-Api-Version": "2022-11-28",
-        },
-        method="GET",
-    )
+class AuthorityRedirectHandler(urllib.request.HTTPRedirectHandler):
+    # urllib forwards every request header, including Authorization, to a
+    # redirect target on any host. Refuse to leave the issuing origin before
+    # the redirected request is built, so no header can cross authorities.
+    def redirect_request(self, request, fp, code, msg, headers, newurl):
+        if origin_identity(newurl) != origin_identity(request.full_url):
+            raise ValueError("authenticated request redirected to another authority")
+        return super().redirect_request(request, fp, code, msg, headers, newurl)
+
+
+opener = urllib.request.build_opener(AuthorityRedirectHandler)
+
+
+def rate_limit_detail(error, authenticated):
+    if error.code not in (403, 429):
+        return None
+    remaining = error.headers.get("X-RateLimit-Remaining")
+    retry_after = error.headers.get("Retry-After")
+    if remaining != "0" and retry_after is None:
+        return None
+    token_sent = authenticated and github_token is not None
+    budget = "authenticated" if token_sent else "anonymous"
+    limit = error.headers.get("X-RateLimit-Limit")
+    if limit is not None and re.fullmatch(r"[0-9]+", limit):
+        parts = [f"GitHub API rate limit exhausted ({budget} budget, {limit} requests per hour)"]
+    else:
+        parts = [f"GitHub API rate limit exhausted ({budget} budget)"]
+    if not token_sent:
+        parts.append("the anonymous budget is shared by every process behind this public IP")
+    reset = error.headers.get("X-RateLimit-Reset")
+    if reset is not None and re.fullmatch(r"[0-9]+", reset):
+        reset_at = int(reset)
+        reset_text = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(reset_at))
+        wait_minutes = max(0, math.ceil((reset_at - time.time()) / 60))
+        parts.append(f"resets at {reset_text} (about {wait_minutes} min)")
+    elif retry_after is not None:
+        parts.append(f"retry after {retry_after}s")
+    if not token_sent:
+        parts.append("set GH_TOKEN or GITHUB_TOKEN to verify with your own authenticated budget")
+    return "; ".join(parts)
+
+
+def fetch_bytes_once(url, limit, expected_origin, authenticated=False):
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "slop-skill-installer/1",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if authenticated and github_token is not None:
+        headers["Authorization"] = f"Bearer {github_token}"
+    request = urllib.request.Request(url, headers=headers, method="GET")
     try:
-        with urllib.request.urlopen(request, timeout=request_timeout_seconds) as response:
+        with opener.open(request, timeout=request_timeout_seconds) as response:
             final_url = response.geturl()
             expected = urllib.parse.urlsplit(expected_origin)
             final = urllib.parse.urlsplit(final_url)
@@ -254,6 +316,11 @@ def fetch_bytes_once(url, limit, expected_origin):
     except urllib.error.HTTPError as error:
         if error.code >= 500:
             raise RetryableDownloadError(f"HTTP {error.code}") from error
+        detail = rate_limit_detail(error, authenticated)
+        if detail is not None:
+            raise ValueError(
+                f"authenticated download failed: HTTP {error.code}: {url}: {detail}"
+            ) from error
         raise ValueError(f"authenticated download failed: HTTP {error.code}: {url}") from error
     except (TimeoutError, socket.timeout) as error:
         raise RetryableDownloadError(
@@ -276,13 +343,13 @@ def fetch_bytes_once(url, limit, expected_origin):
     return contents
 
 
-def fetch_bytes(url, limit, expected_origin):
+def fetch_bytes(url, limit, expected_origin, authenticated=False):
     # Integrity, authority, and size violations above raise ValueError and are
     # never retried; only per-attempt timeouts and HTTP 5xx repeat, bounded.
     last_reason = None
     for attempt in range(1, download_attempts + 1):
         try:
-            return fetch_bytes_once(url, limit, expected_origin)
+            return fetch_bytes_once(url, limit, expected_origin, authenticated)
         except RetryableDownloadError as error:
             last_reason = error.reason
             if attempt < download_attempts:
@@ -319,7 +386,10 @@ def api_json(path, query=()):
     url = f"{api_origin}{path}"
     if query_string:
         url = f"{url}?{query_string}"
-    return decode_json(fetch_bytes(url, max_api_bytes, api_origin), f"GitHub API response for {path}")
+    return decode_json(
+        fetch_bytes(url, max_api_bytes, api_origin, authenticated=True),
+        f"GitHub API response for {path}",
+    )
 
 
 def pull_records(revision):


### PR DESCRIPTION
Closes #417.

## What changed

- `src/lib/install-command.ts`: the generated installer reads `GH_TOKEN`, then `GITHUB_TOKEN`, and sends it as a `Bearer` header on GitHub API requests only. Raw and artifact fetches never carry it, and nothing writes it to disk. Without either variable the installer behaves exactly as before.
- Cross-origin redirects are now refused before they are followed. `urllib` forwards every request header, including `Authorization`, to a redirect target on any host; the existing check ran only after the redirected request had been sent.
- HTTP 403 or 429 with `X-RateLimit-Remaining: 0` or `Retry-After` now reports the exhausted budget (anonymous or authenticated), the limit, the UTC reset time, and, when anonymous, the token remedy. Rate-limit responses are still not retried.
- `scripts/render-install-guide.mjs`: one paragraph in every generated install guide explaining the shared anonymous budget and the optional token.
- `src/lib/install-command.test.ts`: four loopback tests. Token sent to the API authority on every request and to the raw authority on none, and no token bytes in the installed tree; `GITHUB_TOKEN` fallback and rejection of a token that cannot be a header value; exhausted-limit message for both budgets with exactly one request and no activation; cross-origin redirect refused with zero requests reaching the decoy server.

## Why

Every installer run costs 6 anonymous GitHub API calls, the guide asks agents to re-run it at every session start, and the anonymous budget is 60 per hour per public IP shared with everything else on that network. A contributor hit this today on the ASI installer. Details and measurements in the linked issue.

## Trust model

Unchanged. GitHub remains the independent trust root; the same endpoints are queried with the same validation. The token only changes which budget those queries draw on. The redirect guard tightens the existing "mutable redirects" rejection.

## Evidence (head f7073f858d5bd2f9ae1d38b01c6cf0e2cc91e051)

- `bun x vitest run src/lib/install-command.test.ts scripts/prepare-site.test.ts`: 32 passed.
- `bun run typecheck`, `bun run lint:check`, `bun run format:check`: clean (lint warnings are pre-existing and none are in the changed files).
- `bun run test`: vitest 86 files, 1000 tests passed. `skill-tests` 123 pass, 6 fail; all 6 are `assertPinnedNodeRuntime` in `contribute-to-eliza.test.ts` expecting Node 24.15.0 on a machine running 25.2.1, a local environment mismatch unrelated to this change. CI runs the pinned toolchain.
- Generated archive: `contribute-to-asi.skill` sha256 `8f245e6f5f704761c4610ea74b5faeec7d8d68ff09af37750bf9381b3e37241a`, byte-identical to the archive slop.cash serves (the installer is not part of the archive).
- Fresh real-repository forward test with the regenerated ASI installer against live `api.github.com`, `raw.githubusercontent.com`, and `slop.cash`, revision `4581bbf7efd3d4a6edaaf91a6faf1447fd160414`, into a temporary skills root:
  - anonymous: `Installed contribute-to-asi at verified revision 4581bbf7...` in 3.4s
  - `GH_TOKEN` set: same result in 1.9s; `grep` for the token prefix over the installed tree finds nothing
  - re-runs: `already verified ... no changes made` on both
  - anonymous core budget read from `/rate_limit` before and after each re-run: authenticated run 47 remaining before, 47 after; anonymous run 47 before, 41 after (6 calls)
- UI, deploy, DNS, TLS, redirects, security headers: N/A - no UI or deployment change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
