### PR TITLE
Add month-specific reward cap support without changing budgets

### DIFF
--- a/scripts/check-project-transitions.test.ts
+++ b/scripts/check-project-transitions.test.ts
@@ -3,6 +3,8 @@ import asi from "../projects/asi/project.json";
 import deltaStar from "../projects/delta-star/project.json";
 import eliza from "../projects/eliza/project.json";
 import heirElementsSdk from "../projects/heir-elements-sdk/project.json";
+import { assertProjectDefinition } from "../src/lib/project-schema.mjs";
+import { resolveRewardCapMinor } from "../src/lib/reward-cap.mjs";
 import {
   validateProjectTransitions,
   validateProposalFundingTransitions,
@@ -94,7 +96,10 @@ describe("project transition gate", () => {
       instrumentId: null,
       fundingState: eliza.reward.fundingState,
       committedMinor: eliza.reward.committedMinor,
-      monthlyCapMinor: eliza.reward.monthlyCapMinor,
+      monthlyCapMinor: resolveRewardCapMinor(
+        assertProjectDefinition(eliza),
+        "2026-08",
+      ),
     };
     const proposal = {
       kind: "reward-allocation",

--- a/src/lib/allocation-funding-basis.mjs
+++ b/src/lib/allocation-funding-basis.mjs
@@ -1,3 +1,5 @@
+import { resolveRewardCapMinor } from "./reward-cap.mjs";
+
 /** Stable public identity, never a mutable list index or observed balance. */
 function instrumentIdentity(instrument) {
   return instrument.kind === "squads-v4-vault"
@@ -61,6 +63,6 @@ export function deriveAllocationFundingBasis(project, cycleId) {
       BigInt(committedMinor) > 0n ? instrumentIdentity(instrument) : null,
     fundingState: project.reward.fundingState,
     committedMinor,
-    monthlyCapMinor: project.reward.monthlyCapMinor,
+    monthlyCapMinor: resolveRewardCapMinor(project, cycleId),
   });
 }

--- a/src/lib/exact-cycle-funding.test.ts
+++ b/src/lib/exact-cycle-funding.test.ts
@@ -85,6 +85,41 @@ function proposal(cycleId: string) {
 }
 afterEach(() => vi.restoreAllMocks());
 describe("exact-cycle reviewed funding", () => {
+  it("validates an August instrument against August's cap instead of September's", () => {
+    const baseline = structuredClone(fundedProject());
+    const candidate = {
+      ...baseline,
+      reward: {
+        ...baseline.reward,
+        cycleCaps: [
+          { cycleId: "2026-08", monthlyCapMinor: "10000000000" },
+          { cycleId: "2026-09", monthlyCapMinor: "5000000000" },
+        ],
+      },
+    };
+    const instrument = candidate.funding.commitments?.[0];
+    if (!instrument?.monthlyCommitment) throw new Error("missing instrument");
+    const withAmount = (amountMinor: string) => ({
+      ...candidate,
+      reward: { ...candidate.reward, committedMinor: amountMinor },
+      funding: {
+        ...candidate.funding,
+        commitments: [
+          {
+            ...instrument,
+            monthlyCommitment: { ...instrument.monthlyCommitment, amountMinor },
+          },
+        ],
+      },
+    });
+    expect(() =>
+      assertProjectDefinition(withAmount("10000000000")),
+    ).not.toThrow();
+    expect(() => assertProjectDefinition(withAmount("10000010000"))).toThrow(
+      /monthly reward caps/,
+    );
+  });
+
   it("keeps September promotion paused when only June was funded", () => {
     const project = fundedProject();
     const instrument = project.funding.commitments?.[0];

--- a/src/lib/funding-instruments.mjs
+++ b/src/lib/funding-instruments.mjs
@@ -1,3 +1,5 @@
+import { resolveRewardCapMinor } from "./reward-cap.mjs";
+
 /**
  * Validates reviewed committed-funding instrument references. Each instrument
  * points at a third-party, immutable, audited on-chain contract that Slop
@@ -282,9 +284,6 @@ export function assertMonthlyCommitmentPolicy(project) {
     }
   }
   const cycles = new Set();
-  const cap =
-    BigInt(project.reward.monthlyCapMinor) +
-    BigInt(project.reward.reviewBudget?.monthlyCapMinor ?? "0");
   for (const instrument of instruments) {
     const monthly = instrument.monthlyCommitment;
     if (!monthly) {
@@ -300,6 +299,9 @@ export function assertMonthlyCommitmentPolicy(project) {
     cycles.add(monthly.cycleId);
     // Do not reinterpret immutable historical authority or caps under today's policy.
     if (instrument.replacedAt !== null) continue;
+    const cap =
+      BigInt(resolveRewardCapMinor(project, monthly.cycleId)) +
+      BigInt(project.reward.reviewBudget?.monthlyCapMinor ?? "0");
     if (BigInt(monthly.amountMinor) > cap)
       throw new TypeError(
         "monthly instrument amount exceeds the monthly reward caps",

--- a/src/lib/project-schema.mjs
+++ b/src/lib/project-schema.mjs
@@ -820,6 +820,7 @@ function validateReward(
   const reward = record(value, field);
   const hasExternal = Object.hasOwn(reward, "externalOpportunity");
   const hasReviewBudget = Object.hasOwn(reward, "reviewBudget");
+  const hasCycleCaps = Object.hasOwn(reward, "cycleCaps");
   exactKeys(
     reward,
     [
@@ -828,6 +829,7 @@ function validateReward(
       "currency",
       "cycle",
       ...(hasExternal ? ["externalOpportunity"] : []),
+      ...(hasCycleCaps ? ["cycleCaps"] : []),
       "feeBasisPoints",
       "fundingState",
       "kind",
@@ -884,6 +886,31 @@ function validateReward(
     ) {
       throw new TypeError(`${field} monthly pool policy is inconsistent`);
     }
+    if (hasCycleCaps) {
+      if (!Array.isArray(reward.cycleCaps) || reward.cycleCaps.length === 0) {
+        throw new TypeError(`${field}.cycleCaps must be a nonempty array`);
+      }
+      let previousCycle = "";
+      for (const entry of reward.cycleCaps) {
+        const cap = record(entry, `${field}.cycleCaps entry`);
+        exactKeys(
+          cap,
+          ["cycleId", "monthlyCapMinor"],
+          `${field}.cycleCaps entry`,
+        );
+        if (
+          typeof cap.cycleId !== "string" ||
+          !/^\d{4}-(?:0[1-9]|1[0-2])$/u.test(cap.cycleId) ||
+          cap.cycleId <= previousCycle
+        ) {
+          throw new TypeError(
+            `${field}.cycleCaps must have unique chronological UTC months`,
+          );
+        }
+        formatMonthlyCapDisplay(cap.monthlyCapMinor);
+        previousCycle = cap.cycleId;
+      }
+    }
     if (hasReviewBudget) {
       validateReviewBudget(
         reward.reviewBudget,
@@ -894,6 +921,7 @@ function validateReward(
   } else if (reward.kind === "external-prize-share") {
     if (
       hasReviewBudget ||
+      hasCycleCaps ||
       !hasExternal ||
       reward.currency !== null ||
       reward.chain !== null ||

--- a/src/lib/project-view.ts
+++ b/src/lib/project-view.ts
@@ -25,6 +25,7 @@ import {
   type ProjectDefinition,
   type ProjectId,
 } from "./projects.mjs";
+import { resolveRewardCapMinor } from "./reward-cap.mjs";
 import type { ProjectRunReceipt } from "./run-receipts";
 
 export const MAX_CREDITED_TOKENS_PER_OUTCOME = 1_000_000;
@@ -652,6 +653,8 @@ export function createProjectView(
 
   let reward: ProjectRewardProjection;
   if (project.reward.kind === "monthly-pool") {
+    const capMinor =
+      fundingBasis?.monthlyCapMinor ?? resolveRewardCapMinor(project, cycleId);
     const monthlyCapMinor = allocationFundingMinor(
       fundingBasis ?? deriveAllocationFundingBasis(project, cycleId),
     );
@@ -662,12 +665,9 @@ export function createProjectView(
     );
     // A cap-based simulation is informational. Only the funding-backed
     // projection may flow into a reward proposal.
-    const simulated = allocateIntegerTotal(
-      BigInt(project.reward.monthlyCapMinor),
-      leaders,
-    );
+    const simulated = allocateIntegerTotal(BigInt(capMinor), leaders);
     const simulatedCents = allocateIntegerTotal(
-      BigInt(project.reward.monthlyCapMinor) / 10_000n,
+      BigInt(capMinor) / 10_000n,
       leaders,
     );
     for (const entry of leaders) {
@@ -684,7 +684,7 @@ export function createProjectView(
       kind: "monthly-pool",
       currency: "USDC",
       chain: "solana",
-      capMinor: project.reward.monthlyCapMinor,
+      capMinor,
       projectedPrincipalMinor: [...projected.values()]
         .reduce((total, amount) => total + amount, 0n)
         .toString(),

--- a/src/lib/projects.d.mts
+++ b/src/lib/projects.d.mts
@@ -31,6 +31,11 @@ export interface ProjectReviewBudgetPolicy {
 }
 
 export interface ProjectRewardPolicy {
+  /** Exact-cycle overrides; unlisted cycles use monthlyCapMinor. */
+  readonly cycleCaps?: readonly {
+    readonly cycleId: string;
+    readonly monthlyCapMinor: string;
+  }[];
   readonly kind: RewardKind;
   readonly currency: "USDC" | null;
   readonly chain: "solana" | null;

--- a/src/lib/reward-cap.d.mts
+++ b/src/lib/reward-cap.d.mts
@@ -1,0 +1,5 @@
+import type { ProjectDefinition } from "./projects.mjs";
+export function resolveRewardCapMinor(
+  project: ProjectDefinition,
+  cycleId: string,
+): string;

--- a/src/lib/reward-cap.mjs
+++ b/src/lib/reward-cap.mjs
@@ -1,0 +1,13 @@
+/** Resolve a reviewed manifest's exact UTC cycle override. No project identities
+ * or dates are inferred; unlisted cycles retain the default cap policy. */
+export function resolveRewardCapMinor(project, cycleId) {
+  if (
+    typeof cycleId !== "string" ||
+    !/^\d{4}-(?:0[1-9]|1[0-2])$/u.test(cycleId)
+  )
+    throw new TypeError("reward cap requires a valid UTC cycle month");
+  return (
+    project.reward.cycleCaps?.find((cap) => cap.cycleId === cycleId)
+      ?.monthlyCapMinor ?? project.reward.monthlyCapMinor
+  );
+}

--- a/src/lib/reward-cap.test.ts
+++ b/src/lib/reward-cap.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import delta from "../../projects/delta-star/project.json";
+import eliza from "../../projects/eliza/project.json";
+import { snapshotFixture } from "../../tests/fixtures";
+import { deriveAllocationFundingBasis } from "./allocation-funding-basis.mjs";
+import { assertProjectDefinition } from "./project-schema.mjs";
+import { createProjectView } from "./project-view";
+import * as projects from "./projects.mjs";
+import { resolveRewardCapMinor } from "./reward-cap.mjs";
+import { createRewardCycleProposal } from "./reward-cycle";
+
+const synthetic = structuredClone(eliza);
+const project = assertProjectDefinition({
+  ...synthetic,
+  reward: {
+    ...synthetic.reward,
+    cycleCaps: [
+      { cycleId: "2026-08", monthlyCapMinor: "10000000000" },
+      { cycleId: "2026-09", monthlyCapMinor: "5000000000" },
+    ],
+  },
+});
+afterEach(() => vi.restoreAllMocks());
+function snapshotFor(cycleId: string, next: string) {
+  const snapshot = snapshotFixture(`${next}-02T00:00:00.000Z`);
+  snapshot.window = {
+    days: 35,
+    from: `${cycleId}-01T00:00:00.000Z`,
+    to: `${next}-02T00:00:00.000Z`,
+  };
+  snapshot.source.verificationWindow = { ...snapshot.window };
+  snapshot.ledger = snapshot.ledger.map((event) => ({
+    ...event,
+    occurredAt: event.occurredAt.replace("2026-07", cycleId),
+  }));
+  return snapshot;
+}
+
+describe("manifest cycle caps", () => {
+  it.each([
+    ["2026-08", "2026-09", "10000000000"],
+    ["2026-09", "2026-10", "5000000000"],
+  ])(
+    "resolves %s in funding, simulation, and generated proposals",
+    (cycleId, next, cap) => {
+      vi.spyOn(projects, "findProject").mockReturnValue(project);
+      expect(resolveRewardCapMinor(project, cycleId)).toBe(cap);
+      expect(
+        deriveAllocationFundingBasis(project, cycleId).monthlyCapMinor,
+      ).toBe(cap);
+      const snapshot = snapshotFor(cycleId, next);
+      const view = createProjectView(snapshot, project.id, cycleId);
+      expect(view.reward).toMatchObject({
+        capMinor: cap,
+        projectedPrincipalMinor: "0",
+      });
+      expect(
+        view.leaders
+          .reduce((sum, row) => sum + BigInt(row.simulatedMinor ?? "0"), 0n)
+          .toString(),
+      ).toBe(cap);
+      expect(
+        view.leaders
+          .reduce(
+            (sum, row) => sum + BigInt(row.simulatedDisplayMinor ?? "0"),
+            0n,
+          )
+          .toString(),
+      ).toBe(cap);
+      const proposal = createRewardCycleProposal({
+        projectId: project.id,
+        cycleId,
+        snapshot,
+        generatedAt: `${next}-02T00:00:00.000Z`,
+        sourceSnapshotSha256: "a".repeat(64),
+      });
+      expect(proposal).toMatchObject({
+        capMinor: "0",
+        fundingBasis: { monthlyCapMinor: cap },
+      });
+    },
+  );
+
+  it("preserves frozen proposal funding bases", () => {
+    vi.spyOn(projects, "findProject").mockReturnValue(project);
+    const cycleId = "2026-08";
+    const snapshot = snapshotFor(cycleId, "2026-09");
+    const fundingBasis = {
+      ...deriveAllocationFundingBasis(project, cycleId),
+      monthlyCapMinor: "3000000000",
+    };
+    const proposal = createRewardCycleProposal({
+      projectId: project.id,
+      cycleId,
+      snapshot,
+      fundingBasis,
+      generatedAt: "2026-09-02T00:00:00.000Z",
+      sourceSnapshotSha256: "a".repeat(64),
+    });
+    expect(proposal).toMatchObject({ capMinor: "0", fundingBasis });
+    expect(
+      createProjectView(snapshot, project.id, cycleId, fundingBasis).reward,
+    ).toMatchObject({ capMinor: "3000000000" });
+  });
+
+  it("uses manifest defaults for unlisted cycles and unfamiliar project identities", () => {
+    const { cycleCaps: _history, ...reward } = project.reward;
+    const unknown = {
+      ...project,
+      id: "future-project",
+      reward: { ...reward, monthlyCapMinor: "123000000" },
+    };
+    expect(resolveRewardCapMinor(unknown, "2026-08")).toBe("123000000");
+    expect(
+      deriveAllocationFundingBasis(unknown, "2026-09").monthlyCapMinor,
+    ).toBe("123000000");
+    expect(resolveRewardCapMinor(project, "2026-07")).toBe("5000000000");
+    expect(resolveRewardCapMinor(project, "2026-10")).toBe("5000000000");
+    expect(
+      resolveRewardCapMinor(assertProjectDefinition(delta), "2026-08"),
+    ).toBe("0");
+    expect(() => resolveRewardCapMinor(project, "2026-13")).toThrow();
+  });
+
+  it.each(
+    [
+      [],
+      null,
+      {},
+      [{ cycleId: "2026-8", monthlyCapMinor: "1000000" }],
+      [{ cycleId: "2026-13", monthlyCapMinor: "1000000" }],
+      [{ cycleId: "2026-08", monthlyCapMinor: "01" }],
+      [{ cycleId: "2026-08", monthlyCapMinor: 1000000 }],
+      [{ cycleId: "2026-08", monthlyCapMinor: "-1" }],
+      [{ cycleId: "2026-08", monthlyCapMinor: "1000001" }],
+      [{ cycleId: "2026-08", monthlyCapMinor: "1000000000010000" }],
+      [{ cycleId: "2026-08", monthlyCapMinor: "1000000", extra: true }],
+      [{ cycleId: "2026-08" }],
+      [
+        { cycleId: "2026-08", monthlyCapMinor: "1000000" },
+        { cycleId: "2026-08", monthlyCapMinor: "2000000" },
+      ],
+      [
+        { cycleId: "2026-09", monthlyCapMinor: "1000000" },
+        { cycleId: "2026-08", monthlyCapMinor: "2000000" },
+      ],
+    ].map((cycleCaps) => ({ cycleCaps })),
+  )("rejects malformed or ambiguous cap history %#", ({ cycleCaps }) => {
+    expect(() =>
+      assertProjectDefinition({
+        ...eliza,
+        reward: { ...eliza.reward, cycleCaps },
+      }),
+    ).toThrow();
+  });
+
+  it("rejects cap history on external prizes", () => {
+    expect(() =>
+      assertProjectDefinition({
+        ...delta,
+        reward: { ...delta.reward, cycleCaps: project.reward.cycleCaps },
+      }),
+    ).toThrow();
+  });
+});


### PR DESCRIPTION
Adds optional, strictly validated `reward.cycleCaps` and resolves an exact UTC month consistently in funding bases, active funding-instrument limits, cap simulations, and proposal factories. Frozen funding bases retain their recorded cap; unlisted months retain the manifest default.

This is the schema/history prerequisite for a separate Eliza August $10,000 / September $5,000 policy and app/data PR. The trusted-base checker cannot accept a new manifest field until this support lands. **No actual budget changes:** project manifests and the generated registry are byte-identical to develop; production Eliza remains at its $5,000 default with no cap history. Tests use cloned synthetic histories and test-local project lookup spies.

Validation for `7f8614597aea52bef244d98e035fc69481f41463` (base `f6373451de96ba95d4a9c16d27cf18f41a24d8bc`):

- Lockfile dependencies installed with `bun install --frozen-lockfile`.
- `bun run verify`: PASS (exit 0), using pinned Node 24.15.0 and Bun 1.3.14. Includes 1,022 Vitest tests across 86 files, 129 skill tests with zero failures, registry/funding/cycle/protocol checks, dependency audit, typecheck, formatting, lint, and final build (174 public files). The initial runtime mismatch was resolved by selecting the installed pinned Node; no source changes were needed.
- Current-head and immutable trusted-base project-transition checks passed for all four projects.
- Standard exact-head `bun run test:e2e`: passed, 37 browser checks plus two Pages contracts; three configured duplicate-reflow skips. Covers 1440, 1024, 768, and 320 px viewports, accessibility and reflow, error recovery, public records, and byte-consistent skill/archive endpoints.
- All hosted exact-head checks PASS: [skill/data/build/browser](https://github.com/SlopDotCash/slopdotcash/actions/runs/34498140659/job/102941773403), [project transitions](https://github.com/SlopDotCash/slopdotcash/actions/runs/34498140908/job/102941773391), [funding records](https://github.com/SlopDotCash/slopdotcash/actions/runs/34498140946/job/102941773704), and [unsafe destinations](https://github.com/SlopDotCash/slopdotcash/actions/runs/34498140836/job/102941773305). Production deployment correctly skipped.
- Fresh GitHub snapshot generated 2026-09-10T15:34:32.455Z, bounded and parsed, validated and written with the exported generator atomic writer; data is ignored and not committed.
- Deployment log, immutable production URL, deployed bytes, DNS, TLS, redirects, and production headers: N/A - support-only PR; merge and deployment are reserved for central coordination.

Only the ten named cap-support files are changed. No UI source changes or captured evidence are committed. Do not merge or deploy as part of this prerequisite task.

Local evidence retained outside Git at `/Users/shawwalters/slop-cycle-cap-policy/evidence/`: `verify.log`, `e2e.log`, `trusted-base-transitions.log`, `project-transitions.log`, `source-snapshot.log`, and `artifact-digests.json`. Checkout clean after validation; remote head remains the SHA above. Ready for central merge; prerequisite deployment is intentionally deferred to the following application release.
