### PR TITLE
Pin reviewed payment bootstrap and fix admission run discovery

### DIFF
--- a/protocol/fresh-cycle-payments.md
+++ b/protocol/fresh-cycle-payments.md
@@ -32,11 +32,13 @@ candidate manifest, or environment assertion.
 The loader rejects shallow history, requires continuous two-parent develop merges
 since that checkpoint, and replays every policy/allocation/reservation transition.
 For each merge it also verifies the actual successful `pull_request_target` run
-at the exact first-parent base, the pinned workflow bytes, successful named job,
+with a receipt bound to the exact first-parent base, the pinned workflow bytes, successful named job,
 and a digest-checked workflow receipt binding PR number, base, head, run and attempt.
 A context name and shared Actions app ID alone are insufficient provenance.
-GitHub sometimes reports an empty run `pull_requests` list; the receipt supplies
-that binding. Missing or expired evidence after the latest reviewed checkpoint
+GitHub can report the PR head in run `head_sha` and an empty `pull_requests`
+list. Lookup checks both exact base and head revisions; the digest-checked receipt
+supplies the base/head/PR binding. Unrelated runs on the same base cannot admit a
+merge or hide a later matching receipt. Missing or expired evidence after the latest reviewed checkpoint
 fails release closed. Workflow receipts currently have 90-day retention. The
 checkpoint migration below preserves verified admission through a later revision,
 including nonempty permanent reservations, so earlier receipt expiry does not

--- a/protocol/fresh-cycle-payments.md
+++ b/protocol/fresh-cycle-payments.md
@@ -18,8 +18,14 @@ Ruleset-only protection is not implemented by this bounded verifier.
 Review a complete canonical checkpoint with the workflow installed, an empty
 `funding/payment-reservations.json`, and no fresh-cycle policies. Pin its exact
 commit in `PAYMENT_BOOTSTRAP_CHECKPOINT` in `scripts/payment-admission.ts` through
-review and deploy the updated verifier. The default is deliberately unconfigured;
-no real checkpoint, fee wallet, instrument or project activation is supplied here.
+review and deploy the updated verifier. The selected bootstrap is canonical
+PR #425 merge
+`614d983be2ae703ea4d5b4240191ce84be5d244a`. Its full Git history is retained,
+its reservation ledger and migration descriptor chain are empty, and its four
+projects have no fresh-cycle policies and remain payment-disabled. This source
+pin requires operator review and deployment of the updated verifier; it does not
+configure branch protection, select fee wallets or instruments, or activate
+payments.
 The checkpoint is a reviewed trust root in verifier code, never a CLI argument,
 candidate manifest, or environment assertion.
 
@@ -82,8 +88,9 @@ and verifies all pinned snapshots against complete first-parent history, retaini
 the permanent ledger, then checks live receipts only after the latest checkpoint.
 Migration cannot omit obligations, drop reservations, change principal/fees or
 existing plan bytes, reprice allocations, retire money, or reuse issued vaults.
-The initial empty bootstrap remains the original trust root. No actual bootstrap,
-checkpoint descriptor, snapshot or project activation is supplied in this change.
+The initial empty bootstrap remains the original trust root. The bootstrap pin
+above does not add a migration descriptor or snapshot, and does not activate a
+project.
 
 ## Exact cycle activation and release
 

--- a/scripts/payment-admission.test.ts
+++ b/scripts/payment-admission.test.ts
@@ -1,9 +1,15 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { PAYMENT_RESERVATION_CHECK } from "../src/lib/payment-reservations";
 import {
   assertAdmissionReceipt,
   assertReservationRunProvenance,
   verifyHistoricalPaymentAdmission,
+  verifyReservationAdmissionRuns,
 } from "./payment-admission";
+import * as receipts from "./payment-admission-receipt";
+import * as history from "./payment-reservation-history";
+
+afterEach(() => vi.restoreAllMocks());
 
 const expected = {
   base: "a".repeat(40),
@@ -47,7 +53,9 @@ describe("historical payment admission", () => {
   it.each([
     { path: ".github/workflows/forged.yml" },
     { event: "pull_request" },
-    { head_sha: expected.head },
+    { head_sha: "c".repeat(40) },
+    { run_started_at: "invalid" },
+    { run_started_at: "2026-09-10T09:02:00Z" },
     { conclusion: "failure" },
     { updated_at: "2026-09-10T10:01:00Z" },
     { repository: { full_name: "attacker/fork" } },
@@ -55,5 +63,90 @@ describe("historical payment admission", () => {
     expect(() =>
       assertReservationRunProvenance({ ...run, ...change }, expected),
     ).toThrow(/provenance/);
+  });
+});
+
+describe("canonical admission run discovery", () => {
+  function inventory(mode: "head" | "base", mismatchFirst = false) {
+    const matching = {
+      ...run,
+      id: 7,
+      run_attempt: 1,
+      head_sha: mode === "head" ? expected.head : expected.base,
+    };
+    return vi.spyOn(history, "reservationGithub").mockImplementation((path) => {
+      if (path.includes("/jobs?"))
+        return {
+          total_count: 1,
+          jobs: [
+            {
+              name: PAYMENT_RESERVATION_CHECK,
+              conclusion: "success",
+              completed_at: "2026-09-10T09:01:00Z",
+            },
+          ],
+        };
+      const selected = path.includes(`head_sha=${matching.head_sha}&`);
+      const runs = selected ? [matching] : [];
+      if (mismatchFirst && path.includes(`head_sha=${expected.base}&`))
+        runs.unshift({ ...matching, id: 6, head_sha: expected.base });
+      return { total_count: runs.length, workflow_runs: runs };
+    });
+  }
+  it.each(["head", "base"] as const)(
+    "accepts %s-indexed REST metadata only with an exact receipt",
+    (mode) => {
+      const lookup = inventory(mode);
+      const receipt = vi
+        .spyOn(receipts, "verifyReceipt")
+        .mockImplementation(() => {});
+      expect(() => verifyReservationAdmissionRuns(expected)).not.toThrow();
+      expect(lookup).toHaveBeenCalledWith(
+        expect.stringContaining(`head_sha=${expected.head}&`),
+      );
+      expect(lookup).toHaveBeenCalledWith(
+        expect.stringContaining(`head_sha=${expected.base}&`),
+      );
+      expect(receipt).toHaveBeenCalledWith(7, {
+        base: expected.base,
+        head: expected.head,
+        number: expected.number,
+        runId: 7,
+        attempt: 1,
+      });
+    },
+  );
+  it("continues past an unrelated receipt on the same base", () => {
+    inventory("head", true);
+    const receipt = vi
+      .spyOn(receipts, "verifyReceipt")
+      .mockImplementation((id) => {
+        if (id === 6)
+          throw new TypeError(
+            "Workflow admission receipt differs from exact PR inputs",
+          );
+      });
+    expect(() => verifyReservationAdmissionRuns(expected)).not.toThrow();
+    expect(receipt.mock.calls.map(([id]) => id)).toEqual([6, 7]);
+  });
+  it("rejects successful runs when every receipt is missing or mismatched", () => {
+    inventory("head", true);
+    vi.spyOn(receipts, "verifyReceipt").mockImplementation(() => {
+      throw new Error("unavailable");
+    });
+    expect(() => verifyReservationAdmissionRuns(expected)).toThrow(
+      /No exact successful/,
+    );
+  });
+  it("rejects an incomplete run inventory even when it contains a successful run", () => {
+    vi.spyOn(history, "reservationGithub").mockReturnValue({
+      total_count: 101,
+      workflow_runs: [run],
+    });
+    const receipt = vi.spyOn(receipts, "verifyReceipt");
+    expect(() => verifyReservationAdmissionRuns(expected)).toThrow(
+      /Incomplete/,
+    );
+    expect(receipt).not.toHaveBeenCalled();
   });
 });

--- a/scripts/payment-admission.test.ts
+++ b/scripts/payment-admission.test.ts
@@ -24,7 +24,7 @@ const run = {
 describe("historical payment admission", () => {
   it("requires an explicitly reviewed bootstrap, not current protection alone", async () => {
     await expect(
-      verifyHistoricalPaymentAdmission("/unused", "a".repeat(40)),
+      verifyHistoricalPaymentAdmission("/unused", "a".repeat(40), null),
     ).rejects.toThrow(/bootstrap/);
   });
   it("accepts the exact base workflow with a separately bound receipt", () => {

--- a/scripts/payment-admission.ts
+++ b/scripts/payment-admission.ts
@@ -62,13 +62,16 @@ export function assertReservationRunProvenance(
   if (
     r.path !== WORKFLOW ||
     r.event !== "pull_request_target" ||
-    r.head_sha !== expected.base ||
+    ![expected.base, expected.head].includes(r.head_sha ?? "") ||
     r.status !== "completed" ||
     r.conclusion !== "success" ||
     r.repository?.full_name !== PAYMENT_REPOSITORY ||
     !r.run_started_at ||
     !r.updated_at ||
+    !Number.isFinite(Date.parse(r.run_started_at)) ||
     !Number.isFinite(Date.parse(r.updated_at)) ||
+    !Number.isFinite(Date.parse(expected.mergedAt)) ||
+    Date.parse(r.run_started_at) > Date.parse(r.updated_at) ||
     Date.parse(r.updated_at) > Date.parse(expected.mergedAt)
   )
     throw new TypeError(
@@ -206,55 +209,12 @@ export async function verifyHistoricalPaymentAdmission(
     if (matches.length !== 1)
       throw new TypeError("Cannot prove exact merged admission PR");
     const pr = matches[0];
-    const runs = reservationGithub(
-      `repos/${PAYMENT_REPOSITORY}/actions/workflows/payment-reservations.yml/runs?event=pull_request_target&head_sha=${base}&per_page=100`,
-    ) as {
-      total_count?: number;
-      workflow_runs?: ({ id: number } & Record<string, unknown>)[];
-    };
-    if (!Array.isArray(runs.workflow_runs) || (runs.total_count ?? 101) > 100)
-      throw new TypeError("Incomplete trusted workflow run inventory");
-    let proven = false;
-    for (const run of runs.workflow_runs) {
-      try {
-        assertReservationRunProvenance(run, {
-          base,
-          head: parents[1],
-          number: pr.number,
-          mergedAt: pr.merged_at,
-        });
-      } catch {
-        continue;
-      }
-      const jobs = reservationGithub(
-        `repos/${PAYMENT_REPOSITORY}/actions/runs/${run.id}/jobs?per_page=100`,
-      ) as {
-        total_count?: number;
-        jobs?: { name: string; conclusion: string; completed_at: string }[];
-      };
-      if (
-        (jobs.total_count ?? 101) <= 100 &&
-        jobs.jobs?.some(
-          (j) =>
-            j.name === PAYMENT_RESERVATION_CHECK &&
-            j.conclusion === "success" &&
-            Date.parse(j.completed_at) <= Date.parse(pr.merged_at),
-        )
-      ) {
-        verifyReceipt(run.id, {
-          base,
-          head: parents[1],
-          number: pr.number,
-          runId: run.id,
-          attempt: Number(run.run_attempt),
-        });
-        proven = true;
-      }
-    }
-    if (!proven)
-      throw new TypeError(
-        "No exact successful trusted reservation gate before merge",
-      );
+    verifyReservationAdmissionRuns({
+      base,
+      head: parents[1],
+      number: pr.number,
+      mergedAt: pr.merged_at,
+    });
     // Re-evaluate each historical admission using exact immutable inputs. Current
     // protection cannot bless a rewritten prefix or previously invalid policy.
     await checkPaymentReservationRecords(
@@ -267,4 +227,76 @@ export async function verifyHistoricalPaymentAdmission(
   }
   if (base !== revision)
     throw new TypeError("Bootstrap is not on canonical first-parent history");
+}
+
+/** REST run head_sha may identify the PR head instead of the trusted checkout.
+ * The immutable workflow and its digest-checked receipt bind the executed base.
+ * Search both exact revisions; never rely on a display status or PR list alone. */
+export function verifyReservationAdmissionRuns(expected: {
+  base: string;
+  head: string;
+  number: number;
+  mergedAt: string;
+}) {
+  const candidates = new Map<
+    number,
+    { id: number } & Record<string, unknown>
+  >();
+  for (const revision of new Set([expected.base, expected.head])) {
+    const runs = reservationGithub(
+      `repos/${PAYMENT_REPOSITORY}/actions/workflows/payment-reservations.yml/runs?event=pull_request_target&head_sha=${revision}&per_page=100`,
+    ) as {
+      total_count?: number;
+      workflow_runs?: ({ id: number } & Record<string, unknown>)[];
+    };
+    if (!Array.isArray(runs.workflow_runs) || (runs.total_count ?? 101) > 100)
+      throw new TypeError("Incomplete trusted workflow run inventory");
+    for (const run of runs.workflow_runs) {
+      if (!Number.isSafeInteger(run.id) || run.id < 1)
+        throw new TypeError("Invalid trusted workflow run identity");
+      candidates.set(run.id, run);
+    }
+  }
+  for (const run of candidates.values()) {
+    try {
+      assertReservationRunProvenance(run, expected);
+    } catch {
+      continue;
+    }
+    if (!Number.isSafeInteger(run.run_attempt) || Number(run.run_attempt) < 1)
+      continue;
+    const jobs = reservationGithub(
+      `repos/${PAYMENT_REPOSITORY}/actions/runs/${run.id}/jobs?per_page=100`,
+    ) as {
+      total_count?: number;
+      jobs?: { name: string; conclusion: string; completed_at: string }[];
+    };
+    if (
+      (jobs.total_count ?? 101) > 100 ||
+      !jobs.jobs?.some(
+        (job) =>
+          job.name === PAYMENT_RESERVATION_CHECK &&
+          job.conclusion === "success" &&
+          Date.parse(job.completed_at) <= Date.parse(expected.mergedAt),
+      )
+    )
+      continue;
+    try {
+      verifyReceipt(run.id, {
+        base: expected.base,
+        head: expected.head,
+        number: expected.number,
+        runId: run.id,
+        attempt: Number(run.run_attempt),
+      });
+    } catch {
+      // Another PR can have a successful run on the same base. Only an exact
+      // authenticated receipt admits this merge; unavailable evidence never does.
+      continue;
+    }
+    return;
+  }
+  throw new TypeError(
+    "No exact successful trusted reservation gate before merge",
+  );
 }

--- a/scripts/payment-admission.ts
+++ b/scripts/payment-admission.ts
@@ -7,7 +7,8 @@ export { assertAdmissionReceipt } from "./payment-admission-receipt";
  * after reviewing a complete canonical checkpoint with an empty reservation
  * ledger, no activation policies, and this exact trusted workflow installed.
  * A value read from a candidate branch, environment or CLI is not a trust root. */
-export const PAYMENT_BOOTSTRAP_CHECKPOINT: string | null = null;
+export const PAYMENT_BOOTSTRAP_CHECKPOINT: string | null =
+  "614d983be2ae703ea4d5b4240191ce84be5d244a";
 export function requirePaymentBootstrapCheckpoint(): string {
   if (!PAYMENT_BOOTSTRAP_CHECKPOINT)
     throw new TypeError(

--- a/scripts/payment-checkpoints.test.ts
+++ b/scripts/payment-checkpoints.test.ts
@@ -230,6 +230,11 @@ function liveEvidence(f: ReturnType<typeof fixture>, expired = false) {
           },
         ],
       };
+    if (
+      path.includes("/actions/workflows/") &&
+      path.includes(`head_sha=${f.head}`)
+    )
+      return { total_count: 0, workflow_runs: [] };
     if (path.includes("/actions/runs/7/jobs"))
       return {
         total_count: 1,

--- a/scripts/payment-checkpoints.test.ts
+++ b/scripts/payment-checkpoints.test.ts
@@ -444,7 +444,14 @@ describe("reviewed payment checkpoint migration", () => {
       /already exists/,
     );
   });
-  it("CLI requires a new artifact directory and does not configure a real pin", async () => {
+  it("CLI rejects invalid arguments and an unconfigured bootstrap", async () => {
+    vi.spyOn(admission, "requirePaymentBootstrapCheckpoint").mockImplementation(
+      () => {
+        throw new TypeError(
+          "Configure reviewed bootstrap before checkpoint migration",
+        );
+      },
+    );
     expect(() =>
       parsePaymentCheckpointArguments(["--revision", "a".repeat(40)]),
     ).toThrow(/Usage/);

--- a/scripts/payment-checkpoints.test.ts
+++ b/scripts/payment-checkpoints.test.ts
@@ -326,7 +326,7 @@ describe("reviewed payment checkpoint migration", () => {
       verifyHistoricalPaymentAdmission(f.root, f.accepted, f.bootstrap, [
         f.pin,
       ]),
-    ).rejects.toThrow(/expired/);
+    ).rejects.toThrow(/No exact successful trusted reservation gate/);
   });
   it.each(["drop", "reprice", "omit-history"])(
     "rejects %s in a checkpoint snapshot even with a recomputed snapshot hash",


### PR DESCRIPTION
Pins the payment admission bootstrap to canonical PR #425 merge `614d983be2ae703ea4d5b4240191ce84be5d244a` and repairs historical workflow discovery. The previous verifier searched only base-indexed runs and rejected the repository's genuine successful runs, whose REST `head_sha` identifies the PR head. It now searches both exact revisions while still requiring the trusted event, pinned workflow, successful pre-merge job, and digest-checked receipt binding base, head, PR number, run and attempt. An unrelated receipt on the same base cannot hide a later matching receipt; missing or mismatched evidence still fails closed.

The original root, empty reservation ledger, complete obligation history and disabled project policies are preserved. No financial activation, amount, fee recipient, reservation, signing or payment changes.

Validation at final rebased head `b05135e32a1f93b3f4cd9c0653f98f5396379221`: 15 admission regression tests and typecheck pass. The repaired production verifier authenticated real canonical history from the proposed bootstrap through PR #431 merge `5710ee3793553092398ff8e8f39224674abe9ff4`; the original implementation failed that same live check. Full final-head local verification passed: 1,397 unit tests, 129 skill tests, typecheck, lint, formatting and production build. All 81 local browser tests and three Pages contracts passed on the final head. Desktop/mobile captures confirmed 52 missing wallets with no application errors or failed first-party requests after loading completed. All final hosted checks passed, including 81 browser tests and three Pages contracts in run 34554118538. Prior-head checks are not evidence for this head.

Payment activation remains separate from this source merge. The release verifier still requires enforced classic branch protection, independent approving review under those settings, reviewed financial inputs and the full cycle review. Live protection is currently absent; this PR does not configure it, enable payments or waive the 14-day review. Related to #406.

Checkpoint migration fixtures now model both exact lookup revisions and assert that expired required receipts still fail closed. The final head includes the merged wallet refresh from #431, including its corrected 52-missing-wallet browser census. [Final hosted run](https://github.com/SlopDotCash/slopdotcash/actions/runs/34554118538).
