### PR TITLE
Keep payout steps and navigation readable at enlarged text sizes

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -72,12 +72,16 @@ textarea:focus-visible {
 
 .header-inner {
   display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
   min-height: 64px;
   align-items: center;
   justify-content: space-between;
 }
 
 .wordmark {
+  flex-shrink: 0;
+  white-space: nowrap;
   font-size: 16px;
   font-weight: 800;
   letter-spacing: -0.04em;
@@ -85,11 +89,16 @@ textarea:focus-visible {
 
 .nav-links {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 22px;
   color: #4f4a41;
   font-size: 13px;
   font-weight: 600;
+}
+
+.nav-links a {
+  overflow-wrap: normal;
 }
 
 .funding-kind,
@@ -1308,6 +1317,7 @@ small {
 
 .footer-brand-row {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
   gap: 20px;
@@ -3192,6 +3202,7 @@ small {
 }
 .payout-steps button {
   display: flex;
+  overflow-wrap: normal;
   align-items: center;
   gap: 0.5rem;
   padding: 0.8rem;
@@ -3298,7 +3309,7 @@ small {
   }
   .payout-steps {
     display: grid;
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 12em), 1fr));
   }
   .review-cycle-selector select {
     width: 100%;

--- a/tests/e2e/funding-wallet-qa.spec.ts
+++ b/tests/e2e/funding-wallet-qa.spec.ts
@@ -67,6 +67,28 @@ async function audit(page: Page, info: TestInfo, label: string) {
     contentType: "image/png",
   });
   expect(result.violations, label).toEqual([]);
+  const splitWords = await page.evaluate(() => {
+    const failures: string[] = [];
+    for (const element of document.querySelectorAll(
+      ".site-header a, .wordmark, .payout-steps button",
+    )) {
+      if (!(element as HTMLElement).offsetWidth) continue;
+      const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT);
+      for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+        for (const match of (node.textContent ?? "").matchAll(/\S+/g)) {
+          const range = document.createRange();
+          range.setStart(node, match.index);
+          range.setEnd(node, match.index + match[0].length);
+          const lines = new Set(
+            [...range.getClientRects()].map((rect) => Math.round(rect.top)),
+          );
+          if (lines.size > 1) failures.push(match[0]);
+        }
+      }
+    }
+    return failures;
+  });
+  expect(splitWords, `${label} keeps navigation words intact`).toEqual([]);
   expect(
     await page.evaluate(
       () => document.documentElement.scrollWidth - innerWidth,


### PR DESCRIPTION
At 200% text size, the header squeezed navigation words into individual-letter lines and the mobile payout flow forced enlarged labels into two narrow columns. Keep brand words intact, let header/footer rows wrap, and size payout-step columns from available space and font size.

Extend the existing browser accessibility audit to detect words split across lines using text ranges. The regression fails on deployed `81ca923` and passes with this change across all four viewports. Keyboard navigation, WCAG AA checks, console/network assertions and the disabled-payment boundary also pass. Desktop and mobile screenshots were visually reviewed.

Validation: frozen-lockfile install, build, typecheck and targeted four-viewport browser checks passed. Full `bun run verify` passed on head `94701cf0b8c48682dd31c0a6312a23b5b1673af5`: 1,397 unit tests, 129 skill tests, dependency audit, validators, typecheck, formatting, lint and build. All five required hosted checks passed, including 84 browser checks: [exact-head run](https://github.com/SlopDotCash/slopdotcash/actions/runs/34565550441). The deployment job is intentionally skipped for PRs. No scoring, payment policy, funding or settlement behavior changes. Deployment evidence is not yet applicable: this PR awaits independent review and protected merge.
