### PR TITLE
fix(site): serve the how-it-works, receipts, and cycles routes

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,6 +1,9 @@
 /skill.md /projects/eliza/skill.md 301
 /deck / 200
 /deck/* / 200
+/how-it-works / 200
+/receipts / 200
+/cycles / 200
 /projects/new / 200
 /projects/:project/funding/ / 200
 /projects/:project/funding / 200

--- a/scripts/prepare-site.test.ts
+++ b/scripts/prepare-site.test.ts
@@ -478,6 +478,9 @@ describe("contribution skill package", () => {
     expect(redirects).toContain("/projects/:project/funding / 200");
     expect(redirects).toContain("/projects/:project / 200");
     expect(redirects).toContain("/cycles/:project/:cycle / 200");
+    expect(redirects).toContain("/how-it-works / 200");
+    expect(redirects).toContain("/receipts / 200");
+    expect(redirects).toContain("/cycles / 200");
     expect(readFileSync(join(publicRoot, "404.html"), "utf8")).toContain(
       "The requested Slop page or artifact does not exist.",
     );


### PR DESCRIPTION
## What is broken

The site navigation links to `/how-it-works`, `/receipts`, and `/cycles`. All three return Cloudflare's `404.html` on production:

```
curl -s -o /dev/null -w '%{http_code}' https://slop.cash/how-it-works   # 404
curl -s -o /dev/null -w '%{http_code}' https://slop.cash/receipts       # 404
curl -s -o /dev/null -w '%{http_code}' https://slop.cash/cycles         # 404
```

`src/App.tsx` has routed all three since #311 (c197c08, 2 Sep), but `public/_redirects` was last changed on 16 Aug (619b1f2) and has no rewrite for them. Every other client route (`/deck`, `/projects/:project`, `/cycles/:project/:cycle`, and so on) already has one, which is why project and cycle pages work.

## What changed

- `public/_redirects`: three single-page rewrites, same form as the existing `/deck / 200` rule.
- `scripts/prepare-site.test.ts`: the discovery-files test now asserts the three rules alongside the existing ones.

No route, component, or generated artifact changes. `_routes.json` is untouched: like `/deck`, these paths are served by static hosting, not the Pages Function.

## Verification

- `bunx vitest run scripts/prepare-site.test.ts`: 9 passed
- Biome check on the test file: clean
- After release, expect 200 with the app shell on all three URLs above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
