### PR TITLE
Fix production API authority in browser verification

### DIFF
--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -767,13 +767,19 @@ test("serves byte-consistent install and read-only artifacts for every project",
     "https://identity.slop.cash",
   ]);
 
-  const privateApiResponse = await request.post("/api/v1/runs", {
-    data: {},
-  });
-  const originProtocol = new URL(baseURL ?? "http://127.0.0.1:4466").protocol;
+  const siteOrigin = baseURL ?? "http://127.0.0.1:4466";
+  const originProtocol = new URL(siteOrigin).protocol;
   if (originProtocol !== "http:" && originProtocol !== "https:") {
     throw new Error(`unsupported test origin protocol: ${originProtocol}`);
   }
+  // Production clients use the API authority, not a website-host alias.
+  // Local Pages checks still exercise the local function's HTTPS rejection.
+  const privateApiOrigin =
+    originProtocol === "https:" ? "https://api.slop.cash" : siteOrigin;
+  const privateApiResponse = await request.post(
+    new URL("/api/v1/runs", privateApiOrigin).href,
+    { data: {} },
+  );
   const privateApiExpectation =
     originProtocol === "https:"
       ? { status: 401, error: "unauthorized" }


### PR DESCRIPTION
The production artifact browser check posts its unauthenticated probe to the website host, which returns 404. Production clients and the release workflow use `https://api.slop.cash`, where the probe correctly returns 401. This made a healthy deployed API fail the browser contract check.

Use the canonical API authority for HTTPS production checks and retain the local Pages function for HTTP checks, including its required `https_required` rejection. Unsupported protocols still fail. No application, payment, policy or deployment behavior changes.

Validation on head `6930ffc4a0d9ce0e37cf457e003377b844a44872`:

- Frozen-lockfile install and `bun run verify` passed: 1,397 unit tests, 129 skill tests, dependency audit, typecheck, formatting, lint, all registry/lifecycle validators, and build.
- Corrected production browser suite passed 20 checks across four viewports: routes, wallet pages, funding flow, accessibility, 200% text, and artifact/download contracts.
- Local Cloudflare Pages artifact contract passed, exercising the HTTP `https_required` rejection.
- Pre-payment safety regression suite passed 105 cases on canonical application code.
- The original production failure was reproduced: website authority returned 404; canonical API authority returned the required 401. The correction changes the test target only.

All five required hosted checks passed, including 84 browser checks: [exact-head run](https://github.com/SlopDotCash/slopdotcash/actions/runs/34564306177). The deployment job is intentionally skipped for PRs. Independent approval is required under the protected branch policy; this PR does not bypass it. No payments or real wallet registrations are performed by these probes.
