### PR TITLE
Verify payout observation expiry at the boundary and without focus

### DIFF
--- a/tests/squads-tracking.test.tsx
+++ b/tests/squads-tracking.test.tsx
@@ -13,7 +13,6 @@ import {
 
 afterEach(() => {
   cleanup();
-  vi.useRealTimers();
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
@@ -138,8 +137,6 @@ describe("Squads tracker public contract", () => {
   });
   it("expires observations on the interval without a focus event or new fetch", async () => {
     const { published, observation, cycle } = await fixture();
-    vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
-    const intervals = vi.spyOn(window, "setInterval");
     const fetcher = vi.fn(
       async (url: string) =>
         new Response(
@@ -153,15 +150,15 @@ describe("Squads tracker public contract", () => {
     vi.stubGlobal("fetch", fetcher);
     render(<SquadsTracking cycle={cycle} />);
     await screen.findByText("Proposal executed · settlement unverified");
-    await waitFor(() =>
-      expect(intervals).toHaveBeenCalledWith(expect.any(Function), 1000),
-    );
     vi.spyOn(Date, "now").mockReturnValue(
       Date.parse(observation.observedAt) + 300000,
     );
-    act(() => vi.advanceTimersByTime(1000));
     expect(
-      screen.getByText("Execution observation stale · refresh required"),
+      await screen.findByText(
+        "Execution observation stale · refresh required",
+        {},
+        { timeout: 5000 },
+      ),
     ).toBeVisible();
     expect(fetcher).toHaveBeenCalledTimes(2);
   });

--- a/tests/squads-tracking.test.tsx
+++ b/tests/squads-tracking.test.tsx
@@ -13,6 +13,7 @@ import {
 
 afterEach(() => {
   cleanup();
+  vi.useRealTimers();
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
@@ -119,15 +120,50 @@ describe("Squads tracker public contract", () => {
       expect(listeners).toHaveBeenCalledWith("focus", expect.any(Function)),
     );
     expect(fetcher.mock.calls[1][0]).toBe(published.observationUrl);
-    vi.spyOn(Date, "now").mockReturnValue(
-      Date.parse(observation.observedAt) + 300000,
-    );
+    const clock = vi.spyOn(Date, "now");
+    clock.mockReturnValue(Date.parse(observation.observedAt) + 299999);
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+    });
+    expect(
+      screen.getByText("Proposal executed · settlement unverified"),
+    ).toBeVisible();
+    clock.mockReturnValue(Date.parse(observation.observedAt) + 300000);
     await act(async () => {
       window.dispatchEvent(new Event("focus"));
     });
     expect(
       screen.getByText("Execution observation stale · refresh required"),
     ).toBeVisible();
+  });
+  it("expires observations on the interval without a focus event or new fetch", async () => {
+    const { published, observation, cycle } = await fixture();
+    vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+    const intervals = vi.spyOn(window, "setInterval");
+    const fetcher = vi.fn(
+      async (url: string) =>
+        new Response(
+          JSON.stringify(
+            url.startsWith("/data/")
+              ? { schemaVersion: 1, executions: [published] }
+              : observation,
+          ),
+        ),
+    );
+    vi.stubGlobal("fetch", fetcher);
+    render(<SquadsTracking cycle={cycle} />);
+    await screen.findByText("Proposal executed · settlement unverified");
+    await waitFor(() =>
+      expect(intervals).toHaveBeenCalledWith(expect.any(Function), 1000),
+    );
+    vi.spyOn(Date, "now").mockReturnValue(
+      Date.parse(observation.observedAt) + 300000,
+    );
+    act(() => vi.advanceTimersByTime(1000));
+    expect(
+      screen.getByText("Execution observation stale · refresh required"),
+    ).toBeVisible();
+    expect(fetcher).toHaveBeenCalledTimes(2);
   });
   it("shows partial batch execution without reporting settlement", async () => {
     const { published, observation, cycle } = await fixture(true);


### PR DESCRIPTION
Extend the payout execution-status regression to cover both sides of the five-minute boundary and expiry without a focus event or another fetch. Preserve the focus-listener synchronization and async React update already merged in #435.

The interval test uses the real scheduler with a controlled observation clock, avoiding mixed fake timers that interfered with Testing Library polling in hosted CI. No application, payment or settlement behavior changes.

Validation at `93286124e7222a072e1eb648f599552a343be193`: frozen install and full `bun run verify` passed (1,401 unit tests, 129 skill tests, registry/schema checks, dependency audit, types, format/lint and build). All five required hosted checks passed; the browser matrix passed 81 tests plus 3 Pages integration tests, with no retries. [Hosted evidence](https://github.com/SlopDotCash/slopdotcash/actions/runs/34570616230). The previous pre-rebase and mixed-timer failures are superseded, not treated as green evidence. Real payouts remain disabled.
