### PR TITLE
fix: restore complete contributor records and exact simulated shares

### DIFF
--- a/scripts/sync-cycle-index.ts
+++ b/scripts/sync-cycle-index.ts
@@ -28,6 +28,7 @@ import {
   assertLeaderboardSnapshot,
   type LeaderboardSnapshot,
 } from "../src/lib/leaderboard";
+import { createProjectView } from "../src/lib/project-view";
 import { findProject, type ProjectId } from "../src/lib/projects.mjs";
 import { createRewardCycleProposal } from "../src/lib/reward-cycle";
 import { finalizeRewardAllocation } from "../src/lib/reward-finalization";
@@ -259,6 +260,12 @@ async function buildCycle(
     throw new Error("required cycle files vanished");
   assertLeaderboardSnapshot(snapshotFile.value);
   const snapshot = snapshotFile.value;
+  const exactScores = new Map(
+    createProjectView(snapshot, projectId, cycleId).leaders.map((leader) => [
+      leader.actor.id,
+      leader.scoreThirds,
+    ]),
+  );
   const rawProposal = proposalFile.value as { kind?: unknown };
   const files = new Map(
     [...loaded.entries()]
@@ -322,6 +329,7 @@ async function buildCycle(
         contributors: proposal.entries.map((entry) => ({
           actor: entry.actor,
           score: entry.score,
+          scoreThirds: exactScores.get(entry.actor.id) ?? 0,
           state: "external-share",
           suggestedMinor: "0",
           approvedMinor: "0",
@@ -512,6 +520,7 @@ async function buildCycle(
         return {
           actor: entry.actor,
           score: entry.score,
+          scoreThirds: exactScores.get(entry.actor.id) ?? 0,
           state:
             paid?.state === "paid" ? "paid" : (approved?.state ?? entry.state),
           suggestedMinor: entry.suggestedMinor,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -861,7 +861,7 @@ function ReviewerLeaderboard({
               </tr>
             </thead>
             <tbody>
-              {reviewers.slice(0, 20).map((reviewer) => (
+              {reviewers.map((reviewer) => (
                 <tr
                   className="leader-row global-leader-row reviewer-leader-row"
                   key={reviewer.actor.id}
@@ -957,7 +957,8 @@ function GlobalLeaderboard({
         <summary>How it works</summary>
         <p>
           Accepted contributions earn points. Current rankings show today's
-          estimated shares. Payouts are off during beta.
+          estimated shares at the published monthly cap, not approved payouts.
+          Funding-backed proposals use verified committed funds.
         </p>
       </details>
       {mode === "current" ? (
@@ -1006,6 +1007,11 @@ function GlobalLeaderboard({
                   </strong>
                   <span>{selectedRewardLabel}</span>
                 </div>
+                {selectedView.reward.kind === "monthly-pool" ? (
+                  <p>
+                    Simulated at {selectedRewardLabel}. Not an approved payout.
+                  </p>
+                ) : null}
                 {selectedView.reward.kind === "external-prize-share" ? (
                   <p>Prize sponsor controls eligibility and payment.</p>
                 ) : null}
@@ -1029,7 +1035,7 @@ function GlobalLeaderboard({
                         </tr>
                       </thead>
                       <tbody>
-                        {selectedView.leaders.slice(0, 20).map((leader) => (
+                        {selectedView.leaders.map((leader) => (
                           <tr
                             className="leader-row global-leader-row"
                             key={leader.actor.id}
@@ -1053,8 +1059,10 @@ function GlobalLeaderboard({
                               </Link>
                             </td>
                             <td data-label="Accepted score">
-                              <strong title={`Exact score ${leader.score}`}>
-                                {formatScore(leader.score)}
+                              <strong
+                                title={`Exact score ${leader.scoreThirds}/3`}
+                              >
+                                {formatThirds(leader.scoreThirds)}
                               </strong>
                             </td>
                             <td data-label="Simulated share">
@@ -1117,7 +1125,7 @@ function GlobalLeaderboard({
                   </tr>
                 </thead>
                 <tbody>
-                  {leaders.slice(0, 20).map((leader, index) => (
+                  {leaders.map((leader, index) => (
                     <tr
                       className="leader-row global-leader-row global-record-row"
                       key={leader.actor.id}
@@ -1489,8 +1497,8 @@ function InstallPanel({ project }: { project: ProjectDefinition }) {
 }
 
 function RewardValue({ leader }: { leader: ProjectContributor }) {
-  return leader.projectedMinor !== null ? (
-    formatMicroUsdc(leader.projectedDisplayMinor ?? leader.projectedMinor)
+  return leader.simulatedMinor !== null ? (
+    formatMicroUsdc(leader.simulatedDisplayMinor ?? leader.simulatedMinor)
   ) : (
     <>{formatPercent(leader.projectedSharePartsPerMillion ?? 0)} share</>
   );
@@ -1508,6 +1516,12 @@ function ProjectLeaderboard({
       <div className="section-heading">
         <h2>{formatCycleMonth(view.cycle.id)} leaderboard.</h2>
         <p className="data-freshness">Updated {formatDate(updatedAt)}</p>
+        {view.reward.kind === "monthly-pool" ? (
+          <p>
+            Shares simulate the {monthlyPoolLabel(view.project.reward)} cap. Not
+            approved payouts.
+          </p>
+        ) : null}
       </div>
       {view.leaders.length === 0 ? (
         <EmptyState text="No accepted outcomes in this cycle yet." />
@@ -1547,8 +1561,8 @@ function ProjectLeaderboard({
                     </Link>
                   </td>
                   <td>
-                    <strong title={`Exact score ${leader.score}`}>
-                      {formatScore(leader.score)}
+                    <strong title={`Exact score ${leader.scoreThirds}/3`}>
+                      {formatThirds(leader.scoreThirds)}
                     </strong>
                     {leader.computeBonusBasisPoints > 0 ? (
                       <small>
@@ -2556,8 +2570,8 @@ function ProfilePage({
                       <small>{view.cycle.id}</small>
                     </span>
                     <span className="profile-project-stat">
-                      <strong title={`Exact score ${leader.score}`}>
-                        {formatScore(leader.score)} score
+                      <strong title={`Exact score ${leader.scoreThirds}/3`}>
+                        {formatThirds(leader.scoreThirds)} score
                       </strong>
                       <small>
                         {leader.acceptedOutcomeCount} accepted outcome
@@ -2754,7 +2768,11 @@ function ArchivedCycleLeaderboard({ cycle }: { cycle: CycleIndexEntry }) {
                       {contributor.actor.login}
                     </Link>
                   </th>
-                  <td>{contributor.score}</td>
+                  <td>
+                    {formatThirds(
+                      contributor.scoreThirds ?? contributor.score * 3,
+                    )}
+                  </td>
                   <td>
                     {formatMicroUsdc(contributor.suggestedMinor)}
                     {contributor.lines ? (

--- a/src/lib/cycle-index.test.ts
+++ b/src/lib/cycle-index.test.ts
@@ -79,6 +79,31 @@ function index(cycles: CycleIndexEntry[] = [entry()]): CycleIndex {
 }
 
 describe("public cycle index", () => {
+  it("publishes a proposed below-minimum hold without claiming approval", () => {
+    const cycle = entry();
+    cycle.contributors[0].state = "held-below-minimum";
+    cycle.contributors[0].suggestedMinor = "1000000";
+    cycle.reward.suggestedMinor = "1000000";
+    expect(
+      assertCycleIndex(index([cycle])).cycles[0].contributors[0].state,
+    ).toBe("held-below-minimum");
+    cycle.contributors[0].approvedMinor = "1000000";
+    cycle.reward.approvedMinor = "1000000";
+    cycle.reward.feeMinor = "10000";
+    expect(() => assertCycleIndex(index([cycle]))).toThrow();
+  });
+
+  it("preserves exact thirds and refuses a conflicting whole-point score", () => {
+    const cycle = entry();
+    cycle.contributors[0].score = 0;
+    cycle.contributors[0].scoreThirds = 1;
+    expect(
+      assertCycleIndex(index([cycle])).cycles[0].contributors[0].scoreThirds,
+    ).toBe(1);
+    cycle.contributors[0].scoreThirds = 3;
+    expect(() => assertCycleIndex(index([cycle]))).toThrow(/scoreThirds/u);
+  });
+
   function approvedCarry(
     shared: bigint,
     review: bigint | null = null,

--- a/src/lib/cycle-index.test.ts
+++ b/src/lib/cycle-index.test.ts
@@ -84,9 +84,7 @@ describe("public cycle index", () => {
     cycle.contributors[0].state = "held-below-minimum";
     cycle.contributors[0].suggestedMinor = "1000000";
     cycle.reward.suggestedMinor = "1000000";
-    expect(
-      assertCycleIndex(index([cycle])).cycles[0].contributors[0].state,
-    ).toBe("held-below-minimum");
+    expect(() => assertCycleIndex(index([cycle]))).not.toThrow();
     cycle.contributors[0].approvedMinor = "1000000";
     cycle.reward.approvedMinor = "1000000";
     cycle.reward.feeMinor = "10000";
@@ -97,9 +95,7 @@ describe("public cycle index", () => {
     const cycle = entry();
     cycle.contributors[0].score = 0;
     cycle.contributors[0].scoreThirds = 1;
-    expect(
-      assertCycleIndex(index([cycle])).cycles[0].contributors[0].scoreThirds,
-    ).toBe(1);
+    expect(() => assertCycleIndex(index([cycle]))).not.toThrow();
     cycle.contributors[0].scoreThirds = 3;
     expect(() => assertCycleIndex(index([cycle]))).toThrow(/scoreThirds/u);
   });

--- a/src/lib/cycle-index.ts
+++ b/src/lib/cycle-index.ts
@@ -100,6 +100,7 @@ export interface CycleIndexEntry {
   contributors: Array<{
     actor: { id: string; login: string };
     score: number;
+    scoreThirds?: number;
     state:
       | "approved"
       | "excluded"
@@ -608,6 +609,7 @@ function cycleEntry(value: unknown, index: number): CycleIndexEntry {
         "approvedMinor",
         "paidMinor",
         "score",
+        ...(Object.hasOwn(contributor, "scoreThirds") ? ["scoreThirds"] : []),
         "sharePartsPerMillion",
         "state",
         "suggestedMinor",
@@ -629,6 +631,15 @@ function cycleEntry(value: unknown, index: number): CycleIndexEntry {
       Number(contributor.score) < 0
     ) {
       throw new TypeError(`${contributorField}.score is invalid`);
+    }
+    const scoreThirds = contributor.scoreThirds;
+    if (
+      Object.hasOwn(contributor, "scoreThirds") &&
+      (!Number.isSafeInteger(scoreThirds) ||
+        Number(scoreThirds) < 0 ||
+        Math.floor(Number(scoreThirds) / 3) !== contributor.score)
+    ) {
+      throw new TypeError(`${contributorField}.scoreThirds is invalid`);
     }
     if (!contributorStates.has(String(contributor.state))) {
       throw new TypeError(`${contributorField}.state is invalid`);
@@ -694,6 +705,9 @@ function cycleEntry(value: unknown, index: number): CycleIndexEntry {
     return {
       actor: { id: actorId, login },
       score: Number(contributor.score),
+      ...(scoreThirds === undefined
+        ? {}
+        : { scoreThirds: Number(scoreThirds) }),
       state,
       suggestedMinor,
       approvedMinor,
@@ -858,6 +872,7 @@ function cycleEntry(value: unknown, index: number): CycleIndexEntry {
         (contributor) =>
           contributor.state !== "proposed" &&
           contributor.state !== "unclaimed" &&
+          contributor.state !== "held-below-minimum" &&
           contributor.state !== "held",
       ));
   const paymentReadyStateInvalid =

--- a/src/lib/global-leaderboard.test.ts
+++ b/src/lib/global-leaderboard.test.ts
@@ -101,4 +101,26 @@ describe("createGlobalLeaders", () => {
     expect(leader.projects).toBe(2);
     expect(leader.cycles).toBe(3);
   });
+  it("retains an archived contributor whose fractional score was stored as zero", () => {
+    const { snapshot, views } = projectViews();
+    const cycle = archivedElizaCycle("2026-06", 0);
+    cycle.contributors[0].scoreThirds = 1;
+    cycle.contributors[0].actor = {
+      id: "U_archived_fraction",
+      login: "fraction-only",
+    };
+    const index = cycleIndexFixture();
+    index.cycles = [cycle];
+    expect(
+      createGlobalLeaders(snapshot, views, index).find(
+        (leader) => leader.actor.id === "U_archived_fraction",
+      ),
+    ).toMatchObject({
+      actor: { login: "fraction-only" },
+      projects: 1,
+      cycles: 1,
+      paidMinor: 0n,
+      score: 1 / 3,
+    });
+  });
 });

--- a/src/lib/global-leaderboard.ts
+++ b/src/lib/global-leaderboard.ts
@@ -79,9 +79,12 @@ export function createGlobalLeaders(
         currentActors.get(contributor.actor.id) ??
         actorFromCycle(contributor.actor);
       const current = byActor.get(actor.id) ?? emptyLeader(actor);
-      current.score += contributor.score;
+      current.score += contributor.scoreThirds ?? contributor.score * 3;
       current.paidMinor += BigInt(contributor.paidMinor);
-      if (contributor.score > 0) {
+      if (
+        (contributor.scoreThirds ?? contributor.score * 3) > 0 ||
+        contributor.state !== "excluded"
+      ) {
         current.cycleKeys.add(key);
         current.projectIds.add(cycle.projectId);
       }
@@ -100,7 +103,7 @@ export function createGlobalLeaders(
     if (archivedCycleKeys.has(key)) continue;
     const current = byActor.get(event.actor.id) ?? emptyLeader(event.actor);
     current.actor = event.actor;
-    current.score += event.points;
+    current.score += event.scoreThirds ?? Math.round(event.points * 3);
     current.cycleKeys.add(key);
     current.projectIds.add(project.id);
     byActor.set(event.actor.id, current);
@@ -122,11 +125,12 @@ export function createGlobalLeaders(
         leader.score > 0 ||
         leader.tokens > 0 ||
         leader.projectedMinor > 0n ||
-        leader.paidMinor > 0n,
+        leader.paidMinor > 0n ||
+        leader.cycleKeys.size > 0,
     )
     .map<GlobalLeader>((leader) => ({
       actor: leader.actor,
-      score: leader.score,
+      score: leader.score / 3,
       tokens: leader.tokens,
       projectedMinor: leader.projectedMinor,
       paidMinor: leader.paidMinor,

--- a/src/lib/project-view.test.ts
+++ b/src/lib/project-view.test.ts
@@ -96,6 +96,8 @@ describe("project views", () => {
       score: 24,
       projectedMinor: "0",
       projectedDisplayMinor: "0",
+      simulatedMinor: "5000000000",
+      simulatedDisplayMinor: "5000000000",
       projectedSharePartsPerMillion: null,
     });
     expect(eliza.ledger).toHaveLength(6);
@@ -119,6 +121,42 @@ describe("project views", () => {
       totalSharePartsPerMillion: 900_000,
       platformSharePartsPerMillion: 100_000,
     });
+  });
+
+  it("keeps one-third contributors in exact simulations without funding a payout", () => {
+    const snapshot = snapshotFixture();
+    const event = snapshot.ledger[0];
+    snapshot.ledger = [
+      { ...event, points: 1 / 3, scoreThirds: 1 },
+      {
+        ...event,
+        id: "second-event",
+        actor: SECOND_ACTOR,
+        points: 2 / 3,
+        scoreThirds: 2,
+      },
+    ];
+    const view = createProjectView(snapshot, "eliza", "2026-07");
+    expect(
+      view.leaders.map((entry) => [entry.actor.id, entry.simulatedMinor]),
+    ).toEqual([
+      [SECOND_ACTOR.id, "3333333333"],
+      [event.actor.id, "1666666667"],
+    ]);
+    expect(view.leaders.map((entry) => entry.projectedMinor)).toEqual([
+      "0",
+      "0",
+    ]);
+    expect(
+      view.leaders.reduce(
+        (sum, entry) => sum + BigInt(entry.simulatedDisplayMinor ?? "0"),
+        0n,
+      ),
+    ).toBe(5_000_000_000n);
+    snapshot.ledger.reverse();
+    expect(createProjectView(snapshot, "eliza", "2026-07").leaders).toEqual(
+      view.leaders,
+    );
   });
 
   it("keeps still-open opportunities across cycle bounds and reports cap fill", () => {
@@ -249,7 +287,7 @@ describe("project views", () => {
       confidence: "verified-device",
     });
     expect(view.leaders[0].computeBonusBasisPoints).toBe(0);
-    expect(view.leaders[0].adjustedWeight).toBe(240_000);
+    expect(view.leaders[0].adjustedWeight).toBe(720_000);
   });
 
   it("binds a private-trace evidence bonus to its exact scored outcome", () => {
@@ -262,7 +300,7 @@ describe("project views", () => {
 
     const view = createProjectView(snapshot, "eliza", "2026-07");
     expect(view.leaders[0].adjustedWeight).toBe(
-      baseline.leaders[0].adjustedWeight + event.points * 1_500,
+      baseline.leaders[0].adjustedWeight + event.points * 4_500,
     );
     expect(view.leaders[0].computeBonusBasisPoints).toBe(
       Math.floor((event.points * 3 * 1_500) / (baseline.leaders[0].score * 3)),

--- a/src/lib/project-view.ts
+++ b/src/lib/project-view.ts
@@ -45,6 +45,9 @@ export interface ProjectContributor {
   rank: number;
   actor: GitHubActor;
   score: number;
+  scoreThirds: number;
+  simulatedMinor: string | null;
+  simulatedDisplayMinor: string | null;
   adjustedWeight: number;
   computeBonusBasisPoints: number;
   points: Record<ScoreCategory, number>;
@@ -592,7 +595,10 @@ export function createProjectView(
       rank: 0,
       actor,
       score,
-      adjustedWeight: Math.floor(weightedThirdBasisPoints / 3),
+      scoreThirds: rawThirds,
+      simulatedMinor: null,
+      simulatedDisplayMinor: null,
+      adjustedWeight: weightedThirdBasisPoints,
       computeBonusBasisPoints: computeBonus,
       points,
       acceptedOutcomeCount: events.length,
@@ -654,7 +660,21 @@ export function createProjectView(
       monthlyCapMinor / 10_000n,
       leaders,
     );
+    // A cap-based simulation is informational. Only the funding-backed
+    // projection may flow into a reward proposal.
+    const simulated = allocateIntegerTotal(
+      BigInt(project.reward.monthlyCapMinor),
+      leaders,
+    );
+    const simulatedCents = allocateIntegerTotal(
+      BigInt(project.reward.monthlyCapMinor) / 10_000n,
+      leaders,
+    );
     for (const entry of leaders) {
+      entry.simulatedMinor = (simulated.get(entry.actor.id) ?? 0n).toString();
+      entry.simulatedDisplayMinor = (
+        (simulatedCents.get(entry.actor.id) ?? 0n) * 10_000n
+      ).toString();
       entry.projectedMinor = (projected.get(entry.actor.id) ?? 0n).toString();
       entry.projectedDisplayMinor = (
         (projectedCents.get(entry.actor.id) ?? 0n) * 10_000n

--- a/tests/app.test.tsx
+++ b/tests/app.test.tsx
@@ -582,8 +582,11 @@ describe("discovery", () => {
       screen.getByText("How it works", { selector: "summary" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/Payouts are off during beta/u),
+      screen.getByText(
+        /Funding-backed proposals use verified committed funds/u,
+      ),
     ).toBeInTheDocument();
+    expect(within(leaderboard).getByText("$5,000")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "View more" })).toHaveAttribute(
       "href",
       "/projects/eliza",

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -174,6 +174,9 @@ test("discovers both reward models and a score-ranked global ledger", async ({
   await page.reload({ waitUntil: "networkidle" });
   const snapshot = await loadSnapshot(request);
   await loadCycles(request);
+  await expect(
+    page.locator(".global-leader-grid .global-leader-row"),
+  ).toHaveCount(createProjectView(snapshot, "eliza").leaders.length);
 
   await expect(
     page.getByRole("heading", {
@@ -290,7 +293,9 @@ test("discovers both reward models and a score-ranked global ledger", async ({
     .locator(".leaderboard-methodology")
     .getByText("How it works")
     .click();
-  await expect(page.getByText(/Payouts are off during beta/u)).toBeVisible();
+  await expect(
+    page.getByText(/Funding-backed proposals use verified committed funds/u),
+  ).toBeVisible();
   await expect(page.getByRole("link", { name: "View more" })).toHaveAttribute(
     "href",
     "/projects/eliza",
@@ -367,6 +372,7 @@ test("discovers both reward models and a score-ranked global ledger", async ({
 test("starts Eliza with one prompt and no separate payout form", async ({
   context,
   page,
+  request,
 }) => {
   await context.grantPermissions(["clipboard-read", "clipboard-write"]);
   await page.goto("/projects/eliza", { waitUntil: "networkidle" });
@@ -515,9 +521,16 @@ test("starts Eliza with one prompt and no separate payout form", async ({
         );
       }, 0),
     );
-  // The project cap is policy, not funded principal. With no reviewed
-  // commitment, the leaderboard must not turn that cap into projected money.
-  expect(displayedProjectionCents).toBe(0);
+  const view = createProjectView(await loadSnapshot(request), "eliza");
+  expect(displayedProjectionCents).toBe(
+    view.leaders.length
+      ? Number(BigInt(view.project.reward.monthlyCapMinor) / 10_000n)
+      : 0,
+  );
+  expect(view.leaders.every((leader) => leader.projectedMinor === "0")).toBe(
+    true,
+  );
+  await expect(page.getByText(/Shares simulate the/u)).toBeVisible();
   await expect(page.getByText("Live from GitHub")).toHaveCount(0);
   await expect(page.getByText("How credit survives review")).toHaveCount(0);
 });

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -175,7 +175,9 @@ test("discovers both reward models and a score-ranked global ledger", async ({
   const snapshot = await loadSnapshot(request);
   await loadCycles(request);
   await expect(
-    page.locator(".global-leader-grid .global-leader-row"),
+    page.locator(
+      ".global-leader-grid .global-leader-row:not(.reviewer-leader-row)",
+    ),
   ).toHaveCount(createProjectView(snapshot, "eliza").leaders.length);
 
   await expect(


### PR DESCRIPTION
The simulated-share column used verified committed funding, so an unfunded $5,000 target displayed $0 for every contributor. Calculate a separate cap-based simulation and keep funding-backed proposal amounts unchanged. Preserve integer third-point weights through allocation and publish exact fractional scores in current and archived views.

Remove the inaccessible top-20 cutoff from contributor and reviewer tables, retain historical contributor rows, and accept the below-minimum review state emitted by the proposal generator. These changes support the August payout audit without approving or sending payments.

Addresses #407 and the display/validation portions of #411; prerequisite for #406. The complete August rebuild has 108 Eliza contributors and reconciles all 4,668 non-bot Eliza merges against an independent 4,706-merge census (38 Dependabot exclusions). 89 August contributors have no September events. All missing-wallet contributors remain included.

The locally reviewed August drafts remain unpublished: current manifests commit $0 and disable payments, and freezing a zero-funded proposal would bind August to that funding basis. A reviewed August funding instrument and public allocation review remain necessary. No wallet or payment authority is inferred.

Validation at `0bc812f8fd01b6bc68ec072ad56b7df17d4fb87f`:
- `bun run verify`: passed with Node 24.15.0 and the frozen lockfile; 1,006 tests and 129 skill tests.
- Hosted run https://github.com/SlopDotCash/slopdotcash/actions/runs/34445436430 passed: 41 browser cases across desktop/tablet/mobile, 2 Pages contract cases, accessibility, keyboard/text enlargement, console/network diagnostics, and downloadable artifact contracts. Three redundant viewport-specific reflow cases intentionally skip outside the wide-desktop scenario.
- Trusted funding, project-transition, and unsafe-destination gates passed.
- Independent integer allocation reconciles every August simulated micro-USDC share and each project's total.
- August snapshot SHA-256: `01d1e6c42b11112561fc65bea9672b6966737bf95425ef97c9d9d0aa371cf37e`.

Production deployment and custom-domain byte verification remain a separate post-merge boundary. Funding, signer availability, wallet control, and payment settlement are not established by these checks. Captured audit artifacts and screenshots are not committed.
