### PR TITLE
fix(trace): log the cause of private trace API 5xx responses

### DIFF
--- a/backend/trace/handler.ts
+++ b/backend/trace/handler.ts
@@ -69,6 +69,34 @@ function json(status: number, body: Record<string, unknown>): Response {
   });
 }
 
+const MAX_LOGGED_MESSAGE_CHARS = 1000;
+
+// Server-side detail for 5xx responses. The client still receives only
+// "Internal error"; this object is what an operator reads in Workers logs.
+// Path segments after the route family are dropped because one-time upload
+// capabilities travel in the path. Headers and bodies are never logged.
+function describeApiFailure(
+  request: Request,
+  parts: readonly string[],
+  status: number,
+  caught: unknown,
+): Record<string, unknown> {
+  const error = caught instanceof Error ? caught : null;
+  const code = (caught as Partial<ApiError> | null)?.code;
+  const message =
+    error?.message ?? (typeof caught === "string" ? caught : String(caught));
+  return {
+    status,
+    method: request.method,
+    route: parts[0] ?? null,
+    pathSegments: parts.length,
+    code: typeof code === "string" ? code : null,
+    name: error?.name ?? typeof caught,
+    message: message.slice(0, MAX_LOGGED_MESSAGE_CHARS),
+    stack: error?.stack ?? null,
+  };
+}
+
 async function readPrivateIntakeStatus(
   deps: TraceApiDependencies,
 ): Promise<Response> {
@@ -1063,7 +1091,12 @@ export async function handleTraceApi(
       Number(error.status) <= 599
         ? Number(error.status)
         : 500;
-    if (status >= 500) console.error("private trace API failure");
+    if (status >= 500) {
+      console.error(
+        "private trace API failure",
+        describeApiFailure(request, parts, status, caught),
+      );
+    }
     const response = json(status, {
       error:
         typeof error.code === "string" &&

--- a/functions/api/v1/trace-api.test.ts
+++ b/functions/api/v1/trace-api.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { signApiToken, verifyApiToken } from "../../../backend/trace/auth";
 import type {
   AttachTraceInput,
@@ -1460,6 +1460,107 @@ describe("private trace API", () => {
     expect(response.status).toBe(422);
     expect(store.bytes.size).toBe(0);
     expect(store.objects.size).toBe(0);
+  });
+
+  it("logs the cause of an unexpected failure without echoing it to the client", async () => {
+    const logged = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const deps: TraceApiDependencies = {
+        ...dependencies(),
+        privateIntakeStatus: async () => {
+          throw new Error("intake probe exploded");
+        },
+      };
+      const response = await handleTraceApi(
+        new Request("https://api.slop.cash/api/v1/private-request-intake"),
+        deps,
+      );
+      expect(response.status).toBe(500);
+      expect(await response.json()).toEqual({
+        error: "internal_error",
+        message: "Internal error",
+      });
+      expect(logged).toHaveBeenCalledTimes(1);
+      const [label, detail] = logged.mock.calls[0] as [
+        string,
+        Record<string, unknown>,
+      ];
+      expect(label).toBe("private trace API failure");
+      expect(detail).toMatchObject({
+        status: 500,
+        method: "GET",
+        route: "private-request-intake",
+        pathSegments: 1,
+        code: null,
+        name: "Error",
+        message: "intake probe exploded",
+      });
+      expect(typeof detail.stack).toBe("string");
+    } finally {
+      logged.mockRestore();
+    }
+  });
+
+  it("keeps upload capabilities out of the failure log", async () => {
+    const store = new MemoryPersistence();
+    const deps = dependencies(store);
+    const contributor = await token("42", "octocat", ["contributor"]);
+    const created = await createRun(
+      deps,
+      contributor,
+      "create_log_run_key_0001",
+    );
+    const { serverRunId } = (await created.json()) as { serverRunId: string };
+    const bytes = new TextEncoder().encode(
+      "private trace that must not be logged",
+    );
+    const digest = await sha256Hex(bytes);
+    const intent = await handleTraceApi(
+      request(
+        `runs/${serverRunId}/trace-intents`,
+        "POST",
+        contributor,
+        JSON.stringify({
+          sha256: digest,
+          sizeBytes: bytes.byteLength,
+          contentType: "text/plain",
+        }),
+        {
+          "content-type": "application/json",
+          "idempotency-key": "upload_log_key_0001",
+        },
+      ),
+      deps,
+    );
+    const { uploadUrl } = (await intent.json()) as { uploadUrl: string };
+    const capability = new URL(uploadUrl).pathname.split("/").at(-1) ?? "";
+    expect(capability.length).toBeGreaterThan(0);
+
+    const logged = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      store.failNextPut = true;
+      const response = await handleTraceApi(
+        new Request(uploadUrl, {
+          method: "PUT",
+          body: bytes.slice().buffer,
+          headers: {
+            "content-type": "text/plain",
+            digest: `sha-256=${digest}`,
+          },
+        }),
+        deps,
+      );
+      expect(response.status).toBe(500);
+      expect(logged).toHaveBeenCalledTimes(1);
+      const serialized = JSON.stringify(logged.mock.calls[0]);
+      expect(serialized).toContain('"route":"trace-uploads"');
+      expect(serialized).toContain('"pathSegments":2');
+      expect(serialized).toContain("transient R2 failure");
+      expect(serialized).not.toContain(capability);
+      expect(serialized).not.toContain("private trace that must not be logged");
+    } finally {
+      logged.mockRestore();
+    }
   });
 
   it("does not burn an upload capability on validation or transient storage failure", async () => {


### PR DESCRIPTION
Follow-up to #353 (closed). The client-side recovery paths landed in #341 and #342, but the server still cannot say why a request failed.

## What changed

- `backend/trace/handler.ts`: the catch-all for the private trace API logged the bare string `private trace API failure` on every 5xx. It now logs a structured object next to that label: `status`, `method`, `route` (first path segment), `pathSegments`, `code`, `name`, `message` (capped at 1000 chars), and `stack`.
- What is deliberately left out: path segments after the route family, because one-time upload capabilities travel in the path (`trace-uploads/<capability>`); request headers; request and response bodies. Trace bytes never reach the log.
- The client response is unchanged. A 5xx still returns `{"error":"internal_error","message":"Internal error"}` (or the thrown code), so nothing new is exposed to callers.

## Why

A contributor reported `trace upload request returned HTTP 500` on a review-lane run (#353). Intake was live and the API was healthy on probe, so it was a one-off, but the Workers log for that request carried no cause, route, or stack. Every future one-off has the same problem until the log says something.

## Tests

`functions/api/v1/trace-api.test.ts`, two new cases:

- an unexpected throw on `GET private-request-intake` returns the unchanged 500 body and logs status, method, route, code, name, message, and a stack
- a transient storage failure on `PUT trace-uploads/<capability>` logs `route: "trace-uploads"` and the persistence error, and the serialized log contains neither the capability nor the trace bytes

## Verification

- `bunx vitest run functions/api/v1/trace-api.test.ts`: 39 passed
- `bunx vitest run`: 86 files, 1002 passed
- `bun run typecheck`: passed
- `bun x @biomejs/biome check` on both changed files: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
