### PR TITLE
ci: route code releases to production credentials and drop the approval job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,15 +61,6 @@ jobs:
             echo "sha=$GITHUB_SHA" >> "$GITHUB_OUTPUT"
           fi
 
-  approve:
-    name: Approve code release
-    needs: [source, quality]
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-24.04
-    environment: eliza-army-production
-    steps:
-      - run: echo "Approved tested code release"
-
   quality:
     name: Skill, data, build, and browser checks
     needs: source
@@ -262,12 +253,11 @@ jobs:
   deploy:
     name: Deploy trusted production bundle
     if: >-
-      always() && needs.quality.result == 'success' &&
-      (needs.approve.result == 'success' || github.event_name == 'schedule') &&
+      needs.quality.result == 'success' &&
       ((github.event_name == 'push' && github.ref == 'refs/heads/develop') ||
       (github.event_name == 'schedule' && github.ref == 'refs/heads/develop') ||
       (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/develop'))
-    needs: [source, quality, approve]
+    needs: [source, quality]
     env:
       RELEASE_SHA: ${{ needs.source.outputs.sha }}
     permissions:
@@ -276,11 +266,14 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     concurrency:
-      # Only publication holds this lock. Code approval waits in its own job.
+      # Only publication holds this lock. Neither environment requires a
+      # manual reviewer: the protected develop merge is the release decision.
       group: slop-production
       cancel-in-progress: false
     environment:
-      name: slop-data-refresh
+      # Code releases need the Workers-scoped production credentials for the
+      # identity Worker; unattended refreshes get only the Pages-scoped token.
+      name: ${{ github.event_name == 'schedule' && 'slop-data-refresh' || 'eliza-army-production' }}
       url: https://slop.cash
     steps:
       - name: Checkout exact deployment tooling

--- a/scripts/deployment-contract.test.mjs
+++ b/scripts/deployment-contract.test.mjs
@@ -333,7 +333,7 @@ describe("slop.cash deployment contract", () => {
     expect(deployJob).toContain("group: slop-production");
     expect(deployJob).toContain("cancel-in-progress: false");
     expect(deployJob).toContain(
-      "name: ${{ github.event_name == 'schedule' && 'slop-data-refresh' || 'eliza-army-production' }}",
+      `name: \${{ github.event_name == 'schedule' && 'slop-data-refresh' || 'eliza-army-production' }}`,
     );
     expect(workflow).not.toContain("environment: eliza-army-production");
   });

--- a/scripts/deployment-contract.test.mjs
+++ b/scripts/deployment-contract.test.mjs
@@ -332,12 +332,15 @@ describe("slop.cash deployment contract", () => {
     );
     expect(deployJob).toContain("group: slop-production");
     expect(deployJob).toContain("cancel-in-progress: false");
-    expect(deployJob).toContain(`name: slop-data-refresh`);
+    expect(deployJob).toContain(
+      "name: ${{ github.event_name == 'schedule' && 'slop-data-refresh' || 'eliza-army-production' }}",
+    );
+    expect(workflow).not.toContain("environment: eliza-army-production");
   });
 
   it("limits unattended refreshes to released source and data-only bundles", () => {
     expect(workflow).toContain("node scripts/released-source.mjs");
-    expect(workflow).toContain("needs: [source, quality, approve]");
+    expect(workflow).toContain("needs: [source, quality]");
     expect(deployJob).toContain("node scripts/check-data-refresh-bundle.mjs");
     const check = deployJob.indexOf(
       "node scripts/check-data-refresh-bundle.mjs",

--- a/scripts/release-flow.test.mjs
+++ b/scripts/release-flow.test.mjs
@@ -32,7 +32,7 @@ describe("independent release and intake paths", () => {
     expect(jobs.deploy.if).not.toContain("needs.approve");
     expect(jobs.deploy.concurrency.group).toBe("slop-production");
     expect(jobs.deploy.environment.name).toBe(
-      "${{ github.event_name == 'schedule' && 'slop-data-refresh' || 'eliza-army-production' }}",
+      `\${{ github.event_name == 'schedule' && 'slop-data-refresh' || 'eliza-army-production' }}`,
     );
     const publication = jobs.deploy.steps.find(
       (step) => step.id === "pages-deploy",

--- a/scripts/release-flow.test.mjs
+++ b/scripts/release-flow.test.mjs
@@ -25,16 +25,15 @@ function workflow(path) {
 }
 
 describe("independent release and intake paths", () => {
-  it("waits for code approval outside the publication lock, while refreshes can publish", () => {
+  it("routes code releases to production credentials without a manual approval job, while refreshes can publish", () => {
     const { jobs } = workflow(".github/workflows/deploy.yml");
-    expect(jobs.approve.environment).toBe("eliza-army-production");
-    expect(jobs.approve.concurrency).toBeUndefined();
-    expect(jobs.deploy.needs).toContain("approve");
-    expect(jobs.deploy.if).toContain(
-      "needs.approve.result == 'success' || github.event_name == 'schedule'",
-    );
+    expect(jobs.approve).toBeUndefined();
+    expect(jobs.deploy.needs).toEqual(["source", "quality"]);
+    expect(jobs.deploy.if).not.toContain("needs.approve");
     expect(jobs.deploy.concurrency.group).toBe("slop-production");
-    expect(jobs.deploy.environment.name).toBe("slop-data-refresh");
+    expect(jobs.deploy.environment.name).toBe(
+      "${{ github.event_name == 'schedule' && 'slop-data-refresh' || 'eliza-army-production' }}",
+    );
     const publication = jobs.deploy.steps.find(
       (step) => step.id === "pages-deploy",
     ).run;


### PR DESCRIPTION
Fixes #442.

## Why

Since #439 and #441 the `deploy` job always ran under `slop-data-refresh`, so a push release used the Pages-only Cloudflare token and failed closed at the identity schedule readback. Run 34674206606 (release of 815ac3f) failed this way at 09:06Z today after approval, and the site is still at 85e1d9e. All four `skills/contribute-to-*` trees changed in #441, so every installer now refuses the published archives.

## What

- Restore the per-event environment on `deploy`: push and manual runs use `eliza-army-production` and its Workers-scoped token, scheduled refreshes keep `slop-data-refresh` and the Pages-only token.
- Remove the standalone `approve` job and the `needs.approve` condition.
- Update `release-flow.test.mjs` and `deployment-contract.test.mjs` to assert the new graph.

## Why no approval job

Only two admins can push. `develop` requires a pull request with the five trusted checks green, enforces that on admins, and blocks force pushes. The merge is the release decision, so a second click by the same person only created the parked-release pattern (#302). The required reviewers on `eliza-army-production` have already been removed; the deployment branch policy (develop only) is unchanged. No token scope is broadened.

## Verification

`vitest run scripts/release-flow.test.mjs scripts/deployment-contract.test.mjs`: 19 passed. Prettier and biome clean on the changed files.

Once merged, the release of the merge commit rebuilds all four archives from develop head and the installers clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
