### PR TITLE
Unify contributor rankings and de-emphasize community projects

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -77,7 +77,11 @@ import {
   PROJECTS,
   type ProjectDefinition,
 } from "./lib/projects.mjs";
-import { formatThirds, selectReviewerLeaders } from "./lib/reviewer-leaders";
+import {
+  formatThirds,
+  selectReviewerLeaders,
+  type ReviewerLeader,
+} from "./lib/reviewer-leaders";
 import { feeForPrincipal, PLATFORM_FEE_BASIS_POINTS } from "./lib/rewards";
 import {
   type PublicSignerReport,
@@ -777,76 +781,14 @@ function Avatar({
   );
 }
 
-function ReviewerLeaderboard({
-  caption,
-  cycleMonth,
-  ledger,
-  reviewBudget,
-}: {
-  caption: string;
-  cycleMonth: string;
-  ledger: readonly ScoreEvent[];
-  reviewBudget?: ProjectDefinition["reward"]["reviewBudget"];
-}) {
-  const reviewers = selectReviewerLeaders(ledger);
+function ReviewContribution({ reviewer }: { reviewer?: ReviewerLeader }) {
+  if (!reviewer) return null;
   return (
-    <div className="reviewer-leaderboard">
-      <div className="leaderboard-cycle-summary">
-        <div>
-          <strong>{cycleMonth} · Reviewers</strong>
-          <span>
-            Scored reviews keep their shared-pool treatment.{" "}
-            {reviewBudget
-              ? `${reviewBudgetLabel(reviewBudget)}.`
-              : "No additive review line is declared."}
-          </span>
-        </div>
-      </div>
-      {reviewers.length === 0 ? (
-        <EmptyState text="No scored reviews in this project cycle yet." />
-      ) : (
-        <div className="leader-table global-leader-table">
-          <table className="leader-grid global-leader-grid">
-            <caption className="visually-hidden">{caption}</caption>
-            <thead>
-              <tr className="leader-row leader-head global-leader-head reviewer-leader-row">
-                <th scope="col">Rank</th>
-                <th scope="col">Reviewer</th>
-                <th scope="col">Review score</th>
-              </tr>
-            </thead>
-            <tbody>
-              {reviewers.map((reviewer) => (
-                <tr
-                  className="leader-row global-leader-row reviewer-leader-row"
-                  key={reviewer.actor.id}
-                >
-                  <td className="rank-cell">#{reviewer.rank}</td>
-                  <td className="person-cell">
-                    <Link
-                      className="person-link"
-                      href={`/contributors/${encodeURIComponent(reviewer.actor.login)}`}
-                    >
-                      <Avatar actor={reviewer.actor} />
-                      <span>
-                        <strong>{reviewer.actor.login}</strong>
-                        <small>
-                          {reviewer.reviewEventCount} scored review
-                          {reviewer.reviewEventCount === 1 ? "" : "s"}
-                        </small>
-                      </span>
-                    </Link>
-                  </td>
-                  <td data-label="Review score">
-                    <strong>{formatThirds(reviewer.reviewThirds)}</strong>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
-    </div>
+    <small>
+      Includes {formatThirds(reviewer.reviewThirds)} review points ·{" "}
+      {reviewer.reviewEventCount} scored review
+      {reviewer.reviewEventCount === 1 ? "" : "s"}
+    </small>
   );
 }
 
@@ -866,6 +808,12 @@ function GlobalLeaderboard({
   );
   const selectedView =
     views.find((view) => view.project.id === selectedProjectId) ?? views[0];
+  const reviewers = new Map(
+    selectReviewerLeaders(selectedView?.ledger ?? []).map((reviewer) => [
+      reviewer.actor.id,
+      reviewer,
+    ]),
+  );
   const cycleMonth = selectedView
     ? formatCycleMonth(selectedView.cycle.id)
     : "Current month";
@@ -961,6 +909,13 @@ function GlobalLeaderboard({
                     {cycleMonth} · {selectedView.project.name}
                   </strong>
                   <span>{selectedRewardLabel}</span>
+                  {selectedView.project.reward.reviewBudget ? (
+                    <span>
+                      {reviewBudgetLabel(
+                        selectedView.project.reward.reviewBudget,
+                      )}
+                    </span>
+                  ) : null}
                 </div>
                 {selectedView.reward.kind === "monthly-pool" ? (
                   <p>
@@ -1019,6 +974,9 @@ function GlobalLeaderboard({
                               >
                                 {formatThirds(leader.scoreThirds)}
                               </strong>
+                              <ReviewContribution
+                                reviewer={reviewers.get(leader.actor.id)}
+                              />
                             </td>
                             <td data-label="Simulated share">
                               <strong>
@@ -1030,12 +988,6 @@ function GlobalLeaderboard({
                       </tbody>
                     </table>
                   </div>
-                  <ReviewerLeaderboard
-                    caption={`${selectedView.project.name} ${cycleMonth} reviewer leaderboard`}
-                    cycleMonth={cycleMonth}
-                    ledger={selectedView.ledger}
-                    reviewBudget={selectedView.project.reward.reviewBudget}
-                  />
                   <Link
                     className="leaderboard-project-link"
                     href={`/projects/${selectedView.project.slug}`}
@@ -1174,14 +1126,16 @@ function HomePage({ state, retry }: { state: DataState; retry: () => void }) {
             ))}
           </div>
         </section>
-        <section className="project-tier" aria-labelledby="community-projects">
-          <h3 id="community-projects">Community</h3>
-          <div className="project-grid">
-            {communityProjects.map((project) => (
-              <ProjectCard key={project.id} project={project} />
-            ))}
-          </div>
-        </section>
+        {communityProjects.length > 0 ? (
+          <details className="project-tier community-projects">
+            <summary>Community projects</summary>
+            <div className="project-grid">
+              {communityProjects.map((project) => (
+                <ProjectCard key={project.id} project={project} />
+              ))}
+            </div>
+          </details>
+        ) : null}
       </section>
       <section className="section shell audience-section">
         <div className="audience-grid">
@@ -1466,11 +1420,20 @@ function ProjectLeaderboard({
   updatedAt: string;
   view: ProjectView;
 }) {
+  const reviewers = new Map(
+    selectReviewerLeaders(view.ledger).map((reviewer) => [
+      reviewer.actor.id,
+      reviewer,
+    ]),
+  );
   return (
     <section className="section project-leader-section">
       <div className="section-heading">
         <h2>{formatCycleMonth(view.cycle.id)} leaderboard.</h2>
         <p className="data-freshness">Updated {formatDate(updatedAt)}</p>
+        {view.project.reward.reviewBudget ? (
+          <p>{reviewBudgetLabel(view.project.reward.reviewBudget)}</p>
+        ) : null}
         {view.reward.kind === "monthly-pool" ? (
           <p>
             Shares simulate the {monthlyPoolLabel(view.project.reward)} cap. Not
@@ -1519,6 +1482,9 @@ function ProjectLeaderboard({
                     <strong title={`Exact score ${leader.scoreThirds}/3`}>
                       {formatThirds(leader.scoreThirds)}
                     </strong>
+                    <ReviewContribution
+                      reviewer={reviewers.get(leader.actor.id)}
+                    />
                     {leader.computeBonusBasisPoints > 0 ? (
                       <small>
                         +{leader.computeBonusBasisPoints / 100}% receipt
@@ -1537,12 +1503,6 @@ function ProjectLeaderboard({
           </table>
         </div>
       )}
-      <ReviewerLeaderboard
-        caption={`${view.project.name} ${formatCycleMonth(view.cycle.id)} reviewer leaderboard`}
-        cycleMonth={formatCycleMonth(view.cycle.id)}
-        ledger={view.ledger}
-        reviewBudget={view.project.reward.reviewBudget}
-      />
     </section>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -79,8 +79,8 @@ import {
 } from "./lib/projects.mjs";
 import {
   formatThirds,
-  selectReviewerLeaders,
   type ReviewerLeader,
+  selectReviewerLeaders,
 } from "./lib/reviewer-leaders";
 import { feeForPrincipal, PLATFORM_FEE_BASIS_POINTS } from "./lib/rewards";
 import {
@@ -784,9 +784,10 @@ function Avatar({
 function ReviewContribution({ reviewer }: { reviewer?: ReviewerLeader }) {
   if (!reviewer) return null;
   return (
-    <small>
-      Includes {formatThirds(reviewer.reviewThirds)} review points ·{" "}
-      {reviewer.reviewEventCount} scored review
+    <small className="review-score-detail">
+      Includes {formatThirds(reviewer.reviewThirds)} review point
+      {reviewer.reviewThirds === 3 ? "" : "s"} · {reviewer.reviewEventCount}{" "}
+      scored review
       {reviewer.reviewEventCount === 1 ? "" : "s"}
     </small>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -969,7 +969,10 @@ function GlobalLeaderboard({
                                 </span>
                               </Link>
                             </td>
-                            <td data-label="Accepted score">
+                            <td
+                              className="combined-score"
+                              data-label="Accepted score"
+                            >
                               <strong
                                 title={`Exact score ${leader.scoreThirds}/3`}
                               >
@@ -1056,7 +1059,10 @@ function GlobalLeaderboard({
                           </span>
                         </Link>
                       </td>
-                      <td data-label="Accepted score">
+                      <td
+                        className="combined-score"
+                        data-label="Accepted score"
+                      >
                         <strong title={`Exact score ${leader.score}`}>
                           {formatScore(leader.score)}
                         </strong>

--- a/src/styles.css
+++ b/src/styles.css
@@ -3407,3 +3407,8 @@ small {
   font-weight: 600;
   padding: 12px 0;
 }
+
+.review-score-detail {
+  display: block;
+  margin-top: 4px;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -881,10 +881,6 @@ p {
   font-weight: 700;
 }
 
-.reviewer-leaderboard {
-  margin-top: 22px;
-}
-
 .leaderboard-cycle-summary,
 .leaderboard-record-summary {
   display: flex;
@@ -1658,10 +1654,6 @@ small {
 .global-leader-head,
 .global-leader-row {
   grid-template-columns: 72px minmax(220px, 1.5fr) 0.6fr 0.8fr;
-}
-
-.reviewer-leader-row {
-  grid-template-columns: 72px minmax(220px, 1.5fr) 0.8fr;
 }
 
 .event-list,
@@ -3408,4 +3400,10 @@ small {
 .funding-quality-review th {
   padding: 0.4rem;
   text-align: left;
+}
+
+.community-projects > summary {
+  cursor: pointer;
+  font-weight: 600;
+  padding: 12px 0;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -2953,6 +2953,15 @@ small {
     gap: 16px;
   }
 
+  .global-leader-row > td.combined-score {
+    display: block;
+  }
+
+  .global-leader-row > td.combined-score::before {
+    display: block;
+    margin-bottom: 4px;
+  }
+
   .global-leader-row > td:nth-child(n + 3)::before {
     content: attr(data-label);
     color: var(--muted);

--- a/tests/app.test.tsx
+++ b/tests/app.test.tsx
@@ -597,9 +597,7 @@ describe("discovery", () => {
     expect(
       screen.getByRole("heading", { name: "Featured" }),
     ).toBeInTheDocument();
-    expect(
-      screen.getByRole("heading", { name: "Community" }),
-    ).toBeInTheDocument();
+    expect(screen.queryByText("Community projects")).not.toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Eliza" })).toBeInTheDocument();
     expect(
       screen.getByRole("heading", { name: "Delta Star" }),
@@ -643,16 +641,14 @@ describe("discovery", () => {
     ).not.toBeInTheDocument();
     expect(screen.queryByText("THE GITARMY NETWORK")).not.toBeInTheDocument();
     expect(screen.queryByText("Work in. Money out.")).not.toBeInTheDocument();
-    expect(screen.getAllByText("finish-line")).toHaveLength(2);
-    const reviewerTable = screen.getByRole("table", {
-      name: /reviewer leaderboard/u,
-    });
-    const reviewerRow = within(reviewerTable)
-      .getByText("finish-line")
-      .closest("tr");
-    expect(reviewerRow).not.toBeNull();
-    expect(reviewerRow).toHaveTextContent("1 scored review");
-    expect(reviewerRow).toHaveTextContent("3");
+    expect(screen.getAllByText("finish-line")).toHaveLength(1);
+    expect(
+      screen.queryByRole("table", { name: /reviewer leaderboard/u }),
+    ).not.toBeInTheDocument();
+    const contributorRow = screen.getByText("finish-line").closest("tr");
+    expect(contributorRow).toHaveTextContent(
+      "Includes 3 review points · 1 scored review",
+    );
 
     fireEvent.click(screen.getByRole("tab", { name: "All-time record" }));
     const record = screen.getByRole("table", {

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -222,12 +222,14 @@ test("discovers both reward models and a score-ranked global ledger", async ({
   await expect(
     page.getByRole("heading", { exact: true, name: "Featured" }),
   ).toBeVisible();
-  await expect(
-    page.getByRole("heading", { exact: true, name: "Community" }),
-  ).toBeVisible();
+  const community = page.locator("details.community-projects");
+  await expect(community).not.toHaveAttribute("open", "");
+  await expect(community.locator("a.project-card")).toBeHidden();
+  await community.locator("summary").focus();
+  await page.keyboard.press("Enter");
   await expect(
     page.locator(
-      '.project-tier[aria-labelledby="community-projects"] a.project-card[href="/projects/heir-elements-sdk"]',
+      'details.community-projects a.project-card[href="/projects/heir-elements-sdk"]',
     ),
   ).toBeVisible();
   await expect(

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -235,6 +235,19 @@ test("discovers both reward models and a score-ranked global ledger", async ({
   await expect(
     page.getByRole("heading", { exact: true, name: "Delta Star" }),
   ).toBeVisible();
+  const scoreLineCounts = await page
+    .locator(".combined-score > strong")
+    .evaluateAll((scores) =>
+      scores.map((score) => {
+        const range = document.createRange();
+        range.selectNodeContents(score);
+        return new Set(
+          [...range.getClientRects()].map((rect) => Math.round(rect.top)),
+        ).size;
+      }),
+    );
+  expect(scoreLineCounts.length).toBeGreaterThan(0);
+  expect(scoreLineCounts.every((count) => count === 1)).toBe(true);
   const elizaCard = page.locator('a.project-card[href="/projects/eliza"]');
   await expect(elizaCard.getByText("Unfunded", { exact: true })).toHaveCount(0);
   await expect(elizaCard.getByText("$5k", { exact: true })).toBeVisible();

--- a/tests/squads-tracking.test.tsx
+++ b/tests/squads-tracking.test.tsx
@@ -1,4 +1,4 @@
-import { act, cleanup, render, screen } from "@testing-library/react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { CycleIndexEntry } from "../src/lib/cycle-index";
 import {
@@ -110,15 +110,21 @@ describe("Squads tracker public contract", () => {
       );
     });
     vi.stubGlobal("fetch", fetcher);
+    const listeners = vi.spyOn(window, "addEventListener");
     render(<SquadsTracking cycle={cycle} />);
     expect(
       await screen.findByText("Proposal executed · settlement unverified"),
     ).toBeVisible();
+    await waitFor(() =>
+      expect(listeners).toHaveBeenCalledWith("focus", expect.any(Function)),
+    );
     expect(fetcher.mock.calls[1][0]).toBe(published.observationUrl);
     vi.spyOn(Date, "now").mockReturnValue(
       Date.parse(observation.observedAt) + 300000,
     );
-    act(() => window.dispatchEvent(new Event("focus")));
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+    });
     expect(
       screen.getByText("Execution observation stale · refresh required"),
     ).toBeVisible();


### PR DESCRIPTION
The monthly homepage and project pages showed separate contributor and reviewer rankings, repeating people whose review credit was already included in the main score. Show one ranked row per contributor and include their review points and review count beneath the combined score. Keep additive review-budget disclosures, score calculations, ranking and shares unchanged. Addresses #409.

Put community projects in a keyboard-operable disclosure below featured projects, collapsed initially. Omit the disclosure when there are no eligible community projects. Project inventory and listing tiers still come from the manifests. Addresses #410.

Validation on exact head `e8f9170bb265d008aa2f4225885c5c642f806f84`: `bun run verify` passed, including 1,400 unit tests and 129 skill tests. Full browser matrix passed 81 cases with 3 intentional viewport-specific skips, followed by all 3 Pages contracts. Checks cover desktop, tablet and 320px mobile, WCAG AA, 200% text, keyboard operation, console/network failures and published artifact bytes. Deployment evidence is pending the protected release.

Visual review caught and repaired score-number wrapping on mobile. The browser regression now checks that combined score numbers stay on one line. Desktop and 320px mobile were visually reviewed after the repair.

Also stabilize the Squads tracker expiry test that failed production run 34567319005: wait for the focus listener to be installed before dispatching focus, and flush the resulting React update. The test continues to assert expiry at five minutes and never claims settlement. Its four focused cases pass.

The tested head contains merged #434. Hosted checks must complete before merge; previous intermediate heads are superseded.
