### PR TITLE
fix(intake): fall through to the live GitHub check when the bundle attestation is stale

### DIFF
--- a/functions/api/v1/[[path]].ts
+++ b/functions/api/v1/[[path]].ts
@@ -115,6 +115,13 @@ async function privateIntakeStatus(
   fetchImpl: typeof fetch,
   now: () => Date,
 ): Promise<PrivateIntakeStatus> {
+  // The reviewed Pages bundle carries a build-time attestation that GitHub
+  // private vulnerability reporting was enabled for the released revision. A
+  // fresh attestation answers without any external request. A missing,
+  // malformed or expired attestation is not itself evidence that intake is
+  // disabled, so it falls through to the bounded live GitHub check below
+  // instead of failing closed on the age of a deploy. Only GitHub's own
+  // answer, or the inability to obtain one, decides availability.
   if (assets !== undefined) {
     try {
       const url = new URL(PRIVATE_INTAKE_ATTESTATION_PATH, requestUrl);
@@ -124,20 +131,23 @@ async function privateIntakeStatus(
           headers: { accept: "application/json" },
         }),
       );
-      if (!response.ok) return { status: "unavailable" };
-      const value = await readBoundedJson(
-        response,
-        MAX_PRIVATE_INTAKE_RESPONSE_BYTES,
-      );
-      const attestation = parsePrivateIntakeAttestation(value, now());
-      if (attestation === null) return { status: "unavailable" };
-      return {
-        status: "verified",
-        enabled: true,
-        verifiedAt: attestation.verifiedAt,
-      };
+      if (response.ok) {
+        const value = await readBoundedJson(
+          response,
+          MAX_PRIVATE_INTAKE_RESPONSE_BYTES,
+        );
+        const attestation = parsePrivateIntakeAttestation(value, now());
+        if (attestation !== null) {
+          return {
+            status: "verified",
+            enabled: true,
+            verifiedAt: attestation.verifiedAt,
+          };
+        }
+      }
     } catch {
-      return { status: "unavailable" };
+      // The bundle attestation is an optimization, not the authority.
+      // Continue to the bounded live GitHub check.
     }
   }
   if (cache !== undefined) {

--- a/functions/api/v1/trace-api.test.ts
+++ b/functions/api/v1/trace-api.test.ts
@@ -565,6 +565,140 @@ describe("private trace API", () => {
     });
   });
 
+  it("falls through to the live GitHub check when the bundle attestation has expired", async () => {
+    const originalFetch = globalThis.fetch;
+    const githubRequests: string[] = [];
+    try {
+      globalThis.fetch = (async (input: RequestInfo | URL) => {
+        githubRequests.push(String(input));
+        return new Response(JSON.stringify({ enabled: true }), {
+          status: 200,
+        });
+      }) as unknown as typeof fetch;
+      const expiredAt = new Date(
+        Date.now() - 50 * 60 * 60 * 1000,
+      ).toISOString();
+      const response = await onPagesRequest({
+        request: new Request(
+          "https://api.slop.cash/api/v1/private-request-intake",
+        ),
+        env: {
+          SLOP_DB: {} as never,
+          PRIVATE_TRACES: {} as never,
+          TRACE_AUTH_SECRET: SECRET,
+          SLOP_IDENTITY: {
+            fetch: async () => new Response(null, { status: 401 }),
+          },
+          ASSETS: {
+            fetch: async () =>
+              new Response(
+                JSON.stringify({
+                  enabled: true,
+                  source: "github-public-status",
+                  verifiedAt: expiredAt,
+                  revision: "a".repeat(40),
+                }),
+                { status: 200 },
+              ),
+          },
+        },
+      });
+
+      expect(githubRequests).toEqual([
+        "https://api.github.com/repos/SlopDotCash/slopdotcash/private-vulnerability-reporting",
+      ]);
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({
+        enabled: true,
+        source: "github-public-status",
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("falls through to the live GitHub check when the bundle attestation is missing", async () => {
+    const originalFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = (async () =>
+        new Response(JSON.stringify({ enabled: true }), {
+          status: 200,
+        })) as unknown as typeof fetch;
+      const response = await onPagesRequest({
+        request: new Request(
+          "https://api.slop.cash/api/v1/private-request-intake",
+        ),
+        env: {
+          SLOP_DB: {} as never,
+          PRIVATE_TRACES: {} as never,
+          TRACE_AUTH_SECRET: SECRET,
+          SLOP_IDENTITY: {
+            fetch: async () => new Response(null, { status: 401 }),
+          },
+          ASSETS: {
+            fetch: async () => new Response(null, { status: 404 }),
+          },
+        },
+      });
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({
+        enabled: true,
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("still fails closed when the bundle attestation has expired and GitHub cannot answer", async () => {
+    const originalFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = (async () =>
+        new Response(JSON.stringify({ message: "API rate limit exceeded" }), {
+          status: 403,
+          headers: {
+            "x-ratelimit-remaining": "0",
+            "x-ratelimit-reset": "999999999999",
+          },
+        })) as unknown as typeof fetch;
+      const expiredAt = new Date(
+        Date.now() - 50 * 60 * 60 * 1000,
+      ).toISOString();
+      const response = await onPagesRequest({
+        request: new Request(
+          "https://api.slop.cash/api/v1/private-request-intake",
+        ),
+        env: {
+          SLOP_DB: {} as never,
+          PRIVATE_TRACES: {} as never,
+          TRACE_AUTH_SECRET: SECRET,
+          SLOP_IDENTITY: {
+            fetch: async () => new Response(null, { status: 401 }),
+          },
+          ASSETS: {
+            fetch: async () =>
+              new Response(
+                JSON.stringify({
+                  enabled: true,
+                  source: "github-public-status",
+                  verifiedAt: expiredAt,
+                  revision: "a".repeat(40),
+                }),
+                { status: 200 },
+              ),
+          },
+        },
+      });
+
+      expect(response.status).toBe(503);
+      await expect(response.json()).resolves.toEqual({
+        error: "private_intake_unavailable",
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it("serves a cached public private intake verification", async () => {
     const originalFetch = globalThis.fetch;
     const originalCaches = Object.getOwnPropertyDescriptor(

--- a/src/lib/private-intake-attestation.ts
+++ b/src/lib/private-intake-attestation.ts
@@ -1,8 +1,9 @@
 export const PRIVATE_INTAKE_ATTESTATION_PATH =
   "/data/private-intake-attestation.json";
-// Two full scheduled-refresh days. Every production refresh needs a human
-// environment approval, so a window shorter than a night plus one missed day
-// guarantees a recurring fail-closed intake outage (issue #302).
+// Two full scheduled-refresh days. Within this window the deployed attestation
+// answers intake status without an external request. Past it, the API falls
+// through to a bounded live GitHub check (issue #429), so an unrenewed deploy
+// slows the answer down rather than taking intake offline (issue #302).
 export const PRIVATE_INTAKE_ATTESTATION_MAX_AGE_MS = 49 * 60 * 60 * 1000;
 
 export type PrivateIntakeAttestation = {


### PR DESCRIPTION
## TL;DR

Contributor intake currently goes offline whenever the deployed attestation is older than 49 hours, which happens whenever no deploy has published for two days. This PR makes a stale attestation fall through to the live GitHub check that the API already performs when no bundle is present, instead of failing closed on the age of a deploy. Nothing manual is needed to keep intake up any more. Follows the conversation with Drew on 11 Sep about eliminating the manual dependency entirely.

## What changes

- `functions/api/v1/[[path]].ts`: in `privateIntakeStatus`, a missing, malformed or expired bundle attestation no longer returns `unavailable`. It continues to the existing edge-cached, bounded, redirect-rejecting GitHub check. A fresh attestation is still served directly with no external request.
- `src/lib/private-intake-attestation.ts`: comment on the 49 hour constant updated to describe what the window now means. The value is unchanged.
- `functions/api/v1/trace-api.test.ts`: three new tests. Expired attestation plus GitHub enabled returns 200 and hits exactly the GitHub endpoint. Missing attestation plus GitHub enabled returns 200. Expired attestation plus a rate limited GitHub still returns 503 `private_intake_unavailable`.

## What does not change

- The 49 hour window, the attestation format, the build-time verifier and the deploy workflow are untouched.
- Fail-closed on a malformed, redirected or rate limited GitHub response is unchanged and still covered by the existing tests.
- The reviewed bundle attestation remains the fast path. The live check only runs when the bundle cannot vouch.

## Why this is the right layer

The attestation only asserts that GitHub private vulnerability reporting was enabled at the released revision. When it expires, the honest question is "is it enabled now", and the API already knows how to ask GitHub that with a 5 minute edge cache. Refusing contributors because a deploy did not happen answers a different question. Issue #429 describes how a merged release awaiting approval can starve every scheduled refresh; with this change that starvation delays data, not intake.

## Verification

- `bun x vitest run`: 114 files, 1412 tests passed on develop head 85e1d9e plus this change.
- The two fall-through tests fail without the source change and pass with it.
- `bun run typecheck` clean. Biome reports nothing on the three changed files.

Happy for you to take this over and land it under your own authorship if you prefer, since it is release-path code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
